### PR TITLE
Map world event

### DIFF
--- a/mappings/net/minecraft/client/network/handler/NetworkGameHandlerClient.mapping
+++ b/mappings/net/minecraft/client/network/handler/NetworkGameHandlerClient.mapping
@@ -79,7 +79,7 @@ CLASS none/bmf net/minecraft/client/network/handler/NetworkGameHandlerClient
 		ARG 0 packet
 	METHOD a onChunkData (Lnone/gv;)V
 		ARG 0 packet
-	METHOD a onEffect (Lnone/gw;)V
+	METHOD a onWorldEvent (Lnone/gw;)V
 		ARG 0 packet
 	METHOD a onParticle (Lnone/gx;)V
 		ARG 0 packet

--- a/mappings/net/minecraft/client/render/bpb.mapping
+++ b/mappings/net/minecraft/client/render/bpb.mapping
@@ -11,9 +11,18 @@ CLASS none/bpb net/minecraft/client/render/bpb
 	FIELD z destroyStages [Lnone/bxe;
 	METHOD <init> (Lnone/bdr;)V
 		ARG 0 game
+	METHOD a onGlobalWorldEvent (ILnone/cn;I)V
+		ARG 0 eventId
+		ARG 1 pos
+		ARG 2 data
 	METHOD a onParticle (IZDDDDDD[I)V
 		ARG 0 typeId
 		ARG 1 ignoreRange
+	METHOD a onWorldEvent (Lnone/aam;ILnone/cn;I)V
+		ARG 0 player
+		ARG 1 eventId
+		ARG 2 pos
+		ARG 3 data
 	METHOD a onSound (Lnone/aam;Lnone/nk;Lnone/nm;DDDFF)V
 		ARG 0 player
 		ARG 1 sound

--- a/mappings/net/minecraft/network/handler/INetworkGameHandlerClient.mapping
+++ b/mappings/net/minecraft/network/handler/INetworkGameHandlerClient.mapping
@@ -65,7 +65,7 @@ CLASS none/fo net/minecraft/network/handler/INetworkGameHandlerClient
 		ARG 0 packet
 	METHOD a onChunkData (Lnone/gv;)V
 		ARG 0 packet
-	METHOD a onEffect (Lnone/gw;)V
+	METHOD a onWorldEvent (Lnone/gw;)V
 		ARG 0 packet
 	METHOD a onParticle (Lnone/gx;)V
 		ARG 0 packet

--- a/mappings/net/minecraft/network/packet/client/CPacketWorldEvent.mapping
+++ b/mappings/net/minecraft/network/packet/client/CPacketWorldEvent.mapping
@@ -1,21 +1,21 @@
-CLASS none/gw net/minecraft/network/packet/client/CPacketEffect
-	FIELD a effectId I
+CLASS none/gw net/minecraft/network/packet/client/CPacketWorldEvent
+	FIELD a eventId I
 	FIELD b pos Lnone/cn;
-	FIELD c effectData I
-	FIELD d disableRelativeVolume Z
+	FIELD c data I
+	FIELD d global Z
 	METHOD <init> (ILnone/cn;IZ)V
-		ARG 0 effectId
+		ARG 0 eventId
 		ARG 1 pos
-		ARG 2 effectData
-		ARG 3 disableRelativeVolume
-	METHOD a disableRelativeVolume ()Z
+		ARG 2 data
+		ARG 3 global
+	METHOD a isGlobal ()Z
 	METHOD a readPacket (Lnone/es;)V
 		ARG 0 packet
 	METHOD a applyPacket (Lnone/ev;)V
 		ARG 0 handler
 	METHOD a applyPacket (Lnone/fo;)V
 		ARG 0 handler
-	METHOD b getEffectId ()I
+	METHOD b getEventId ()I
 	METHOD b writePacket (Lnone/es;)V
 		ARG 0 packet
 	METHOD c getEffectData ()I

--- a/mappings/net/minecraft/world/IWorldListener.mapping
+++ b/mappings/net/minecraft/world/IWorldListener.mapping
@@ -1,7 +1,16 @@
 CLASS none/aiy net/minecraft/world/IWorldListener
+	METHOD a onGlobalWorldEvent (ILnone/cn;I)V
+		ARG 0 eventId
+		ARG 1 pos
+		ARG 2 data
 	METHOD a onParticle (IZDDDDDD[I)V
 		ARG 0 typeId
 		ARG 1 ignoreRange
+	METHOD a onWorldEvent (Lnone/aam;ILnone/cn;I)V
+		ARG 0 player
+		ARG 1 eventId
+		ARG 2 pos
+		ARG 3 data
 	METHOD a onSound (Lnone/aam;Lnone/nk;Lnone/nm;DDDFF)V
 		ARG 0 player
 		ARG 1 sound

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -83,6 +83,10 @@ CLASS none/aiw net/minecraft/world/World
 	METHOD a isChunkLoaded (IIZ)Z
 		ARG 0 chunkX
 		ARG 1 chunkZ
+	METHOD a fireGlobalWorldEvent (ILnone/cn;I)V
+		ARG 0 eventId
+		ARG 1 pos
+		ARG 2 data
 	METHOD a spawnParticle (IZDDDDDD[I)V
 		ARG 0 typeId
 		ARG 1 ignoreRange
@@ -103,6 +107,11 @@ CLASS none/aiw net/minecraft/world/World
 		ARG 5 category
 		ARG 6 volume
 		ARG 7 pitch
+	METHOD a fireWorldEvent (Lnone/aam;ILnone/cn;I)V
+		ARG 0 player
+		ARG 1 eventId
+		ARG 2 pos
+		ARG 3 data
 	METHOD a playSound (Lnone/aam;Lnone/cn;Lnone/nk;Lnone/nm;FF)V
 		ARG 0 player
 		ARG 1 pos
@@ -201,6 +210,10 @@ CLASS none/aiw net/minecraft/world/World
 	METHOD b ()Lnone/aiw;
 	METHOD b setSeaLevel (I)V
 		ARG 0 seaLevel
+	METHOD b fireWorldEvent (ILnone/cn;I)V
+		ARG 0 eventId
+		ARG 1 pos
+		ARG 2 data
 	METHOD b setTimeOfDay (J)V
 		ARG 0 value
 	METHOD b getPlayers (Ljava/lang/Class;Lcom/google/common/base/Predicate;)Ljava/util/List;

--- a/mappings/net/minecraft/world/WorldListenerServer.mapping
+++ b/mappings/net/minecraft/world/WorldListenerServer.mapping
@@ -1,9 +1,18 @@
 CLASS none/lv net/minecraft/world/WorldListenerServer
 	FIELD a server Lnet/minecraft/server/MinecraftServer;
 	FIELD b world Lnone/lu;
+	METHOD a onGlobalWorldEvent (ILnone/cn;I)V
+		ARG 0 eventId
+		ARG 1 pos
+		ARG 2 data
 	METHOD a onParticle (IZDDDDDD[I)V
 		ARG 0 typeId
 		ARG 1 ignoreRange
+	METHOD a onWorldEvent (Lnone/aam;ILnone/cn;I)V
+		ARG 0 player
+		ARG 1 eventId
+		ARG 2 pos
+		ARG 3 data
 	METHOD a onSound (Lnone/aam;Lnone/nk;Lnone/nm;DDDFF)V
 		ARG 0 player
 		ARG 1 sound

--- a/mappings/none/vx.mapping
+++ b/mappings/none/vx.mapping
@@ -1,7 +1,16 @@
 CLASS none/vx
+	METHOD a onGlobalWorldEvent (ILnone/cn;I)V
+		ARG 0 eventId
+		ARG 1 pos
+		ARG 2 data
 	METHOD a onParticle (IZDDDDDD[I)V
 		ARG 0 typeId
 		ARG 1 ignoreRange
+	METHOD a onWorldEvent (Lnone/aam;ILnone/cn;I)V
+		ARG 0 player
+		ARG 1 eventId
+		ARG 2 pos
+		ARG 3 data
 	METHOD a onSound (Lnone/aam;Lnone/nk;Lnone/nm;DDDFF)V
 		ARG 0 player
 		ARG 1 sound


### PR DESCRIPTION
Renamed the packet previously called `Effect` to `WorldEvent` too. Mojang calls this "level event" it appears. There's global and normal world events and they basically seem to play sounds and spawn particles when received by the client (ender dragon / wither sounds being global events).

Should I keep it named as `Effect`? What are your opinions?
