### PR TITLE
Restore names which Mojang have started to obfuscate

### DIFF
--- a/mappings/chs.mapping
+++ b/mappings/chs.mapping
@@ -1,0 +1,6 @@
+CLASS chs
+	FIELD a ALWAYS_FALSE Lchs;
+	FIELD b ALWAYS_TRUE Lchs;
+	METHOD a and (Lchs;)Lchs;
+	METHOD b or (Lchs;)Lchs;
+	METHOD expand (Lchi;Ljava/util/function/Consumer;)Z

--- a/mappings/cht.mapping
+++ b/mappings/cht.mapping
@@ -1,0 +1,2 @@
+CLASS cht
+	METHOD expand (Lchi;Ljava/util/function/Consumer;)Z

--- a/mappings/cib.mapping
+++ b/mappings/cib.mapping
@@ -1,0 +1,2 @@
+CLASS cib
+	METHOD expand (Lchi;Ljava/util/function/Consumer;)Z

--- a/mappings/cie.mapping
+++ b/mappings/cie.mapping
@@ -1,0 +1,2 @@
+CLASS cie
+	METHOD expand (Lchi;Ljava/util/function/Consumer;)Z

--- a/mappings/ddq.mapping
+++ b/mappings/ddq.mapping
@@ -1,0 +1,3 @@
+CLASS ddq
+	FIELD a TRUE Lddq;
+	FIELD b FALSE Lddq;

--- a/mappings/net/minecraft/block/dispenser/DispenserBehavior.mapping
+++ b/mappings/net/minecraft/block/dispenser/DispenserBehavior.mapping
@@ -1,2 +1,3 @@
 CLASS fa net/minecraft/block/dispenser/DispenserBehavior
+	FIELD a NOOP Lfa;
 	METHOD dispense (Leu;Lavs;)Lavs;

--- a/mappings/net/minecraft/client/font/BlankGlyph.mapping
+++ b/mappings/net/minecraft/client/font/BlankGlyph.mapping
@@ -1,2 +1,3 @@
 CLASS cql net/minecraft/client/font/BlankGlyph
 	FIELD a INSTANCE Lcql;
+	METHOD getAdvance ()F

--- a/mappings/net/minecraft/client/font/Glyph.mapping
+++ b/mappings/net/minecraft/client/font/Glyph.mapping
@@ -1,1 +1,6 @@
 CLASS clz net/minecraft/client/font/Glyph
+	METHOD a getBearingX ()F
+	METHOD a getAdvance (Z)F
+	METHOD b getBoldOffset ()F
+	METHOD c getShadowOffset ()F
+	METHOD getAdvance ()F

--- a/mappings/net/minecraft/client/font/TextureFont.mapping
+++ b/mappings/net/minecraft/client/font/TextureFont.mapping
@@ -9,4 +9,5 @@ CLASS cqo net/minecraft/client/font/TextureFont
 			ARG 0 manager
 	CLASS cqo$b
 		FIELD g advance I
+		METHOD getAdvance ()F
 	FIELD a LOGGER Lorg/apache/logging/log4j/Logger;

--- a/mappings/net/minecraft/client/font/TrueTypeFont.mapping
+++ b/mappings/net/minecraft/client/font/TrueTypeFont.mapping
@@ -1,6 +1,8 @@
 CLASS cmc net/minecraft/client/font/TrueTypeFont
 	CLASS cmc$a
 		FIELD f advance F
+		METHOD a getBearingX ()F
+		METHOD getAdvance ()F
 	FIELD a LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD b info Lorg/lwjgl/stb/STBTTFontinfo;
 	FIELD g stbScaleFactor F

--- a/mappings/net/minecraft/client/font/UnicodeTextureFont.mapping
+++ b/mappings/net/minecraft/client/font/UnicodeTextureFont.mapping
@@ -2,5 +2,10 @@ CLASS cqr net/minecraft/client/font/UnicodeTextureFont
 	CLASS cqr$a Loader
 		METHOD a load (Lwc;)Lcma;
 			ARG 0 manager
+	CLASS cqr$b
+		FIELD e image Lcmn;
+		METHOD b getBoldOffset ()F
+		METHOD c getShadowOffset ()F
+		METHOD getAdvance ()F
 	FIELD a LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD c widths [B

--- a/mappings/net/minecraft/sortme/RuleTest.mapping
+++ b/mappings/net/minecraft/sortme/RuleTest.mapping
@@ -1,1 +1,2 @@
 CLASS cbu net/minecraft/sortme/RuleTest
+	METHOD a register (Ljava/lang/String;Lcbu;)Lcbu;

--- a/mappings/net/minecraft/sortme/StructurePiece.mapping
+++ b/mappings/net/minecraft/sortme/StructurePiece.mapping
@@ -1,1 +1,3 @@
 CLASS bxc net/minecraft/sortme/StructurePiece
+	METHOD a setPieceId (Lbxc;Ljava/lang/String;)Lbxc;
+	METHOD load (Lcbv;Lhp;)Lcba;

--- a/mappings/net/minecraft/sortme/StructurePoolElement.mapping
+++ b/mappings/net/minecraft/sortme/StructurePoolElement.mapping
@@ -1,1 +1,2 @@
 CLASS bxx net/minecraft/sortme/StructurePoolElement
+	METHOD a register (Ljava/lang/String;Lbxx;)Lbxx;

--- a/mappings/net/minecraft/sortme/StructureProcessor.mapping
+++ b/mappings/net/minecraft/sortme/StructureProcessor.mapping
@@ -1,1 +1,2 @@
 CLASS cby net/minecraft/sortme/StructureProcessor
+	METHOD a register (Ljava/lang/String;Lcby;)Lcby;

--- a/mappings/net/minecraft/stat/StatFormatter.mapping
+++ b/mappings/net/minecraft/stat/StatFormatter.mapping
@@ -1,1 +1,6 @@
 CLASS xn net/minecraft/stat/StatFormatter
+	FIELD a DECIMAL_FORMAT Ljava/text/DecimalFormat;
+	FIELD b DEFAULT Lxn;
+	FIELD c DIVIDE_BY_TEN Lxn;
+	FIELD d DISTANCE Lxn;
+	FIELD e TIME Lxn;

--- a/mappings/net/minecraft/util/BooleanBiFunction.mapping
+++ b/mappings/net/minecraft/util/BooleanBiFunction.mapping
@@ -1,1 +1,17 @@
 CLASS ckt net/minecraft/util/BooleanBiFunction
+	FIELD a FALSE Lckt;
+	FIELD b NOT_OR Lckt;
+	FIELD c ONLY_SECOND Lckt;
+	FIELD d NOT_FIRST Lckt;
+	FIELD e ONLY_FIRST Lckt;
+	FIELD f NOT_SECOND Lckt;
+	FIELD g NOT_SAME Lckt;
+	FIELD h NOT_AND Lckt;
+	FIELD i AND Lckt;
+	FIELD j SAME Lckt;
+	FIELD k SECOND Lckt;
+	FIELD l CAUSES Lckt;
+	FIELD m FIRST Lckt;
+	FIELD n CAUSED_BY Lckt;
+	FIELD o OR Lckt;
+	FIELD p TRUE Lckt;

--- a/mappings/net/minecraft/world/loot/condition/AlternativeLootCondition.mapping
+++ b/mappings/net/minecraft/world/loot/condition/AlternativeLootCondition.mapping
@@ -1,5 +1,9 @@
 CLASS cjk net/minecraft/world/loot/condition/AlternativeLootCondition
+	CLASS cjk$a Builder
+		METHOD a or (Lcjt$a;)Lcjk$a;
+		METHOD build ()Lcjt;
 	CLASS cjk$b Factory
 		METHOD a toJson (Lcom/google/gson/JsonObject;Lcjt;Lcom/google/gson/JsonSerializationContext;)V
 		METHOD b fromJson (Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Lcjt;
 	FIELD a terms [Lcjt;
+	METHOD a or ([Lcjt$a;)Lcjk$a;

--- a/mappings/net/minecraft/world/loot/condition/BlockStatePropertyLootCondition.mapping
+++ b/mappings/net/minecraft/world/loot/condition/BlockStatePropertyLootCondition.mapping
@@ -1,4 +1,6 @@
 CLASS cjs net/minecraft/world/loot/condition/BlockStatePropertyLootCondition
+	CLASS cjs$a
+		METHOD build ()Lcjt;
 	CLASS cjs$b Factory
 		METHOD a toJson (Lcom/google/gson/JsonObject;Lcjt;Lcom/google/gson/JsonSerializationContext;)V
 		METHOD b fromJson (Lcom/google/gson/JsonObject;Lcom/google/gson/JsonDeserializationContext;)Lcjt;

--- a/mappings/net/minecraft/world/loot/condition/LootCondition.mapping
+++ b/mappings/net/minecraft/world/loot/condition/LootCondition.mapping
@@ -1,5 +1,8 @@
 CLASS cjt net/minecraft/world/loot/condition/LootCondition
 	CLASS cjt$a Builder
+		METHOD a invert ()Lcjt$a;
+		METHOD a or (Lcjt$a;)Lcjk$a;
+		METHOD build ()Lcjt;
 	CLASS cjt$b Factory
 		FIELD a id Lpy;
 		FIELD b conditionClass Ljava/lang/Class;

--- a/mappings/y.mapping
+++ b/mappings/y.mapping
@@ -1,0 +1,3 @@
+CLASS y
+	FIELD a AND Ly;
+	FIELD b OR Ly;

--- a/mappings/yg.mapping
+++ b/mappings/yg.mapping
@@ -1,0 +1,2 @@
+CLASS yg
+	METHOD deserialize (Lcom/mojang/datafixers/Dynamic;)Ljava/lang/Object;


### PR DESCRIPTION
This does not restore all names which have changed, as some (`RuleTest`, `Structure*`, are just registry entries and so are handled elsewhere).

I think I've caught all of them, but do tell me if not!