### PR TITLE
Map RuleTests and StructureProcessors

### DIFF
--- a/mappings/cbh.mapping
+++ b/mappings/cbh.mapping
@@ -1,3 +1,5 @@
 CLASS cbh
+	FIELD a all Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD b remaining Lit/unimi/dsi/fastutil/longs/LongSet;
 	METHOD a deserialize (Lhq;)V
 	METHOD b serialize (Lhq;)Lhq;

--- a/mappings/cto.mapping
+++ b/mappings/cto.mapping
@@ -1,4 +1,5 @@
 CLASS cto
+	FIELD a client Lcof;
 	METHOD a onContainerPropertyUpdate (Lasd;II)V
 		ARG 1 container
 		ARG 2 propertyId

--- a/mappings/gw.mapping
+++ b/mappings/gw.mapping
@@ -1,0 +1,2 @@
+CLASS gw
+	FIELD a LOGGER Lorg/apache/logging/log4j/Logger;

--- a/mappings/net/minecraft/client/font/FontType.mapping
+++ b/mappings/net/minecraft/client/font/FontType.mapping
@@ -1,0 +1,10 @@
+CLASS cra net/minecraft/client/font/FontType
+	FIELD d REGISTRY Ljava/util/Map;
+	FIELD e id Ljava/lang/String;
+	FIELD f factory Ljava/util/function/Function;
+	METHOD <init> (Ljava/lang/String;ILjava/lang/String;Ljava/util/function/Function;)V
+		ARG 3 id
+		ARG 4 factory
+	METHOD a create (Lcom/google/gson/JsonObject;)Lcqz;
+	METHOD a byId (Ljava/lang/String;)Lcra;
+		ARG 0 id

--- a/mappings/net/minecraft/client/util/MonitorFactory.mapping
+++ b/mappings/net/minecraft/client/util/MonitorFactory.mapping
@@ -1,0 +1,1 @@
+CLASS cmw net/minecraft/client/util/MonitorFactory

--- a/mappings/net/minecraft/sortme/RuleTest.mapping
+++ b/mappings/net/minecraft/sortme/RuleTest.mapping
@@ -1,2 +1,0 @@
-CLASS ccd net/minecraft/sortme/RuleTest
-	METHOD a register (Ljava/lang/String;Lccd;)Lccd;

--- a/mappings/net/minecraft/sortme/StructureProcessor.mapping
+++ b/mappings/net/minecraft/sortme/StructureProcessor.mapping
@@ -1,2 +1,0 @@
-CLASS cch net/minecraft/sortme/StructureProcessor
-	METHOD a register (Ljava/lang/String;Lcch;)Lcch;

--- a/mappings/net/minecraft/sortme/rule/AbstractRuleTest.mapping
+++ b/mappings/net/minecraft/sortme/rule/AbstractRuleTest.mapping
@@ -1,0 +1,3 @@
+CLASS ccc net/minecraft/sortme/rule/AbstractRuleTest
+	METHOD a getRuleTest ()Lccd;
+	METHOD a test (Lbom;Ljava/util/Random;)Z

--- a/mappings/net/minecraft/sortme/rule/AlwaysTrueRuleTest.mapping
+++ b/mappings/net/minecraft/sortme/rule/AlwaysTrueRuleTest.mapping
@@ -1,0 +1,4 @@
+CLASS cbq net/minecraft/sortme/rule/AlwaysTrueRuleTest
+	FIELD a INSTANCE Lcbq;
+	METHOD a getRuleTest ()Lccd;
+	METHOD a test (Lbom;Ljava/util/Random;)Z

--- a/mappings/net/minecraft/sortme/rule/BlockMatchRuleTest.mapping
+++ b/mappings/net/minecraft/sortme/rule/BlockMatchRuleTest.mapping
@@ -1,0 +1,6 @@
+CLASS cbs net/minecraft/sortme/rule/BlockMatchRuleTest
+	FIELD a block Lbft;
+	METHOD <init> (Lbft;)V
+		ARG 1 block
+	METHOD a getRuleTest ()Lccd;
+	METHOD a test (Lbom;Ljava/util/Random;)Z

--- a/mappings/net/minecraft/sortme/rule/BlockStateMatchRuleTest.mapping
+++ b/mappings/net/minecraft/sortme/rule/BlockStateMatchRuleTest.mapping
@@ -1,0 +1,6 @@
+CLASS cbu net/minecraft/sortme/rule/BlockStateMatchRuleTest
+	FIELD a blockState Lbom;
+	METHOD <init> (Lbom;)V
+		ARG 1 blockState
+	METHOD a getRuleTest ()Lccd;
+	METHOD a test (Lbom;Ljava/util/Random;)Z

--- a/mappings/net/minecraft/sortme/rule/RandomBlockMatchRuleTest.mapping
+++ b/mappings/net/minecraft/sortme/rule/RandomBlockMatchRuleTest.mapping
@@ -1,0 +1,8 @@
+CLASS cbz net/minecraft/sortme/rule/RandomBlockMatchRuleTest
+	FIELD a block Lbft;
+	FIELD b probability F
+	METHOD <init> (Lbft;F)V
+		ARG 1 block
+		ARG 2 probability
+	METHOD a getRuleTest ()Lccd;
+	METHOD a test (Lbom;Ljava/util/Random;)Z

--- a/mappings/net/minecraft/sortme/rule/RandomBlockStateMatchRuleTest.mapping
+++ b/mappings/net/minecraft/sortme/rule/RandomBlockStateMatchRuleTest.mapping
@@ -1,0 +1,8 @@
+CLASS cca net/minecraft/sortme/rule/RandomBlockStateMatchRuleTest
+	FIELD a blockState Lbom;
+	FIELD b probability F
+	METHOD <init> (Lbom;F)V
+		ARG 1 blockState
+		ARG 2 probability
+	METHOD a getRuleTest ()Lccd;
+	METHOD a test (Lbom;Ljava/util/Random;)Z

--- a/mappings/net/minecraft/sortme/rule/RuleTest.mapping
+++ b/mappings/net/minecraft/sortme/rule/RuleTest.mapping
@@ -1,0 +1,4 @@
+CLASS ccd net/minecraft/sortme/rule/RuleTest
+	METHOD a register (Ljava/lang/String;Lccd;)Lccd;
+		ARG 0 id
+		ARG 1 test

--- a/mappings/net/minecraft/sortme/rule/TagMatchRuleTest.mapping
+++ b/mappings/net/minecraft/sortme/rule/TagMatchRuleTest.mapping
@@ -1,0 +1,6 @@
+CLASS ccj net/minecraft/sortme/rule/TagMatchRuleTest
+	FIELD a tag Lxy;
+	METHOD <init> (Lxy;)V
+		ARG 1 tag
+	METHOD a getRuleTest ()Lccd;
+	METHOD a test (Lbom;Ljava/util/Random;)Z

--- a/mappings/net/minecraft/sortme/structures/processor/AbstractStructureProcessor.mapping
+++ b/mappings/net/minecraft/sortme/structures/processor/AbstractStructureProcessor.mapping
@@ -1,0 +1,3 @@
+CLASS ccg net/minecraft/sortme/structures/processor/AbstractStructureProcessor
+	METHOD a getStructureProcessor ()Lcch;
+	METHOD a process (Lbaw;Let;Lcci$b;Lcci$b;Lccf;)Lcci$b;

--- a/mappings/net/minecraft/sortme/structures/processor/BlockIgnoreStructureProcessor.mapping
+++ b/mappings/net/minecraft/sortme/structures/processor/BlockIgnoreStructureProcessor.mapping
@@ -1,0 +1,6 @@
+CLASS cbr net/minecraft/sortme/structures/processor/BlockIgnoreStructureProcessor
+	FIELD d blocks Lcom/google/common/collect/ImmutableList;
+	METHOD <init> (Lcom/google/common/collect/ImmutableList;)V
+		ARG 1 blocks
+	METHOD a getStructureProcessor ()Lcch;
+	METHOD a process (Lbaw;Let;Lcci$b;Lcci$b;Lccf;)Lcci$b;

--- a/mappings/net/minecraft/sortme/structures/processor/BlockRotStructureProcessor.mapping
+++ b/mappings/net/minecraft/sortme/structures/processor/BlockRotStructureProcessor.mapping
@@ -1,0 +1,6 @@
+CLASS cbt net/minecraft/sortme/structures/processor/BlockRotStructureProcessor
+	FIELD a integrity F
+	METHOD <init> (F)V
+		ARG 1 integrity
+	METHOD a getStructureProcessor ()Lcch;
+	METHOD a process (Lbaw;Let;Lcci$b;Lcci$b;Lccf;)Lcci$b;

--- a/mappings/net/minecraft/sortme/structures/processor/GravityStructureProcessor.mapping
+++ b/mappings/net/minecraft/sortme/structures/processor/GravityStructureProcessor.mapping
@@ -1,0 +1,8 @@
+CLASS cbv net/minecraft/sortme/structures/processor/GravityStructureProcessor
+	FIELD a heightmap Lbrs$a;
+	FIELD b offset I
+	METHOD <init> (Lbrs$a;I)V
+		ARG 1 heightmap
+		ARG 2 offset
+	METHOD a getStructureProcessor ()Lcch;
+	METHOD a process (Lbaw;Let;Lcci$b;Lcci$b;Lccf;)Lcci$b;

--- a/mappings/net/minecraft/sortme/structures/processor/JigsawReplacementStructureProcessor.mapping
+++ b/mappings/net/minecraft/sortme/structures/processor/JigsawReplacementStructureProcessor.mapping
@@ -1,0 +1,4 @@
+CLASS cbw net/minecraft/sortme/structures/processor/JigsawReplacementStructureProcessor
+	FIELD a INSTANCE Lcbw;
+	METHOD a getStructureProcessor ()Lcch;
+	METHOD a process (Lbaw;Let;Lcci$b;Lcci$b;Lccf;)Lcci$b;

--- a/mappings/net/minecraft/sortme/structures/processor/NopStructureProcessor.mapping
+++ b/mappings/net/minecraft/sortme/structures/processor/NopStructureProcessor.mapping
@@ -1,0 +1,4 @@
+CLASS cbx net/minecraft/sortme/structures/processor/NopStructureProcessor
+	FIELD a INSTANCE Lcbx;
+	METHOD a getStructureProcessor ()Lcch;
+	METHOD a process (Lbaw;Let;Lcci$b;Lcci$b;Lccf;)Lcci$b;

--- a/mappings/net/minecraft/sortme/structures/processor/RuleStructureProcessor.mapping
+++ b/mappings/net/minecraft/sortme/structures/processor/RuleStructureProcessor.mapping
@@ -1,0 +1,6 @@
+CLASS ccb net/minecraft/sortme/structures/processor/RuleStructureProcessor
+	FIELD a rules Lcom/google/common/collect/ImmutableList;
+	METHOD <init> (Lcom/google/common/collect/ImmutableList;)V
+		ARG 1 rules
+	METHOD a getStructureProcessor ()Lcch;
+	METHOD a process (Lbaw;Let;Lcci$b;Lcci$b;Lccf;)Lcci$b;

--- a/mappings/net/minecraft/sortme/structures/processor/StructureProcessor.mapping
+++ b/mappings/net/minecraft/sortme/structures/processor/StructureProcessor.mapping
@@ -1,0 +1,4 @@
+CLASS cch net/minecraft/sortme/structures/processor/StructureProcessor
+	METHOD a register (Ljava/lang/String;Lcch;)Lcch;
+		ARG 0 id
+		ARG 1 processor

--- a/mappings/net/minecraft/world/gen/feature/StructureFeatures.mapping
+++ b/mappings/net/minecraft/world/gen/feature/StructureFeatures.mapping
@@ -1,3 +1,3 @@
-CLASS cbg
+CLASS cbg net/minecraft/world/gen/feature/StructureFeatures
 	FIELD q logger Lorg/apache/logging/log4j/Logger;
 	METHOD a registerStructure (Ljava/lang/String;Lbxk;)Lbxk;

--- a/mappings/th.mapping
+++ b/mappings/th.mapping
@@ -1,0 +1,2 @@
+CLASS th
+	FIELD d pos Let;

--- a/mappings/yh.mapping
+++ b/mappings/yh.mapping
@@ -1,0 +1,3 @@
+CLASS yh
+	FIELD a LOGGER Lorg/apache/logging/log4j/Logger;
+	METHOD a deserialize (Lcom/mojang/datafixers/Dynamic;Lfk;Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;


### PR DESCRIPTION
Just need to decide what exact package to put them in, noting that they seem to be in the same package when Mojang mapped.

```
CL: cax net/minecraft/world/level/chunk/generator/feature/StructureFeatures
CL: cbh net/minecraft/world/level/chunk/generator/rule/AlwaysTrueRuleTest
CL: cbi net/minecraft/world/level/chunk/generator/rule/BlockIgnoreProcessor
CL: cbj net/minecraft/world/level/chunk/generator/rule/BlockMatchRuleTest
CL: cbk net/minecraft/world/level/chunk/generator/rule/BlockRotProcessor
CL: cbl net/minecraft/world/level/chunk/generator/rule/BlockStateMatchRuleTest
CL: cbm net/minecraft/world/level/chunk/generator/rule/GravityProcessor
CL: cbn net/minecraft/world/level/chunk/generator/rule/JigsawReplacementProcessor
CL: cbo net/minecraft/world/level/chunk/generator/rule/NopProcessor
CL: cbq net/minecraft/world/level/chunk/generator/rule/RandomBlockMatchRuleTest
CL: cbr net/minecraft/world/level/chunk/generator/rule/RandomBlockStateMatchRuleTest
CL: cbs net/minecraft/world/level/chunk/generator/rule/RuleProcessor
CL: cbt net/minecraft/world/level/chunk/generator/rule/AbstractRuleTest
CL: cbu net/minecraft/world/level/chunk/generator/rule/RuleTest
CL: cbx net/minecraft/world/level/chunk/generator/rule/AbstractStructureProcessor
CL: cby net/minecraft/world/level/chunk/generator/rule/StructureProcessor
CL: cca net/minecraft/world/level/chunk/generator/rule/TagMatchRuleTest
CL: ccc net/minecraft/world/level/chunk/generator/surfacebuilder/BadlandsSurfaceBuilder
```

**edit**: *the mappings above are an exert from my private mapping set*.