### PR TITLE
Re-add mappings for Nameable

### DIFF
--- a/mappings/net/minecraft/block/entity/BannerBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BannerBlockEntity.mapping
@@ -17,6 +17,6 @@ CLASS bnj net/minecraft/block/entity/BannerBlockEntity
 		ARG 0 stack
 	METHOD b toTag (Lhs;)Lhs;
 	METHOD c getPatternList ()Ljava/util/List;
-	METHOD f ()Ljd;
+	METHOD f getCustomName ()Ljd;
 	METHOD g getPatternColorList ()Ljava/util/List;
 	METHOD j initPatternLists ()V

--- a/mappings/net/minecraft/block/entity/BarrelBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BarrelBlockEntity.mapping
@@ -15,6 +15,6 @@ CLASS bnl net/minecraft/block/entity/BarrelBlockEntity
 	METHOD b removeInvStack (I)Lawo;
 	METHOD b toTag (Lhs;)Lhs;
 	METHOD c isInvEmpty ()Z
-	METHOD f ()Ljd;
+	METHOD f getCustomName ()Ljd;
 	METHOD m getContainerId ()Ljava/lang/String;
 	METHOD p getInvStackList ()Lfh;

--- a/mappings/net/minecraft/block/entity/BeaconBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BeaconBlockEntity.mapping
@@ -39,7 +39,7 @@ CLASS bnm net/minecraft/block/entity/BeaconBlockEntity
 	METHOD e tick ()V
 	METHOD e getPotionEffectById (I)Lagn;
 		ARG 0 id
-	METHOD f ()Ljd;
+	METHOD f getCustomName ()Ljd;
 	METHOD i getInvPropertyCount ()I
 	METHOD m getContainerId ()Ljava/lang/String;
 	METHOD s getLevel ()I

--- a/mappings/net/minecraft/block/entity/BrewingStandBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BrewingStandBlockEntity.mapping
@@ -35,7 +35,7 @@ CLASS bns net/minecraft/block/entity/BrewingStandBlockEntity
 	METHOD c isInvEmpty ()Z
 	METHOD c getInvProperty (I)I
 	METHOD e tick ()V
-	METHOD f ()Ljd;
+	METHOD f getCustomName ()Ljd;
 	METHOD i getInvPropertyCount ()I
 	METHOD m getContainerId ()Ljava/lang/String;
 	METHOD q canCraft ()Z

--- a/mappings/net/minecraft/block/entity/EnchantingTableBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/EnchantingTableBlockEntity.mapping
@@ -9,5 +9,5 @@ CLASS boa net/minecraft/block/entity/EnchantingTableBlockEntity
 	METHOD a setCustomName (Ljd;)V
 	METHOD b toTag (Lhs;)Lhs;
 	METHOD e tick ()V
-	METHOD f ()Ljd;
+	METHOD f getCustomName ()Ljd;
 	METHOD m getContainerId ()Ljava/lang/String;

--- a/mappings/net/minecraft/block/entity/FurnaceBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/FurnaceBlockEntity.mapping
@@ -36,5 +36,5 @@ CLASS bni net/minecraft/block/entity/FurnaceBlockEntity
 	METHOD c isInvEmpty ()Z
 	METHOD c getInvProperty (I)I
 	METHOD e tick ()V
-	METHOD f ()Ljd;
+	METHOD f getCustomName ()Ljd;
 	METHOD i getInvPropertyCount ()I

--- a/mappings/net/minecraft/block/entity/LootableContainerBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/LootableContainerBlockEntity.mapping
@@ -16,6 +16,6 @@ CLASS bok net/minecraft/block/entity/LootableContainerBlockEntity
 	METHOD d checkLootInteraction (Larb;)V
 	METHOD d deserializeLootTable (Lhs;)Z
 	METHOD e serializeLootTable (Lhs;)Z
-	METHOD f ()Ljd;
+	METHOD f getCustomName ()Ljd;
 	METHOD g getLootTableId ()Lqc;
 	METHOD p getInvStackList ()Lfh;

--- a/mappings/net/minecraft/client/network/ClientDummyContainerProvider.mapping
+++ b/mappings/net/minecraft/client/network/ClientDummyContainerProvider.mapping
@@ -4,7 +4,8 @@ CLASS ddo net/minecraft/client/network/ClientDummyContainerProvider
 	METHOD <init> (Ljava/lang/String;Ljd;)V
 		ARG 1 id
 	METHOD R_ getName ()Ljd;
+	METHOD S_ hasCustomName ()Z
 	METHOD a createContainer (Lara;Larb;)Lasw;
 		ARG 1 playerInv
-	METHOD f ()Ljd;
+	METHOD f getCustomName ()Ljd;
 	METHOD m getContainerId ()Ljava/lang/String;

--- a/mappings/net/minecraft/container/DoubleLockableContainer.mapping
+++ b/mappings/net/minecraft/container/DoubleLockableContainer.mapping
@@ -5,6 +5,7 @@ CLASS afh net/minecraft/container/DoubleLockableContainer
 	METHOD <init> (Ljd;Lafu;Lafu;)V
 		ARG 2 first
 	METHOD R_ getName ()Ljd;
+	METHOD S_ hasCustomName ()Z
 	METHOD U_ clearInv ()V
 	METHOD Z_ getInvSize ()I
 	METHOD a getInvStack (I)Lawo;
@@ -28,7 +29,7 @@ CLASS afh net/minecraft/container/DoubleLockableContainer
 	METHOD c isInvEmpty ()Z
 	METHOD c getInvProperty (I)I
 	METHOD c_ onInvClose (Larb;)V
-	METHOD f ()Ljd;
+	METHOD f getCustomName ()Ljd;
 	METHOD h markDirty ()V
 	METHOD i getInvPropertyCount ()I
 	METHOD k getContainerLock ()Laft;

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -70,6 +70,7 @@ CLASS agv net/minecraft/entity/Entity
 	METHOD R getType ()Lagz;
 	METHOD R_ getName ()Ljd;
 	METHOD S getEntityId ()I
+	METHOD S_ hasCustomName ()Z
 	METHOD T getScoreboardTags ()Ljava/util/Set;
 	METHOD U kill ()V
 	METHOD V getDataTracker ()Lpu;
@@ -256,7 +257,7 @@ CLASS agv net/minecraft/entity/Entity
 	METHOD e setInPortal (Let;)V
 	METHOD e toTag (Lhs;)Lhs;
 	METHOD e setSneaking (Z)V
-	METHOD f ()Ljd;
+	METHOD f getCustomName ()Ljd;
 	METHOD f addVelocity (DDD)V
 		ARG 1 deltaX
 	METHOD f getRotationVec (F)Lcmd;

--- a/mappings/net/minecraft/inventory/BasicInventory.mapping
+++ b/mappings/net/minecraft/inventory/BasicInventory.mapping
@@ -18,5 +18,5 @@ CLASS afx net/minecraft/inventory/BasicInventory
 	METHOD b removeInvStack (I)Lawo;
 	METHOD b removeListener (Lafk;)V
 	METHOD c isInvEmpty ()Z
-	METHOD f ()Ljd;
+	METHOD f getCustomName ()Ljd;
 	METHOD h markDirty ()V

--- a/mappings/net/minecraft/util/Nameable.mapping
+++ b/mappings/net/minecraft/util/Nameable.mapping
@@ -1,4 +1,5 @@
 CLASS afv net/minecraft/util/Nameable
 	METHOD Q getDisplayName ()Ljd;
 	METHOD R_ getName ()Ljd;
-	METHOD f ()Ljd;
+	METHOD S_ hasCustomName ()Z
+	METHOD f getCustomName ()Ljd;


### PR DESCRIPTION
Well, sort of. Previously there used to be `.hasCustomName`, but that was changed in the latest snapshot to check if another method (`f`, or `.getCustomName`) was not null.