### PR TITLE
Add mappings for tracking recent damage to entities

### DIFF
--- a/mappings/net/minecraft/client/gui/ingame/GuiDeath.mapping
+++ b/mappings/net/minecraft/client/gui/ingame/GuiDeath.mapping
@@ -1,6 +1,8 @@
 CLASS biy net/minecraft/client/gui/ingame/GuiDeath
 	FIELD a ticksSinceDeath I
 	FIELD f msg Lgk;
+	METHOD <init> (Lgk;)V
+		ARG 0 deathMessage
 	METHOD a onKeyPressed (CI)V
 	METHOD a draw (IIF)V
 	METHOD a onWidgetPressed (Lbhk;)V

--- a/mappings/net/minecraft/client/player/EntityPlayerClient.mapping
+++ b/mappings/net/minecraft/client/player/EntityPlayerClient.mapping
@@ -33,9 +33,14 @@ CLASS bsm net/minecraft/client/player/EntityPlayerClient
 	METHOD b heal (F)V
 	METHOD c getBlockPos ()Ldx;
 	METHOD c setCurrentHand (Lsw;)V
+	METHOD d damage (Ltm;F)V
+		ARG 0 damageSource
+		ARG 1 damage
 	METHOD g getForwardVector (F)Lbfp;
 	METHOD g sendChatMessage (Ljava/lang/String;)V
 	METHOD n updateMovement ()V
 	METHOD n setClientPermissionLevel (I)V
 	METHOD o stopRiding ()V
+	METHOD q updateHealth (F)V
+		ARG 0 health
 	METHOD z closeGui ()V

--- a/mappings/net/minecraft/entity/EntityLiving.mapping
+++ b/mappings/net/minecraft/entity/EntityLiving.mapping
@@ -11,6 +11,7 @@ CLASS uk net/minecraft/entity/EntityLiving
 	FIELD b ATTR_SPRINTING_SPEED_BOOST_ID Ljava/util/UUID;
 	FIELD br STUCK_ARROWS Llx;
 	FIELD bs attributeContainer Lvb;
+	FIELD bt damageTracker Ltl;
 	FIELD bu activePotionEffects Ljava/util/Map;
 	FIELD by attacker Luk;
 	FIELD bz lastAttackedTime I
@@ -70,6 +71,7 @@ CLASS uk net/minecraft/entity/EntityLiving
 	METHOD cA getMainHand ()Luj;
 	METHOD cK isFallFlying ()Z
 	METHOD ca getSoundDeath ()Lpb;
+	METHOD cc getDamageTracker ()Ltl;
 	METHOD ce getHealthMaximum ()F
 	METHOD cf getStuckArrows ()I
 	METHOD ch getAttributeContainer ()Lvb;
@@ -80,6 +82,9 @@ CLASS uk net/minecraft/entity/EntityLiving
 	METHOD cu isSleeping ()Z
 	METHOD cw doPushLogic ()V
 	METHOD cy getAbsorptionAmount ()F
+	METHOD d damage (Ltm;F)V
+		ARG 0 damageSource
+		ARG 1 damage
 	METHOD e handleFallDamage (FF)V
 	METHOD e getSoundFall (I)Lpb;
 	METHOD f setStuckArrows (I)V

--- a/mappings/net/minecraft/entity/damage/DamageRecord.mapping
+++ b/mappings/net/minecraft/entity/damage/DamageRecord.mapping
@@ -1,0 +1,20 @@
+CLASS tj net/minecraft/entity/damage/DamageRecord
+	FIELD a damageSource Ltm;
+	FIELD b entityAge I
+	FIELD c damage F
+	FIELD d entityHealth F
+	FIELD e fallDeathSuffix Ljava/lang/String;
+	FIELD f fallDistance F
+	METHOD <init> (Ltm;IFFLjava/lang/String;F)V
+		ARG 0 damageSource
+		ARG 1 entityAge
+		ARG 2 entityOriginalHealth
+		ARG 3 damage
+		ARG 4 fallDeathSuffix
+		ARG 5 fallDistance
+	METHOD a getDamageSource ()Ltm;
+	METHOD c getDamage ()F
+	METHOD f isAttackerLiving ()Z
+	METHOD g getFallDeathSuffix ()Ljava/lang/String;
+	METHOD h getAttackerName ()Lgk;
+	METHOD j getFallDistance ()F

--- a/mappings/net/minecraft/entity/damage/DamageTracker.mapping
+++ b/mappings/net/minecraft/entity/damage/DamageTracker.mapping
@@ -1,0 +1,25 @@
+CLASS tl net/minecraft/entity/damage/DamageTracker
+	FIELD a recentDamage Ljava/util/List;
+	FIELD b entity Luk;
+	FIELD c ageOnLastDamage I
+	FIELD d ageOnLastAttacked I
+	FIELD e ageOnLastUpdate I
+	FIELD f recentlyAttacked Z
+	FIELD g hasDamage Z
+	FIELD h fallDeathSuffix Ljava/lang/String;
+	METHOD <init> (Luk;)V
+		ARG 0 entity
+	METHOD a setFallDeathSuffix ()V
+	METHOD a getFallDeathSuffix (Ltj;)Ljava/lang/String;
+		ARG 0 damage
+	METHOD a onDamage (Ltm;FF)V
+		ARG 0 damageSource
+		ARG 1 originalHealth
+		ARG 2 damage
+	METHOD b getDeathMessage ()Lgk;
+	METHOD c getBiggestAttacker ()Luk;
+	METHOD f getTimeSinceLastAttack ()I
+	METHOD g update ()V
+	METHOD h getEntity ()Luk;
+	METHOD j getBiggestFall ()Ltj;
+	METHOD k clearFallDeathSuffix ()V

--- a/mappings/net/minecraft/entity/player/EntityPlayer.mapping
+++ b/mappings/net/minecraft/entity/player/EntityPlayer.mapping
@@ -108,6 +108,9 @@ CLASS acu net/minecraft/entity/player/EntityPlayer
 	METHOD cu isSleeping ()Z
 	METHOD cy getAbsorptionAmount ()F
 	METHOD d getOfflinePlayerUuid (Ljava/lang/String;)Ljava/util/UUID;
+	METHOD d damage (Ltm;F)V
+		ARG 0 damageSource
+		ARG 1 damage
 	METHOD da isSpawnForced ()Z
 	METHOD db getEnchantmentTableSeed ()I
 	METHOD dd getHungerManager ()Laef;

--- a/mappings/net/minecraft/network/packet/client/CPacketEventCombat.mapping
+++ b/mappings/net/minecraft/network/packet/client/CPacketEventCombat.mapping
@@ -4,6 +4,17 @@ CLASS ip net/minecraft/network/packet/client/CPacketEventCombat
 		FIELD b END Lip$a;
 		FIELD c DEATH Lip$a;
 	FIELD a type Lip$a;
+	FIELD b entityId I
+	FIELD c attackerEntityId I
+	FIELD d timeSinceLastAttack I
+	FIELD e deathMessage Lgk;
+	METHOD <init> (Ltl;Lip$a;)V
+		ARG 0 damageTracker
+		ARG 1 combatType
+	METHOD <init> (Ltl;Lip$a;Z)V
+		ARG 0 damageTracker
+		ARG 1 combatType
+		ARG 2 includeDeathMessage
 	METHOD a readPacket (Lgb;)V
 		ARG 0 buf
 	METHOD a applyPacket (Lge;)V


### PR DESCRIPTION
Each entity has a `DamageTracker` for keeping track of fall damage and attacks received, so it can create a descriptive message when the entity dies.