### PR TITLE
GlHandler classes and whatnot

### DIFF
--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -14,7 +14,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 		METHOD b disable ()V
 		METHOD a setState (Z)V
 			ARG 0 newState
-	CLASS none/bos$d
+	CLASS none/bos$d ClearState
 		FIELD a clearDepth D
 		FIELD b clearColor Lnone/bos$e;
 	CLASS none/bos$e
@@ -37,6 +37,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	FIELD g blendFunc Lnone/bos$b;
 	FIELD h depth Lnone/bos$k;
 	FIELD k polygonOffset Lnone/bos$p;
+	FIELD n clearState Lnone/bos$d;
 	FIELD p normalizeEnabled Lnone/bos$c;
 	FIELD s shadeModel I
 	FIELD t rescaleNormalEnabled Lnone/bos$c;

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -7,6 +7,8 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD a capState Lnone/bos$c;
 		FIELD b sfactor I
 		FIELD c dfactor I
+		FIELD d srcAlpha I
+		FIELD e dstAlpha I
 	CLASS none/bos$c CapabilityTracker
 		FIELD a cap I
 		FIELD b state Z

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -35,6 +35,21 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD a capState Lnone/bos$c;
 		FIELD b mask Z
 		FIELD c func I
+	CLASS none/bos$l DstBlendFactor
+		FIELD a CONSTANT_ALPHA Lnone/bos$l;
+		FIELD b CONSTANT_COLOR Lnone/bos$l;
+		FIELD c DST_ALPHA Lnone/bos$l;
+		FIELD d DST_COLOR Lnone/bos$l;
+		FIELD e ONE Lnone/bos$l;
+		FIELD f ONE_MINUS_CONSTANT_ALPHA Lnone/bos$l;
+		FIELD g ONE_MINUS_CONSTANT_COLOR Lnone/bos$l;
+		FIELD h ONE_MINUS_DST_ALPHA Lnone/bos$l;
+		FIELD i ONE_MINUS_DST_COLOR Lnone/bos$l;
+		FIELD j ONE_MINUS_SRC_ALPHA Lnone/bos$l;
+		FIELD k ONE_MINUS_SRC_COLOR Lnone/bos$l;
+		FIELD l SRC_ALPHA Lnone/bos$l;
+		FIELD m SRC_COLOR Lnone/bos$l;
+		FIELD n ZERO Lnone/bos$l;
 	CLASS none/bos$o LogicOp
 		FIELD a AND Lnone/bos$o;
 		FIELD b AND_INVERTED Lnone/bos$o;
@@ -68,21 +83,6 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD m SRC_ALPHA_SATURATE Lnone/bos$r;
 		FIELD n SRC_COLOR Lnone/bos$r;
 		FIELD o ZERO Lnone/bos$r;
-	CLASS none/bos$l DstBlendFactor
-		FIELD a CONSTANT_ALPHA Lnone/bos$l;
-		FIELD b CONSTANT_COLOR Lnone/bos$l;
-		FIELD c DST_ALPHA Lnone/bos$l;
-		FIELD d DST_COLOR Lnone/bos$l;
-		FIELD e ONE Lnone/bos$l;
-		FIELD f ONE_MINUS_CONSTANT_ALPHA Lnone/bos$l;
-		FIELD g ONE_MINUS_CONSTANT_COLOR Lnone/bos$l;
-		FIELD h ONE_MINUS_DST_ALPHA Lnone/bos$l;
-		FIELD i ONE_MINUS_DST_COLOR Lnone/bos$l;
-		FIELD j ONE_MINUS_SRC_ALPHA Lnone/bos$l;
-		FIELD k ONE_MINUS_SRC_COLOR Lnone/bos$l;
-		FIELD l SRC_ALPHA Lnone/bos$l;
-		FIELD m SRC_COLOR Lnone/bos$l;
-		FIELD n ZERO Lnone/bos$l;
 	CLASS none/bos$p PolygonOffsetState
 		FIELD a capFill Lnone/bos$c;
 		FIELD b capLine Lnone/bos$c;

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -17,7 +17,11 @@ CLASS none/bos net/minecraft/client/GlHandler
 	CLASS none/bos$d ClearState
 		FIELD a clearDepth D
 		FIELD b clearColor Lnone/bos$e;
-	CLASS none/bos$e
+	CLASS none/bos$e Color4
+		FIELD a red F
+		FIELD b green F
+		FIELD c blue F
+		FIELD d alpha F
 	CLASS none/bos$h
 		FIELD b face I
 		FIELD c mode I

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -1,4 +1,8 @@
 CLASS none/bos net/minecraft/client/GlHandler
+	CLASS none/bos$a AlphaTestState
+		FIELD a capState Lnone/bos$c;
+		FIELD b func I
+		FIELD c ref F
 	CLASS none/bos$b
 		FIELD b sfactor I
 		FIELD c dfactor I
@@ -24,6 +28,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD d units F
 	CLASS none/bos$x
 		FIELD b boundTexture I
+	FIELD c alphaTestState Lnone/bos$a;
 	FIELD d lightSystemEnabled Lnone/bos$c;
 	FIELD e lightSourceEnabled [Lnone/bos$c;
 	FIELD f colorMaterial Lnone/bos$h;
@@ -57,6 +62,8 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD a clearColor (FFFF)V
 	METHOD a disableLight (I)V
 	METHOD a alphaFunc (IF)V
+		ARG 0 func
+		ARG 1 ref
 	METHOD a colorMaterial (II)V
 		ARG 0 face
 		ARG 1 mode
@@ -97,10 +104,12 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD c texCoordPointer (IIII)V
 	METHOD c colorPointer (IIILjava/nio/ByteBuffer;)V
 	METHOD c getFloat (ILjava/nio/FloatBuffer;)V
+	METHOD d enableAlphaTest ()V
 	METHOD d lineWidth (F)V
 	METHOD d blendEquation (I)V
 	METHOD d polygonMode (II)V
 	METHOD d vertexPointer (IIII)V
+	METHOD e disableAlphaTest ()V
 	METHOD e vertex (FFF)V
 	METHOD e deleteLists (II)V
 	METHOD e colorPointer (IIII)V

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -22,6 +22,9 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD b green F
 		FIELD c blue F
 		FIELD d alpha F
+	CLASS none/bos$f LogicOpState
+		FIELD a capState Lnone/bos$c;
+		FIELD b opcode I
 	CLASS none/bos$h
 		FIELD b face I
 		FIELD c mode I
@@ -29,6 +32,23 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD a capState Lnone/bos$c;
 		FIELD b mask Z
 		FIELD c func I
+	CLASS none/bos$o LogicOp
+		FIELD a AND Lnone/bos$o;
+		FIELD b AND_INVERTED Lnone/bos$o;
+		FIELD c AND_REVERSE Lnone/bos$o;
+		FIELD d CLEAR Lnone/bos$o;
+		FIELD e COPY Lnone/bos$o;
+		FIELD f COPY_INVERTED Lnone/bos$o;
+		FIELD g EQUIV Lnone/bos$o;
+		FIELD h INVERT Lnone/bos$o;
+		FIELD i NAND Lnone/bos$o;
+		FIELD j NOOP Lnone/bos$o;
+		FIELD k NOR Lnone/bos$o;
+		FIELD l OR Lnone/bos$o;
+		FIELD m OR_INVERTED Lnone/bos$o;
+		FIELD n OR_REVERSE Lnone/bos$o;
+		FIELD o SET Lnone/bos$o;
+		FIELD p XOR Lnone/bos$o;
 	CLASS none/bos$p
 		FIELD c factor F
 		FIELD d units F
@@ -41,6 +61,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	FIELD g blendFunc Lnone/bos$b;
 	FIELD h depth Lnone/bos$k;
 	FIELD k polygonOffset Lnone/bos$p;
+	FIELD l logicOpState Lnone/bos$f;
 	FIELD n clearState Lnone/bos$d;
 	FIELD p normalizeEnabled Lnone/bos$c;
 	FIELD s shadeModel I
@@ -87,6 +108,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD a getInteger (ILjava/nio/IntBuffer;)V
 	METHOD a multMatrix (Ljava/nio/FloatBuffer;)V
 	METHOD a (Lnone/bos$u;ILjava/nio/FloatBuffer;)V
+	METHOD a logicOp (Lnone/bos$o;)V
 	METHOD a multMatrix (Lorg/lwjgl/util/vector/Quaternion;)V
 	METHOD a depthMask (Z)V
 	METHOD a colorMask (ZZZZ)V
@@ -140,4 +162,6 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD t genLists (I)I
 	METHOD u getString (I)Ljava/lang/String;
 	METHOD v getInteger (I)I
+	METHOD w disableColorLogicOp ()V
+	METHOD x enableColorLogicOp ()V
 	METHOD x cullFace (I)V

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -36,6 +36,13 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD a capState Lnone/bos$c;
 		FIELD b face I
 		FIELD c mode I
+	CLASS none/bos$i FaceSides
+		FIELD a FRONT Lnone/bos$i;
+		FIELD b BACK Lnone/bos$i;
+		FIELD c FRONT_AND_BACK Lnone/bos$i;
+	CLASS none/bos$j CullFaceState
+		FIELD a capState Lnone/bos$c;
+		FIELD b mode I
 	CLASS none/bos$k DepthTestState
 		FIELD a capState Lnone/bos$c;
 		FIELD b mask Z
@@ -113,6 +120,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	FIELD g blendFunc Lnone/bos$b;
 	FIELD h depth Lnone/bos$k;
 	FIELD i fogState Lnone/bos$n;
+	FIELD j cullFaceState Lnone/bos$j;
 	FIELD k polygonOffset Lnone/bos$p;
 	FIELD l logicOpState Lnone/bos$f;
 	FIELD n clearState Lnone/bos$d;
@@ -164,6 +172,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD a lightModel (ILjava/nio/FloatBuffer;)V
 	METHOD a getInteger (ILjava/nio/IntBuffer;)V
 	METHOD a multMatrix (Ljava/nio/FloatBuffer;)V
+	METHOD a cullFace (Lnone/bos$i;)V
 	METHOD a fogMode (Lnone/bos$m;)V
 	METHOD a logicOp (Lnone/bos$o;)V
 	METHOD a blendFunc (Lnone/bos$r;Lnone/bos$l;)V
@@ -226,7 +235,9 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD o disableFog ()V
 	METHOD p enableFog ()V
 	METHOD p disableClientState (I)V
+	METHOD q disableCullFace ()V
 	METHOD q enableClientState (I)V
+	METHOD r enableCullFace ()V
 	METHOD r begin (I)V
 	METHOD s disablePolygonOffsetFill ()V
 	METHOD s callList (I)V

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -83,7 +83,9 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD l SRC_ALPHA Lnone/bos$l;
 		FIELD m SRC_COLOR Lnone/bos$l;
 		FIELD n ZERO Lnone/bos$l;
-	CLASS none/bos$p
+	CLASS none/bos$p PolygonOffsetState
+		FIELD a capFill Lnone/bos$c;
+		FIELD b capLine Lnone/bos$c;
 		FIELD c factor F
 		FIELD d units F
 	CLASS none/bos$x Texture2DState
@@ -203,7 +205,9 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD p disableClientState (I)V
 	METHOD q enableClientState (I)V
 	METHOD r begin (I)V
+	METHOD s disablePolygonOffsetFill ()V
 	METHOD s callList (I)V
+	METHOD t enablePolygonOffsetFill ()V
 	METHOD t genLists (I)I
 	METHOD u getString (I)Ljava/lang/String;
 	METHOD v getInteger (I)I

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -94,6 +94,10 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD b capLine Lnone/bos$c;
 		FIELD c factor F
 		FIELD d units F
+	CLASS none/bos$w RenderMode
+		FIELD a DEFAULT Lnone/bos$w;
+		FIELD b PLAYER_SKIN Lnone/bos$w;
+		FIELD c TRANSPARENT_MODEL Lnone/bos$w;
 	CLASS none/bos$r SrcBlendFactor
 		FIELD a CONSTANT_ALPHA Lnone/bos$r;
 		FIELD b CONSTANT_COLOR Lnone/bos$r;
@@ -118,10 +122,10 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD d dpfail I
 		FIELD e dppass I
 	CLASS none/bos$u TexCoord
-		FIELD a s Lnone/bos$u;
-		FIELD b t Lnone/bos$u;
-		FIELD c r Lnone/bos$u;
-		FIELD d q Lnone/bos$u;
+		FIELD a S Lnone/bos$u;
+		FIELD b T Lnone/bos$u;
+		FIELD c R Lnone/bos$u;
+		FIELD d Q Lnone/bos$u;
 	CLASS none/bos$v TexGenCoordState
 		FIELD a capState Lnone/bos$c;
 		FIELD b coord I

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -12,8 +12,8 @@ CLASS none/bos net/minecraft/client/GlHandler
 	CLASS none/bos$c CapabilityTracker
 		FIELD a cap I
 		FIELD b state Z
-		METHOD a enable ()V
-		METHOD b disable ()V
+		METHOD a disable ()V
+		METHOD b enable ()V
 		METHOD a setState (Z)V
 			ARG 0 newState
 	CLASS none/bos$d ClearState
@@ -155,10 +155,10 @@ CLASS none/bos net/minecraft/client/GlHandler
 	FIELD u colorMask Lnone/bos$g;
 	FIELD v color Lnone/bos$e;
 	METHOD A genTextures ()I
-	METHOD B disableNormalize ()V
-	METHOD C enableNormalize ()V
-	METHOD D disableRescaleNormal ()V
-	METHOD E enableRescaleNormal ()V
+	METHOD B enableNormalize ()V
+	METHOD C disableNormalize ()V
+	METHOD D enableRescaleNormal ()V
+	METHOD E disableRescaleNormal ()V
 	METHOD F loadIdentity ()V
 	METHOD G pushMatrix ()V
 	METHOD H popMatrix ()V
@@ -175,7 +175,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 		ARG 1 units
 	METHOD a normal (FFF)V
 	METHOD a clearColor (FFFF)V
-	METHOD a disableLight (I)V
+	METHOD a enableLight (I)V
 	METHOD a alphaFunc (IF)V
 		ARG 0 func
 		ARG 1 ref
@@ -200,7 +200,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD a logicOp (Lnone/bos$o;)V
 	METHOD a blendFunc (Lnone/bos$r;Lnone/bos$l;)V
 	METHOD a blendFuncSeparate (Lnone/bos$r;Lnone/bos$l;Lnone/bos$r;Lnone/bos$l;)V
-	METHOD a disableTextureGen (Lnone/bos$u;)V
+	METHOD a enableTextureGen (Lnone/bos$u;)V
 	METHOD a texGenMode (Lnone/bos$u;I)V
 	METHOD a texGen (Lnone/bos$u;ILjava/nio/FloatBuffer;)V
 	METHOD a multMatrix (Lorg/lwjgl/util/vector/Quaternion;)V
@@ -211,7 +211,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD b texCoord (FF)V
 	METHOD b scale (FFF)V
 	METHOD b rotate (FFFF)V
-	METHOD b enableLight (I)V
+	METHOD b disableLight (I)V
 	METHOD b blendFunc (II)V
 	METHOD b fog (ILjava/nio/FloatBuffer;)V
 	METHOD b texParameter (IIF)V
@@ -220,7 +220,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD b texSubImage2D (IIIIIIIILjava/nio/IntBuffer;)V
 	METHOD b vertexPointer (IIILjava/nio/ByteBuffer;)V
 	METHOD b texEnv (IILjava/nio/FloatBuffer;)V
-	METHOD b enableTextureGen (Lnone/bos$u;)V
+	METHOD b disableTextureGen (Lnone/bos$u;)V
 	METHOD c popAttrib ()V
 	METHOD c fogEnd (F)V
 	METHOD c translate (FFF)V
@@ -232,50 +232,50 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD c colorPointer (IIILjava/nio/ByteBuffer;)V
 	METHOD c getFloat (ILjava/nio/FloatBuffer;)V
 	METHOD c getTexGenCoordState (Lnone/bos$u;)Lnone/bos$v;
-	METHOD d enableAlphaTest ()V
+	METHOD d disableAlphaTest ()V
 	METHOD d lineWidth (F)V
 	METHOD d color (FFF)V
 	METHOD d blendEquation (I)V
 	METHOD d polygonMode (II)V
 	METHOD d vertexPointer (IIII)V
-	METHOD e disableAlphaTest ()V
+	METHOD e enableAlphaTest ()V
 	METHOD e vertex (FFF)V
 	METHOD e deleteLists (II)V
 	METHOD e colorPointer (IIII)V
-	METHOD f disableLightSystem ()V
+	METHOD f enableLightSystem ()V
 	METHOD f logicOp (I)V
 	METHOD f newList (II)V
 	METHOD f drawArrays (III)V
-	METHOD g enableLightSystem ()V
+	METHOD g disableLightSystem ()V
 	METHOD g activeTexture (I)V
 	METHOD g pixelStore (II)V
-	METHOD h disableColorMaterial ()V
+	METHOD h enableColorMaterial ()V
 	METHOD h deleteTextures (I)V
-	METHOD i enableColorMaterial ()V
+	METHOD i disableColorMaterial ()V
 	METHOD i bindTexture (I)V
-	METHOD j enableDepthTest ()V
+	METHOD j disableDepthTest ()V
 	METHOD j shadeModel (I)V
-	METHOD k disableDepthTest ()V
-	METHOD l enableBlend ()V
-	METHOD m disableBlend ()V
+	METHOD k enableDepthTest ()V
+	METHOD l disableBlend ()V
+	METHOD m enableBlend ()V
 	METHOD m clear (I)V
 	METHOD n matrixMode (I)V
-	METHOD o disableFog ()V
-	METHOD p enableFog ()V
+	METHOD o enableFog ()V
+	METHOD p disableFog ()V
 	METHOD p disableClientState (I)V
-	METHOD q disableCullFace ()V
+	METHOD q enableCullFace ()V
 	METHOD q enableClientState (I)V
-	METHOD r enableCullFace ()V
+	METHOD r disableCullFace ()V
 	METHOD r begin (I)V
-	METHOD s disablePolygonOffsetFill ()V
+	METHOD s enablePolygonOffsetFill ()V
 	METHOD s callList (I)V
-	METHOD t enablePolygonOffsetFill ()V
+	METHOD t disablePolygonOffsetFill ()V
 	METHOD t genLists (I)I
 	METHOD u getString (I)Ljava/lang/String;
 	METHOD v getInteger (I)I
-	METHOD w disableColorLogicOp ()V
+	METHOD w enableColorLogicOp ()V
 	METHOD w fogMode (I)V
-	METHOD x enableColorLogicOp ()V
+	METHOD x disableColorLogicOp ()V
 	METHOD x cullFace (I)V
-	METHOD y disableTexture2D ()V
-	METHOD z enableTexture2D ()V
+	METHOD y enableTexture2D ()V
+	METHOD z disableTexture2D ()V

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -3,7 +3,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD a capState Lnone/bos$c;
 		FIELD b func I
 		FIELD c ref F
-	CLASS none/bos$b
+	CLASS none/bos$b BlendFuncState
 		FIELD a capState Lnone/bos$c;
 		FIELD b sfactor I
 		FIELD c dfactor I
@@ -49,6 +49,37 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD n OR_REVERSE Lnone/bos$o;
 		FIELD o SET Lnone/bos$o;
 		FIELD p XOR Lnone/bos$o;
+	CLASS none/bos$r SrcBlendFactor
+		FIELD a CONSTANT_ALPHA Lnone/bos$r;
+		FIELD b CONSTANT_COLOR Lnone/bos$r;
+		FIELD c DST_ALPHA Lnone/bos$r;
+		FIELD d DST_COLOR Lnone/bos$r;
+		FIELD e ONE Lnone/bos$r;
+		FIELD f ONE_MINUS_CONSTANT_ALPHA Lnone/bos$r;
+		FIELD g ONE_MINUS_CONSTANT_COLOR Lnone/bos$r;
+		FIELD h ONE_MINUS_DST_ALPHA Lnone/bos$r;
+		FIELD i ONE_MINUS_DST_COLOR Lnone/bos$r;
+		FIELD j ONE_MINUS_SRC_ALPHA Lnone/bos$r;
+		FIELD k ONE_MINUS_SRC_COLOR Lnone/bos$r;
+		FIELD l SRC_ALPHA Lnone/bos$r;
+		FIELD m SRC_ALPHA_SATURATE Lnone/bos$r;
+		FIELD n SRC_COLOR Lnone/bos$r;
+		FIELD o ZERO Lnone/bos$r;
+	CLASS none/bos$l DstBlendFactor
+		FIELD a CONSTANT_ALPHA Lnone/bos$l;
+		FIELD b CONSTANT_COLOR Lnone/bos$l;
+		FIELD c DST_ALPHA Lnone/bos$l;
+		FIELD d DST_COLOR Lnone/bos$l;
+		FIELD e ONE Lnone/bos$l;
+		FIELD f ONE_MINUS_CONSTANT_ALPHA Lnone/bos$l;
+		FIELD g ONE_MINUS_CONSTANT_COLOR Lnone/bos$l;
+		FIELD h ONE_MINUS_DST_ALPHA Lnone/bos$l;
+		FIELD i ONE_MINUS_DST_COLOR Lnone/bos$l;
+		FIELD j ONE_MINUS_SRC_ALPHA Lnone/bos$l;
+		FIELD k ONE_MINUS_SRC_COLOR Lnone/bos$l;
+		FIELD l SRC_ALPHA Lnone/bos$l;
+		FIELD m SRC_COLOR Lnone/bos$l;
+		FIELD n ZERO Lnone/bos$l;
 	CLASS none/bos$p
 		FIELD c factor F
 		FIELD d units F
@@ -97,6 +128,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 		ARG 1 mode
 	METHOD a texEnv (IIF)V
 	METHOD a texEnv (III)V
+	METHOD a blendFuncSeparate (IIII)V
 	METHOD a copyTexSubImage2D (IIIIIIII)V
 	METHOD a texImage2D (IIIIIIIILjava/nio/IntBuffer;)V
 	METHOD a readPixels (IIIIIILjava/nio/IntBuffer;)V
@@ -107,8 +139,10 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD a lightModel (ILjava/nio/FloatBuffer;)V
 	METHOD a getInteger (ILjava/nio/IntBuffer;)V
 	METHOD a multMatrix (Ljava/nio/FloatBuffer;)V
-	METHOD a (Lnone/bos$u;ILjava/nio/FloatBuffer;)V
 	METHOD a logicOp (Lnone/bos$o;)V
+	METHOD a blendFunc (Lnone/bos$r;Lnone/bos$l;)V
+	METHOD a blendFuncSeparate (Lnone/bos$r;Lnone/bos$l;Lnone/bos$r;Lnone/bos$l;)V
+	METHOD a (Lnone/bos$u;ILjava/nio/FloatBuffer;)V
 	METHOD a multMatrix (Lorg/lwjgl/util/vector/Quaternion;)V
 	METHOD a depthMask (Z)V
 	METHOD a colorMask (ZZZZ)V
@@ -153,6 +187,8 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD j enableDepthTest ()V
 	METHOD j shadeModel (I)V
 	METHOD k disableDepthTest ()V
+	METHOD l enableBlend ()V
+	METHOD m disableBlend ()V
 	METHOD m clear (I)V
 	METHOD n matrixMode (I)V
 	METHOD p disableClientState (I)V

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -117,6 +117,20 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD c sfail I
 		FIELD d dpfail I
 		FIELD e dppass I
+	CLASS none/bos$u TexCoord
+		FIELD a s Lnone/bos$u;
+		FIELD b t Lnone/bos$u;
+		FIELD c r Lnone/bos$u;
+		FIELD d q Lnone/bos$u;
+	CLASS none/bos$v TexGenCoordState
+		FIELD a capState Lnone/bos$c;
+		FIELD b coord I
+		FIELD c mode I
+	CLASS none/bos$w TexGenState
+		FIELD a s Lnone/bos$v;
+		FIELD b t Lnone/bos$v;
+		FIELD c r Lnone/bos$v;
+		FIELD d q Lnone/bos$v;
 	CLASS none/bos$x Texture2DState
 		FIELD a capState Lnone/bos$c;
 		FIELD b boundTexture I
@@ -130,6 +144,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	FIELD j cullFaceState Lnone/bos$j;
 	FIELD k polygonOffset Lnone/bos$p;
 	FIELD l logicOpState Lnone/bos$f;
+	FIELD m texGenState Lnone/bos$w;
 	FIELD n clearState Lnone/bos$d;
 	FIELD o stencilState Lnone/bos$t;
 	FIELD p normalizeEnabled Lnone/bos$c;
@@ -185,7 +200,9 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD a logicOp (Lnone/bos$o;)V
 	METHOD a blendFunc (Lnone/bos$r;Lnone/bos$l;)V
 	METHOD a blendFuncSeparate (Lnone/bos$r;Lnone/bos$l;Lnone/bos$r;Lnone/bos$l;)V
-	METHOD a (Lnone/bos$u;ILjava/nio/FloatBuffer;)V
+	METHOD a disableTextureGen (Lnone/bos$u;)V
+	METHOD a texGenMode (Lnone/bos$u;I)V
+	METHOD a texGen (Lnone/bos$u;ILjava/nio/FloatBuffer;)V
 	METHOD a multMatrix (Lorg/lwjgl/util/vector/Quaternion;)V
 	METHOD a depthMask (Z)V
 	METHOD a colorMask (ZZZZ)V
@@ -203,6 +220,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD b texSubImage2D (IIIIIIIILjava/nio/IntBuffer;)V
 	METHOD b vertexPointer (IIILjava/nio/ByteBuffer;)V
 	METHOD b texEnv (IILjava/nio/FloatBuffer;)V
+	METHOD b enableTextureGen (Lnone/bos$u;)V
 	METHOD c popAttrib ()V
 	METHOD c fogEnd (F)V
 	METHOD c translate (FFF)V
@@ -213,6 +231,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD c texCoordPointer (IIII)V
 	METHOD c colorPointer (IIILjava/nio/ByteBuffer;)V
 	METHOD c getFloat (ILjava/nio/FloatBuffer;)V
+	METHOD c getTexGenCoordState (Lnone/bos$u;)Lnone/bos$v;
 	METHOD d enableAlphaTest ()V
 	METHOD d lineWidth (F)V
 	METHOD d blendEquation (I)V

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -94,10 +94,12 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD b capLine Lnone/bos$c;
 		FIELD c factor F
 		FIELD d units F
-	CLASS none/bos$w RenderMode
-		FIELD a DEFAULT Lnone/bos$w;
-		FIELD b PLAYER_SKIN Lnone/bos$w;
-		FIELD c TRANSPARENT_MODEL Lnone/bos$w;
+	CLASS none/bos$q RenderMode
+		FIELD a DEFAULT Lnone/bos$q;
+		FIELD b PLAYER_SKIN Lnone/bos$q;
+		FIELD c TRANSPARENT_MODEL Lnone/bos$q;
+		METHOD a begin ()V
+		METHOD b end ()V
 	CLASS none/bos$r SrcBlendFactor
 		FIELD a CONSTANT_ALPHA Lnone/bos$r;
 		FIELD b CONSTANT_COLOR Lnone/bos$r;
@@ -205,6 +207,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD a fogMode (Lnone/bos$m;)V
 	METHOD a logicOp (Lnone/bos$o;)V
 	METHOD a blendFunc (Lnone/bos$r;Lnone/bos$l;)V
+	METHOD a beginRenderMode (Lnone/bos$q;)V
 	METHOD a blendFuncSeparate (Lnone/bos$r;Lnone/bos$l;Lnone/bos$r;Lnone/bos$l;)V
 	METHOD a enableTextureGen (Lnone/bos$u;)V
 	METHOD a texGenMode (Lnone/bos$u;I)V
@@ -226,6 +229,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD b texSubImage2D (IIIIIIIILjava/nio/IntBuffer;)V
 	METHOD b vertexPointer (IIILjava/nio/ByteBuffer;)V
 	METHOD b texEnv (IILjava/nio/FloatBuffer;)V
+	METHOD b endRenderMode (Lnone/bos$q;)V
 	METHOD b disableTextureGen (Lnone/bos$u;)V
 	METHOD c popAttrib ()V
 	METHOD c fogEnd (F)V

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -4,6 +4,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD b func I
 		FIELD c ref F
 	CLASS none/bos$b
+		FIELD a capState Lnone/bos$c;
 		FIELD b sfactor I
 		FIELD c dfactor I
 	CLASS none/bos$c CapabilityTracker
@@ -20,7 +21,8 @@ CLASS none/bos net/minecraft/client/GlHandler
 	CLASS none/bos$h
 		FIELD b face I
 		FIELD c mode I
-	CLASS none/bos$k
+	CLASS none/bos$k DepthTestState
+		FIELD a capState Lnone/bos$c;
 		FIELD b mask Z
 		FIELD c func I
 	CLASS none/bos$p
@@ -121,7 +123,9 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD g pixelStore (II)V
 	METHOD h deleteTextures (I)V
 	METHOD i bindTexture (I)V
+	METHOD j enableDepthTest ()V
 	METHOD j shadeModel (I)V
+	METHOD k disableDepthTest ()V
 	METHOD m clear (I)V
 	METHOD n matrixMode (I)V
 	METHOD p disableClientState (I)V

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -134,6 +134,8 @@ CLASS none/bos net/minecraft/client/GlHandler
 	CLASS none/bos$x Texture2DState
 		FIELD a capState Lnone/bos$c;
 		FIELD b boundTexture I
+	FIELD a matrixBuf Ljava/nio/FloatBuffer;
+	FIELD b vectorBuf Ljava/nio/FloatBuffer;
 	FIELD c alphaTestState Lnone/bos$a;
 	FIELD d lightSystemEnabled Lnone/bos$c;
 	FIELD e lightSourceEnabled [Lnone/bos$c;

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -27,7 +27,8 @@ CLASS none/bos net/minecraft/client/GlHandler
 	CLASS none/bos$f LogicOpState
 		FIELD a capState Lnone/bos$c;
 		FIELD b opcode I
-	CLASS none/bos$h
+	CLASS none/bos$h ColorMaterialState
+		FIELD a capState Lnone/bos$c;
 		FIELD b face I
 		FIELD c mode I
 	CLASS none/bos$k DepthTestState
@@ -186,9 +187,11 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD f newList (II)V
 	METHOD f drawArrays (III)V
 	METHOD g enableLightSystem ()V
-	METHOD g activeTexture ()V
+	METHOD g activeTexture (I)V
 	METHOD g pixelStore (II)V
+	METHOD h disableColorMaterial ()V
 	METHOD h deleteTextures (I)V
+	METHOD i enableColorMaterial ()V
 	METHOD i bindTexture (I)V
 	METHOD j enableDepthTest ()V
 	METHOD j shadeModel (I)V

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -110,6 +110,13 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD m SRC_ALPHA_SATURATE Lnone/bos$r;
 		FIELD n SRC_COLOR Lnone/bos$r;
 		FIELD o ZERO Lnone/bos$r;
+	CLASS none/bos$s StencilSubState
+		FIELD a func I
+	CLASS none/bos$t StencilState
+		FIELD a subState Lnone/bos$s;
+		FIELD c sfail I
+		FIELD d dpfail I
+		FIELD e dppass I
 	CLASS none/bos$x Texture2DState
 		FIELD a capState Lnone/bos$c;
 		FIELD b boundTexture I
@@ -124,6 +131,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	FIELD k polygonOffset Lnone/bos$p;
 	FIELD l logicOpState Lnone/bos$f;
 	FIELD n clearState Lnone/bos$d;
+	FIELD o stencilState Lnone/bos$t;
 	FIELD p normalizeEnabled Lnone/bos$c;
 	FIELD q activeTexture I
 	FIELD r texture2DState [Lnone/bos$x;

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -2,6 +2,13 @@ CLASS none/bos net/minecraft/client/GlHandler
 	CLASS none/bos$b
 		FIELD b sfactor I
 		FIELD c dfactor I
+	CLASS none/bos$c CapabilityTracker
+		FIELD a cap I
+		FIELD b state Z
+		METHOD a enable ()V
+		METHOD b disable ()V
+		METHOD a setState (Z)V
+			ARG 0 newState
 	CLASS none/bos$d
 		FIELD a clearDepth D
 		FIELD b clearColor Lnone/bos$e;
@@ -17,14 +24,22 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD d units F
 	CLASS none/bos$x
 		FIELD b boundTexture I
+	FIELD d lightSystemEnabled Lnone/bos$c;
+	FIELD e lightSourceEnabled [Lnone/bos$c;
 	FIELD f colorMaterial Lnone/bos$h;
 	FIELD g blendFunc Lnone/bos$b;
 	FIELD h depth Lnone/bos$k;
 	FIELD k polygonOffset Lnone/bos$p;
+	FIELD p normalizeEnabled Lnone/bos$c;
 	FIELD s shadeModel I
+	FIELD t rescaleNormalEnabled Lnone/bos$c;
 	FIELD u colorMask Lnone/bos$g;
 	FIELD v color Lnone/bos$e;
 	METHOD A genTextures ()I
+	METHOD B disableNormalize ()V
+	METHOD C enableNormalize ()V
+	METHOD D disableRescaleNormal ()V
+	METHOD E enableRescaleNormal ()V
 	METHOD F loadIdentity ()V
 	METHOD G pushMatrix ()V
 	METHOD H popMatrix ()V
@@ -40,6 +55,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 		ARG 1 units
 	METHOD a normal (FFF)V
 	METHOD a clearColor (FFFF)V
+	METHOD a disableLight (I)V
 	METHOD a alphaFunc (IF)V
 	METHOD a colorMaterial (II)V
 		ARG 0 face
@@ -64,6 +80,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD b texCoord (FF)V
 	METHOD b scale (FFF)V
 	METHOD b rotate (FFFF)V
+	METHOD b enableLight (I)V
 	METHOD b blendFunc (II)V
 	METHOD b texParameter (IIF)V
 	METHOD b texParameter (III)V
@@ -87,9 +104,11 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD e vertex (FFF)V
 	METHOD e deleteLists (II)V
 	METHOD e colorPointer (IIII)V
+	METHOD f disableLightSystem ()V
 	METHOD f logicOp (I)V
 	METHOD f newList (II)V
 	METHOD f drawArrays (III)V
+	METHOD g enableLightSystem ()V
 	METHOD g pixelStore (II)V
 	METHOD h deleteTextures (I)V
 	METHOD i bindTexture (I)V

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -85,7 +85,8 @@ CLASS none/bos net/minecraft/client/GlHandler
 	CLASS none/bos$p
 		FIELD c factor F
 		FIELD d units F
-	CLASS none/bos$x
+	CLASS none/bos$x Texture2DState
+		FIELD a capState Lnone/bos$c;
 		FIELD b boundTexture I
 	FIELD c alphaTestState Lnone/bos$a;
 	FIELD d lightSystemEnabled Lnone/bos$c;
@@ -97,6 +98,8 @@ CLASS none/bos net/minecraft/client/GlHandler
 	FIELD l logicOpState Lnone/bos$f;
 	FIELD n clearState Lnone/bos$d;
 	FIELD p normalizeEnabled Lnone/bos$c;
+	FIELD q activeTexture I
+	FIELD r texture2DState [Lnone/bos$x;
 	FIELD s shadeModel I
 	FIELD t rescaleNormalEnabled Lnone/bos$c;
 	FIELD u colorMask Lnone/bos$g;
@@ -183,6 +186,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD f newList (II)V
 	METHOD f drawArrays (III)V
 	METHOD g enableLightSystem ()V
+	METHOD g activeTexture ()V
 	METHOD g pixelStore (II)V
 	METHOD h deleteTextures (I)V
 	METHOD i bindTexture (I)V
@@ -203,3 +207,5 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD w disableColorLogicOp ()V
 	METHOD x enableColorLogicOp ()V
 	METHOD x cullFace (I)V
+	METHOD y disableTexture2D ()V
+	METHOD z enableTexture2D ()V

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -55,6 +55,16 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD l SRC_ALPHA Lnone/bos$l;
 		FIELD m SRC_COLOR Lnone/bos$l;
 		FIELD n ZERO Lnone/bos$l;
+	CLASS none/bos$m FogMode
+		FIELD a LINEAR Lnone/bos$m;
+		FIELD b EXP Lnone/bos$m;
+		FIELD c EXP2 Lnone/bos$m;
+	CLASS none/bos$n FogState
+		FIELD a capState Lnone/bos$c;
+		FIELD b mode I
+		FIELD c density F
+		FIELD d start F
+		FIELD e end F
 	CLASS none/bos$o LogicOp
 		FIELD a AND Lnone/bos$o;
 		FIELD b AND_INVERTED Lnone/bos$o;
@@ -102,6 +112,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	FIELD f colorMaterial Lnone/bos$h;
 	FIELD g blendFunc Lnone/bos$b;
 	FIELD h depth Lnone/bos$k;
+	FIELD i fogState Lnone/bos$n;
 	FIELD k polygonOffset Lnone/bos$p;
 	FIELD l logicOpState Lnone/bos$f;
 	FIELD n clearState Lnone/bos$d;
@@ -127,6 +138,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD a clearDepth (D)V
 	METHOD a scale (DDD)V
 	METHOD a ortho (DDDDDD)V
+	METHOD a fogDensity (F)V
 	METHOD a polygonOffset (FF)V
 		ARG 0 factor
 		ARG 1 units
@@ -152,6 +164,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD a lightModel (ILjava/nio/FloatBuffer;)V
 	METHOD a getInteger (ILjava/nio/IntBuffer;)V
 	METHOD a multMatrix (Ljava/nio/FloatBuffer;)V
+	METHOD a fogMode (Lnone/bos$m;)V
 	METHOD a logicOp (Lnone/bos$o;)V
 	METHOD a blendFunc (Lnone/bos$r;Lnone/bos$l;)V
 	METHOD a blendFuncSeparate (Lnone/bos$r;Lnone/bos$l;Lnone/bos$r;Lnone/bos$l;)V
@@ -160,11 +173,13 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD a depthMask (Z)V
 	METHOD a colorMask (ZZZZ)V
 	METHOD b translate (DDD)V
+	METHOD b fogStart (F)V
 	METHOD b texCoord (FF)V
 	METHOD b scale (FFF)V
 	METHOD b rotate (FFFF)V
 	METHOD b enableLight (I)V
 	METHOD b blendFunc (II)V
+	METHOD b fog (ILjava/nio/FloatBuffer;)V
 	METHOD b texParameter (IIF)V
 	METHOD b texParameter (III)V
 	METHOD b viewport (IIII)V
@@ -172,10 +187,11 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD b vertexPointer (IIILjava/nio/ByteBuffer;)V
 	METHOD b texEnv (IILjava/nio/FloatBuffer;)V
 	METHOD c popAttrib ()V
-	METHOD c (F)V
+	METHOD c fogEnd (F)V
 	METHOD c translate (FFF)V
 	METHOD c color (FFFF)V
 	METHOD c depthFunc (I)V
+	METHOD c fog (II)V
 	METHOD c getTexLevelParameter (III)I
 	METHOD c texCoordPointer (IIII)V
 	METHOD c colorPointer (IIILjava/nio/ByteBuffer;)V
@@ -207,6 +223,8 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD m disableBlend ()V
 	METHOD m clear (I)V
 	METHOD n matrixMode (I)V
+	METHOD o disableFog ()V
+	METHOD p enableFog ()V
 	METHOD p disableClientState (I)V
 	METHOD q enableClientState (I)V
 	METHOD r begin (I)V
@@ -217,6 +235,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD u getString (I)Ljava/lang/String;
 	METHOD v getInteger (I)I
 	METHOD w disableColorLogicOp ()V
+	METHOD w fogMode (I)V
 	METHOD x enableColorLogicOp ()V
 	METHOD x cullFace (I)V
 	METHOD y disableTexture2D ()V

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -234,6 +234,7 @@ CLASS none/bos net/minecraft/client/GlHandler
 	METHOD c getTexGenCoordState (Lnone/bos$u;)Lnone/bos$v;
 	METHOD d enableAlphaTest ()V
 	METHOD d lineWidth (F)V
+	METHOD d color (FFF)V
 	METHOD d blendEquation (I)V
 	METHOD d polygonMode (II)V
 	METHOD d vertexPointer (IIII)V

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -89,6 +89,11 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD n OR_REVERSE Lnone/bos$o;
 		FIELD o SET Lnone/bos$o;
 		FIELD p XOR Lnone/bos$o;
+	CLASS none/bos$p PolygonOffsetState
+		FIELD a capFill Lnone/bos$c;
+		FIELD b capLine Lnone/bos$c;
+		FIELD c factor F
+		FIELD d units F
 	CLASS none/bos$r SrcBlendFactor
 		FIELD a CONSTANT_ALPHA Lnone/bos$r;
 		FIELD b CONSTANT_COLOR Lnone/bos$r;
@@ -105,11 +110,6 @@ CLASS none/bos net/minecraft/client/GlHandler
 		FIELD m SRC_ALPHA_SATURATE Lnone/bos$r;
 		FIELD n SRC_COLOR Lnone/bos$r;
 		FIELD o ZERO Lnone/bos$r;
-	CLASS none/bos$p PolygonOffsetState
-		FIELD a capFill Lnone/bos$c;
-		FIELD b capLine Lnone/bos$c;
-		FIELD c factor F
-		FIELD d units F
 	CLASS none/bos$x Texture2DState
 		FIELD a capState Lnone/bos$c;
 		FIELD b boundTexture I

--- a/mappings/net/minecraft/client/GlHandler.mapping
+++ b/mappings/net/minecraft/client/GlHandler.mapping
@@ -27,6 +27,11 @@ CLASS none/bos net/minecraft/client/GlHandler
 	CLASS none/bos$f LogicOpState
 		FIELD a capState Lnone/bos$c;
 		FIELD b opcode I
+	CLASS none/bos$g ColorMask
+		FIELD a red Z
+		FIELD b green Z
+		FIELD c blue Z
+		FIELD d alpha Z
 	CLASS none/bos$h ColorMaterialState
 		FIELD a capState Lnone/bos$c;
 		FIELD b face I


### PR DESCRIPTION
Should be ready for pulling once reviewed and hit with a truck.

This implements mappings for pretty much everything. What's missing:
- `GlHandler$1`, which appears to create an array to map `TexCoord.[STRQ]` to `[1234]` as a static field. I don't know how to integrate this, and this class only appears to be used by one function which _does_ have a mapping.
- `GlHandler.I`, which sets all fields in the colour buffer to `-1.0f`. I have no idea why you would do such a thing, and I cannot get a name for this.
- A couple of fields from the completely unused stencil buffer state tracker. As the tracker appears to be incomplete, the meanings of these fields cannot be confirmed.
- Anything else I missed.

Comments will be appreciated.
