### PR TITLE
WIP Scoreboard Mappings

### DIFF
--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -146,6 +146,7 @@ CLASS none/sg net/minecraft/entity/Entity
 	METHOD aM isSneaking ()Z
 	METHOD aO isGlowing ()Z
 	METHOD aP isInvisible ()Z
+	METHOD aQ getScoreboardTeam ()Lnone/bdd;
 	METHOD aR getBreath ()I
 	METHOD aU getHeadPitch ()F
 	METHOD aa getSoundSwim ()Lnone/nk;
@@ -209,6 +210,7 @@ CLASS none/sg net/minecraft/entity/Entity
 		ARG 2 z
 	METHOD e handleFallDamage (FF)V
 		ARG 0 fallDistance
+	METHOD e (Lnone/aam;)Z
 	METHOD e serialize (Lnone/dt;)Lnone/dt;
 		ARG 0 tag
 	METHOD e setSneaking (Z)V

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -103,6 +103,8 @@ CLASS none/sg net/minecraft/entity/Entity
 		ARG 0 mirror
 	METHOD a applyRotation (Lnone/apl;)F
 		ARG 0 rotation
+	METHOD a isTeamPlayer (Lnone/bdd;)Z
+		ARG 0 team
 	METHOD a addCrashInformation (Lnone/c;)V
 		ARG 0 element
 	METHOD a setPositionAndAngles (Lnone/cn;FF)V
@@ -269,6 +271,8 @@ CLASS none/sg net/minecraft/entity/Entity
 	METHOD o_ getPistonBehavior ()Lnone/ayu;
 	METHOD p dismountVehicle ()V
 	METHOD p stopRiding (Lnone/sg;)V
+		ARG 0 entity
+	METHOD r isTeammate (Lnone/sg;)Z
 		ARG 0 entity
 	METHOD u setPositionAndAngles (Lnone/sg;)V
 		ARG 0 other

--- a/mappings/net/minecraft/entity/passive/EntityTameable.mapping
+++ b/mappings/net/minecraft/entity/passive/EntityTameable.mapping
@@ -5,6 +5,7 @@ CLASS none/ta net/minecraft/entity/passive/EntityTameable
 		ARG 0 player
 	METHOD a deserializeCustomData (Lnone/dt;)V
 		ARG 0 tag
+	METHOD aQ getScoreboardTeam ()Lnone/bdd;
 	METHOD b getOwnerUuid ()Ljava/util/UUID;
 	METHOD b setOwnerUuid (Ljava/util/UUID;)V
 		ARG 0 value

--- a/mappings/net/minecraft/entity/passive/EntityTameable.mapping
+++ b/mappings/net/minecraft/entity/passive/EntityTameable.mapping
@@ -20,4 +20,6 @@ CLASS none/ta net/minecraft/entity/passive/EntityTameable
 	METHOD i initDataTracker ()V
 	METHOD q setTamed (Z)V
 		ARG 0 value
+	METHOD r isTeammate (Lnone/sg;)Z
+		ARG 0 entity
 	METHOD r setSitting (Z)V

--- a/mappings/net/minecraft/entity/player/EntityPlayer.mapping
+++ b/mappings/net/minecraft/entity/player/EntityPlayer.mapping
@@ -50,6 +50,8 @@ CLASS none/aam net/minecraft/entity/player/EntityPlayer
 		ARG 0 value
 	METHOD a getUuidFromProfile (Lcom/mojang/authlib/GameProfile;)Ljava/util/UUID;
 		ARG 0 profile
+	METHOD a shouldDamagePlayer (Lnone/aam;)Z
+		ARG 0 target
 	METHOD a isSkinOverlayVisible (Lnone/aan;)Z
 		ARG 0 part
 	METHOD a openBookEditor (Lnone/aes;Lnone/rb;)V

--- a/mappings/net/minecraft/entity/player/EntityPlayer.mapping
+++ b/mappings/net/minecraft/entity/player/EntityPlayer.mapping
@@ -101,6 +101,7 @@ CLASS none/aam net/minecraft/entity/player/EntityPlayer
 	METHOD aE getDefaultPortalCooldown ()I
 	METHOD aG getItemsHand ()Ljava/lang/Iterable;
 	METHOD aH getItemsArmor ()Ljava/lang/Iterable;
+	METHOD aQ getScoreboardTeam ()Lnone/bdd;
 	METHOD aa getSoundSwim ()Lnone/nk;
 	METHOD ab getSoundSplash ()Lnone/nk;
 	METHOD b serializeCustomData (Lnone/dt;)V
@@ -124,10 +125,12 @@ CLASS none/aam net/minecraft/entity/player/EntityPlayer
 	METHOD d getOfflinePlayerUuid (Ljava/lang/String;)Ljava/util/UUID;
 		ARG 0 nickname
 	METHOD da getEnderChestInventory ()Lnone/acs;
+	METHOD db getScoreboard ()Lnone/bdb;
 	METHOD dc getReducedDebugInfo ()Z
 	METHOD df getItemCooldownManager ()Lnone/aer;
 	METHOD e handleFallDamage (FF)V
 		ARG 0 fallDistance
+	METHOD e (Lnone/aam;)Z
 	METHOD f attack (Lnone/sg;)V
 		ARG 0 entity
 	METHOD g shouldEchoCommandFeedback ()Z

--- a/mappings/net/minecraft/entity/player/EntityPlayerServer.mapping
+++ b/mappings/net/minecraft/entity/player/EntityPlayerServer.mapping
@@ -16,6 +16,8 @@ CLASS none/lw net/minecraft/entity/player/EntityPlayerServer
 	METHOD a hasPermission (ILjava/lang/String;)Z
 		ARG 0 permissionLevel
 		ARG 1 commandName
+	METHOD a shouldDamagePlayer (Lnone/aam;)Z
+		ARG 0 target
 	METHOD a onContainerPropertyUpdate (Lnone/abx;II)V
 		ARG 0 container
 		ARG 1 propertyId
@@ -60,6 +62,7 @@ CLASS none/lw net/minecraft/entity/player/EntityPlayerServer
 	METHOD c getBlockPos ()Lnone/cn;
 	METHOD c changeWorld (I)Lnone/sg;
 		ARG 0 worldId
+	METHOD di isPvpEnabled ()Z
 	METHOD e setCameraEntity (Lnone/sg;)V
 		ARG 0 entity
 	METHOD f attack (Lnone/sg;)V

--- a/mappings/net/minecraft/item/map/MapState.mapping
+++ b/mappings/net/minecraft/item/map/MapState.mapping
@@ -1,4 +1,4 @@
-CLASS none/bam net/minecraft/item/map/MapContainer
+CLASS none/bam net/minecraft/item/map/MapState
 	FIELD e showIcons Z
 	FIELD f scale B
 	FIELD g colorArray [B

--- a/mappings/net/minecraft/nbt/CompoundWrapper.mapping
+++ b/mappings/net/minecraft/nbt/CompoundWrapper.mapping
@@ -6,7 +6,7 @@ CLASS none/bak net/minecraft/nbt/CompoundWrapper
 	METHOD a deserialize (Lnone/dt;)V
 		ARG 0 tag
 	METHOD a setDirty (Z)V
-		ARG 0 dirty
+		ARG 0 value
 	METHOD b serialize (Lnone/dt;)Lnone/dt;
 		ARG 0 tag
 	METHOD c markDirty ()V

--- a/mappings/net/minecraft/nbt/CompoundWrapper.mapping
+++ b/mappings/net/minecraft/nbt/CompoundWrapper.mapping
@@ -1,0 +1,13 @@
+CLASS none/bak net/minecraft/nbt/CompoundWrapper
+	FIELD a baseTag Ljava/lang/String;
+	FIELD b dirty Z
+	METHOD <init> (Ljava/lang/String;)V
+		ARG 0 baseTag
+	METHOD a deserialize (Lnone/dt;)V
+		ARG 0 tag
+	METHOD a setDirty (Z)V
+		ARG 0 dirty
+	METHOD b serialize (Lnone/dt;)Lnone/dt;
+		ARG 0 tag
+	METHOD c markDirty ()V
+	METHOD d getDirty ()Z

--- a/mappings/net/minecraft/network/packet/client/CPacketScoreboardDisplay.mapping
+++ b/mappings/net/minecraft/network/packet/client/CPacketScoreboardDisplay.mapping
@@ -3,6 +3,7 @@ CLASS none/hq net/minecraft/network/packet/client/CPacketScoreboardDisplay
 	FIELD b name Ljava/lang/String;
 	METHOD <init> (ILnone/bcx;)V
 		ARG 0 location
+		ARG 1 objective
 	METHOD a getLocation ()I
 	METHOD a readPacket (Lnone/es;)V
 		ARG 0 packet

--- a/mappings/net/minecraft/network/packet/client/CPacketScoreboardUpdate.mapping
+++ b/mappings/net/minecraft/network/packet/client/CPacketScoreboardUpdate.mapping
@@ -1,9 +1,27 @@
 CLASS none/ia net/minecraft/network/packet/client/CPacketScoreboardUpdate
+	CLASS none/ia$a MODE
+		FIELD a UPDATE Lnone/ia$a;
+		FIELD b DELETE Lnone/ia$a;
+	FIELD a playerName Ljava/lang/String;
+	FIELD b objectiveName Ljava/lang/String;
+	FIELD c score I
+	FIELD d mode Lnone/ia$a;
+	METHOD <init> (Ljava/lang/String;)V
+		ARG 0 playerName
+	METHOD <init> (Ljava/lang/String;Lnone/bcx;)V
+		ARG 0 playerName
+		ARG 1 objective
+	METHOD <init> (Lnone/bcz;)V
+		ARG 0 score
+	METHOD a getPlayerName ()Ljava/lang/String;
 	METHOD a readPacket (Lnone/es;)V
 		ARG 0 packet
 	METHOD a applyPacket (Lnone/ev;)V
 		ARG 0 handler
 	METHOD a applyPacket (Lnone/fo;)V
 		ARG 0 handler
+	METHOD b getObjectiveName ()Ljava/lang/String;
 	METHOD b writePacket (Lnone/es;)V
 		ARG 0 packet
+	METHOD c getScore ()I
+	METHOD d getMode ()Lnone/ia$a;

--- a/mappings/net/minecraft/network/packet/client/CPacketTeam.mapping
+++ b/mappings/net/minecraft/network/packet/client/CPacketTeam.mapping
@@ -9,6 +9,13 @@ CLASS none/hz net/minecraft/network/packet/client/CPacketTeam
 	FIELD h playerList Ljava/util/Collection;
 	FIELD i mode I
 	FIELD j flags I
+	METHOD <init> (Lnone/bcy;I)V
+		ARG 0 team
+		ARG 1 mode
+	METHOD <init> (Lnone/bcy;Ljava/util/Collection;I)V
+		ARG 0 team
+		ARG 1 playerList
+		ARG 2 mode
 	METHOD a getTeamName ()Ljava/lang/String;
 	METHOD a readPacket (Lnone/es;)V
 		ARG 0 packet

--- a/mappings/net/minecraft/scoreboard/IScoreboardCriterion.mapping
+++ b/mappings/net/minecraft/scoreboard/IScoreboardCriterion.mapping
@@ -1,4 +1,4 @@
-CLASS none/bdh net/minecraft/scoreboard/IScoreboardObjective
+CLASS none/bdh net/minecraft/scoreboard/IScoreboardCriterion
 	CLASS none/bdh$a Type
 		FIELD a INTEGER Lnone/bdh$a;
 		FIELD b HEARTS Lnone/bdh$a;

--- a/mappings/net/minecraft/scoreboard/IScoreboardCriterion.mapping
+++ b/mappings/net/minecraft/scoreboard/IScoreboardCriterion.mapping
@@ -2,13 +2,14 @@ CLASS none/bdh net/minecraft/scoreboard/IScoreboardCriterion
 	CLASS none/bdh$a Type
 		FIELD a INTEGER Lnone/bdh$a;
 		FIELD b HEARTS Lnone/bdh$a;
-		FIELD c NAME_TO_TYPE_MAP Ljava/util/Map;
+		FIELD c NAME_LOOKUP Ljava/util/Map;
 		FIELD d name Ljava/lang/String;
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
 			ARG 0 name
 		METHOD a getName ()Ljava/lang/String;
 		METHOD a byName (Ljava/lang/String;)Lnone/bdh$a;
 			ARG 0 name
+		METHOD values values ()[Lnone/bdh$a;
 	FIELD a OBJECTIVES Ljava/util/Map;
 	FIELD b DUMMY Lnone/bdh;
 	FIELD c TRIGGER Lnone/bdh;
@@ -21,6 +22,8 @@ CLASS none/bdh net/minecraft/scoreboard/IScoreboardCriterion
 	FIELD j ARMOR Lnone/bdh;
 	FIELD k XP Lnone/bdh;
 	FIELD l LEVEL Lnone/bdh;
+	FIELD m TEAM_KILLS [Lnone/bdh;
+	FIELD n TEAM_KILLED_BY [Lnone/bdh;
 	METHOD a getName ()Ljava/lang/String;
 	METHOD b isReadOnly ()Z
 	METHOD c getType ()Lnone/bdh$a;

--- a/mappings/net/minecraft/scoreboard/ScoreboardBase.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardBase.mapping
@@ -1,0 +1,11 @@
+CLASS none/bdb net/minecraft/scoreboard/ScoreboardBase
+	METHOD a getObjectiveForSlot (I)Lnone/bcx;
+	METHOD a syncMode0 (Lnone/bcy;)V
+		ARG 0 team
+	METHOD b syncMode2 (Lnone/bcy;)V
+		ARG 0 team
+	METHOD c getObjectives ()Ljava/util/Collection;
+	METHOD c syncMode1 (Lnone/bcy;)V
+		ARG 0 team
+	METHOD e getPlayerScores ()Ljava/util/Collection;
+	METHOD g getTeams ()Ljava/util/Collection;

--- a/mappings/net/minecraft/scoreboard/ScoreboardBase.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardBase.mapping
@@ -52,7 +52,7 @@ CLASS none/bdb net/minecraft/scoreboard/ScoreboardBase
 	METHOD c getPlayerScore (Ljava/lang/String;Lnone/bcx;)Lnone/bcz;
 		ARG 0 player
 		ARG 1 objective
-	METHOD c stopTrackingObjective (Lnone/bcx;)V
+	METHOD c updateRemovedObjective (Lnone/bcx;)V
 		ARG 0 objective
 	METHOD c updateRemovedTeam (Lnone/bcy;)V
 		ARG 0 team

--- a/mappings/net/minecraft/scoreboard/ScoreboardBase.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardBase.mapping
@@ -11,18 +11,26 @@ CLASS none/bdb net/minecraft/scoreboard/ScoreboardBase
 	METHOD a setObjectiveSlot (ILnone/bcx;)V
 		ARG 0 slot
 		ARG 1 objective
+	METHOD a updatePlayerScore (Ljava/lang/String;)V
+		ARG 0 playerName
 	METHOD a addPlayerToTeam (Ljava/lang/String;Ljava/lang/String;)Z
 		ARG 0 playerName
 		ARG 1 teamName
+	METHOD a updatePlayerScore (Ljava/lang/String;Lnone/bcx;)V
+		ARG 0 playerName
+		ARG 1 objective
 	METHOD a removePlayerFromTeam (Ljava/lang/String;Lnone/bcy;)V
 		ARG 0 playerName
 		ARG 1 team
 	METHOD a addObjective (Ljava/lang/String;Lnone/bdh;)Lnone/bcx;
 		ARG 0 name
 		ARG 1 criterion
-	METHOD a syncObjective (Lnone/bcx;)V
-	METHOD a syncMode0 (Lnone/bcy;)V
+	METHOD a updateObjective (Lnone/bcx;)V
+		ARG 0 value
+	METHOD a updateScoreboardTeamAndPlayers (Lnone/bcy;)V
 		ARG 0 team
+	METHOD a updateScore (Lnone/bcz;)V
+		ARG 0 value
 	METHOD a getObjectives (Lnone/bdh;)Ljava/util/Collection;
 		ARG 0 criterion
 	METHOD a resetEntityScore (Lnone/sg;)V
@@ -34,7 +42,9 @@ CLASS none/bdb net/minecraft/scoreboard/ScoreboardBase
 	METHOD b playerHasObjective (Ljava/lang/String;Lnone/bcx;)Z
 		ARG 0 playerName
 		ARG 1 objective
-	METHOD b syncMode2 (Lnone/bcy;)V
+	METHOD b updateExistingObjective (Lnone/bcx;)V
+		ARG 0 value
+	METHOD b updateScoreboardTeam (Lnone/bcy;)V
 		ARG 0 team
 	METHOD c getObjectives ()Ljava/util/Collection;
 	METHOD c getPlayerObjectives (Ljava/lang/String;)Ljava/util/Map;
@@ -42,7 +52,9 @@ CLASS none/bdb net/minecraft/scoreboard/ScoreboardBase
 	METHOD c getPlayerScore (Ljava/lang/String;Lnone/bcx;)Lnone/bcz;
 		ARG 0 player
 		ARG 1 objective
-	METHOD c syncMode1 (Lnone/bcy;)V
+	METHOD c stopTrackingObjective (Lnone/bcx;)V
+		ARG 0 objective
+	METHOD c updateRemovedTeam (Lnone/bcy;)V
 		ARG 0 team
 	METHOD d getKnownPlayers ()Ljava/util/Collection;
 	METHOD d getTeam (Ljava/lang/String;)Lnone/bcy;

--- a/mappings/net/minecraft/scoreboard/ScoreboardBase.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardBase.mapping
@@ -1,11 +1,70 @@
 CLASS none/bdb net/minecraft/scoreboard/ScoreboardBase
+	FIELD a objectiveMap Ljava/util/Map;
+	FIELD b criteriaMap Ljava/util/Map;
+	FIELD c playerObjectives Ljava/util/Map;
+	FIELD d objectiveSlots [Lnone/bcx;
+	FIELD e teamMap Ljava/util/Map;
+	FIELD f playerTeamMap Ljava/util/Map;
+	FIELD g cachedDisplaySlotNames [Ljava/lang/String;
 	METHOD a getObjectiveForSlot (I)Lnone/bcx;
+		ARG 0 slot
+	METHOD a setObjectiveSlot (ILnone/bcx;)V
+		ARG 0 slot
+		ARG 1 objective
+	METHOD a addPlayerToTeam (Ljava/lang/String;Ljava/lang/String;)Z
+		ARG 0 playerName
+		ARG 1 teamName
+	METHOD a removePlayerFromTeam (Ljava/lang/String;Lnone/bcy;)V
+		ARG 0 playerName
+		ARG 1 team
+	METHOD a addObjective (Ljava/lang/String;Lnone/bdh;)Lnone/bcx;
+		ARG 0 name
+		ARG 1 criterion
+	METHOD a syncObjective (Lnone/bcx;)V
 	METHOD a syncMode0 (Lnone/bcy;)V
 		ARG 0 team
+	METHOD a getObjectives (Lnone/bdh;)Ljava/util/Collection;
+		ARG 0 criterion
+	METHOD a resetEntityScore (Lnone/sg;)V
+		ARG 0 entity
+	METHOD b getDisplaySlotName (I)Ljava/lang/String;
+		ARG 0 slotId
+	METHOD b getObjective (Ljava/lang/String;)Lnone/bcx;
+		ARG 0 name
+	METHOD b playerHasObjective (Ljava/lang/String;Lnone/bcx;)Z
+		ARG 0 playerName
+		ARG 1 objective
 	METHOD b syncMode2 (Lnone/bcy;)V
 		ARG 0 team
 	METHOD c getObjectives ()Ljava/util/Collection;
+	METHOD c getPlayerObjectives (Ljava/lang/String;)Ljava/util/Map;
+		ARG 0 playerName
+	METHOD c getPlayerScore (Ljava/lang/String;Lnone/bcx;)Lnone/bcz;
+		ARG 0 player
+		ARG 1 objective
 	METHOD c syncMode1 (Lnone/bcy;)V
 		ARG 0 team
+	METHOD d getKnownPlayers ()Ljava/util/Collection;
+	METHOD d getTeam (Ljava/lang/String;)Lnone/bcy;
+		ARG 0 teamName
+	METHOD d resetPlayerScore (Ljava/lang/String;Lnone/bcx;)V
+		ARG 0 playerName
+		ARG 1 objective
+	METHOD d removeTeam (Lnone/bcy;)V
+		ARG 0 team
 	METHOD e getPlayerScores ()Ljava/util/Collection;
+	METHOD e addTeam (Ljava/lang/String;)Lnone/bcy;
+		ARG 0 teamName
+	METHOD f getTeamNames ()Ljava/util/Collection;
+	METHOD f clearPlayerTeam (Ljava/lang/String;)Z
+		ARG 0 player
 	METHOD g getTeams ()Ljava/util/Collection;
+	METHOD g getPlayerTeam (Ljava/lang/String;)Lnone/bcy;
+		ARG 0 playerName
+	METHOD h getDisplaySlotNames ()[Ljava/lang/String;
+	METHOD h getDisplaySlotId (Ljava/lang/String;)I
+		ARG 0 slotName
+	METHOD i getAllPlayerScores (Lnone/bcx;)Ljava/util/Collection;
+		ARG 0 objective
+	METHOD k removeObjective (Lnone/bcx;)V
+		ARG 0 objective

--- a/mappings/net/minecraft/scoreboard/ScoreboardBase.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardBase.mapping
@@ -1,10 +1,10 @@
 CLASS none/bdb net/minecraft/scoreboard/ScoreboardBase
-	FIELD a objectiveMap Ljava/util/Map;
-	FIELD b criteriaMap Ljava/util/Map;
-	FIELD c playerObjectives Ljava/util/Map;
+	FIELD a objectiveLookup Ljava/util/Map;
+	FIELD b criterionObjectiveLookup Ljava/util/Map;
+	FIELD c playerObjectiveLookup Ljava/util/Map;
 	FIELD d objectiveSlots [Lnone/bcx;
-	FIELD e teamMap Ljava/util/Map;
-	FIELD f playerTeamMap Ljava/util/Map;
+	FIELD e teamLookup Ljava/util/Map;
+	FIELD f playerTeamLookup Ljava/util/Map;
 	FIELD g cachedDisplaySlotNames [Ljava/lang/String;
 	METHOD a getObjectiveForSlot (I)Lnone/bcx;
 		ARG 0 slot

--- a/mappings/net/minecraft/scoreboard/ScoreboardCriterion.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardCriterion.mapping
@@ -1,0 +1,7 @@
+CLASS none/bdf net/minecraft/scoreboard/ScoreboardCriterion
+	FIELD o name Ljava/lang/String;
+	METHOD <init> (Ljava/lang/String;)V
+		ARG 0 name
+	METHOD a getName ()Ljava/lang/String;
+	METHOD b isReadOnly ()Z
+	METHOD c getType ()Lnone/bdh$a;

--- a/mappings/net/minecraft/scoreboard/ScoreboardCriterionHearts.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardCriterionHearts.mapping
@@ -1,0 +1,3 @@
+CLASS none/bdg net/minecraft/scoreboard/ScoreboardCriterionHearts
+	METHOD b isReadOnly ()Z
+	METHOD c getType ()Lnone/bdh$a;

--- a/mappings/net/minecraft/scoreboard/ScoreboardCriterionReadOnly.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardCriterionReadOnly.mapping
@@ -1,0 +1,2 @@
+CLASS none/bdi net/minecraft/scoreboard/ScoreboardCriterionReadOnly
+	METHOD b isReadOnly ()Z

--- a/mappings/net/minecraft/scoreboard/ScoreboardCriterionStat.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardCriterionStat.mapping
@@ -1,4 +1,4 @@
-CLASS none/bdj net/minecraft/scoreboard/ScoreboardObjectiveStat
+CLASS none/bdj net/minecraft/scoreboard/ScoreboardCriterionStat
 	FIELD o stat Lnone/nu;
 	METHOD <init> (Lnone/nu;)V
 		ARG 0 stat

--- a/mappings/net/minecraft/scoreboard/ScoreboardCriterionTeamKill.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardCriterionTeamKill.mapping
@@ -1,0 +1,8 @@
+CLASS none/bde net/minecraft/scoreboard/ScoreboardCriterionTeamKill
+	FIELD o formattedName Ljava/lang/String;
+	METHOD <init> (Ljava/lang/String;Lnone/a;)V
+		ARG 0 prefix
+		ARG 1 teamColor
+	METHOD a getName ()Ljava/lang/String;
+	METHOD b isReadOnly ()Z
+	METHOD c getType ()Lnone/bdh$a;

--- a/mappings/net/minecraft/scoreboard/ScoreboardObjective.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardObjective.mapping
@@ -1,6 +1,19 @@
 CLASS none/bcx net/minecraft/scoreboard/ScoreboardObjective
+	FIELD a scoreboard Lnone/bdb;
 	FIELD b name Ljava/lang/String;
-	FIELD c objective Lnone/bdh;
+	FIELD c criterion Lnone/bdh;
+	FIELD d criterionType Lnone/bdh$a;
+	FIELD e displayName Ljava/lang/String;
+	METHOD <init> (Lnone/bdb;Ljava/lang/String;Lnone/bdh;)V
+		ARG 0 scoreboard
+		ARG 1 name
+		ARG 2 criterion
+	METHOD a getScoreboard ()Lnone/bdb;
+	METHOD a setDisplayName (Ljava/lang/String;)V
+		ARG 0 value
+	METHOD a setCriterionType (Lnone/bdh$a;)V
+		ARG 0 value
 	METHOD b getName ()Ljava/lang/String;
 	METHOD c getObjective ()Lnone/bdh;
 	METHOD d getDisplayName ()Ljava/lang/String;
+	METHOD e getCriterionType ()Lnone/bdh$a;

--- a/mappings/net/minecraft/scoreboard/ScoreboardObjective.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardObjective.mapping
@@ -14,6 +14,6 @@ CLASS none/bcx net/minecraft/scoreboard/ScoreboardObjective
 	METHOD a setCriterionType (Lnone/bdh$a;)V
 		ARG 0 value
 	METHOD b getName ()Ljava/lang/String;
-	METHOD c getObjective ()Lnone/bdh;
+	METHOD c getCriterion ()Lnone/bdh;
 	METHOD d getDisplayName ()Ljava/lang/String;
 	METHOD e getCriterionType ()Lnone/bdh$a;

--- a/mappings/net/minecraft/scoreboard/ScoreboardObjective.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardObjective.mapping
@@ -1,7 +1,6 @@
-CLASS none/bdf net/minecraft/scoreboard/ScoreboardObjective
-	FIELD o name Ljava/lang/String;
-	METHOD <init> (Ljava/lang/String;)V
-		ARG 0 name
-	METHOD a getName ()Ljava/lang/String;
-	METHOD b isReadOnly ()Z
-	METHOD c getType ()Lnone/bdh$a;
+CLASS none/bcx net/minecraft/scoreboard/ScoreboardObjective
+	FIELD b name Ljava/lang/String;
+	FIELD c objective Lnone/bdh;
+	METHOD b getName ()Ljava/lang/String;
+	METHOD c getObjective ()Lnone/bdh;
+	METHOD d getDisplayName ()Ljava/lang/String;

--- a/mappings/net/minecraft/scoreboard/ScoreboardObjectiveHearts.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardObjectiveHearts.mapping
@@ -1,3 +1,0 @@
-CLASS none/bdg net/minecraft/scoreboard/ScoreboardObjectiveHearts
-	METHOD b isReadOnly ()Z
-	METHOD c getType ()Lnone/bdh$a;

--- a/mappings/net/minecraft/scoreboard/ScoreboardObjectiveReadOnly.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardObjectiveReadOnly.mapping
@@ -1,2 +1,0 @@
-CLASS none/bdi net/minecraft/scoreboard/ScoreboardObjectiveReadOnly
-	METHOD b isReadOnly ()Z

--- a/mappings/net/minecraft/scoreboard/ScoreboardPlayerScore.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardPlayerScore.mapping
@@ -1,4 +1,8 @@
 CLASS none/bcz net/minecraft/scoreboard/ScoreboardPlayerScore
+	CLASS none/bcz$1
+		METHOD a compare (Lnone/bcz;Lnone/bcz;)I
+			ARG 0 score1
+			ARG 1 score2
 	FIELD a COMPARATOR Ljava/util/Comparator;
 	FIELD b scoreboard Lnone/bdb;
 	FIELD c objective Lnone/bcx;

--- a/mappings/net/minecraft/scoreboard/ScoreboardPlayerScore.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardPlayerScore.mapping
@@ -1,6 +1,26 @@
 CLASS none/bcz net/minecraft/scoreboard/ScoreboardPlayerScore
 	FIELD a COMPARATOR Ljava/util/Comparator;
+	FIELD b scoreboard Lnone/bdb;
+	FIELD c objective Lnone/bcx;
+	FIELD d playerName Ljava/lang/String;
+	FIELD e score I
+	FIELD f disabled Z
+	FIELD g forceUpdate Z
+	METHOD <init> (Lnone/bdb;Lnone/bcx;Ljava/lang/String;)V
+		ARG 0 scoreboard
+		ARG 1 objective
+		ARG 2 playerName
+	METHOD a incrementScore ()V
+	METHOD a incrementScore (I)V
+		ARG 0 value
+	METHOD a setDisabled (Z)V
+		ARG 0 value
+	METHOD b decrementScore (I)V
+		ARG 0 value
 	METHOD c getScore ()I
-	METHOD d ()Lnone/bcx;
-	METHOD e getName ()Ljava/lang/String;
-	METHOD g isLocked ()Z
+	METHOD c setScore (I)V
+		ARG 0 value
+	METHOD d getObjective ()Lnone/bcx;
+	METHOD e getPlayerName ()Ljava/lang/String;
+	METHOD f getScoreboard ()Lnone/bdb;
+	METHOD g isDisabled ()Z

--- a/mappings/net/minecraft/scoreboard/ScoreboardPlayerScore.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardPlayerScore.mapping
@@ -1,4 +1,5 @@
 CLASS none/bcz net/minecraft/scoreboard/ScoreboardPlayerScore
+	FIELD a COMPARATOR Ljava/util/Comparator;
 	METHOD c getScore ()I
 	METHOD d ()Lnone/bcx;
 	METHOD e getName ()Ljava/lang/String;

--- a/mappings/net/minecraft/scoreboard/ScoreboardPlayerScore.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardPlayerScore.mapping
@@ -1,0 +1,5 @@
+CLASS none/bcz net/minecraft/scoreboard/ScoreboardPlayerScore
+	METHOD c getScore ()I
+	METHOD d ()Lnone/bcx;
+	METHOD e getName ()Ljava/lang/String;
+	METHOD g isLocked ()Z

--- a/mappings/net/minecraft/scoreboard/ScoreboardServer.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardServer.mapping
@@ -1,24 +1,46 @@
 CLASS none/lb net/minecraft/scoreboard/ScoreboardServer
 	FIELD a server Lnet/minecraft/server/MinecraftServer;
-	FIELD c syncTasks [Ljava/lang/Runnable;
+	FIELD b trackedObjectives Ljava/util/Set;
+	FIELD c updateTasks [Ljava/lang/Runnable;
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;)V
 		ARG 0 server
 	METHOD a setObjectiveSlot (ILnone/bcx;)V
 		ARG 0 slot
 		ARG 1 objective
-	METHOD a addSyncTask (Ljava/lang/Runnable;)V
+	METHOD a addUpdateTask (Ljava/lang/Runnable;)V
 		ARG 0 runnableTask
+	METHOD a updatePlayerScore (Ljava/lang/String;)V
+		ARG 0 playerName
 	METHOD a addPlayerToTeam (Ljava/lang/String;Ljava/lang/String;)Z
 		ARG 0 playerName
 		ARG 1 teamName
+	METHOD a updatePlayerScore (Ljava/lang/String;Lnone/bcx;)V
+		ARG 0 playerName
+		ARG 1 objective
 	METHOD a removePlayerFromTeam (Ljava/lang/String;Lnone/bcy;)V
 		ARG 0 playerName
 		ARG 1 team
-	METHOD a syncObjective (Lnone/bcx;)V
-	METHOD a syncMode0 (Lnone/bcy;)V
+	METHOD a updateObjective (Lnone/bcx;)V
+		ARG 0 value
+	METHOD a updateScoreboardTeamAndPlayers (Lnone/bcy;)V
 		ARG 0 team
-	METHOD b performSyncTasks ()V
-	METHOD b syncMode2 (Lnone/bcy;)V
+	METHOD a updateScore (Lnone/bcz;)V
+		ARG 0 value
+	METHOD b performUpdateTasks ()V
+	METHOD b updateExistingObjective (Lnone/bcx;)V
+		ARG 0 value
+	METHOD b updateScoreboardTeam (Lnone/bcy;)V
 		ARG 0 team
-	METHOD c syncMode1 (Lnone/bcy;)V
+	METHOD c stopTrackingObjective (Lnone/bcx;)V
+		ARG 0 objective
+	METHOD c updateRemovedTeam (Lnone/bcy;)V
 		ARG 0 team
+	METHOD d getPacketHandlersForObjective (Lnone/bcx;)Ljava/util/List;
+		ARG 0 objective
+	METHOD e addTrackedObjective (Lnone/bcx;)V
+		ARG 0 objective
+	METHOD f getPacketHandlersForObjectiveRemoval (Lnone/bcx;)Ljava/util/List;
+		ARG 0 objective
+	METHOD g removeObjective (Lnone/bcx;)V
+	METHOD h checkObjectiveDisplaySlot (Lnone/bcx;)I
+		ARG 0 objective

--- a/mappings/net/minecraft/scoreboard/ScoreboardServer.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardServer.mapping
@@ -1,0 +1,14 @@
+CLASS none/lb net/minecraft/scoreboard/ScoreboardServer
+	FIELD a server Lnet/minecraft/server/MinecraftServer;
+	FIELD c syncTasks [Ljava/lang/Runnable;
+	METHOD <init> (Lnet/minecraft/server/MinecraftServer;)V
+		ARG 0 server
+	METHOD a addSyncTask (Ljava/lang/Runnable;)V
+		ARG 0 runnableTask
+	METHOD a syncMode0 (Lnone/bcy;)V
+		ARG 0 team
+	METHOD b performSyncTasks ()V
+	METHOD b syncMode2 (Lnone/bcy;)V
+		ARG 0 team
+	METHOD c syncMode1 (Lnone/bcy;)V
+		ARG 0 team

--- a/mappings/net/minecraft/scoreboard/ScoreboardServer.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardServer.mapping
@@ -3,8 +3,18 @@ CLASS none/lb net/minecraft/scoreboard/ScoreboardServer
 	FIELD c syncTasks [Ljava/lang/Runnable;
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;)V
 		ARG 0 server
+	METHOD a setObjectiveSlot (ILnone/bcx;)V
+		ARG 0 slot
+		ARG 1 objective
 	METHOD a addSyncTask (Ljava/lang/Runnable;)V
 		ARG 0 runnableTask
+	METHOD a addPlayerToTeam (Ljava/lang/String;Ljava/lang/String;)Z
+		ARG 0 playerName
+		ARG 1 teamName
+	METHOD a removePlayerFromTeam (Ljava/lang/String;Lnone/bcy;)V
+		ARG 0 playerName
+		ARG 1 team
+	METHOD a syncObjective (Lnone/bcx;)V
 	METHOD a syncMode0 (Lnone/bcy;)V
 		ARG 0 team
 	METHOD b performSyncTasks ()V

--- a/mappings/net/minecraft/scoreboard/ScoreboardServer.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardServer.mapping
@@ -1,6 +1,6 @@
 CLASS none/lb net/minecraft/scoreboard/ScoreboardServer
 	FIELD a server Lnet/minecraft/server/MinecraftServer;
-	FIELD b trackedObjectives Ljava/util/Set;
+	FIELD b knownObjectives Ljava/util/Set;
 	FIELD c updateTasks [Ljava/lang/Runnable;
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;)V
 		ARG 0 server
@@ -31,16 +31,16 @@ CLASS none/lb net/minecraft/scoreboard/ScoreboardServer
 		ARG 0 value
 	METHOD b updateScoreboardTeam (Lnone/bcy;)V
 		ARG 0 team
-	METHOD c stopTrackingObjective (Lnone/bcx;)V
+	METHOD c updateRemovedObjective (Lnone/bcx;)V
 		ARG 0 objective
 	METHOD c updateRemovedTeam (Lnone/bcy;)V
 		ARG 0 team
-	METHOD d getPacketHandlersForObjective (Lnone/bcx;)Ljava/util/List;
+	METHOD d getPacketHandlersForObjectiveAdd (Lnone/bcx;)Ljava/util/List;
 		ARG 0 objective
-	METHOD e addTrackedObjective (Lnone/bcx;)V
+	METHOD e addObjective (Lnone/bcx;)V
 		ARG 0 objective
 	METHOD f getPacketHandlersForObjectiveRemoval (Lnone/bcx;)Ljava/util/List;
 		ARG 0 objective
 	METHOD g removeObjective (Lnone/bcx;)V
-	METHOD h checkObjectiveDisplaySlot (Lnone/bcx;)I
+	METHOD h getObjectiveDisplaySlot (Lnone/bcx;)I
 		ARG 0 objective

--- a/mappings/net/minecraft/scoreboard/ScoreboardState.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardState.mapping
@@ -1,0 +1,19 @@
+CLASS none/bdc net/minecraft/scoreboard/ScoreboardState
+	FIELD b LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD c scoreboard Lnone/bdb;
+	FIELD d tag Lnone/dt;
+	METHOD <init> (Ljava/lang/String;)V
+		ARG 0 rootTag
+	METHOD a serializeTeams ()Lnone/dz;
+	METHOD a setScoreboard (Lnone/bdb;)V
+		ARG 0 scoreboard
+	METHOD a deserialize (Lnone/dt;)V
+		ARG 0 tag
+	METHOD a deserializeTeams (Lnone/dz;)V
+	METHOD b serializeObjectives ()Lnone/dz;
+	METHOD b serialize (Lnone/dt;)Lnone/dt;
+		ARG 0 tag
+	METHOD b deserializeObjectives (Lnone/dz;)V
+	METHOD c deserializeDisplaySlots (Lnone/dt;)V
+	METHOD c deserializePlayerScores (Lnone/dz;)V
+	METHOD e serializePlayerScores ()Lnone/dz;

--- a/mappings/net/minecraft/scoreboard/ScoreboardState.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardState.mapping
@@ -17,7 +17,11 @@ CLASS none/bdc net/minecraft/scoreboard/ScoreboardState
 	METHOD b serialize (Lnone/dt;)Lnone/dt;
 		ARG 0 tag
 	METHOD b deserializeObjectives (Lnone/dz;)V
+		ARG 0 list
 	METHOD c deserializeDisplaySlots (Lnone/dt;)V
 		ARG 0 tag
 	METHOD c deserializePlayerScores (Lnone/dz;)V
+		ARG 0 list
+	METHOD d serializeSlots (Lnone/dt;)V
+		ARG 0 compound
 	METHOD e serializePlayerScores ()Lnone/dz;

--- a/mappings/net/minecraft/scoreboard/ScoreboardState.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardState.mapping
@@ -5,6 +5,9 @@ CLASS none/bdc net/minecraft/scoreboard/ScoreboardState
 	METHOD <init> (Ljava/lang/String;)V
 		ARG 0 rootTag
 	METHOD a serializeTeams ()Lnone/dz;
+	METHOD a deserializeTeamPlayers (Lnone/bcy;Lnone/dz;)V
+		ARG 0 team
+		ARG 1 list
 	METHOD a setScoreboard (Lnone/bdb;)V
 		ARG 0 scoreboard
 	METHOD a deserialize (Lnone/dt;)V
@@ -15,5 +18,6 @@ CLASS none/bdc net/minecraft/scoreboard/ScoreboardState
 		ARG 0 tag
 	METHOD b deserializeObjectives (Lnone/dz;)V
 	METHOD c deserializeDisplaySlots (Lnone/dt;)V
+		ARG 0 tag
 	METHOD c deserializePlayerScores (Lnone/dz;)V
 	METHOD e serializePlayerScores ()Lnone/dz;

--- a/mappings/net/minecraft/scoreboard/ScoreboardSynchronizer.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardSynchronizer.mapping
@@ -1,0 +1,5 @@
+CLASS none/baj net/minecraft/scoreboard/ScoreboardSynchronizer
+	FIELD a compound Lnone/bak;
+	METHOD <init> (Lnone/bak;)V
+		ARG 0 compound
+	METHOD run run ()V

--- a/mappings/net/minecraft/scoreboard/ScoreboardTeam.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardTeam.mapping
@@ -1,0 +1,53 @@
+CLASS none/bcy net/minecraft/scoreboard/ScoreboardTeam
+	FIELD a scoreboard Lnone/bdb;
+	FIELD b name Ljava/lang/String;
+	FIELD c playerList Ljava/util/Set;
+	FIELD d displayName Ljava/lang/String;
+	FIELD e prefix Ljava/lang/String;
+	FIELD f suffix Ljava/lang/String;
+	FIELD g allowFriendlyFire Z
+	FIELD h showFriendlyInvisibles Z
+	FIELD i nameTagVisibilityRule Lnone/bdd$b;
+	FIELD j deathMessageVisibilityRule Lnone/bdd$b;
+	FIELD k displayFormat Lnone/a;
+	FIELD l collisionRule Lnone/bdd$a;
+	METHOD <init> (Lnone/bdb;Ljava/lang/String;)V
+		ARG 0 scoreboard
+		ARG 1 name
+	METHOD a setFriendlyFlagsBitwise (I)V
+		ARG 0 flags
+	METHOD a setDisplayName (Ljava/lang/String;)V
+		ARG 0 displayName
+	METHOD a setTeamColor (Lnone/a;)V
+		ARG 0 color
+	METHOD a setCollisionRule (Lnone/bdd$a;)V
+		ARG 0 rule
+	METHOD a setNameTagVisibilityRule (Lnone/bdd$b;)V
+		ARG 0 rule
+	METHOD a applyFormatting (Lnone/bdd;Ljava/lang/String;)Ljava/lang/String;
+		ARG 0 team
+		ARG 1 value
+	METHOD a setAllowFriendlyFire (Z)V
+		ARG 0 allowFriendlyFire
+	METHOD b getName ()Ljava/lang/String;
+	METHOD b setPrefix (Ljava/lang/String;)V
+		ARG 0 prefix
+	METHOD b setDeathMessageVisibilityRule (Lnone/bdd$b;)V
+		ARG 0 rule
+	METHOD b setShowFriendlyInvisibles (Z)V
+		ARG 0 showFriendlyInvisibles
+	METHOD c getDisplayName ()Ljava/lang/String;
+	METHOD c setSuffix (Ljava/lang/String;)V
+		ARG 0 suffix
+	METHOD d getPlayerList ()Ljava/util/Collection;
+	METHOD d applyFormatting (Ljava/lang/String;)Ljava/lang/String;
+		ARG 0 value
+	METHOD e getPrefix ()Ljava/lang/String;
+	METHOD f getSuffix ()Ljava/lang/String;
+	METHOD g getAllowFriendlyFire ()Z
+	METHOD h getShowFriendlyInvisibles ()Z
+	METHOD i getNameTagVisibilityRule ()Lnone/bdd$b;
+	METHOD j getDeathMessageVisibilityRule ()Lnone/bdd$b;
+	METHOD k getCollisionRule ()Lnone/bdd$a;
+	METHOD l getFriendlyFlagsBitwise ()I
+	METHOD m getTeamColor ()Lnone/a;

--- a/mappings/net/minecraft/scoreboard/ScoreboardTeam.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardTeam.mapping
@@ -15,30 +15,30 @@ CLASS none/bcy net/minecraft/scoreboard/ScoreboardTeam
 		ARG 0 scoreboard
 		ARG 1 name
 	METHOD a setFriendlyFlagsBitwise (I)V
-		ARG 0 flags
+		ARG 0 value
 	METHOD a setDisplayName (Ljava/lang/String;)V
-		ARG 0 displayName
+		ARG 0 value
 	METHOD a setTeamColor (Lnone/a;)V
 		ARG 0 color
 	METHOD a setCollisionRule (Lnone/bdd$a;)V
-		ARG 0 rule
+		ARG 0 value
 	METHOD a setNameTagVisibilityRule (Lnone/bdd$b;)V
-		ARG 0 rule
+		ARG 0 value
 	METHOD a applyFormatting (Lnone/bdd;Ljava/lang/String;)Ljava/lang/String;
 		ARG 0 team
 		ARG 1 value
 	METHOD a setAllowFriendlyFire (Z)V
-		ARG 0 allowFriendlyFire
+		ARG 0 value
 	METHOD b getName ()Ljava/lang/String;
 	METHOD b setPrefix (Ljava/lang/String;)V
-		ARG 0 prefix
+		ARG 0 value
 	METHOD b setDeathMessageVisibilityRule (Lnone/bdd$b;)V
-		ARG 0 rule
+		ARG 0 value
 	METHOD b setShowFriendlyInvisibles (Z)V
-		ARG 0 showFriendlyInvisibles
+		ARG 0 value
 	METHOD c getDisplayName ()Ljava/lang/String;
 	METHOD c setSuffix (Ljava/lang/String;)V
-		ARG 0 suffix
+		ARG 0 value
 	METHOD d getPlayerList ()Ljava/util/Collection;
 	METHOD d applyFormatting (Ljava/lang/String;)Ljava/lang/String;
 		ARG 0 value

--- a/mappings/net/minecraft/scoreboard/ScoreboardTeamBase.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardTeamBase.mapping
@@ -6,7 +6,7 @@ CLASS none/bdd net/minecraft/scoreboard/ScoreboardTeamBase
 		FIELD d PUSH_SELF Lnone/bdd$a;
 		FIELD e name Ljava/lang/String;
 		FIELD f id I
-		FIELD g NAME_TO_RULE_MAP Ljava/util/Map;
+		FIELD g NAME_LOOKUP Ljava/util/Map;
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;I)V
 			ARG 0 name
 			ARG 1 id
@@ -20,14 +20,14 @@ CLASS none/bdd net/minecraft/scoreboard/ScoreboardTeamBase
 		FIELD d HIDE_SELF Lnone/bdd$b;
 		FIELD e name Ljava/lang/String;
 		FIELD f id I
-		FIELD g NAME_TO_RULE_MAP Ljava/util/Map;
+		FIELD g NAME_LOOKUP Ljava/util/Map;
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;I)V
 			ARG 0 name
 			ARG 1 id
 		METHOD a getNames ()[Ljava/lang/String;
 		METHOD a byName (Ljava/lang/String;)Lnone/bdd$b;
 			ARG 0 name
-	METHOD a equals (Lnone/bdd;)Z
+	METHOD a isEqual (Lnone/bdd;)Z
 		ARG 0 team
 	METHOD b getName ()Ljava/lang/String;
 	METHOD d getPlayerList ()Ljava/util/Collection;

--- a/mappings/net/minecraft/scoreboard/ScoreboardTeamBase.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardTeamBase.mapping
@@ -1,4 +1,4 @@
-CLASS none/bdd
+CLASS none/bdd net/minecraft/scoreboard/ScoreboardTeamBase
 	CLASS none/bdd$a CollisionRule
 		FIELD a ALWAYS Lnone/bdd$a;
 		FIELD b NEVER Lnone/bdd$a;
@@ -10,7 +10,7 @@ CLASS none/bdd
 		METHOD a getNames ()[Ljava/lang/String;
 		METHOD a byName (Ljava/lang/String;)Lnone/bdd$a;
 			ARG 0 name
-	CLASS none/bdd$b NameTagVisibilityRule
+	CLASS none/bdd$b VisibilityRule
 		FIELD a ALWAYS Lnone/bdd$b;
 		FIELD b NEVER Lnone/bdd$b;
 		FIELD c HIDE_OTHERS Lnone/bdd$b;
@@ -21,3 +21,15 @@ CLASS none/bdd
 		METHOD a getNames ()[Ljava/lang/String;
 		METHOD a byName (Ljava/lang/String;)Lnone/bdd$b;
 			ARG 0 name
+	METHOD a equals (Lnone/bdd;)Z
+		ARG 0 team
+	METHOD b getName ()Ljava/lang/String;
+	METHOD d getPlayerList ()Ljava/util/Collection;
+	METHOD d applyFormatting (Ljava/lang/String;)Ljava/lang/String;
+		ARG 0 value
+	METHOD g getAllowFriendlyFire ()Z
+	METHOD h getShowFriendlyInvisibles ()Z
+	METHOD i getNameTagVisibilityRule ()Lnone/bdd$b;
+	METHOD j getDeathMessageVisibilityRule ()Lnone/bdd$b;
+	METHOD k getCollisionRule ()Lnone/bdd$a;
+	METHOD m getTeamColor ()Lnone/a;

--- a/mappings/net/minecraft/scoreboard/ScoreboardTeamBase.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardTeamBase.mapping
@@ -7,6 +7,9 @@ CLASS none/bdd net/minecraft/scoreboard/ScoreboardTeamBase
 		FIELD e name Ljava/lang/String;
 		FIELD f id I
 		FIELD g NAME_TO_RULE_MAP Ljava/util/Map;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;I)V
+			ARG 0 name
+			ARG 1 id
 		METHOD a getNames ()[Ljava/lang/String;
 		METHOD a byName (Ljava/lang/String;)Lnone/bdd$a;
 			ARG 0 name
@@ -18,6 +21,9 @@ CLASS none/bdd net/minecraft/scoreboard/ScoreboardTeamBase
 		FIELD e name Ljava/lang/String;
 		FIELD f id I
 		FIELD g NAME_TO_RULE_MAP Ljava/util/Map;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;I)V
+			ARG 0 name
+			ARG 1 id
 		METHOD a getNames ()[Ljava/lang/String;
 		METHOD a byName (Ljava/lang/String;)Lnone/bdd$b;
 			ARG 0 name

--- a/mappings/net/minecraft/scoreboard/ScoreboardTeamBase.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardTeamBase.mapping
@@ -13,6 +13,7 @@ CLASS none/bdd net/minecraft/scoreboard/ScoreboardTeamBase
 		METHOD a getNames ()[Ljava/lang/String;
 		METHOD a byName (Ljava/lang/String;)Lnone/bdd$a;
 			ARG 0 name
+		METHOD values values ()[Lnone/bdd$a;
 	CLASS none/bdd$b VisibilityRule
 		FIELD a ALWAYS Lnone/bdd$b;
 		FIELD b NEVER Lnone/bdd$b;
@@ -27,6 +28,7 @@ CLASS none/bdd net/minecraft/scoreboard/ScoreboardTeamBase
 		METHOD a getNames ()[Ljava/lang/String;
 		METHOD a byName (Ljava/lang/String;)Lnone/bdd$b;
 			ARG 0 name
+		METHOD values values ()[Lnone/bdd$b;
 	METHOD a isEqual (Lnone/bdd;)Z
 		ARG 0 team
 	METHOD b getName ()Ljava/lang/String;

--- a/mappings/net/minecraft/sortme/ScoreSomething.mapping
+++ b/mappings/net/minecraft/sortme/ScoreSomething.mapping
@@ -1,1 +1,0 @@
-CLASS none/bcz net/minecraft/sortme/ScoreSomething

--- a/mappings/net/minecraft/text/TextFormat.mapping
+++ b/mappings/net/minecraft/text/TextFormat.mapping
@@ -31,3 +31,4 @@ CLASS none/a net/minecraft/text/TextFormat
 	METHOD a stripFormatting (Ljava/lang/String;)Ljava/lang/String;
 		ARG 0 str
 	METHOD b getId ()I
+	METHOD e getFormatName ()Ljava/lang/String;

--- a/mappings/net/minecraft/text/TextFormat.mapping
+++ b/mappings/net/minecraft/text/TextFormat.mapping
@@ -23,6 +23,7 @@ CLASS none/a net/minecraft/text/TextFormat
 	FIELD t UNDERLINE Lnone/a;
 	FIELD u ITALIC Lnone/a;
 	FIELD v RESET Lnone/a;
+	FIELD w NAME_LOOKUP Ljava/util/Map;
 	FIELD x FORMAT_PATTERN Ljava/util/regex/Pattern;
 	FIELD y name Ljava/lang/String;
 	FIELD z formatChar C
@@ -31,4 +32,9 @@ CLASS none/a net/minecraft/text/TextFormat
 	METHOD a stripFormatting (Ljava/lang/String;)Ljava/lang/String;
 		ARG 0 str
 	METHOD b getId ()I
+	METHOD b getFormatByName (Ljava/lang/String;)Lnone/a;
+		ARG 0 name
+	METHOD c sanitizeName (Ljava/lang/String;)Ljava/lang/String;
+		ARG 0 name
 	METHOD e getFormatName ()Ljava/lang/String;
+	METHOD values values ()[Lnone/a;

--- a/mappings/net/minecraft/world/VillageState.mapping
+++ b/mappings/net/minecraft/world/VillageState.mapping
@@ -1,4 +1,4 @@
-CLASS none/wi
+CLASS none/wi net/minecraft/world/VillageState
 	METHOD a deserialize (Lnone/dt;)V
 		ARG 0 tag
 	METHOD b serialize (Lnone/dt;)Lnone/dt;

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -1,6 +1,7 @@
 CLASS none/aiw net/minecraft/world/World
 	FIELD B lootTableHandler Lnone/bbm;
 	FIELD C profiler Lnone/os;
+	FIELD D scoreboard Lnone/bdb;
 	FIELD E isRemote Z
 	FIELD J ambientDarkness I
 	FIELD L calendar Ljava/util/Calendar;

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -151,6 +151,7 @@ CLASS none/aiw net/minecraft/world/World
 		ARG 6 destroyBlocks
 	METHOD a (Lnone/sg;Lnone/bcs;Lcom/google/common/base/Predicate;)Ljava/util/List;
 	METHOD ac ()Ljava/util/Calendar;
+	METHOD ad getScoreboard ()Lnone/bdb;
 	METHOD ae getDifficulty ()Lnone/qz;
 	METHOD af getAmbientDarkness ()I
 	METHOD aj getWorldBorder ()Lnone/atg;

--- a/mappings/net/minecraft/world/WorldFeatureState.mapping
+++ b/mappings/net/minecraft/world/WorldFeatureState.mapping
@@ -1,4 +1,4 @@
-CLASS none/bdc
+CLASS none/axq net/minecraft/world/WorldFeatureState
 	METHOD a deserialize (Lnone/dt;)V
 		ARG 0 tag
 	METHOD b serialize (Lnone/dt;)Lnone/dt;

--- a/mappings/none/axq.mapping
+++ b/mappings/none/axq.mapping
@@ -1,5 +1,0 @@
-CLASS none/axq
-	METHOD a deserialize (Lnone/dt;)V
-		ARG 0 tag
-	METHOD b serialize (Lnone/dt;)Lnone/dt;
-		ARG 0 tag

--- a/mappings/none/bak.mapping
+++ b/mappings/none/bak.mapping
@@ -1,5 +1,0 @@
-CLASS none/bak
-	METHOD a deserialize (Lnone/dt;)V
-		ARG 0 tag
-	METHOD b serialize (Lnone/dt;)Lnone/dt;
-		ARG 0 tag

--- a/mappings/none/bcx.mapping
+++ b/mappings/none/bcx.mapping
@@ -1,5 +1,0 @@
-CLASS none/bcx
-	FIELD b name Ljava/lang/String;
-	FIELD c objective Lnone/bdh;
-	METHOD b getName ()Ljava/lang/String;
-	METHOD c getObjective ()Lnone/bdh;

--- a/mappings/none/bcy.mapping
+++ b/mappings/none/bcy.mapping
@@ -1,3 +1,0 @@
-CLASS none/bcy
-	METHOD c ()Ljava/lang/String;
-	METHOD e ()Ljava/lang/String;

--- a/mappings/none/bde.mapping
+++ b/mappings/none/bde.mapping
@@ -1,5 +1,0 @@
-CLASS none/bde
-	FIELD o formattedName Ljava/lang/String;
-	METHOD a getName ()Ljava/lang/String;
-	METHOD b isReadOnly ()Z
-	METHOD c getType ()Lnone/bdh$a;


### PR DESCRIPTION
Definitely some mappings I'm iffy about (ScoreboardServer particularily). I'll probably add some more mappings to this -- coverage on some of these Scoreboard classes is pretty lacking, just wanted to get a commit down so I could get feedback on current state.

`CompoundWrapper` could probably use a better name, it's an abstract class for use in tag serializers. Mostly used in save handlers to serialize/deserialize specific components of an object's state.

Existing mapping changes:
`IScoreboardObjective` -> `IScoreboardCriterion`
`ScoreboardObjective` -> `ScoreboardCriterion`
`ScoreboardObjectiveReadOnly` -> `ScoreboardCriterionReadOnly`
`ScoreboardObjectiveHearts` -> `ScoreboardCriterionHearts`
`MapContainer` -> `MapState`
`net.mc.sortme.ScoreSomething` -> `net.mc.scoreboard.ScoreboardPlayerScore`
