### PR TITLE
Vec3d fully mapped; Polar2f identified

### DIFF
--- a/mappings/net/minecraft/util/math/BlockPos.mapping
+++ b/mappings/net/minecraft/util/math/BlockPos.mapping
@@ -24,6 +24,8 @@ CLASS none/cn net/minecraft/util/math/BlockPos
 		METHOD c setOffset (Lnone/cu;I)Lnone/cn$a;
 			ARG 0 facing
 			ARG 1 distance
+		METHOD d crossProduct (Lnone/dk;)Lnone/dk;
+			ARG 0 vec
 		METHOD g set (Lnone/dk;)Lnone/cn$a;
 			ARG 0 vec
 		METHOD h toImmutable ()Lnone/cn;
@@ -115,9 +117,13 @@ CLASS none/cn net/minecraft/util/math/BlockPos
 	METHOD c north ()Lnone/cn;
 	METHOD c down (I)Lnone/cn;
 		ARG 0 distance
+	METHOD c crossProduct (Lnone/dk;)Lnone/cn;
+		ARG 0 vec
 	METHOD d south ()Lnone/cn;
 	METHOD d north (I)Lnone/cn;
 		ARG 0 distance
+	METHOD d crossProduct (Lnone/dk;)Lnone/dk;
+		ARG 0 vec
 	METHOD e west ()Lnone/cn;
 	METHOD e south (I)Lnone/cn;
 		ARG 0 distance

--- a/mappings/net/minecraft/util/math/BlockPos.mapping
+++ b/mappings/net/minecraft/util/math/BlockPos.mapping
@@ -1,4 +1,10 @@
 CLASS none/cn net/minecraft/util/math/BlockPos
+	CLASS none/cn$1
+		CLASS none/cn$1$1
+			FIELD b pos Lnone/cn;
+	CLASS none/cn$2
+		CLASS none/cn$2$1
+			FIELD b pos Lnone/cn$a;
 	CLASS none/cn$a Mutable
 		FIELD b x I
 		FIELD c y I
@@ -74,6 +80,14 @@ CLASS none/cn net/minecraft/util/math/BlockPos
 		METHOD t free ()V
 	FIELD a ORIGIN Lnone/cn;
 	FIELD b LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD c BITS_X I
+	FIELD d BITS_Z I
+	FIELD f BITS_Y I
+	FIELD g SHIFT_Y I
+	FIELD h SHIFT_X I
+	FIELD i MASK_X J
+	FIELD j MASK_Y J
+	FIELD k MASK_Z J
 	METHOD <init> (DDD)V
 		ARG 0 x
 		ARG 1 y
@@ -99,6 +113,9 @@ CLASS none/cn net/minecraft/util/math/BlockPos
 		ARG 2 z
 	METHOD a fromLong (J)Lnone/cn;
 		ARG 0 l
+	METHOD a iterateBoxPositions (Lnone/cn;Lnone/cn;)Ljava/lang/Iterable;
+		ARG 0 pos1
+		ARG 1 pos2
 	METHOD a offset (Lnone/cu;)Lnone/cn;
 		ARG 0 facing
 	METHOD a offset (Lnone/cu;I)Lnone/cn;
@@ -109,9 +126,9 @@ CLASS none/cn net/minecraft/util/math/BlockPos
 	METHOD b down ()Lnone/cn;
 	METHOD b up (I)Lnone/cn;
 		ARG 0 distance
-	METHOD b (Lnone/cn;Lnone/cn;)Ljava/lang/Iterable;
-		ARG 0 min
-		ARG 1 max
+	METHOD b iterateBoxPositionsMutable (Lnone/cn;Lnone/cn;)Ljava/lang/Iterable;
+		ARG 0 pos1
+		ARG 1 pos2
 	METHOD b subtract (Lnone/dk;)Lnone/cn;
 		ARG 0 vec
 	METHOD c north ()Lnone/cn;

--- a/mappings/net/minecraft/util/math/Polar2d.mapping
+++ b/mappings/net/minecraft/util/math/Polar2d.mapping
@@ -1,0 +1,6 @@
+CLASS none/bct net/minecraft/util/math/Polar2d
+	FIELD i pitch F
+	FIELD j yaw F
+	METHOD <init> (FF)V
+		ARG 0 pitch
+		ARG 1 yaw

--- a/mappings/net/minecraft/util/math/Polar2f.mapping
+++ b/mappings/net/minecraft/util/math/Polar2f.mapping
@@ -1,4 +1,4 @@
-CLASS none/bct net/minecraft/util/math/Polar2d
+CLASS none/bct net/minecraft/util/math/Polar2f
 	FIELD i pitch F
 	FIELD j yaw F
 	METHOD <init> (FF)V

--- a/mappings/net/minecraft/util/math/Vec3d.mapping
+++ b/mappings/net/minecraft/util/math/Vec3d.mapping
@@ -9,22 +9,47 @@ CLASS none/bcu net/minecraft/util/math/Vec3d
 		ARG 2 z
 	METHOD <init> (Lnone/dk;)V
 		ARG 0 vec
+	METHOD a normalize ()Lnone/bcu;
 	METHOD a multiply (D)Lnone/bcu;
 		ARG 0 scale
 	METHOD a subtract (DDD)Lnone/bcu;
 		ARG 0 x
 		ARG 1 y
 		ARG 2 z
-	METHOD a (Lnone/bcu;)Lnone/bcu;
+	METHOD a rotateX (F)Lnone/bcu;
+		ARG 0 radians
+	METHOD a coerce (FF)Lnone/bcu;
+		ARG 0 pitch
+		ARG 1 yaw
+	METHOD a coerce (Lnone/bct;)Lnone/bcu;
+		ARG 0 polar
+	METHOD a reverseSubtract (Lnone/bcu;)Lnone/bcu;
 		ARG 0 vec
+	METHOD a castByX (Lnone/bcu;D)Lnone/bcu;
+		ARG 0 target
+		ARG 1 newX
+	METHOD b length ()D
 	METHOD b add (DDD)Lnone/bcu;
 		ARG 0 x
 		ARG 1 y
 		ARG 2 z
+	METHOD b rotateY (F)Lnone/bcu;
+		ARG 0 radians
+	METHOD b dotProduct (Lnone/bcu;)D
+		ARG 0 vec
+	METHOD b castByY (Lnone/bcu;D)Lnone/bcu;
+		ARG 0 target
+		ARG 1 newY
+	METHOD c lengthSquared ()D
 	METHOD c getSquaredDistanceTo (DDD)D
 		ARG 0 x
 		ARG 1 y
 		ARG 2 z
+	METHOD c crossProduct (Lnone/bcu;)Lnone/bcu;
+		ARG 0 vec
+	METHOD c castByZ (Lnone/bcu;D)Lnone/bcu;
+		ARG 0 target
+		ARG 1 newZ
 	METHOD d subtract (Lnone/bcu;)Lnone/bcu;
 		ARG 0 vec
 	METHOD e add (Lnone/bcu;)Lnone/bcu;

--- a/mappings/net/minecraft/util/math/Vec3d.mapping
+++ b/mappings/net/minecraft/util/math/Vec3d.mapping
@@ -1,5 +1,5 @@
 CLASS none/bcu net/minecraft/util/math/Vec3d
-	FIELD a ORIGIN Lnone/bcu;
+	FIELD a ZERO Lnone/bcu;
 	FIELD b x D
 	FIELD c y D
 	FIELD d z D
@@ -41,7 +41,7 @@ CLASS none/bcu net/minecraft/util/math/Vec3d
 		ARG 0 target
 		ARG 1 newY
 	METHOD c lengthSquared ()D
-	METHOD c getSquaredDistanceTo (DDD)D
+	METHOD c squaredDistanceTo (DDD)D
 		ARG 0 x
 		ARG 1 y
 		ARG 2 z
@@ -56,7 +56,7 @@ CLASS none/bcu net/minecraft/util/math/Vec3d
 		ARG 0 vec
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 0 other
-	METHOD f getDistanceTo (Lnone/bcu;)D
+	METHOD f distanceTo (Lnone/bcu;)D
 		ARG 0 vec
-	METHOD g getSquaredDistanceTo (Lnone/bcu;)D
+	METHOD g squaredDistanceTo (Lnone/bcu;)D
 		ARG 0 vec

--- a/mappings/net/minecraft/util/math/Vec3d.mapping
+++ b/mappings/net/minecraft/util/math/Vec3d.mapping
@@ -18,10 +18,10 @@ CLASS none/bcu net/minecraft/util/math/Vec3d
 		ARG 2 z
 	METHOD a rotateX (F)Lnone/bcu;
 		ARG 0 radians
-	METHOD a coerce (FF)Lnone/bcu;
+	METHOD a fromPolar (FF)Lnone/bcu;
 		ARG 0 pitch
 		ARG 1 yaw
-	METHOD a coerce (Lnone/bct;)Lnone/bcu;
+	METHOD a fromPolar (Lnone/bct;)Lnone/bcu;
 		ARG 0 polar
 	METHOD a reverseSubtract (Lnone/bcu;)Lnone/bcu;
 		ARG 0 vec

--- a/mappings/net/minecraft/util/math/Vec3i.mapping
+++ b/mappings/net/minecraft/util/math/Vec3i.mapping
@@ -27,8 +27,6 @@ CLASS none/dk net/minecraft/util/math/Vec3i
 		ARG 0 x
 		ARG 1 y
 		ARG 2 z
-	METHOD l compareToImpl (Lnone/dk;)I
-		ARG 0 vec
 	METHOD n getSquaredDistanceTo (Lnone/dk;)D
 		ARG 0 vec
 	METHOD p getX ()I

--- a/mappings/net/minecraft/util/math/Vec3i.mapping
+++ b/mappings/net/minecraft/util/math/Vec3i.mapping
@@ -2,7 +2,7 @@ CLASS none/dk net/minecraft/util/math/Vec3i
 	FIELD a x I
 	FIELD b y I
 	FIELD c z I
-	FIELD e ORIGIN Lnone/dk;
+	FIELD e ZERO Lnone/dk;
 	METHOD <init> (DDD)V
 		ARG 0 x
 		ARG 1 y

--- a/mappings/net/minecraft/util/math/Vec3i.mapping
+++ b/mappings/net/minecraft/util/math/Vec3i.mapping
@@ -15,19 +15,19 @@ CLASS none/dk net/minecraft/util/math/Vec3i
 		ARG 0 vec
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 0 other
-	METHOD f getSquaredDistanceTo (DDD)D
+	METHOD f squaredDistanceTo (DDD)D
 		ARG 0 x
 		ARG 1 y
 		ARG 2 z
-	METHOD g getSquaredDistanceToCenter (DDD)D
+	METHOD g squaredDistanceToCenter (DDD)D
 		ARG 0 x
 		ARG 1 y
 		ARG 2 z
-	METHOD h getDistanceTo (III)D
+	METHOD h distanceTo (III)D
 		ARG 0 x
 		ARG 1 y
 		ARG 2 z
-	METHOD n getSquaredDistanceTo (Lnone/dk;)D
+	METHOD n squaredDistanceTo (Lnone/dk;)D
 		ARG 0 vec
 	METHOD p getX ()I
 	METHOD q getY ()I

--- a/mappings/net/minecraft/util/math/Vec3i.mapping
+++ b/mappings/net/minecraft/util/math/Vec3i.mapping
@@ -11,6 +11,8 @@ CLASS none/dk net/minecraft/util/math/Vec3i
 		ARG 0 x
 		ARG 1 y
 		ARG 2 z
+	METHOD d crossProduct (Lnone/dk;)Lnone/dk;
+		ARG 0 vec
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 0 other
 	METHOD f getSquaredDistanceTo (DDD)D
@@ -25,6 +27,8 @@ CLASS none/dk net/minecraft/util/math/Vec3i
 		ARG 0 x
 		ARG 1 y
 		ARG 2 z
+	METHOD l compareToImpl (Lnone/dk;)I
+		ARG 0 vec
 	METHOD n getSquaredDistanceTo (Lnone/dk;)D
 		ARG 0 vec
 	METHOD p getX ()I


### PR DESCRIPTION
While we're at it there's a couple of already-mapped names I'd like remapped:
- `getDistanceTo` should be `distanceTo`
- `getSquaredDistanceTo` should be `squaredDistanceTo`

If there's an agreement that this change should be made I'll add it to this PR. Otherwise, review away.
