### PR TITLE
Update some Block mappings

### DIFF
--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -13,6 +13,7 @@ CLASS none/akw net/minecraft/block/Block
 	FIELD v soundGroup Lnone/apu;
 	FIELD x material Lnone/ayo;
 	FIELD y mapColor Lnone/ayp;
+	FIELD z friction F
 	METHOD <init> (Lnone/ayo;)V
 		ARG 0 material
 	METHOD <init> (Lnone/ayo;Lnone/ayp;)V
@@ -57,7 +58,7 @@ CLASS none/akw net/minecraft/block/Block
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 player
-	METHOD a (Lnone/aiu;Lnone/cn;Lnone/aeq;)V
+	METHOD a dropStack (Lnone/aiu;Lnone/cn;Lnone/aeq;)V
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 stack
@@ -68,10 +69,11 @@ CLASS none/akw net/minecraft/block/Block
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 state
-	METHOD a (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
+	METHOD a dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 state
+		ARG 4 fortune
 	METHOD a (Lnone/aiu;Lnone/cn;Lnone/asj;Ljava/util/Random;)V
 		ARG 0 world
 		ARG 1 pos
@@ -213,14 +215,19 @@ CLASS none/akw net/minecraft/block/Block
 		ARG 0 id
 	METHOD b getByBlockById (Ljava/lang/String;)Lnone/akw;
 		ARG 0 id
+	METHOD b dropExperience (Lnone/aiu;Lnone/cn;I)V
+		ARG 0 world
+		ARG 1 pos
+		ARG 2 amount
 	METHOD b (Lnone/aiu;Lnone/cn;Lnone/asj;)V
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 state
-	METHOD b (Lnone/aiu;Lnone/cn;Lnone/asj;I)V
+	METHOD b dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;I)V
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 state
+		ARG 3 fortune
 	METHOD b randomTick (Lnone/aiu;Lnone/cn;Lnone/asj;Ljava/util/Random;)V
 		ARG 0 world
 		ARG 1 pos

--- a/mappings/net/minecraft/block/impl/BlockAir.mapping
+++ b/mappings/net/minecraft/block/impl/BlockAir.mapping
@@ -1,5 +1,5 @@
 CLASS none/akm net/minecraft/block/impl/BlockAir
-	METHOD a (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
+	METHOD a dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 state

--- a/mappings/net/minecraft/block/impl/BlockBanner.mapping
+++ b/mappings/net/minecraft/block/impl/BlockBanner.mapping
@@ -60,7 +60,7 @@ CLASS none/ako net/minecraft/block/impl/BlockBanner
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 state
-	METHOD a (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
+	METHOD a dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 state

--- a/mappings/net/minecraft/block/impl/BlockBarrier.mapping
+++ b/mappings/net/minecraft/block/impl/BlockBarrier.mapping
@@ -1,5 +1,5 @@
 CLASS none/akp net/minecraft/block/impl/BlockBarrier
-	METHOD a (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
+	METHOD a dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 state

--- a/mappings/net/minecraft/block/impl/BlockBed.mapping
+++ b/mappings/net/minecraft/block/impl/BlockBed.mapping
@@ -9,6 +9,7 @@ CLASS none/aku net/minecraft/block/impl/BlockBed
 	FIELD c BOUNDING_BOX Lnone/bcp;
 	METHOD a deserializeState (I)Lnone/asj;
 	METHOD a getDropStack (Lnone/aiu;Lnone/cn;Lnone/asj;)Lnone/aeq;
+	METHOD a dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
 	METHOD a activate (Lnone/aiu;Lnone/cn;Lnone/asj;Lnone/aak;Lnone/qz;Lnone/cu;FFF)Z
 		ARG 0 world
 		ARG 1 pos

--- a/mappings/net/minecraft/block/impl/BlockCocoa.mapping
+++ b/mappings/net/minecraft/block/impl/BlockCocoa.mapping
@@ -2,6 +2,7 @@ CLASS none/alm net/minecraft/block/impl/BlockCocoa
 	FIELD a AGE Lnone/asy;
 	METHOD a deserializeState (I)Lnone/asj;
 	METHOD a getDropStack (Lnone/aiu;Lnone/cn;Lnone/asj;)Lnone/aeq;
+	METHOD a dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
 	METHOD a getStateForPlacement (Lnone/aiu;Lnone/cn;Lnone/cu;FFFILnone/sn;)Lnone/asj;
 	METHOD a applyMirror (Lnone/asj;Lnone/anw;)Lnone/asj;
 	METHOD a applyRotation (Lnone/asj;Lnone/apj;)Lnone/asj;

--- a/mappings/net/minecraft/block/impl/BlockCrop.mapping
+++ b/mappings/net/minecraft/block/impl/BlockCrop.mapping
@@ -8,6 +8,7 @@ CLASS none/alr net/minecraft/block/impl/BlockCrop
 		ARG 2 pos
 		ARG 3 state
 	METHOD a getDropStack (Lnone/aiu;Lnone/cn;Lnone/asj;)Lnone/aeq;
+	METHOD a dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
 	METHOD a (Lnone/aiu;Lnone/cn;Lnone/asj;Z)Z
 		ARG 0 world
 		ARG 1 pos

--- a/mappings/net/minecraft/block/impl/BlockJukebox.mapping
+++ b/mappings/net/minecraft/block/impl/BlockJukebox.mapping
@@ -9,6 +9,7 @@ CLASS none/ann net/minecraft/block/impl/BlockJukebox
 	FIELD a HAS_RECORD Lnone/asv;
 	METHOD a deserializeState (I)Lnone/asj;
 	METHOD a createTileEntity (Lnone/aiu;I)Lnone/arb;
+	METHOD a dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
 	METHOD a activate (Lnone/aiu;Lnone/cn;Lnone/asj;Lnone/aak;Lnone/qz;Lnone/cu;FFF)Z
 	METHOD b createStateFactory ()Lnone/ask;
 	METHOD e serializeState (Lnone/asj;)I

--- a/mappings/net/minecraft/block/impl/BlockLeavesBase.mapping
+++ b/mappings/net/minecraft/block/impl/BlockLeavesBase.mapping
@@ -2,6 +2,7 @@ CLASS none/anp net/minecraft/block/impl/BlockLeavesBase
 	FIELD a DECAYABLE Lnone/asv;
 	FIELD b CHECK_DECAY Lnone/asv;
 	METHOD a getDropAmount (Ljava/util/Random;)I
+	METHOD a dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
 	METHOD a getDropItem (Lnone/asj;Ljava/util/Random;I)Lnone/aeo;
 	METHOD b randomTick (Lnone/aiu;Lnone/cn;Lnone/asj;Ljava/util/Random;)V
 	METHOD f getRenderLayer ()Lnone/aim;

--- a/mappings/net/minecraft/block/impl/BlockMobSpawner.mapping
+++ b/mappings/net/minecraft/block/impl/BlockMobSpawner.mapping
@@ -2,5 +2,6 @@ CLASS none/anx net/minecraft/block/impl/BlockMobSpawner
 	METHOD a getDropAmount (Ljava/util/Random;)I
 	METHOD a createTileEntity (Lnone/aiu;I)Lnone/arb;
 	METHOD a getDropStack (Lnone/aiu;Lnone/cn;Lnone/asj;)Lnone/aeq;
+	METHOD a dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
 	METHOD a getDropItem (Lnone/asj;Ljava/util/Random;I)Lnone/aeo;
 	METHOD f getRenderLayer ()Lnone/aim;

--- a/mappings/net/minecraft/block/impl/BlockMonsterEgg.mapping
+++ b/mappings/net/minecraft/block/impl/BlockMonsterEgg.mapping
@@ -13,6 +13,7 @@ CLASS none/any net/minecraft/block/impl/BlockMonsterEgg
 	METHOD a getDropAmount (Ljava/util/Random;)I
 	METHOD a addStacksForDisplay (Lnone/aeo;Lnone/adq;Lnone/dc;)V
 	METHOD a getDropStack (Lnone/aiu;Lnone/cn;Lnone/asj;)Lnone/aeq;
+	METHOD a dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
 	METHOD b createStateFactory ()Lnone/ask;
 	METHOD e serializeState (Lnone/asj;)I
 	METHOD u getStackFromState (Lnone/asj;)Lnone/aeq;

--- a/mappings/net/minecraft/block/impl/BlockNetherWart.mapping
+++ b/mappings/net/minecraft/block/impl/BlockNetherWart.mapping
@@ -2,6 +2,7 @@ CLASS none/aoc net/minecraft/block/impl/BlockNetherWart
 	METHOD a deserializeState (I)Lnone/asj;
 	METHOD a getDropAmount (Ljava/util/Random;)I
 	METHOD a getDropStack (Lnone/aiu;Lnone/cn;Lnone/asj;)Lnone/aeq;
+	METHOD a dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
 	METHOD a getDropItem (Lnone/asj;Ljava/util/Random;I)Lnone/aeo;
 	METHOD b createStateFactory ()Lnone/ask;
 	METHOD b randomTick (Lnone/aiu;Lnone/cn;Lnone/asj;Ljava/util/Random;)V

--- a/mappings/net/minecraft/block/impl/BlockOre.mapping
+++ b/mappings/net/minecraft/block/impl/BlockOre.mapping
@@ -1,5 +1,6 @@
 CLASS none/aom net/minecraft/block/impl/BlockOre
 	METHOD a getDropAmount (Ljava/util/Random;)I
 	METHOD a getDropStack (Lnone/aiu;Lnone/cn;Lnone/asj;)Lnone/aeq;
+	METHOD a dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
 	METHOD a getDropItem (Lnone/asj;Ljava/util/Random;I)Lnone/aeo;
 	METHOD d getDropItemDamage (Lnone/asj;)I

--- a/mappings/net/minecraft/block/impl/BlockPistonExtension.mapping
+++ b/mappings/net/minecraft/block/impl/BlockPistonExtension.mapping
@@ -2,6 +2,7 @@ CLASS none/asc net/minecraft/block/impl/BlockPistonExtension
 	METHOD a deserializeState (I)Lnone/asj;
 	METHOD a createTileEntity (Lnone/aiu;I)Lnone/arb;
 	METHOD a getDropStack (Lnone/aiu;Lnone/cn;Lnone/asj;)Lnone/aeq;
+	METHOD a dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
 	METHOD a activate (Lnone/aiu;Lnone/cn;Lnone/asj;Lnone/aak;Lnone/qz;Lnone/cu;FFF)Z
 	METHOD a getDropItem (Lnone/asj;Ljava/util/Random;I)Lnone/aeo;
 	METHOD a getCollisionBox (Lnone/asj;Lnone/aiy;Lnone/cn;)Lnone/bcp;

--- a/mappings/net/minecraft/block/impl/BlockPotatoes.mapping
+++ b/mappings/net/minecraft/block/impl/BlockPotatoes.mapping
@@ -1,4 +1,5 @@
 CLASS none/aoq net/minecraft/block/impl/BlockPotatoes
+	METHOD a dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
 	METHOD b getBoundingBox (Lnone/asj;Lnone/aiy;Lnone/cn;)Lnone/bcp;
 	METHOD h getItemSeed ()Lnone/aeo;
 	METHOD i getItemMature ()Lnone/aeo;

--- a/mappings/net/minecraft/block/impl/BlockRedstoneOre.mapping
+++ b/mappings/net/minecraft/block/impl/BlockRedstoneOre.mapping
@@ -1,6 +1,7 @@
 CLASS none/apb net/minecraft/block/impl/BlockRedstoneOre
 	METHOD a getDropAmount (Ljava/util/Random;)I
 	METHOD a getDropStack (Lnone/aiu;Lnone/cn;Lnone/asj;)Lnone/aeq;
+	METHOD a dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
 	METHOD a activate (Lnone/aiu;Lnone/cn;Lnone/asj;Lnone/aak;Lnone/qz;Lnone/cu;FFF)Z
 	METHOD a getDropItem (Lnone/asj;Ljava/util/Random;I)Lnone/aeo;
 	METHOD b randomTick (Lnone/aiu;Lnone/cn;Lnone/asj;Ljava/util/Random;)V

--- a/mappings/net/minecraft/block/impl/BlockSkull.mapping
+++ b/mappings/net/minecraft/block/impl/BlockSkull.mapping
@@ -2,6 +2,7 @@ CLASS none/app net/minecraft/block/impl/BlockSkull
 	METHOD a deserializeState (I)Lnone/asj;
 	METHOD a createTileEntity (Lnone/aiu;I)Lnone/arb;
 	METHOD a getDropStack (Lnone/aiu;Lnone/cn;Lnone/asj;)Lnone/aeq;
+	METHOD a dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
 	METHOD a getStateForPlacement (Lnone/aiu;Lnone/cn;Lnone/cu;FFFILnone/sn;)Lnone/asj;
 	METHOD a getDropItem (Lnone/asj;Ljava/util/Random;I)Lnone/aeo;
 	METHOD a applyMirror (Lnone/asj;Lnone/anw;)Lnone/asj;

--- a/mappings/net/minecraft/block/impl/BlockStem.mapping
+++ b/mappings/net/minecraft/block/impl/BlockStem.mapping
@@ -1,6 +1,7 @@
 CLASS none/aqb net/minecraft/block/impl/BlockStem
 	METHOD a deserializeState (I)Lnone/asj;
 	METHOD a getDropStack (Lnone/aiu;Lnone/cn;Lnone/asj;)Lnone/aeq;
+	METHOD a dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
 	METHOD a getDropItem (Lnone/asj;Ljava/util/Random;I)Lnone/aeo;
 	METHOD b createStateFactory ()Lnone/ask;
 	METHOD b randomTick (Lnone/aiu;Lnone/cn;Lnone/asj;Ljava/util/Random;)V

--- a/mappings/net/minecraft/block/impl/BlockStructureVoid.mapping
+++ b/mappings/net/minecraft/block/impl/BlockStructureVoid.mapping
@@ -1,3 +1,4 @@
 CLASS none/aqh net/minecraft/block/impl/BlockStructureVoid
+	METHOD a dropItems (Lnone/aiu;Lnone/cn;Lnone/asj;FI)V
 	METHOD a getCollisionBox (Lnone/asj;Lnone/aiy;Lnone/cn;)Lnone/bcp;
 	METHOD b getBoundingBox (Lnone/asj;Lnone/aiy;Lnone/cn;)Lnone/bcp;

--- a/mappings/net/minecraft/entity/impl/EntityExperienceOrb.mapping
+++ b/mappings/net/minecraft/entity/impl/EntityExperienceOrb.mapping
@@ -1,4 +1,4 @@
-CLASS none/sk net/minecraft/entity/impl/EntityXPOrb
+CLASS none/sk net/minecraft/entity/impl/EntityExperienceOrb
 	METHOD a deserializeEntityTag (Lnone/dt;)V
 	METHOD b serializeEntityTag (Lnone/dt;)V
 	METHOD m update ()V


### PR DESCRIPTION
> **Fields:** friction
> **Methods:** dropItems, dropStack, dropExperience
> **Parameters:** fortune
> 
> Renamed EntityXPOrb to EntityExperienceOrb

Just a small PR to see if I'm doing things right.
I suppose there's some open questions if you're willing to discuss them:
- `dropItems` could perhaps get a better name. (Just `drop`?)
- `dropStack` and `dropExperience` are static "helper" methods, they could be called `dropXYZFromBlock` though they're already called as `Block.dropXYZ` so I felt like `FromBlock` is unnecessary.
- `dropExperience` could be called `dropExperienceOrbs`, though I personally don't see any added value from being more specific.
- `fortune` could be called `fortuneLevel`
- I didn't know what the float parameter on `dropItems` is used for.
