### PR TITLE
Various mappings around GuiContainer inputs

### DIFF
--- a/mappings/cjf.mapping
+++ b/mappings/cjf.mapping
@@ -1,4 +1,0 @@
-CLASS cjf
-	CLASS cjf$a
-		METHOD equals (Ljava/lang/Object;)Z
-			ARG 0 object

--- a/mappings/clg.mapping
+++ b/mappings/clg.mapping
@@ -1,0 +1,12 @@
+CLASS clg
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
+	METHOD mouseReleased (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode

--- a/mappings/cli.mapping
+++ b/mappings/cli.mapping
@@ -1,0 +1,15 @@
+CLASS cli
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
+	METHOD keyReleased (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
+	METHOD mouseReleased (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode

--- a/mappings/cmo.mapping
+++ b/mappings/cmo.mapping
@@ -8,4 +8,12 @@ CLASS cmo
 	METHOD c width ()I
 	METHOD d getEntryCount ()I
 	METHOD f getScrollbarPosition ()I
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
+	METHOD mouseReleased (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
 	METHOD n getContentHeight ()I

--- a/mappings/cmq.mapping
+++ b/mappings/cmq.mapping
@@ -7,4 +7,12 @@ CLASS cmq
 	METHOD c getWidth ()I
 	METHOD d getEntryCount ()I
 	METHOD f getScrollbarPosition ()I
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
+	METHOD mouseReleased (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
 	METHOD n getContentHeight ()I

--- a/mappings/cmr.mapping
+++ b/mappings/cmr.mapping
@@ -11,4 +11,12 @@ CLASS cmr
 	METHOD c getWidth ()I
 	METHOD d getEntryCount ()I
 	METHOD f getScrollbarPosition ()I
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
+	METHOD mouseReleased (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
 	METHOD n getContentHeight ()I

--- a/mappings/cmu.mapping
+++ b/mappings/cmu.mapping
@@ -5,3 +5,6 @@ CLASS cmu
 		ARG 2 delta
 	METHOD ah_ canClose ()Z
 	METHOD c init ()V
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode

--- a/mappings/coo.mapping
+++ b/mappings/coo.mapping
@@ -9,4 +9,11 @@ CLASS coo
 	METHOD c init ()V
 	METHOD f update ()V
 	METHOD g close ()V
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
 	METHOD n onClosed ()V

--- a/mappings/cqr.mapping
+++ b/mappings/cqr.mapping
@@ -8,4 +8,7 @@ CLASS cqr
 		ARG 2 mouseButton
 	METHOD c init ()V
 	METHOD f update ()V
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
 	METHOD n onClosed ()V

--- a/mappings/net/minecraft/client/gui/Gui.mapping
+++ b/mappings/net/minecraft/client/gui/Gui.mapping
@@ -50,4 +50,7 @@ CLASS cnt net/minecraft/client/gui/Gui
 	METHOD e isPauseScreen ()Z
 	METHOD f update ()V
 	METHOD g close ()V
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
 	METHOD n onClosed ()V

--- a/mappings/net/minecraft/client/gui/GuiContainer.mapping
+++ b/mappings/net/minecraft/client/gui/GuiContainer.mapping
@@ -5,9 +5,19 @@ CLASS cop net/minecraft/client/gui/GuiContainer
 	FIELD h container Laqq;
 	FIELD i left I
 	FIELD s top I
+	FIELD t focusedSlot Lart;
 	FIELD u slots Ljava/util/Set;
 	METHOD <init> (Laqq;)V
 		ARG 0 container
+	METHOD a getSlotAt (DD)Lart;
+		ARG 0 xPosition
+		ARG 1 yPosition
+	METHOD a isClickInContainerBounds (DDIII)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 containerLeftOffset
+		ARG 3 containerTopOffset
+		ARG 4 keyCode
 	METHOD a drawBackground (FII)V
 		ARG 0 delta
 		ARG 1 mouseX
@@ -16,8 +26,19 @@ CLASS cop net/minecraft/client/gui/GuiContainer
 		ARG 0 mouseX
 		ARG 1 mouseY
 		ARG 2 delta
+	METHOD a isPointWithinBounds (IIIIDD)Z
+		ARG 0 xPosition
+		ARG 1 yPosition
+		ARG 2 width
+		ARG 3 height
+		ARG 4 pointX
+		ARG 5 pointY
 	METHOD a drawSlot (Lart;)V
 		ARG 0 slot
+	METHOD a isPointOverSlot (Lart;DD)Z
+		ARG 0 slot
+		ARG 1 pointX
+		ARG 2 pointY
 	METHOD a onMouseClick (Lart;IILaqv;)V
 		ARG 0 slot
 		ARG 1 invSlot
@@ -29,11 +50,28 @@ CLASS cop net/minecraft/client/gui/GuiContainer
 		ARG 2 yPosition
 		ARG 3 text
 	METHOD ah_ canClose ()Z
+	METHOD b drawMousoverTooltip (II)V
+		ARG 0 mouseX
+		ARG 1 mouseY
 	METHOD c init ()V
 	METHOD c drawForeground (II)V
 		ARG 0 mouseX
 		ARG 1 mouseY
+	METHOD d handleHotbarKeyPressed (II)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
 	METHOD e isPauseScreen ()Z
 	METHOD f update ()V
 	METHOD h calculateOffset ()V
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
+	METHOD mouseReleased (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
 	METHOD n onClosed ()V

--- a/mappings/net/minecraft/client/gui/GuiMainMenu.mapping
+++ b/mappings/net/minecraft/client/gui/GuiMainMenu.mapping
@@ -31,4 +31,8 @@ CLASS cny net/minecraft/client/gui/GuiMainMenu
 	METHOD f update ()V
 	METHOD h areRealmsNotificationsEnabled ()Z
 	METHOD i switchToRealms ()V
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
 	METHOD n onClosed ()V

--- a/mappings/net/minecraft/client/gui/container/GuiCraftingTable.mapping
+++ b/mappings/net/minecraft/client/gui/container/GuiCraftingTable.mapping
@@ -7,6 +7,12 @@ CLASS cow net/minecraft/client/gui/container/GuiCraftingTable
 		ARG 0 playerInv
 		ARG 1 world
 		ARG 2 craftingTablePos
+	METHOD a isClickInContainerBounds (DDIII)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 containerLeftOffset
+		ARG 3 containerTopOffset
+		ARG 4 keyCode
 	METHOD a drawBackground (FII)V
 		ARG 0 delta
 		ARG 1 mouseX
@@ -15,6 +21,13 @@ CLASS cow net/minecraft/client/gui/container/GuiCraftingTable
 		ARG 0 mouseX
 		ARG 1 mouseY
 		ARG 2 delta
+	METHOD a isPointWithinBounds (IIIIDD)Z
+		ARG 0 xPosition
+		ARG 1 yPosition
+		ARG 2 width
+		ARG 3 height
+		ARG 4 pointX
+		ARG 5 pointY
 	METHOD a onMouseClick (Lart;IILaqv;)V
 		ARG 0 slot
 		ARG 1 invSlot
@@ -25,4 +38,8 @@ CLASS cow net/minecraft/client/gui/container/GuiCraftingTable
 		ARG 0 mouseX
 		ARG 1 mouseY
 	METHOD f update ()V
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
 	METHOD n onClosed ()V

--- a/mappings/net/minecraft/client/gui/container/GuiEnchanting.mapping
+++ b/mappings/net/minecraft/client/gui/container/GuiEnchanting.mapping
@@ -20,3 +20,7 @@ CLASS cpc net/minecraft/client/gui/container/GuiEnchanting
 		ARG 1 mouseY
 	METHOD f update ()V
 	METHOD h calculateOffset ()V
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode

--- a/mappings/net/minecraft/client/gui/container/GuiFurnace.mapping
+++ b/mappings/net/minecraft/client/gui/container/GuiFurnace.mapping
@@ -5,6 +5,12 @@ CLASS cpd net/minecraft/client/gui/container/GuiFurnace
 	METHOD <init> (Lapa;Ladu;)V
 		ARG 0 playerInv
 		ARG 1 inventory
+	METHOD a isClickInContainerBounds (DDIII)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 containerLeftOffset
+		ARG 3 containerTopOffset
+		ARG 4 keyCode
 	METHOD a drawBackground (FII)V
 		ARG 0 delta
 		ARG 1 mouseX
@@ -23,4 +29,11 @@ CLASS cpd net/minecraft/client/gui/container/GuiFurnace
 		ARG 0 mouseX
 		ARG 1 mouseY
 	METHOD f update ()V
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
 	METHOD n onClosed ()V

--- a/mappings/net/minecraft/client/gui/container/GuiLoom.mapping
+++ b/mappings/net/minecraft/client/gui/container/GuiLoom.mapping
@@ -1,5 +1,11 @@
 CLASS cph net/minecraft/client/gui/container/GuiLoom
 	FIELD w TEXTURE Lpt;
+	METHOD a isClickInContainerBounds (DDIII)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 containerLeftOffset
+		ARG 3 containerTopOffset
+		ARG 4 keyCode
 	METHOD a drawBackground (FII)V
 		ARG 0 delta
 		ARG 1 mouseX
@@ -14,3 +20,7 @@ CLASS cph net/minecraft/client/gui/container/GuiLoom
 		ARG 0 mouseX
 		ARG 1 mouseY
 	METHOD f update ()V
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode

--- a/mappings/net/minecraft/client/gui/ingame/GuiChat.mapping
+++ b/mappings/net/minecraft/client/gui/ingame/GuiChat.mapping
@@ -9,4 +9,11 @@ CLASS cmw net/minecraft/client/gui/ingame/GuiChat
 	METHOD c init ()V
 	METHOD e isPauseScreen ()Z
 	METHOD f update ()V
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
 	METHOD n onClosed ()V

--- a/mappings/net/minecraft/client/gui/ingame/GuiChatSleeping.mapping
+++ b/mappings/net/minecraft/client/gui/ingame/GuiChatSleeping.mapping
@@ -2,3 +2,6 @@ CLASS cnk net/minecraft/client/gui/ingame/GuiChatSleeping
 	METHOD c init ()V
 	METHOD g close ()V
 	METHOD i leaveBed ()V
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode

--- a/mappings/net/minecraft/client/gui/ingame/GuiCreativeInventory.mapping
+++ b/mappings/net/minecraft/client/gui/ingame/GuiCreativeInventory.mapping
@@ -47,6 +47,12 @@ CLASS coy net/minecraft/client/gui/ingame/GuiCreativeInventory
 	FIELD z selectedTab I
 	METHOD <init> (Lapb;)V
 		ARG 0 player
+	METHOD a isClickInContainerBounds (DDIII)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 containerLeftOffset
+		ARG 3 containerTopOffset
+		ARG 4 keyCode
 	METHOD a drawBackground (FII)V
 		ARG 0 delta
 		ARG 1 mouseX
@@ -75,5 +81,19 @@ CLASS coy net/minecraft/client/gui/ingame/GuiCreativeInventory
 		ARG 1 mouseY
 	METHOD f update ()V
 	METHOD h calculateOffset ()V
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
+	METHOD keyReleased (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
 	METHOD m doRenderScrollBar ()Z
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
+	METHOD mouseReleased (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
 	METHOD n onClosed ()V

--- a/mappings/net/minecraft/client/gui/ingame/GuiDeath.mapping
+++ b/mappings/net/minecraft/client/gui/ingame/GuiDeath.mapping
@@ -14,3 +14,7 @@ CLASS cnd net/minecraft/client/gui/ingame/GuiDeath
 		ARG 1 callbackId
 	METHOD e isPauseScreen ()Z
 	METHOD f update ()V
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode

--- a/mappings/net/minecraft/client/gui/ingame/GuiEditBook.mapping
+++ b/mappings/net/minecraft/client/gui/ingame/GuiEditBook.mapping
@@ -17,4 +17,11 @@ CLASS cos net/minecraft/client/gui/ingame/GuiEditBook
 	METHOD d handleTextComponentClick (Liw;)Z
 		ARG 0 component
 	METHOD f update ()V
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
 	METHOD n onClosed ()V

--- a/mappings/net/minecraft/client/gui/ingame/GuiEditSign.mapping
+++ b/mappings/net/minecraft/client/gui/ingame/GuiEditSign.mapping
@@ -9,4 +9,7 @@ CLASS cpl net/minecraft/client/gui/ingame/GuiEditSign
 	METHOD c init ()V
 	METHOD f update ()V
 	METHOD g close ()V
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
 	METHOD n onClosed ()V

--- a/mappings/net/minecraft/client/gui/ingame/GuiInventory.mapping
+++ b/mappings/net/minecraft/client/gui/ingame/GuiInventory.mapping
@@ -1,6 +1,12 @@
 CLASS cpg net/minecraft/client/gui/ingame/GuiInventory
 	METHOD <init> (Lapb;)V
 		ARG 0 player
+	METHOD a isClickInContainerBounds (DDIII)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 containerLeftOffset
+		ARG 3 containerTopOffset
+		ARG 4 keyCode
 	METHOD a drawBackground (FII)V
 		ARG 0 delta
 		ARG 1 mouseX
@@ -11,6 +17,13 @@ CLASS cpg net/minecraft/client/gui/ingame/GuiInventory
 		ARG 2 delta
 	METHOD a drawEntity (IIIFFLafq;)V
 		ARG 5 entity
+	METHOD a isPointWithinBounds (IIIIDD)Z
+		ARG 0 xPosition
+		ARG 1 yPosition
+		ARG 2 width
+		ARG 3 height
+		ARG 4 pointX
+		ARG 5 pointY
 	METHOD a onMouseClick (Lart;IILaqv;)V
 		ARG 0 slot
 		ARG 1 invSlot
@@ -21,4 +34,12 @@ CLASS cpg net/minecraft/client/gui/ingame/GuiInventory
 		ARG 0 mouseX
 		ARG 1 mouseY
 	METHOD f update ()V
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
+	METHOD mouseReleased (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
 	METHOD n onClosed ()V

--- a/mappings/net/minecraft/client/gui/ingame/GuiStructureBlock.mapping
+++ b/mappings/net/minecraft/client/gui/ingame/GuiStructureBlock.mapping
@@ -48,7 +48,14 @@ CLASS cpm net/minecraft/client/gui/ingame/GuiStructureBlock
 	METHOD g close ()V
 	METHOD j updateIgnoreEntitiesButton ()V
 	METHOD k updateShowAirButton ()V
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
 	METHOD m updateShowBoundingBoxButton ()V
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
 	METHOD n onClosed ()V
 	METHOD o updateMirrorButton ()V
 	METHOD s updateRotationButton ()V

--- a/mappings/net/minecraft/client/gui/menu/GuiAdvancements.mapping
+++ b/mappings/net/minecraft/client/gui/menu/GuiAdvancements.mapping
@@ -24,4 +24,11 @@ CLASS coi net/minecraft/client/gui/menu/GuiAdvancements
 		ARG 1 mouseY
 		ARG 2 x
 		ARG 3 y
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
 	METHOD n onClosed ()V

--- a/mappings/net/minecraft/client/gui/menu/GuiLevelSelect.mapping
+++ b/mappings/net/minecraft/client/gui/menu/GuiLevelSelect.mapping
@@ -7,4 +7,7 @@ CLASS cqt net/minecraft/client/gui/menu/GuiLevelSelect
 		ARG 2 delta
 	METHOD c init ()V
 	METHOD f update ()V
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
 	METHOD n onClosed ()V

--- a/mappings/net/minecraft/client/gui/menu/GuiMultiplayer.mapping
+++ b/mappings/net/minecraft/client/gui/menu/GuiMultiplayer.mapping
@@ -13,4 +13,7 @@ CLASS cpp net/minecraft/client/gui/menu/GuiMultiplayer
 		ARG 0 result
 		ARG 1 callbackId
 	METHOD f update ()V
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
 	METHOD n onClosed ()V

--- a/mappings/net/minecraft/client/gui/menu/GuiNewLevel.mapping
+++ b/mappings/net/minecraft/client/gui/menu/GuiNewLevel.mapping
@@ -22,4 +22,11 @@ CLASS cqq net/minecraft/client/gui/menu/GuiNewLevel
 		ARG 2 delta
 	METHOD c init ()V
 	METHOD f update ()V
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
 	METHOD n onClosed ()V

--- a/mappings/net/minecraft/client/gui/menu/GuiRealms.mapping
+++ b/mappings/net/minecraft/client/gui/menu/GuiRealms.mapping
@@ -67,4 +67,15 @@ CLASS cmp net/minecraft/client/gui/menu/GuiRealms
 	METHOD i getFontHeight ()I
 	METHOD j clearWidgets ()V
 	METHOD k getButtons ()Ljava/util/List;
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
+	METHOD mouseReleased (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
 	METHOD n onClosed ()V

--- a/mappings/net/minecraft/client/gui/menu/GuiServerAdd.mapping
+++ b/mappings/net/minecraft/client/gui/menu/GuiServerAdd.mapping
@@ -10,4 +10,7 @@ CLASS cnh net/minecraft/client/gui/menu/GuiServerAdd
 	METHOD c init ()V
 	METHOD f update ()V
 	METHOD g close ()V
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
 	METHOD n onClosed ()V

--- a/mappings/net/minecraft/client/gui/menu/GuiServerConnect.mapping
+++ b/mappings/net/minecraft/client/gui/menu/GuiServerConnect.mapping
@@ -8,4 +8,7 @@ CLASS cnf net/minecraft/client/gui/menu/GuiServerConnect
 		ARG 2 mouseButton
 	METHOD c init ()V
 	METHOD f update ()V
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
 	METHOD n onClosed ()V

--- a/mappings/net/minecraft/client/gui/menu/GuiSettingsControls.mapping
+++ b/mappings/net/minecraft/client/gui/menu/GuiSettingsControls.mapping
@@ -12,3 +12,14 @@ CLASS col net/minecraft/client/gui/menu/GuiSettingsControls
 		ARG 1 mouseY
 		ARG 2 delta
 	METHOD c init ()V
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
+	METHOD mouseReleased (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode

--- a/mappings/net/minecraft/client/gui/menu/GuiSettingsVideo.mapping
+++ b/mappings/net/minecraft/client/gui/menu/GuiSettingsVideo.mapping
@@ -12,3 +12,11 @@ CLASS cnz net/minecraft/client/gui/menu/GuiSettingsVideo
 		ARG 2 delta
 	METHOD c init ()V
 	METHOD g close ()V
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
+	METHOD mouseReleased (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode

--- a/mappings/net/minecraft/client/gui/menu/GuiYesNo.mapping
+++ b/mappings/net/minecraft/client/gui/menu/GuiYesNo.mapping
@@ -28,3 +28,6 @@ CLASS cmz net/minecraft/client/gui/menu/GuiYesNo
 		ARG 0 durationTicks
 	METHOD c init ()V
 	METHOD f update ()V
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode

--- a/mappings/net/minecraft/client/gui/widget/WidgetListBase.mapping
+++ b/mappings/net/minecraft/client/gui/widget/WidgetListBase.mapping
@@ -29,6 +29,17 @@ CLASS clb net/minecraft/client/gui/widget/WidgetListBase
 	METHOD f getScrollbarPosition ()I
 	METHOD f setLeftPos (I)V
 		ARG 0 x1
+	METHOD keyPressed (III)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
+	METHOD mouseClicked (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
+	METHOD mouseReleased (DDI)Z
+		ARG 0 mouseX
+		ARG 1 mouseY
+		ARG 2 keyCode
 	METHOD n getContentHeight ()I
 	METHOD o clampScrollY ()V
 	METHOD p getMaxScrollY ()I

--- a/mappings/net/minecraft/client/settings/KeyBinding.mapping
+++ b/mappings/net/minecraft/client/settings/KeyBinding.mapping
@@ -1,0 +1,17 @@
+CLASS cjg net/minecraft/client/settings/KeyBinding
+	FIELD f defaultKeyCode Lcjf$a;
+	FIELD h keyCode Lcjf$a;
+	METHOD a matches (I)Z
+		ARG 0 mouseKeyCode
+	METHOD a matches (II)Z
+		ARG 0 keyCode
+		ARG 1 scanCode
+	METHOD b setKeyCode (Lcjf$a;)V
+		ARG 0 keyCode
+	METHOD b equals (Lcjg;)Z
+		ARG 0 otherBinding
+	METHOD h getDefaultKeyCode ()Lcjf$a;
+	METHOD i isUnbound ()Z
+	METHOD j getFriendlyName ()Ljava/lang/String;
+	METHOD k isDefault ()Z
+	METHOD l getName ()Ljava/lang/String;

--- a/mappings/net/minecraft/client/sortme/KeyBinding.mapping
+++ b/mappings/net/minecraft/client/sortme/KeyBinding.mapping
@@ -1,1 +1,0 @@
-CLASS cjg net/minecraft/client/sortme/KeyBinding

--- a/mappings/net/minecraft/client/util/InputUtils.mapping
+++ b/mappings/net/minecraft/client/util/InputUtils.mapping
@@ -1,0 +1,38 @@
+CLASS cjf net/minecraft/client/util/InputUtils
+	CLASS cjf$a KeyCode
+		FIELD a name Ljava/lang/String;
+		FIELD b type Lcjf$b;
+		FIELD c keyCode I
+		METHOD <init> (Ljava/lang/String;Lcjf$b;I)V
+			ARG 0 name
+			ARG 1 type
+			ARG 2 keyCode
+		METHOD a getFriendlyName ()Ljava/lang/String;
+		METHOD b getCategory ()Lcjf$b;
+		METHOD c getKeyCode ()I
+		METHOD d getName ()Ljava/lang/String;
+		METHOD equals (Ljava/lang/Object;)Z
+			ARG 0 object
+	CLASS cjf$b KeyType
+		FIELD a KEYBOARD Lcjf$b;
+		FIELD b SCANCODE Lcjf$b;
+		FIELD c MOUSE Lcjf$b;
+		FIELD d mouseButtons [Ljava/lang/String;
+		FIELD e map Lya;
+		FIELD f name Ljava/lang/String;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
+			ARG 0 name
+		METHOD a createFromCode (I)Lcjf$a;
+			ARG 0 code
+		METHOD a mapKey (Lcjf$b;Ljava/lang/String;I)V
+			ARG 0 type
+			ARG 1 name
+			ARG 2 keyCode
+	FIELD a UNKOWN Lcjf$a;
+	METHOD a isPressed (I)Z
+		ARG 0 keyCode
+	METHOD a getByCode (II)Lcjf$a;
+		ARG 0 keyCode
+		ARG 1 scanCode
+	METHOD a getByName (Ljava/lang/String;)Lcjf$a;
+		ARG 0 keyName

--- a/mappings/ya.mapping
+++ b/mappings/ya.mapping
@@ -1,2 +1,4 @@
 CLASS ya
 	METHOD a get (I)Ljava/lang/Object;
+	METHOD a put (ILjava/lang/Object;)V
+	METHOD b has (I)Z


### PR DESCRIPTION
Highlights:

net/minecraft/client/gui/GuiContainer:
 - `keyPressed, keyReleased, mouseClicked, mouseReleased` params mapped

net/minecraft/client/sortme/KeyBinding -> net/minecraft/client/settings/KeyBinding:
 - Mapped most of the KeyCode related functions

net/minecraft/client/util/InputUtils
 - Not sure if this is the best name for this, contains classes for KeyType (KEYBOARD/SCANCODE/MOUSE), KeyCode and some helper methods for getting KeyType/KeyCode by strings and/or int keycodes.
