### PR TITLE
Rename Minecraft => MinecraftGame

### DIFF
--- a/mappings/net/minecraft/client/GameSettings.mapping
+++ b/mappings/net/minecraft/client/GameSettings.mapping
@@ -99,7 +99,7 @@ CLASS none/bds net/minecraft/client/GameSettings
 	FIELD am keySpectatorOutlines Lnone/bdn;
 	FIELD an keysHotbar [Lnone/bdn;
 	FIELD ao keysAll [Lnone/bdn;
-	FIELD ap mc Lnone/bdq;
+	FIELD ap game Lnone/bdq;
 	FIELD aq difficulty Lnone/qy;
 	FIELD at debugEnabled Z
 	FIELD au debugPieEnabled Z

--- a/mappings/net/minecraft/client/MinecraftGame.mapping
+++ b/mappings/net/minecraft/client/MinecraftGame.mapping
@@ -1,4 +1,4 @@
-CLASS none/bdq net/minecraft/client/Minecraft
+CLASS none/bdq net/minecraft/client/MinecraftGame
 	FIELD B profiler Lnone/os;
 	FIELD C isRunning Z
 	FIELD J LOGGER Lorg/apache/logging/log4j/Logger;
@@ -12,7 +12,7 @@ CLASS none/bdq net/minecraft/client/Minecraft
 	FIELD T fullscreen Z
 	FIELD Z snooper Lnone/rk;
 	FIELD aB defaultResourcePacks Ljava/util/List;
-	FIELD aC mcResourcePack Lnone/bxt;
+	FIELD aC gameResourcePack Lnone/bxt;
 	FIELD aD resourcePackDownloader Lnone/byh;
 	FIELD aE languageManager Lnone/byn;
 	FIELD aF blockColorMap Lnone/bdz;

--- a/mappings/net/minecraft/client/audio/MusicTracker.mapping
+++ b/mappings/net/minecraft/client/audio/MusicTracker.mapping
@@ -18,7 +18,7 @@ CLASS none/cat net/minecraft/client/audio/MusicTracker
 		METHOD b getMinDelay ()I
 		METHOD c getMaxDelay ()I
 	FIELD a rand Ljava/util/Random;
-	FIELD b mc Lnone/bdq;
+	FIELD b game Lnone/bdq;
 	FIELD c current Lnone/cag;
 	FIELD d timeUntilNextSong I
 	METHOD <init> (Lnone/bdq;)V

--- a/mappings/net/minecraft/client/gui/Gui.mapping
+++ b/mappings/net/minecraft/client/gui/Gui.mapping
@@ -2,7 +2,7 @@ CLASS none/bgm net/minecraft/client/gui/Gui
 	FIELD a LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD f PROTOCOLS Ljava/util/Set;
 	FIELD g LINE_SPLITTER Lcom/google/common/base/Splitter;
-	FIELD j mc Lnone/bdq;
+	FIELD j game Lnone/bdq;
 	FIELD k itemRenderer Lnone/btq;
 	FIELD l width I
 	FIELD m height I
@@ -34,7 +34,7 @@ CLASS none/bgm net/minecraft/client/gui/Gui
 		ARG 1 x
 		ARG 2 y
 	METHOD a init (Lnone/bdq;II)V
-		ARG 0 mc
+		ARG 0 game
 		ARG 1 width
 		ARG 2 height
 	METHOD a handleButtonPressed (Lnone/bek;)V
@@ -49,7 +49,7 @@ CLASS none/bgm net/minecraft/client/gui/Gui
 		ARG 0 result
 	METHOD b init ()V
 	METHOD b init0 (Lnone/bdq;II)V
-		ARG 0 mc
+		ARG 0 game
 		ARG 1 width
 		ARG 2 height
 	METHOD b addButton (Lnone/bek;)Lnone/bek;

--- a/mappings/net/minecraft/client/gui/container/GuiBeacon.mapping
+++ b/mappings/net/minecraft/client/gui/container/GuiBeacon.mapping
@@ -20,7 +20,7 @@ CLASS none/bhg net/minecraft/client/gui/container/GuiBeacon
 			ARG 1 x
 			ARG 2 y
 		METHOD a draw (Lnone/bdq;II)V
-			ARG 0 mc
+			ARG 0 game
 			ARG 1 mouseX
 			ARG 2 mouseY
 	FIELD u LOGGER Lorg/apache/logging/log4j/Logger;

--- a/mappings/net/minecraft/client/gui/container/GuiVillager.mapping
+++ b/mappings/net/minecraft/client/gui/container/GuiVillager.mapping
@@ -7,7 +7,7 @@ CLASS none/bhw net/minecraft/client/gui/container/GuiVillager
 			ARG 2 y
 			ARG 3 next
 		METHOD a draw (Lnone/bdq;II)V
-			ARG 0 mc
+			ARG 0 game
 			ARG 1 mouseX
 			ARG 2 mouseY
 	FIELD u LOGGER Lorg/apache/logging/log4j/Logger;

--- a/mappings/net/minecraft/client/gui/hud/HudAchievements.mapping
+++ b/mappings/net/minecraft/client/gui/hud/HudAchievements.mapping
@@ -1,6 +1,6 @@
 CLASS none/bgw net/minecraft/client/gui/hud/HudAchievements
 	FIELD a BG_TEX Lnone/kp;
-	FIELD f mc Lnone/bdq;
+	FIELD f game Lnone/bdq;
 	FIELD g scaledWidth I
 	FIELD h scaledHeight I
 	FIELD i title Ljava/lang/String;
@@ -10,7 +10,7 @@ CLASS none/bgw net/minecraft/client/gui/hud/HudAchievements
 	FIELD m itemRenderer Lnone/btq;
 	FIELD n hint Z
 	METHOD <init> (Lnone/bdq;)V
-		ARG 0 mc
+		ARG 0 game
 	METHOD a draw ()V
 	METHOD a show (Lnone/no;)V
 		ARG 0 achievement

--- a/mappings/net/minecraft/client/gui/hud/HudBossBar.mapping
+++ b/mappings/net/minecraft/client/gui/hud/HudBossBar.mapping
@@ -1,9 +1,9 @@
 CLASS none/bej net/minecraft/client/gui/hud/HudBossBar
 	FIELD a BAR_TEX Lnone/kp;
-	FIELD f mc Lnone/bdq;
+	FIELD f game Lnone/bdq;
 	FIELD g bossBars Ljava/util/Map;
 	METHOD <init> (Lnone/bdq;)V
-		ARG 0 mc
+		ARG 0 game
 	METHOD a draw ()V
 	METHOD a drawBossBar (IILnone/qs;)V
 		ARG 0 x

--- a/mappings/net/minecraft/client/gui/hud/HudChat.mapping
+++ b/mappings/net/minecraft/client/gui/hud/HudChat.mapping
@@ -2,9 +2,9 @@ CLASS none/bel net/minecraft/client/gui/hud/HudChat
 	FIELD a LINE_SPLITTER Lcom/google/common/base/Splitter;
 	FIELD f NEWLINE_JOINER Lcom/google/common/base/Joiner;
 	FIELD g LOGGER Lorg/apache/logging/log4j/Logger;
-	FIELD h mc Lnone/bdq;
+	FIELD h game Lnone/bdq;
 	METHOD <init> (Lnone/bdq;)V
-		ARG 0 mc
+		ARG 0 game
 	METHOD a clear ()V
 	METHOD a clampWidth (F)I
 		ARG 0 width

--- a/mappings/net/minecraft/client/gui/hud/HudDebug.mapping
+++ b/mappings/net/minecraft/client/gui/hud/HudDebug.mapping
@@ -1,8 +1,8 @@
 CLASS none/ben net/minecraft/client/gui/hud/HudDebug
-	FIELD a mc Lnone/bdq;
+	FIELD a game Lnone/bdq;
 	FIELD f fontRenderer Lnone/bee;
 	METHOD <init> (Lnone/bdq;)V
-		ARG 0 mc
+		ARG 0 game
 	METHOD a drawLeftInfoText ()V
 	METHOD a draw (Lnone/bei;)V
 		ARG 0 displayScale

--- a/mappings/net/minecraft/client/gui/hud/HudInGame.mapping
+++ b/mappings/net/minecraft/client/gui/hud/HudInGame.mapping
@@ -3,7 +3,7 @@ CLASS none/bef net/minecraft/client/gui/hud/HudInGame
 	FIELD g WIDGETS_TEX Lnone/kp;
 	FIELD h PUMPKIN_BLUR Lnone/kp;
 	FIELD i rand Ljava/util/Random;
-	FIELD j mc Lnone/bdq;
+	FIELD j game Lnone/bdq;
 	FIELD l hudChat Lnone/bel;
 	FIELD r currentStack Lnone/aer;
 	FIELD s hudDebug Lnone/ben;
@@ -12,7 +12,7 @@ CLASS none/bef net/minecraft/client/gui/hud/HudInGame
 	FIELD v hudScoreboard Lnone/bfa;
 	FIELD w hudBossBar Lnone/bej;
 	METHOD <init> (Lnone/bdq;)V
-		ARG 0 mc
+		ARG 0 game
 	METHOD a draw (F)V
 		ARG 0 deltaTicks
 	METHOD a (Lnone/bei;F)V

--- a/mappings/net/minecraft/client/gui/hud/HudScoreboard.mapping
+++ b/mappings/net/minecraft/client/gui/hud/HudScoreboard.mapping
@@ -1,6 +1,6 @@
 CLASS none/bfa net/minecraft/client/gui/hud/HudScoreboard
-	FIELD f mc Lnone/bdq;
+	FIELD f game Lnone/bdq;
 	FIELD g hudInGame Lnone/bef;
 	METHOD <init> (Lnone/bdq;Lnone/bef;)V
-		ARG 0 mc
+		ARG 0 game
 		ARG 1 hudInGame

--- a/mappings/net/minecraft/client/gui/hud/HudSpectator.mapping
+++ b/mappings/net/minecraft/client/gui/hud/HudSpectator.mapping
@@ -1,8 +1,8 @@
 CLASS none/bff net/minecraft/client/gui/hud/HudSpectator
 	FIELD a SPECTATOR_TEX Lnone/kp;
 	FIELD f WIDGETS_TEX Lnone/kp;
-	FIELD g mc Lnone/bdq;
+	FIELD g game Lnone/bdq;
 	FIELD i spectatorMenu Lnone/bjd;
 	METHOD <init> (Lnone/bdq;)V
-		ARG 0 mc
+		ARG 0 game
 	METHOD a draw (Lnone/bei;F)V

--- a/mappings/net/minecraft/client/gui/hud/HudSubtitles.mapping
+++ b/mappings/net/minecraft/client/gui/hud/HudSubtitles.mapping
@@ -11,10 +11,10 @@ CLASS none/bfd net/minecraft/client/gui/hud/HudSubtitles
 			ARG 0 pos
 		METHOD b getTime ()J
 		METHOD c getPosition ()Lnone/bcu;
-	FIELD a mc Lnone/bdq;
+	FIELD a game Lnone/bdq;
 	FIELD f entries Ljava/util/List;
 	METHOD <init> (Lnone/bdq;)V
-		ARG 0 mc
+		ARG 0 game
 	METHOD a draw (Lnone/bei;)V
 		ARG 0 displayScale
 	METHOD a onSoundPlayed (Lnone/cag;Lnone/cay;)V

--- a/mappings/net/minecraft/client/gui/ingame/GuiChat.mapping
+++ b/mappings/net/minecraft/client/gui/ingame/GuiChat.mapping
@@ -1,6 +1,6 @@
 CLASS none/bfp net/minecraft/client/gui/ingame/GuiChat
 	CLASS none/bfp$a
-		FIELD g mc Lnone/bdq;
+		FIELD g game Lnone/bdq;
 	FIELD f LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD r inputText Ljava/lang/String;
 	METHOD <init> (Ljava/lang/String;)V

--- a/mappings/net/minecraft/client/gui/ingame/GuiEditBook.mapping
+++ b/mappings/net/minecraft/client/gui/ingame/GuiEditBook.mapping
@@ -1,7 +1,7 @@
 CLASS none/bhh net/minecraft/client/gui/ingame/GuiEditBook
 	CLASS none/bhh$a
 		METHOD a draw (Lnone/bdq;II)V
-			ARG 0 mc
+			ARG 0 game
 			ARG 1 mouseX
 			ARG 2 mouseY
 	FIELD a LOGGER Lorg/apache/logging/log4j/Logger;

--- a/mappings/net/minecraft/client/gui/menu/GuiServerConnecting.mapping
+++ b/mappings/net/minecraft/client/gui/menu/GuiServerConnecting.mapping
@@ -3,10 +3,10 @@ CLASS none/bft net/minecraft/client/gui/menu/GuiServerConnecting
 	FIELD i parent Lnone/bgm;
 	METHOD <init> (Lnone/bgm;Lnone/bdq;Ljava/lang/String;I)V
 		ARG 0 parent
-		ARG 1 mc
+		ARG 1 game
 	METHOD <init> (Lnone/bgm;Lnone/bdq;Lnone/bmj;)V
 		ARG 0 parent
-		ARG 1 mc
+		ARG 1 game
 		ARG 2 server
 	METHOD a handleKeyPress (CI)V
 		ARG 0 keyChar

--- a/mappings/net/minecraft/client/gui/menu/GuiSettingsAudio.mapping
+++ b/mappings/net/minecraft/client/gui/menu/GuiSettingsAudio.mapping
@@ -1,9 +1,9 @@
 CLASS none/bgq net/minecraft/client/gui/menu/GuiSettingsAudio
 	CLASS none/bgq$a
 		METHOD b (Lnone/bdq;II)V
-			ARG 0 mc
+			ARG 0 game
 		METHOD c isWithinBounds (Lnone/bdq;II)Z
-			ARG 0 mc
+			ARG 0 game
 			ARG 1 mouseX
 			ARG 2 mouseY
 	FIELD a title Ljava/lang/String;

--- a/mappings/net/minecraft/client/gui/widget/WidgetButton.mapping
+++ b/mappings/net/minecraft/client/gui/widget/WidgetButton.mapping
@@ -23,13 +23,13 @@ CLASS none/bek net/minecraft/client/gui/widget/WidgetButton
 	METHOD a setWidth (I)V
 		ARG 0 width
 	METHOD a draw (Lnone/bdq;II)V
-		ARG 0 mc
+		ARG 0 game
 		ARG 1 mouseX
 		ARG 2 mouseY
 	METHOD b getWidth ()I
 	METHOD b (Lnone/bdq;II)V
-		ARG 0 mc
+		ARG 0 game
 	METHOD c isWithinBounds (Lnone/bdq;II)Z
-		ARG 0 mc
+		ARG 0 game
 		ARG 1 mouseX
 		ARG 2 mouseY

--- a/mappings/net/minecraft/client/gui/widget/WidgetButtonLanguage.mapping
+++ b/mappings/net/minecraft/client/gui/widget/WidgetButtonLanguage.mapping
@@ -4,6 +4,6 @@ CLASS none/ber net/minecraft/client/gui/widget/WidgetButtonLanguage
 		ARG 1 x
 		ARG 2 y
 	METHOD a draw (Lnone/bdq;II)V
-		ARG 0 mc
+		ARG 0 game
 		ARG 1 mouseX
 		ARG 2 mouseY

--- a/mappings/net/minecraft/client/network/handler/impl/NetworkGameHandlerClient.mapping
+++ b/mappings/net/minecraft/client/network/handler/impl/NetworkGameHandlerClient.mapping
@@ -6,7 +6,7 @@ CLASS none/bme net/minecraft/client/network/handler/impl/NetworkGameHandlerClien
 	FIELD a maxPlayers I
 	FIELD b LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD c connection Lnone/eq;
-	FIELD f mc Lnone/bdq;
+	FIELD f game Lnone/bdq;
 	FIELD g world Lnone/bmg;
 	FIELD k rand Ljava/util/Random;
 	METHOD a onConnectionLost (Lnone/fa;)V

--- a/mappings/net/minecraft/client/network/handler/impl/NetworkLoginHandlerClient.mapping
+++ b/mappings/net/minecraft/client/network/handler/impl/NetworkLoginHandlerClient.mapping
@@ -1,11 +1,11 @@
 CLASS none/bmd net/minecraft/client/network/handler/impl/NetworkLoginHandlerClient
 	FIELD a LOGGER Lorg/apache/logging/log4j/Logger;
-	FIELD b mc Lnone/bdq;
+	FIELD b game Lnone/bdq;
 	FIELD c parentGui Lnone/bgm;
 	FIELD d connection Lnone/eq;
 	METHOD <init> (Lnone/eq;Lnone/bdq;Lnone/bgm;)V
 		ARG 0 connection
-		ARG 1 mc
+		ARG 1 game
 		ARG 2 parentGui
 	METHOD a onConnectionLost (Lnone/fa;)V
 		ARG 0 reason

--- a/mappings/net/minecraft/client/player/EntityPlayerClient.mapping
+++ b/mappings/net/minecraft/client/player/EntityPlayerClient.mapping
@@ -1,9 +1,9 @@
 CLASS none/bog net/minecraft/client/player/EntityPlayerClient
 	FIELD bY statManager Lnone/nz;
 	FIELD d networkHandler Lnone/bme;
-	FIELD f mc Lnone/bdq;
+	FIELD f game Lnone/bdq;
 	METHOD <init> (Lnone/bdq;Lnone/aiv;Lnone/bme;Lnone/nz;)V
-		ARG 0 mc
+		ARG 0 game
 		ARG 1 world
 		ARG 2 networkHandler
 		ARG 3 statManager

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -3,11 +3,11 @@ CLASS none/bos net/minecraft/client/render/WorldRenderer
 	FIELD e LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD f RAIN_LOC Lnone/kp;
 	FIELD g SNOW_LOC Lnone/kp;
-	FIELD h mc Lnone/bdq;
+	FIELD h game Lnone/bdq;
 	FIELD i resourceContainer Lnone/byc;
 	FIELD j rand Ljava/util/Random;
 	METHOD <init> (Lnone/bdq;Lnone/byc;)V
-		ARG 0 mc
+		ARG 0 game
 		ARG 1 resourceContainer
 	METHOD a (FJ)V
 		ARG 0 deltaTicks

--- a/mappings/net/minecraft/client/render/entity/impl/EntityRendererItemFrame.mapping
+++ b/mappings/net/minecraft/client/render/entity/impl/EntityRendererItemFrame.mapping
@@ -1,6 +1,6 @@
 CLASS none/btp net/minecraft/client/render/entity/impl/EntityRendererItemFrame
 	FIELD a MAP_BACKGROUND_TEX Lnone/kp;
-	FIELD b mc Lnone/bdq;
+	FIELD b game Lnone/bdq;
 	FIELD g MODEL_NORMAL Lnone/bzq;
 	FIELD h MODEL_MAP Lnone/bzq;
 	FIELD i itemRenderer Lnone/btq;

--- a/mappings/net/minecraft/client/world/WorldClient.mapping
+++ b/mappings/net/minecraft/client/world/WorldClient.mapping
@@ -1,5 +1,5 @@
 CLASS none/bmg net/minecraft/client/world/WorldClient
-	FIELD K mc Lnone/bdq;
+	FIELD K game Lnone/bdq;
 	FIELD b netHandler Lnone/bme;
 	FIELD c chunkProvider Lnone/bmc;
 	METHOD a getEntityById (I)Lnone/sf;
@@ -24,6 +24,6 @@ CLASS none/bmg net/minecraft/client/world/WorldClient
 		ARG 0 value
 	METHOD b onSpawnEntity (Lnone/sf;)V
 		ARG 0 entity
-	METHOD c getMinecraft (Lnone/bmg;)Lnone/bdq;
+	METHOD c getGameInstance (Lnone/bmg;)Lnone/bdq;
 	METHOD n createChunkProvider ()Lnone/atj;
 	METHOD t updateWeather ()V

--- a/mappings/net/minecraft/server/IntegratedServer.mapping
+++ b/mappings/net/minecraft/server/IntegratedServer.mapping
@@ -1,6 +1,6 @@
 CLASS none/cal net/minecraft/server/IntegratedServer
 	FIELD k LOGGER Lorg/apache/logging/log4j/Logger;
-	FIELD l mc Lnone/bdq;
+	FIELD l game Lnone/bdq;
 	METHOD A getRunDirectory ()Ljava/io/File;
 	METHOD C doServerTick ()V
 	METHOD Z isSnooperEnabled ()Z

--- a/mappings/net/minecraft/sortme/KeyBindingGui.mapping
+++ b/mappings/net/minecraft/sortme/KeyBindingGui.mapping
@@ -1,6 +1,6 @@
 CLASS none/bhb net/minecraft/sortme/KeyBindingGui
 	FIELD u gui Lnone/bhc;
-	FIELD v mc Lnone/bdq;
+	FIELD v game Lnone/bdq;
 	METHOD <init> (Lnone/bhc;Lnone/bdq;)V
 		ARG 0 gui
-		ARG 1 mc
+		ARG 1 game

--- a/mappings/net/minecraft/sortme/WidgetWorldEntry.mapping
+++ b/mappings/net/minecraft/sortme/WidgetWorldEntry.mapping
@@ -7,7 +7,7 @@ CLASS none/biy net/minecraft/sortme/WidgetWorldEntry
 			ARG 0 result
 	FIELD a LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD b DATE_FORMAT Ljava/text/DateFormat;
-	FIELD e minecraft Lnone/bdq;
+	FIELD e game Lnone/bdq;
 	FIELD f guiWorldSelect Lnone/bix;
 	FIELD g worldSummary Lnone/bax;
 	FIELD h iconLocation Lnone/kp;

--- a/mappings/none/bep.mapping
+++ b/mappings/none/bep.mapping
@@ -1,7 +1,7 @@
 CLASS none/bep
 	METHOD b (Lnone/bdq;II)V
-		ARG 0 mc
+		ARG 0 game
 	METHOD c isWithinBounds (Lnone/bdq;II)Z
-		ARG 0 mc
+		ARG 0 game
 		ARG 1 mouseX
 		ARG 2 mouseY

--- a/mappings/none/beu.mapping
+++ b/mappings/none/beu.mapping
@@ -5,6 +5,6 @@ CLASS none/beu
 	METHOD b setState (Z)V
 		ARG 0 isYesButton
 	METHOD c isWithinBounds (Lnone/bdq;II)Z
-		ARG 0 mc
+		ARG 0 game
 		ARG 1 mouseX
 		ARG 2 mouseY

--- a/mappings/none/bev.mapping
+++ b/mappings/none/bev.mapping
@@ -1,5 +1,5 @@
 CLASS none/bev
 	METHOD a draw (Lnone/bdq;II)V
-		ARG 0 mc
+		ARG 0 game
 		ARG 1 mouseX
 		ARG 2 mouseY

--- a/mappings/none/bfb.mapping
+++ b/mappings/none/bfb.mapping
@@ -1,4 +1,4 @@
 CLASS none/bfb
-	FIELD a mc Lnone/bdq;
+	FIELD a game Lnone/bdq;
 	METHOD <init> (Lnone/bdq;IIIII)V
-		ARG 0 mc
+		ARG 0 game

--- a/mappings/none/bfc.mapping
+++ b/mappings/none/bfc.mapping
@@ -16,8 +16,8 @@ CLASS none/bfc
 		ARG 4 minValue
 		ARG 5 maxValue
 	METHOD b (Lnone/bdq;II)V
-		ARG 0 mc
+		ARG 0 game
 	METHOD c isWithinBounds (Lnone/bdq;II)Z
-		ARG 0 mc
+		ARG 0 game
 		ARG 1 mouseX
 		ARG 2 mouseY

--- a/mappings/none/bfi.mapping
+++ b/mappings/none/bfi.mapping
@@ -2,8 +2,8 @@ CLASS none/bfi
 	FIELD o realmsButton Lnet/minecraft/realms/RealmsButton;
 	METHOD b getWidth ()I
 	METHOD b (Lnone/bdq;II)V
-		ARG 0 mc
+		ARG 0 game
 	METHOD c isWithinBounds (Lnone/bdq;II)Z
-		ARG 0 mc
+		ARG 0 game
 		ARG 1 mouseX
 		ARG 2 mouseY

--- a/mappings/none/bid.mapping
+++ b/mappings/none/bid.mapping
@@ -1,2 +1,2 @@
 CLASS none/bid
-	FIELD a mc Lnone/bdq;
+	FIELD a game Lnone/bdq;

--- a/mappings/none/bif.mapping
+++ b/mappings/none/bif.mapping
@@ -4,6 +4,6 @@ CLASS none/bif
 	FIELD c UNKNOWN_SERVER Lnone/kp;
 	FIELD d SERVER_SELECTION Lnone/kp;
 	FIELD e guiMultiplayer Lnone/bic;
-	FIELD f mc Lnone/bdq;
+	FIELD f game Lnone/bdq;
 	FIELD g serverEntry Lnone/bmj;
 	METHOD a drawIcon (IILnone/kp;)V

--- a/mappings/none/bir.mapping
+++ b/mappings/none/bir.mapping
@@ -1,3 +1,3 @@
 CLASS none/bir
 	METHOD <init> (Lnone/bdq;IILjava/util/List;)V
-		ARG 0 mc
+		ARG 0 game

--- a/mappings/none/bpa.mapping
+++ b/mappings/none/bpa.mapping
@@ -5,10 +5,10 @@ CLASS none/bpa
 	FIELD e CLOUDS_TEX Lnone/kp;
 	FIELD f END_SKY_TEX Lnone/kp;
 	FIELD g FORCEFIELD_TEX Lnone/kp;
-	FIELD h mc Lnone/bdq;
+	FIELD h game Lnone/bdq;
 	FIELD z destroyStages [Lnone/bxd;
 	METHOD <init> (Lnone/bdq;)V
-		ARG 0 mc
+		ARG 0 game
 	METHOD a onSpawnParticle (IZDDDDDD[I)V
 		ARG 0 typeId
 		ARG 1 ignoreRange


### PR DESCRIPTION
This renames the class `Minecraft` to `MinecraftGame` along with fields and parameters from `mc` to `game`.

Also:
- `WorldClient.getMinecraft` => `getGameInstance`
- `MinecraftGame.mcResourcePack` => `gameResourcePack`
