### PR TITLE
Map some World fields / methods and more

### DIFF
--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -150,7 +150,9 @@ CLASS none/aky net/minecraft/block/Block
 		ARG 2 facing
 	METHOD a getRawIdFromBlock (Lnone/aky;)I
 		ARG 0 block
-	METHOD a (Lnone/aky;Lnone/aky;)Z
+	METHOD a areEqual (Lnone/aky;Lnone/aky;)Z
+		ARG 0 a
+		ARG 1 b
 	METHOD a setSoundGroup (Lnone/apw;)Lnone/aky;
 	METHOD a getRenderType (Lnone/asm;)Lnone/api;
 		ARG 0 state

--- a/mappings/net/minecraft/client/gui/menu/WidgetPagedMultiList.mapping
+++ b/mappings/net/minecraft/client/gui/menu/WidgetPagedMultiList.mapping
@@ -125,7 +125,7 @@ CLASS none/bfa net/minecraft/client/gui/menu/WidgetPagedMultiList
 		METHOD g getInitialValue ()F
 	FIELD A currentField Lnone/beh;
 	FIELD u drawables Ljava/util/List;
-	FIELD v registry Lnone/om;
+	FIELD v drawablesById Lnone/om;
 	FIELD w textFields Ljava/util/List;
 	FIELD x pages [[Lnone/bfa$f;
 	FIELD y currentPage I

--- a/mappings/net/minecraft/server/config/ServerConfigurationManager.mapping
+++ b/mappings/net/minecraft/server/config/ServerConfigurationManager.mapping
@@ -57,6 +57,14 @@ CLASS none/mr net/minecraft/server/config/ServerConfigurationManager
 		ARG 1 gameProfile
 	METHOD a getPlayer (Ljava/util/UUID;)Lnone/lw;
 		ARG 0 uuid
+	METHOD a sendToAllPlayersInRange (Lnone/aam;DDDDILnone/fl;)V
+		ARG 0 except
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+		ARG 4 distance
+		ARG 5 worldId
+		ARG 6 packet
 	METHOD a setGameMode (Lnone/aiu;)V
 		ARG 0 gameMode
 	METHOD a handlePlayerLogin (Lnone/eq;Lnone/lw;)V

--- a/mappings/net/minecraft/sortme/DrawableRegistryThingy.mapping
+++ b/mappings/net/minecraft/sortme/DrawableRegistryThingy.mapping
@@ -1,4 +1,0 @@
-CLASS none/om net/minecraft/sortme/DrawableRegistryThingy
-	METHOD a get (I)Ljava/lang/Object;
-	METHOD a put (ILjava/lang/Object;)V
-	METHOD b containsKey (I)Z

--- a/mappings/net/minecraft/util/IntHashMap.mapping
+++ b/mappings/net/minecraft/util/IntHashMap.mapping
@@ -1,0 +1,47 @@
+CLASS none/om net/minecraft/util/IntHashMap
+	CLASS none/om$a Element
+		FIELD a key I
+		FIELD b value Ljava/lang/Object;
+		FIELD c next Lnone/om$a;
+		FIELD d hash I
+		METHOD <init> (IILjava/lang/Object;Lnone/om$a;)V
+			ARG 0 hash
+			ARG 1 key
+			ARG 2 value
+			ARG 3 next
+		METHOD a getKey ()I
+		METHOD b getValue ()Ljava/lang/Object;
+		METHOD equals (Ljava/lang/Object;)Z
+			ARG 0 obj
+	FIELD a elements [Lnone/om$a;
+	FIELD b count I
+	FIELD c capacity I
+	FIELD d capacityFactor F
+	METHOD a get (I)Ljava/lang/Object;
+		ARG 0 key
+	METHOD a getMinBucketIndex (II)I
+		ARG 0 hash
+		ARG 1 length
+	METHOD a addInternal (IILjava/lang/Object;I)V
+		ARG 0 hash
+		ARG 1 key
+		ARG 2 value
+		ARG 3 index
+	METHOD a put (ILjava/lang/Object;)V
+		ARG 0 key
+		ARG 1 value
+	METHOD a reorderElements ([Lnone/om$a;)V
+		ARG 0 buckets
+	METHOD b containsKey (I)Z
+		ARG 0 key
+	METHOD c clear ()V
+	METHOD c getBucketForKey (I)Lnone/om$a;
+		ARG 0 key
+	METHOD d remove (I)Ljava/lang/Object;
+		ARG 0 key
+	METHOD e removeInternal (I)Lnone/om$a;
+		ARG 0 key
+	METHOD g getHashForKey (I)I
+		ARG 0 key
+	METHOD h ensureCapacity (I)V
+		ARG 0 size

--- a/mappings/net/minecraft/util/IntHashMap.mapping
+++ b/mappings/net/minecraft/util/IntHashMap.mapping
@@ -30,7 +30,7 @@ CLASS none/om net/minecraft/util/IntHashMap
 	METHOD a put (ILjava/lang/Object;)V
 		ARG 0 key
 		ARG 1 value
-	METHOD a reorderElements ([Lnone/om$a;)V
+	METHOD a reorder ([Lnone/om$a;)V
 		ARG 0 elements
 	METHOD b containsKey (I)Z
 		ARG 0 key

--- a/mappings/net/minecraft/util/IntHashMap.mapping
+++ b/mappings/net/minecraft/util/IntHashMap.mapping
@@ -19,7 +19,7 @@ CLASS none/om net/minecraft/util/IntHashMap
 	FIELD d capacityFactor F
 	METHOD a get (I)Ljava/lang/Object;
 		ARG 0 key
-	METHOD a getMinBucketIndex (II)I
+	METHOD a getMinElementIndex (II)I
 		ARG 0 hash
 		ARG 1 length
 	METHOD a addInternal (IILjava/lang/Object;I)V
@@ -31,17 +31,17 @@ CLASS none/om net/minecraft/util/IntHashMap
 		ARG 0 key
 		ARG 1 value
 	METHOD a reorderElements ([Lnone/om$a;)V
-		ARG 0 buckets
+		ARG 0 elements
 	METHOD b containsKey (I)Z
 		ARG 0 key
 	METHOD c clear ()V
-	METHOD c getBucketForKey (I)Lnone/om$a;
+	METHOD c getElement (I)Lnone/om$a;
 		ARG 0 key
 	METHOD d remove (I)Ljava/lang/Object;
 		ARG 0 key
 	METHOD e removeInternal (I)Lnone/om$a;
 		ARG 0 key
-	METHOD g getHashForKey (I)I
+	METHOD g getHash (I)I
 		ARG 0 key
 	METHOD h ensureCapacity (I)V
 		ARG 0 size

--- a/mappings/net/minecraft/world/ScheduledBlockTick.mapping
+++ b/mappings/net/minecraft/world/ScheduledBlockTick.mapping
@@ -1,0 +1,19 @@
+CLASS none/ajh net/minecraft/world/ScheduledBlockTick
+	FIELD a pos Lnone/cn;
+	FIELD b time J
+	FIELD c priority I
+	FIELD d ID_COUNTER J
+	FIELD e block Lnone/aky;
+	FIELD f id J
+	METHOD <init> (Lnone/cn;Lnone/aky;)V
+		ARG 0 pos
+		ARG 1 block
+	METHOD a getBlock ()Lnone/aky;
+	METHOD a setPriority (I)V
+		ARG 0 value
+	METHOD a setTime (J)Lnone/ajh;
+		ARG 0 value
+	METHOD a compareTo (Lnone/ajh;)I
+		ARG 0 other
+	METHOD equals (Ljava/lang/Object;)Z
+		ARG 0 obj

--- a/mappings/net/minecraft/world/ScheduledBlockTick.mapping
+++ b/mappings/net/minecraft/world/ScheduledBlockTick.mapping
@@ -2,7 +2,7 @@ CLASS none/ajh net/minecraft/world/ScheduledBlockTick
 	FIELD a pos Lnone/cn;
 	FIELD b time J
 	FIELD c priority I
-	FIELD d ID_COUNTER J
+	FIELD d id_counter J
 	FIELD e block Lnone/aky;
 	FIELD f id J
 	METHOD <init> (Lnone/cn;Lnone/aky;)V

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -26,6 +26,11 @@ CLASS none/aiw net/minecraft/world/World
 	FIELD i players Ljava/util/List;
 	FIELD j globalEntities Ljava/util/List;
 	FIELD k entitiesById Lnone/om;
+	FIELD l randomLocationSeed I
+	FIELD n rainGradientPrev F
+	FIELD o rainGradient F
+	FIELD p thunderGradientPrev F
+	FIELD q thunderGradient F
 	FIELD r rand Ljava/util/Random;
 	FIELD s provider Lnone/auf;
 	FIELD u listeners Ljava/util/List;
@@ -60,6 +65,8 @@ CLASS none/aiw net/minecraft/world/World
 	METHOD S getSaveHandler ()Lnone/bav;
 	METHOD T getProperties ()Lnone/bau;
 	METHOD U getGameRules ()Lnone/ait;
+	METHOD V isThundering ()Z
+	METHOD W isRaining ()Z
 	METHOD a calculateAmbientDarkness (F)I
 	METHOD a getEntityById (I)Lnone/sg;
 		ARG 0 id
@@ -265,7 +272,15 @@ CLASS none/aiw net/minecraft/world/World
 	METHOD g setBlockToAir (Lnone/cn;)Z
 		ARG 0 pos
 	METHOD h setDefaultSpawnClient ()V
+	METHOD h getThunderGradient (F)F
+		ARG 0 deltaTicks
+	METHOD i setThunderGradient (F)V
+		ARG 0 value
+	METHOD j getRainGradient (F)F
+		ARG 0 deltaTicks
 	METHOD k updateEntities ()V
+	METHOD k setRainGradient (F)V
+		ARG 0 value
 	METHOD n createChunkProvider ()Lnone/atk;
 	METHOD o getBlockState (Lnone/cn;)Lnone/asm;
 		ARG 0 pos

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -18,6 +18,7 @@ CLASS none/aiw net/minecraft/world/World
 	FIELD a seaLevel I
 	FIELD b pendingBlockEntities Ljava/util/List;
 	FIELD c unloadedBlockEntities Ljava/util/List;
+	FIELD d tickBlocksInstantly Z
 	FIELD e entities Ljava/util/List;
 	FIELD f unloadedEntities Ljava/util/List;
 	FIELD g blockEntities Ljava/util/List;
@@ -108,10 +109,28 @@ CLASS none/aiw net/minecraft/world/World
 		ARG 0 info
 	METHOD a addBlockEntity (Lnone/are;)Z
 		ARG 0 blockEntity
+	METHOD a getScheduledBlockTicks (Lnone/atp;Z)Ljava/util/List;
+		ARG 0 chunk
+		ARG 1 remove
 	METHOD a isAreaLoaded (Lnone/axa;)Z
 		ARG 0 area
+	METHOD a getScheduledBlockTicks (Lnone/axa;Z)Ljava/util/List;
+		ARG 0 region
+		ARG 1 remove
 	METHOD a isValidPos (Lnone/cn;)Z
 		ARG 0 pos
+	METHOD a hasBlockTickPending (Lnone/cn;Lnone/aky;)Z
+		ARG 0 pos
+		ARG 1 block
+	METHOD a scheduleBlockTick (Lnone/cn;Lnone/aky;I)V
+		ARG 0 pos
+		ARG 1 block
+		ARG 2 delay
+	METHOD a scheduleBlockTick (Lnone/cn;Lnone/aky;II)V
+		ARG 0 pos
+		ARG 1 block
+		ARG 2 delay
+		ARG 3 priority
 	METHOD a updateNeighborsExcept (Lnone/cn;Lnone/aky;Lnone/cu;)V
 		ARG 0 pos
 		ARG 1 changedBlock
@@ -124,6 +143,10 @@ CLASS none/aiw net/minecraft/world/World
 		ARG 0 pos
 		ARG 1 state
 		ARG 2 flags
+	METHOD a tickBlockInstantly (Lnone/cn;Lnone/asm;Ljava/util/Random;)V
+		ARG 0 pos
+		ARG 1 block
+		ARG 2 rand
 	METHOD a isAreaLoaded (Lnone/cn;Lnone/cn;)Z
 		ARG 0 min
 		ARG 1 max
@@ -160,6 +183,8 @@ CLASS none/aiw net/minecraft/world/World
 		ARG 5 createFire
 		ARG 6 destroyBlocks
 	METHOD a (Lnone/sg;Lnone/bcs;Lcom/google/common/base/Predicate;)Ljava/util/List;
+	METHOD a tickScheduledBlocks (Z)Z
+		ARG 0 tickAllNow
 	METHOD ac ()Ljava/util/Calendar;
 	METHOD ad getScoreboard ()Lnone/bdb;
 	METHOD ae getDifficulty ()Lnone/qz;
@@ -186,6 +211,14 @@ CLASS none/aiw net/minecraft/world/World
 		ARG 0 area
 	METHOD b getBiome (Lnone/cn;)Lnone/ajj;
 		ARG 0 pos
+	METHOD b hasBlockTickScheduled (Lnone/cn;Lnone/aky;)Z
+		ARG 0 pos
+		ARG 1 block
+	METHOD b scheduleBlockTickGuaranteedDelay (Lnone/cn;Lnone/aky;II)V
+		ARG 0 pos
+		ARG 1 block
+		ARG 2 delay
+		ARG 3 priority
 	METHOD b markDirty (Lnone/cn;Lnone/are;)V
 		ARG 0 pos
 		ARG 1 entity

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -23,6 +23,7 @@ CLASS none/aiw net/minecraft/world/World
 	FIELD g blockEntities Ljava/util/List;
 	FIELD h tickingBlockEntities Ljava/util/List;
 	FIELD i players Ljava/util/List;
+	FIELD j globalEntities Ljava/util/List;
 	FIELD r rand Ljava/util/Random;
 	FIELD s provider Lnone/auf;
 	FIELD u listeners Ljava/util/List;
@@ -216,6 +217,8 @@ CLASS none/aiw net/minecraft/world/World
 	METHOD d updateNeighbors (Lnone/cn;Lnone/aky;)V
 		ARG 0 pos
 		ARG 1 changedBlock
+	METHOD d addGlobalEntity (Lnone/sg;)Z
+		ARG 0 entity
 	METHOD e updateSleepingStatus ()V
 	METHOD e isBlockLoaded (Lnone/cn;)Z
 		ARG 0 pos

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -24,6 +24,7 @@ CLASS none/aiw net/minecraft/world/World
 	FIELD h tickingBlockEntities Ljava/util/List;
 	FIELD i players Ljava/util/List;
 	FIELD j globalEntities Ljava/util/List;
+	FIELD k entitiesById Lnone/om;
 	FIELD r rand Ljava/util/Random;
 	FIELD s provider Lnone/auf;
 	FIELD u listeners Ljava/util/List;

--- a/mappings/net/minecraft/world/WorldServer.mapping
+++ b/mappings/net/minecraft/world/WorldServer.mapping
@@ -43,6 +43,8 @@ CLASS none/lu net/minecraft/world/WorldServer
 	METHOD c onEntityRemoved (Lnone/sg;)V
 		ARG 0 entity
 	METHOD d update ()V
+	METHOD d addGlobalEntity (Lnone/sg;)Z
+		ARG 0 entity
 	METHOD e updateSleepingStatus ()V
 	METHOD h setDefaultSpawnClient ()V
 	METHOD k updateEntities ()V

--- a/mappings/net/minecraft/world/WorldServer.mapping
+++ b/mappings/net/minecraft/world/WorldServer.mapping
@@ -1,6 +1,9 @@
 CLASS none/lu net/minecraft/world/WorldServer
 	FIELD I server Lnet/minecraft/server/MinecraftServer;
 	FIELD J entityTrackingManager Lnone/lr;
+	FIELD L blockTicksScheduled Ljava/util/Set;
+	FIELD M blockTicksScheduledTreeSet Ljava/util/TreeSet;
+	FIELD U blockTicksPending Ljava/util/List;
 	FIELD a LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD b autoSaveDisabled Z
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;Lnone/bav;Lnone/bau;ILnone/os;)V
@@ -20,6 +23,24 @@ CLASS none/lu net/minecraft/world/WorldServer
 	METHOD a getEntityByUuid (Ljava/util/UUID;)Lnone/sg;
 	METHOD a init (Lnone/aiz;)V
 		ARG 0 info
+	METHOD a getScheduledBlockTicks (Lnone/atp;Z)Ljava/util/List;
+		ARG 0 chunk
+		ARG 1 remove
+	METHOD a getScheduledBlockTicks (Lnone/axa;Z)Ljava/util/List;
+		ARG 0 region
+		ARG 1 remove
+	METHOD a hasBlockTickPending (Lnone/cn;Lnone/aky;)Z
+		ARG 0 pos
+		ARG 1 block
+	METHOD a scheduleBlockTick (Lnone/cn;Lnone/aky;I)V
+		ARG 0 pos
+		ARG 1 block
+		ARG 2 delay
+	METHOD a scheduleBlockTick (Lnone/cn;Lnone/aky;II)V
+		ARG 0 pos
+		ARG 1 block
+		ARG 2 delay
+		ARG 3 priority
 	METHOD a spawnEntity (Lnone/sg;)Z
 		ARG 0 entity
 	METHOD a createExplosion (Lnone/sg;DDDFZZ)Lnone/air;
@@ -30,6 +51,8 @@ CLASS none/lu net/minecraft/world/WorldServer
 		ARG 4 power
 		ARG 5 createFire
 		ARG 6 destroyBlocks
+	METHOD a tickScheduledBlocks (Z)Z
+		ARG 0 tickAllNow
 	METHOD a save (ZLnone/ot;)V
 		ARG 0 entities
 		ARG 1 progress
@@ -38,6 +61,14 @@ CLASS none/lu net/minecraft/world/WorldServer
 	METHOD am shouldSpawnAnimals ()Z
 	METHOD an initDebugWorldProperties ()V
 	METHOD b ()Lnone/aiw;
+	METHOD b hasBlockTickScheduled (Lnone/cn;Lnone/aky;)Z
+		ARG 0 pos
+		ARG 1 block
+	METHOD b scheduleBlockTickGuaranteedDelay (Lnone/cn;Lnone/aky;II)V
+		ARG 0 pos
+		ARG 1 block
+		ARG 2 delay
+		ARG 3 priority
 	METHOD b onEntityAdded (Lnone/sg;)V
 		ARG 0 entity
 	METHOD c onEntityRemoved (Lnone/sg;)V

--- a/mappings/net/minecraft/world/entity/WorldEntityTrackingManager.mapping
+++ b/mappings/net/minecraft/world/entity/WorldEntityTrackingManager.mapping
@@ -3,8 +3,8 @@ CLASS none/lr net/minecraft/world/entity/WorldEntityTrackingManager
 		METHOD a call ()Ljava/lang/String;
 	FIELD a LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD b world Lnone/lu;
-	FIELD c TRACKERS Ljava/util/Set;
-	FIELD d TRACKERS_BY_ID Lnone/om;
+	FIELD c trackers Ljava/util/Set;
+	FIELD d trackersById Lnone/om;
 	METHOD <init> (Lnone/lu;)V
 		ARG 0 world
 	METHOD a startTracking (Lnone/sg;)V


### PR DESCRIPTION
- Mapped `World.globalEntities` and `addGlobalEntity` (used for lightning strikes)
- Mapped `ServerConfigurationManager.sendToAllPlayersInRange` (should this class be renamed?)
- Mapped `IntHashMap` (previously `DrawableRegistryThingy`) and fields using it
- Mapped `ScheduledBlockTick` and related fields / methods in `World` (**Requesting feedback** :green_heart:)
- Mapped raining and thunder related fields / methods in `World`
- Mapped `Block.areEqual`
