### PR TITLE
Map argument types

### DIFF
--- a/mappings/cu.mapping
+++ b/mappings/cu.mapping
@@ -1,8 +1,8 @@
 CLASS cu
-	CLASS cu$a
+	CLASS cu$a FloatRangeArgumentType
 		CLASS cu$a$a
 			METHOD b fromPacket (Liq;)Lcom/mojang/brigadier/arguments/ArgumentType;
-	CLASS cu$b
+	CLASS cu$b IntRangeArgumentType
 		CLASS cu$b$a
 			METHOD b fromPacket (Liq;)Lcom/mojang/brigadier/arguments/ArgumentType;
 	CLASS cu$c

--- a/mappings/ek.mapping
+++ b/mappings/ek.mapping
@@ -1,2 +1,0 @@
-CLASS ek
-	METHOD a register ()V

--- a/mappings/net/minecraft/MinecraftVersion.mapping
+++ b/mappings/net/minecraft/MinecraftVersion.mapping
@@ -1,0 +1,11 @@
+CLASS g net/minecraft/MinecraftVersion
+	FIELD a LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD b id Ljava/lang/String;
+	FIELD c name Ljava/lang/String;
+	FIELD d stable Z
+	FIELD e worldVersion I
+	FIELD f protocolVersion I
+	FIELD g packVersion I
+	FIELD h buildTime Ljava/util/Date;
+	FIELD i releaseTarget Ljava/lang/String;
+	METHOD a get ()Lnet/minecraft/Version;

--- a/mappings/net/minecraft/command/arguments/ArgumentTypes.mapping
+++ b/mappings/net/minecraft/command/arguments/ArgumentTypes.mapping
@@ -1,4 +1,4 @@
-CLASS eh net/minecraft/server/command/ArgumentTypes
+CLASS eh net/minecraft/command/arguments/ArgumentTypes
 	CLASS eh$a Entry
 		FIELD a argClass Ljava/lang/Class;
 		FIELD b serializer Leg;

--- a/mappings/net/minecraft/command/arguments/BlockPosArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/BlockPosArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS dg net/minecraft/command/arguments/BlockPosArgumentType
+	FIELD c EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Ldg;

--- a/mappings/net/minecraft/command/arguments/BlockPredicateArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/BlockPredicateArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS dc net/minecraft/command/arguments/BlockPredicateArgumentType
+	FIELD a EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Ldc;

--- a/mappings/net/minecraft/command/arguments/BlockStateArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/BlockStateArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS dd net/minecraft/command/arguments/BlockStateArgumentType
+	FIELD a EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Ldd;

--- a/mappings/net/minecraft/command/arguments/BrigadierArgumentTypes.mapping
+++ b/mappings/net/minecraft/command/arguments/BrigadierArgumentTypes.mapping
@@ -1,0 +1,2 @@
+CLASS ek net/minecraft/command/arguments/BrigadierArgumentTypes
+	METHOD a register ()V

--- a/mappings/net/minecraft/command/arguments/ColorArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ColorArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS cd net/minecraft/command/arguments/ColorArgumentType
+	FIELD b EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lcd;

--- a/mappings/net/minecraft/command/arguments/ColumnPosArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ColumnPosArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS dh net/minecraft/command/arguments/ColumnPosArgumentType
+	FIELD b EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Ldh;

--- a/mappings/net/minecraft/command/arguments/ComponentArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ComponentArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS ce net/minecraft/command/arguments/ComponentArgumentType
+	FIELD b EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lce;

--- a/mappings/net/minecraft/command/arguments/DimensionArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/DimensionArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS cg net/minecraft/command/arguments/DimensionArgumentType
+	FIELD b EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lcg;

--- a/mappings/net/minecraft/command/arguments/EntityAnchorArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/EntityAnchorArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS ch net/minecraft/command/arguments/EntityAnchorArgumentType
+	FIELD a EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lch;

--- a/mappings/net/minecraft/command/arguments/EntityArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/EntityArgumentType.mapping
@@ -1,5 +1,7 @@
-CLASS cw
-	CLASS cw$c
+CLASS ci net/minecraft/command/arguments/EntityArgumentType
+	CLASS ci$a
 		METHOD a toJson (Lcom/mojang/brigadier/arguments/ArgumentType;Lcom/google/gson/JsonObject;)V
 		METHOD a toPacket (Lcom/mojang/brigadier/arguments/ArgumentType;Liq;)V
 		METHOD b fromPacket (Liq;)Lcom/mojang/brigadier/arguments/ArgumentType;
+	FIELD g EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lci;

--- a/mappings/net/minecraft/command/arguments/EntitySummonArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/EntitySummonArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS cj net/minecraft/command/arguments/EntitySummonArgumentType
+	FIELD b EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lcj;

--- a/mappings/net/minecraft/command/arguments/FunctionArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/FunctionArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS ds net/minecraft/command/arguments/FunctionArgumentType
+	FIELD a EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lds;

--- a/mappings/net/minecraft/command/arguments/GameProfileArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/GameProfileArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS ck net/minecraft/command/arguments/GameProfileArgumentType
+	FIELD b EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lck;

--- a/mappings/net/minecraft/command/arguments/ItemEnchantmentArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ItemEnchantmentArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS cl net/minecraft/command/arguments/ItemEnchantmentArgumentType
+	FIELD b EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lcl;

--- a/mappings/net/minecraft/command/arguments/ItemPredicateArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ItemPredicateArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS dw net/minecraft/command/arguments/ItemPredicateArgumentType
+	FIELD a EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Ldw;

--- a/mappings/net/minecraft/command/arguments/ItemSlotArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ItemSlotArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS cy net/minecraft/command/arguments/ItemSlotArgumentType
+	FIELD a EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lcy;

--- a/mappings/net/minecraft/command/arguments/ItemStackArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ItemStackArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS dt net/minecraft/command/arguments/ItemStackArgumentType
+	FIELD a EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Ldt;

--- a/mappings/net/minecraft/command/arguments/MessageArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/MessageArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS cm net/minecraft/command/arguments/MessageArgumentType
+	FIELD a EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lcm;

--- a/mappings/net/minecraft/command/arguments/MobEffectArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/MobEffectArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS cn net/minecraft/command/arguments/MobEffectArgumentType
+	FIELD b EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lcn;

--- a/mappings/net/minecraft/command/arguments/NbtCompoundTagArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/NbtCompoundTagArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS cf net/minecraft/command/arguments/NbtCompoundTagArgumentType
+	FIELD a EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lcf;

--- a/mappings/net/minecraft/command/arguments/NbtPathArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/NbtPathArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS co net/minecraft/command/arguments/NbtPathArgumentType
+	FIELD c EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lco;

--- a/mappings/net/minecraft/command/arguments/NbtTagArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/NbtTagArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS cp net/minecraft/command/arguments/NbtTagArgumentType
+	FIELD a EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lcp;

--- a/mappings/net/minecraft/command/arguments/ObjectiveArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ObjectiveArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS cq net/minecraft/command/arguments/ObjectiveArgumentType
+	FIELD b EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lcq;

--- a/mappings/net/minecraft/command/arguments/ObjectiveCriteriaArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ObjectiveCriteriaArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS cr net/minecraft/command/arguments/ObjectiveCriteriaArgumentType
+	FIELD b EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lcr;

--- a/mappings/net/minecraft/command/arguments/OperationArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/OperationArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS cs net/minecraft/command/arguments/OperationArgumentType
+	FIELD a EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lcs;

--- a/mappings/net/minecraft/command/arguments/ParticleArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ParticleArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS ct net/minecraft/command/arguments/ParticleArgumentType
+	FIELD b EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lct;

--- a/mappings/net/minecraft/command/arguments/ResourceLocationArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ResourceLocationArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS cv net/minecraft/command/arguments/ResourceLocationArgumentType
+	FIELD d EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lcv;

--- a/mappings/net/minecraft/command/arguments/RotationArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/RotationArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS dk net/minecraft/command/arguments/RotationArgumentType
+	FIELD b EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Ldk;

--- a/mappings/net/minecraft/command/arguments/ScoreHolderArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ScoreHolderArgumentType.mapping
@@ -1,5 +1,6 @@
-CLASS ci
-	CLASS ci$a
+CLASS cw net/minecraft/command/arguments/ScoreHolderArgumentType
+	CLASS cw$c
 		METHOD a toJson (Lcom/mojang/brigadier/arguments/ArgumentType;Lcom/google/gson/JsonObject;)V
 		METHOD a toPacket (Lcom/mojang/brigadier/arguments/ArgumentType;Liq;)V
 		METHOD b fromPacket (Liq;)Lcom/mojang/brigadier/arguments/ArgumentType;
+	FIELD b EXAMPLES Ljava/util/Collection;

--- a/mappings/net/minecraft/command/arguments/ScoreboardSlotArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ScoreboardSlotArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS cx net/minecraft/command/arguments/ScoreboardSlotArgumentType
+	FIELD b EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lcx;

--- a/mappings/net/minecraft/command/arguments/SwizzleArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/SwizzleArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS dl net/minecraft/command/arguments/SwizzleArgumentType
+	FIELD a EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Ldl;

--- a/mappings/net/minecraft/command/arguments/TeamArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/TeamArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS cz net/minecraft/command/arguments/TeamArgumentType
+	FIELD a EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lcz;

--- a/mappings/net/minecraft/command/arguments/TimeArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/TimeArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS da net/minecraft/command/arguments/TimeArgumentType
+	FIELD a EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Lda;

--- a/mappings/net/minecraft/command/arguments/Vec2ArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/Vec2ArgumentType.mapping
@@ -1,0 +1,3 @@
+CLASS dm net/minecraft/command/arguments/Vec2ArgumentType
+	FIELD b EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Ldm;

--- a/mappings/net/minecraft/command/arguments/Vec3ArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/Vec3ArgumentType.mapping
@@ -1,0 +1,4 @@
+CLASS dn net/minecraft/command/arguments/Vec3ArgumentType
+	FIELD c EXAMPLES Ljava/util/Collection;
+	METHOD a create ()Ldn;
+	METHOD a create (Z)Ldn;

--- a/mappings/net/minecraft/command/arguments/serialize/ArgumentSerializer.mapping
+++ b/mappings/net/minecraft/command/arguments/serialize/ArgumentSerializer.mapping
@@ -1,4 +1,4 @@
-CLASS eg net/minecraft/server/command/ArgumentSerializer
+CLASS eg net/minecraft/command/arguments/serialize/ArgumentSerializer
 	METHOD a toJson (Lcom/mojang/brigadier/arguments/ArgumentType;Lcom/google/gson/JsonObject;)V
 	METHOD a toPacket (Lcom/mojang/brigadier/arguments/ArgumentType;Liq;)V
 	METHOD b fromPacket (Liq;)Lcom/mojang/brigadier/arguments/ArgumentType;

--- a/mappings/net/minecraft/server/command/ServerCommandManager.mapping
+++ b/mappings/net/minecraft/server/command/ServerCommandManager.mapping
@@ -7,4 +7,6 @@ CLASS cb net/minecraft/server/command/ServerCommandManager
 		ARG 1 commandSource
 	METHOD a getCommandValidator (Lcb$a;)Ljava/util/function/Predicate;
 	METHOD a writeCommandTree (Ljava/io/File;)V
+	METHOD a literal (Ljava/lang/String;)Lcom/mojang/brigadier/builder/LiteralArgumentBuilder;
+	METHOD a argument (Ljava/lang/String;Lcom/mojang/brigadier/arguments/ArgumentType;)Lcom/mojang/brigadier/builder/RequiredArgumentBuilder;
 	METHOD a sendCommandTree (Luj;)V


### PR DESCRIPTION
*This is somewhat of a follow-up to #193*.

The arguments types are present on both the client and server, therefore they do not need to be in the `net/minecraft/server` package.