### PR TITLE
saturationRestored -> saturationModifier

### DIFF
--- a/mappings/net/minecraft/item/FishItem.mapping
+++ b/mappings/net/minecraft/item/FishItem.mapping
@@ -25,4 +25,4 @@ CLASS avh net/minecraft/item/FishItem
 		ARG 1 stack
 		ARG 2 world
 	METHOD e getHungerRestored (Lavu;)I
-	METHOD f getSaturatationModifier (Lavu;)F
+	METHOD f getSaturationModifier (Lavu;)F

--- a/mappings/net/minecraft/item/FishItem.mapping
+++ b/mappings/net/minecraft/item/FishItem.mapping
@@ -5,16 +5,16 @@ CLASS avh net/minecraft/item/FishItem
 		FIELD c TROPICAL_FISH Lavh$a;
 		FIELD d PUFFERFISH Lavh$a;
 		FIELD e hungerRestored I
-		FIELD f saturationRestored F
+		FIELD f saturationModifier F
 		FIELD g hungerRestoredCooked I
-		FIELD h saturationRestoredCooked F
+		FIELD h saturationModifierCooked F
 		FIELD i cookedVariant Z
 		METHOD a getHungerRestored ()I
 		METHOD a fromStack (Lavu;)Lavh$a;
 			ARG 0 stack
-		METHOD b getSaturationRestored ()F
+		METHOD b getSaturationModifier ()F
 		METHOD c getHungerRestoredCooked ()I
-		METHOD d getSaturationRestoredCooked ()F
+		METHOD d getSaturationModifierCooked ()F
 		METHOD e hasCookedVariant ()Z
 	FIELD a cooked Z
 	FIELD b type Lavh$a;
@@ -25,4 +25,4 @@ CLASS avh net/minecraft/item/FishItem
 		ARG 1 stack
 		ARG 2 world
 	METHOD e getHungerRestored (Lavu;)I
-	METHOD f getSaturatationRestored (Lavu;)F
+	METHOD f getSaturatationModifier (Lavu;)F

--- a/mappings/net/minecraft/item/FoodItem.mapping
+++ b/mappings/net/minecraft/item/FoodItem.mapping
@@ -1,6 +1,6 @@
 CLASS avk net/minecraft/item/FoodItem
 	FIELD a hungerRestored I
-	FIELD b saturationRestored F
+	FIELD b saturationModifier F
 	FIELD c wolfFood Z
 	FIELD d alwaysConsumable Z
 	FIELD k statusEffect Lagd;
@@ -20,4 +20,4 @@ CLASS avk net/minecraft/item/FoodItem
 	METHOD c getUseAction (Lavu;)Laxg;
 	METHOD d isWolfFood ()Z
 	METHOD e getHungerRestored (Lavu;)I
-	METHOD f getSaturatationRestored (Lavu;)F
+	METHOD f getSaturatationModifier (Lavu;)F

--- a/mappings/net/minecraft/item/FoodItem.mapping
+++ b/mappings/net/minecraft/item/FoodItem.mapping
@@ -20,4 +20,4 @@ CLASS avk net/minecraft/item/FoodItem
 	METHOD c getUseAction (Lavu;)Laxg;
 	METHOD d isWolfFood ()Z
 	METHOD e getHungerRestored (Lavu;)I
-	METHOD f getSaturatationModifier (Lavu;)F
+	METHOD f getSaturationModifier (Lavu;)F


### PR DESCRIPTION
Saturation restored is calculated by `hungerRestored * saturationModifier * 2` (see `HungerManager.add(IF)V`), so saturationRestored is an incorrect name for the fields/methods.