### PR TITLE
Map ambientDarkness and isDaylight

### DIFF
--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -2,6 +2,7 @@ CLASS none/aiw net/minecraft/world/World
 	FIELD B lootTableHandler Lnone/bbm;
 	FIELD C profiler Lnone/os;
 	FIELD E isRemote Z
+	FIELD J ambientDarkness I
 	FIELD L calendar Ljava/util/Calendar;
 	FIELD M tickingBlockEntities Z
 	FIELD N border Lnone/atg;
@@ -28,11 +29,13 @@ CLASS none/aiw net/minecraft/world/World
 	METHOD A getBiomeProvider ()Lnone/ajn;
 	METHOD A setSpawnPos (Lnone/cn;)V
 		ARG 0 pos
+	METHOD B isDaylight ()Z
 	METHOD D getLocalDifficulty (Lnone/cn;)Lnone/ra;
 		ARG 0 pos
 	METHOD E isInvalidHeight (Lnone/cn;)Z
 		ARG 0 pos
 	METHOD G getChunkProviderStatus ()Ljava/lang/String;
+	METHOD H updateAmbientDarkness ()V
 	METHOD J getEntitiesToRender ()Ljava/util/List;
 	METHOD K getSeaLevel ()I
 	METHOD L getWorldGenerator ()Lnone/ajb;
@@ -44,6 +47,7 @@ CLASS none/aiw net/minecraft/world/World
 	METHOD S getSaveHandler ()Lnone/bav;
 	METHOD T getProperties ()Lnone/bau;
 	METHOD U getGameRules ()Lnone/ait;
+	METHOD a calculateAmbientDarkness (F)I
 	METHOD a getEntityById (I)Lnone/sg;
 		ARG 0 id
 	METHOD a getChunk (II)Lnone/atp;
@@ -139,6 +143,7 @@ CLASS none/aiw net/minecraft/world/World
 	METHOD a (Lnone/sg;Lnone/bcs;Lcom/google/common/base/Predicate;)Ljava/util/List;
 	METHOD ac ()Ljava/util/Calendar;
 	METHOD ae getDifficulty ()Lnone/qz;
+	METHOD af getAmbientDarkness ()I
 	METHOD aj getWorldBorder ()Lnone/atg;
 	METHOD ak getLootTableHandler ()Lnone/bbm;
 	METHOD b ()Lnone/aiw;
@@ -170,6 +175,8 @@ CLASS none/aiw net/minecraft/world/World
 	METHOD b (Lnone/cn;Z)Z
 	METHOD b onSpawnEntity (Lnone/sg;)V
 		ARG 0 entity
+	METHOD c setAmbientDarkness (I)V
+		ARG 0 value
 	METHOD c setBlockDestroyProgress (ILnone/cn;I)V
 		ARG 0 entityId
 		ARG 1 pos


### PR DESCRIPTION
Unsure about the name `ambientDarkness`. It appears to be the number of full light levels that blocks that receive skylight will be considered lower as (bad wording, hope you understand regardless). It's used for mob AI (skeletons hiding from light, endermen teleporting) and `isDaylight`, which is also used to check if the player can sleep in a bed.
