### PR TITLE
Map DataGenerator

### DIFF
--- a/mappings/net/minecraft/data/DataGenerator.mapping
+++ b/mappings/net/minecraft/data/DataGenerator.mapping
@@ -1,0 +1,13 @@
+CLASS fy net/minecraft/data/DataGenerator
+	FIELD a LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD b inputs Ljava/util/Collection;
+	FIELD c output Ljava/nio/file/Path;
+	FIELD d providers Ljava/util/List;
+	METHOD <init> (Ljava/nio/file/Path;Ljava/util/Collection;)V
+		ARG 1 output
+		ARG 2 inputs
+	METHOD a getInputs ()Ljava/util/Collection;
+	METHOD a install (Lfz;)V
+		ARG 1 provider
+	METHOD b getOutput ()Ljava/nio/file/Path;
+	METHOD c run ()V

--- a/mappings/net/minecraft/data/DataProvider.mapping
+++ b/mappings/net/minecraft/data/DataProvider.mapping
@@ -5,3 +5,4 @@ CLASS fz net/minecraft/data/DataProvider
 		ARG 0 gson
 		ARG 1 cache
 	METHOD a run (Lga;)V
+		ARG 1 cache

--- a/mappings/net/minecraft/data/SnbtProvider.mapping
+++ b/mappings/net/minecraft/data/SnbtProvider.mapping
@@ -3,3 +3,4 @@ CLASS hc net/minecraft/data/SnbtProvider
 	FIELD c root Lfy;
 	METHOD a getName ()Ljava/lang/String;
 	METHOD a run (Lga;)V
+		ARG 1 cache

--- a/mappings/net/minecraft/data/dev/NbtProvider.mapping
+++ b/mappings/net/minecraft/data/dev/NbtProvider.mapping
@@ -3,3 +3,4 @@ CLASS hb net/minecraft/data/dev/NbtProvider
 	FIELD c root Lfy;
 	METHOD a getName ()Ljava/lang/String;
 	METHOD a run (Lga;)V
+		ARG 1 cache

--- a/mappings/net/minecraft/data/report/BlockListProvider.mapping
+++ b/mappings/net/minecraft/data/report/BlockListProvider.mapping
@@ -2,3 +2,4 @@ CLASS gi net/minecraft/data/report/BlockListProvider
 	FIELD b root Lfy;
 	METHOD a getName ()Ljava/lang/String;
 	METHOD a run (Lga;)V
+		ARG 1 cache

--- a/mappings/net/minecraft/data/report/CommandSyntaxProvider.mapping
+++ b/mappings/net/minecraft/data/report/CommandSyntaxProvider.mapping
@@ -2,3 +2,4 @@ CLASS gj net/minecraft/data/report/CommandSyntaxProvider
 	FIELD b root Lfy;
 	METHOD a getName ()Ljava/lang/String;
 	METHOD a run (Lga;)V
+		ARG 1 cache

--- a/mappings/net/minecraft/data/report/ItemListProvider.mapping
+++ b/mappings/net/minecraft/data/report/ItemListProvider.mapping
@@ -2,3 +2,4 @@ CLASS gk net/minecraft/data/report/ItemListProvider
 	FIELD b root Lfy;
 	METHOD a getName ()Ljava/lang/String;
 	METHOD a run (Lga;)V
+		ARG 1 cache

--- a/mappings/net/minecraft/data/server/AbstractTagProvider.mapping
+++ b/mappings/net/minecraft/data/server/AbstractTagProvider.mapping
@@ -6,5 +6,6 @@ CLASS hi net/minecraft/data/server/AbstractTagProvider
 	METHOD <init> (Lfy;Lfk;)V
 		ARG 1 root
 	METHOD a run (Lga;)V
+		ARG 1 cache
 	METHOD a getOutput (Lpy;)Ljava/nio/file/Path;
 	METHOD b configure ()V

--- a/mappings/net/minecraft/data/server/AdvancementsProvider.mapping
+++ b/mappings/net/minecraft/data/server/AdvancementsProvider.mapping
@@ -4,6 +4,7 @@ CLASS gb net/minecraft/data/server/AdvancementsProvider
 	FIELD d root Lfy;
 	METHOD a getName ()Ljava/lang/String;
 	METHOD a run (Lga;)V
+		ARG 1 cache
 	METHOD a getOutput (Ljava/nio/file/Path;Ln;)Ljava/nio/file/Path;
 		ARG 0 rootOutput
 		ARG 1 advancement

--- a/mappings/net/minecraft/data/server/LootTablesProvider.mapping
+++ b/mappings/net/minecraft/data/server/LootTablesProvider.mapping
@@ -4,6 +4,7 @@ CLASS gr net/minecraft/data/server/LootTablesProvider
 	FIELD d root Lfy;
 	METHOD a getName ()Ljava/lang/String;
 	METHOD a run (Lga;)V
+		ARG 1 cache
 	METHOD a getOutput (Ljava/nio/file/Path;Lpy;)Ljava/nio/file/Path;
 		ARG 0 rootOutput
 		ARG 1 lootTableId

--- a/mappings/net/minecraft/data/server/RecipesProvider.mapping
+++ b/mappings/net/minecraft/data/server/RecipesProvider.mapping
@@ -4,3 +4,4 @@ CLASS gv net/minecraft/data/server/RecipesProvider
 	FIELD d root Lfy;
 	METHOD a getName ()Ljava/lang/String;
 	METHOD a run (Lga;)V
+		ARG 1 cache


### PR DESCRIPTION
There's an Enigma bug where if you renamed a class A to B and class C to A, the new class A won't be saved.

I didn't notice back when I refactored the data package a while back that I ended up removing DataGenerator :p