### PR TITLE
Several changes to blocks

### DIFF
--- a/mappings/cmm.mapping
+++ b/mappings/cmm.mapping
@@ -1,0 +1,2 @@
+CLASS cmm
+	METHOD a isEmpty ()Z

--- a/mappings/net/minecraft/block/AbstractPressurePlateBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractPressurePlateBlock.mapping
@@ -44,7 +44,7 @@ CLASS bgl net/minecraft/block/AbstractPressurePlateBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/BambooBlock.mapping
+++ b/mappings/net/minecraft/block/BambooBlock.mapping
@@ -30,7 +30,7 @@ CLASS bgb net/minecraft/block/BambooBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/BambooBlock.mapping
+++ b/mappings/net/minecraft/block/BambooBlock.mapping
@@ -21,7 +21,7 @@ CLASS bgb net/minecraft/block/BambooBlock
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos
-	METHOD a (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
+	METHOD a getCollisionShape (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/BedBlock.mapping
+++ b/mappings/net/minecraft/block/BedBlock.mapping
@@ -54,7 +54,7 @@ CLASS bgo net/minecraft/block/BedBlock
 	METHOD a getPosRandom (Lbpm;Let;)J
 		ARG 1 state
 		ARG 2 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/BellBlock.mapping
+++ b/mappings/net/minecraft/block/BellBlock.mapping
@@ -9,7 +9,7 @@ CLASS bgq net/minecraft/block/BellBlock
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos
-	METHOD a (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
+	METHOD a getCollisionShape (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/BellBlock.mapping
+++ b/mappings/net/minecraft/block/BellBlock.mapping
@@ -27,7 +27,7 @@ CLASS bgq net/minecraft/block/BellBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -24,7 +24,7 @@ CLASS bgs net/minecraft/block/Block
 		FIELD h randomTicks Z
 		FIELD i friction F
 		FIELD j dropTableId Lqc;
-		FIELD k pistonExtension Z
+		FIELD k dynamicBounds Z
 		METHOD <init> (Lcfh;Lcfi;)V
 			ARG 1 material
 			ARG 2 materialColor
@@ -54,12 +54,12 @@ CLASS bgs net/minecraft/block/Block
 		METHOD b dropsLike (Lbgs;)Lbgs$c;
 			ARG 1 source
 		METHOD c ticksRandomly ()Lbgs$c;
-		METHOD d isPistonExtension ()Lbgs$c;
+		METHOD d hasDynamicBounds ()Lbgs$c;
 		METHOD e dropsNothing ()Lbgs$c;
 	FIELD a FACINGS [Ley;
 	FIELD b friction F
 	FIELD c defaultState Lbpm;
-	FIELD d pistonExtension Z
+	FIELD d dynamicBounds Z
 	FIELD e dropTableId Lqc;
 	FIELD f translationKey Ljava/lang/String;
 	FIELD g FACE_CULL_MAP Ljava/lang/ThreadLocal;
@@ -468,7 +468,7 @@ CLASS bgs net/minecraft/block/Block
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos
-	METHOD q isPistonExtension ()Z
+	METHOD q hasDynamicBounds ()Z
 	METHOD q getSoundGroup (Lbpm;)Lblt;
 		ARG 1 state
 	METHOD q getOffsetPos (Lbpm;Lbbb;Let;)Lcmd;

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -259,7 +259,7 @@ CLASS bgs net/minecraft/block/Block
 		ARG 2 world
 		ARG 3 pos
 		ARG 4 rnd
-	METHOD a (Lbpm;Lbbq;Let;I)V
+	METHOD a updateNeighborStates (Lbpm;Lbbq;Let;I)V
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
@@ -295,7 +295,7 @@ CLASS bgs net/minecraft/block/Block
 	METHOD a getPosRandom (Lbpm;Let;)J
 		ARG 1 state
 		ARG 2 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -178,7 +178,7 @@ CLASS bgs net/minecraft/block/Block
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
+	METHOD a getCollisionShape (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos
@@ -316,9 +316,9 @@ CLASS bgs net/minecraft/block/Block
 		ARG 5 stack
 	METHOD a appendProperties (Lbpn$a;)V
 		ARG 1 builder
-	METHOD a (Lcmx;)Z
+	METHOD a isShapeFullCube (Lcmx;)Z
 		ARG 0 shape
-	METHOD a (Lcmx;Ley;)Z
+	METHOD a isFaceFullCube (Lcmx;Ley;)Z
 		ARG 0 shape
 		ARG 1 facing
 	METHOD a matches (Lye;)Z
@@ -450,7 +450,7 @@ CLASS bgs net/minecraft/block/Block
 	METHOD n getFrictionCoefficient ()F
 	METHOD n hasRandomTicks (Lbpm;)Z
 		ARG 1 state
-	METHOD n (Lbpm;Lbbb;Let;)Z
+	METHOD n isFullCube (Lbpm;Lbbb;Let;)Z
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/BlockState.mapping
+++ b/mappings/net/minecraft/block/BlockState.mapping
@@ -28,7 +28,7 @@ CLASS bpm net/minecraft/block/BlockState
 		ARG 1 view
 		ARG 2 pos
 		ARG 3 env
-	METHOD a (Lbbb;Let;Lcmi;)Lcmx;
+	METHOD a getCollisionShape (Lbbb;Let;Lcmi;)Lcmx;
 		ARG 1 view
 		ARG 2 pos
 		ARG 3 ePos
@@ -166,7 +166,7 @@ CLASS bpm net/minecraft/block/BlockState
 		ARG 1 view
 		ARG 2 pos
 	METHOD l hasComparatorOutput ()Z
-	METHOD l (Lbbb;Let;)Lcmx;
+	METHOD l getCollisionShape (Lbbb;Let;)Lcmx;
 		ARG 1 view
 		ARG 2 pos
 	METHOD m getPistonBehavior ()Lcfj;

--- a/mappings/net/minecraft/block/BlockState.mapping
+++ b/mappings/net/minecraft/block/BlockState.mapping
@@ -80,7 +80,7 @@ CLASS bpm net/minecraft/block/BlockState
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 rnd
-	METHOD a (Lbbq;Let;I)V
+	METHOD a updateNeighborStates (Lbbq;Let;I)V
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 flags
@@ -103,7 +103,7 @@ CLASS bpm net/minecraft/block/BlockState
 		ARG 1 state
 	METHOD a getPosRandom (Let;)J
 		ARG 1 pos
-	METHOD a getRenderingState (Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 facing
 		ARG 2 neighborState
 		ARG 3 world

--- a/mappings/net/minecraft/block/BubbleColumnBlock.mapping
+++ b/mappings/net/minecraft/block/BubbleColumnBlock.mapping
@@ -22,7 +22,7 @@ CLASS bgw net/minecraft/block/BubbleColumnBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/CactusBlock.mapping
+++ b/mappings/net/minecraft/block/CactusBlock.mapping
@@ -24,7 +24,7 @@ CLASS bha net/minecraft/block/CactusBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/CactusBlock.mapping
+++ b/mappings/net/minecraft/block/CactusBlock.mapping
@@ -10,7 +10,7 @@ CLASS bha net/minecraft/block/CactusBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
+	METHOD a getCollisionShape (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/CakeBlock.mapping
+++ b/mappings/net/minecraft/block/CakeBlock.mapping
@@ -27,7 +27,7 @@ CLASS bhb net/minecraft/block/CakeBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/CarpetBlock.mapping
+++ b/mappings/net/minecraft/block/CarpetBlock.mapping
@@ -7,7 +7,7 @@ CLASS bnh net/minecraft/block/CarpetBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/ChestBlock.mapping
+++ b/mappings/net/minecraft/block/ChestBlock.mapping
@@ -50,7 +50,7 @@ CLASS bhg net/minecraft/block/ChestBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/ChorusFlowerBlock.mapping
+++ b/mappings/net/minecraft/block/ChorusFlowerBlock.mapping
@@ -10,7 +10,7 @@ CLASS bhh net/minecraft/block/ChorusFlowerBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/ChorusPlantBlock.mapping
+++ b/mappings/net/minecraft/block/ChorusPlantBlock.mapping
@@ -12,7 +12,7 @@ CLASS bhi net/minecraft/block/ChorusPlantBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/CocoaBlock.mapping
+++ b/mappings/net/minecraft/block/CocoaBlock.mapping
@@ -20,7 +20,7 @@ CLASS bhj net/minecraft/block/CocoaBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/ConcretePowderBlock.mapping
+++ b/mappings/net/minecraft/block/ConcretePowderBlock.mapping
@@ -1,7 +1,7 @@
 CLASS bhm net/minecraft/block/ConcretePowderBlock
 	METHOD a getPlacementState (Laus;)Lbpm;
 		ARG 1 ctx
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/ConduitBlock.mapping
+++ b/mappings/net/minecraft/block/ConduitBlock.mapping
@@ -19,7 +19,7 @@ CLASS bhn net/minecraft/block/ConduitBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/CoralBlock.mapping
+++ b/mappings/net/minecraft/block/CoralBlock.mapping
@@ -8,7 +8,7 @@ CLASS bhq net/minecraft/block/CoralBlock
 		ARG 2 world
 		ARG 3 pos
 		ARG 4 oldState
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/CoralBlockBlock.mapping
+++ b/mappings/net/minecraft/block/CoralBlockBlock.mapping
@@ -1,7 +1,7 @@
 CLASS bho net/minecraft/block/CoralBlockBlock
 	METHOD a getPlacementState (Laus;)Lbpm;
 		ARG 1 ctx
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/CoralDeadWallFanBlock.mapping
+++ b/mappings/net/minecraft/block/CoralDeadWallFanBlock.mapping
@@ -17,7 +17,7 @@ CLASS bgj net/minecraft/block/CoralDeadWallFanBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/CoralParentBlock.mapping
+++ b/mappings/net/minecraft/block/CoralParentBlock.mapping
@@ -12,7 +12,7 @@ CLASS bgi net/minecraft/block/CoralParentBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/CoralTubeFanBlock.mapping
+++ b/mappings/net/minecraft/block/CoralTubeFanBlock.mapping
@@ -4,7 +4,7 @@ CLASS bhp net/minecraft/block/CoralTubeFanBlock
 		ARG 2 world
 		ARG 3 pos
 		ARG 4 oldState
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/CoralWallFanBlock.mapping
+++ b/mappings/net/minecraft/block/CoralWallFanBlock.mapping
@@ -4,7 +4,7 @@ CLASS bhr net/minecraft/block/CoralWallFanBlock
 		ARG 2 world
 		ARG 3 pos
 		ARG 4 oldState
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/DoorBlock.mapping
+++ b/mappings/net/minecraft/block/DoorBlock.mapping
@@ -56,7 +56,7 @@ CLASS bib net/minecraft/block/DoorBlock
 	METHOD a getPosRandom (Lbpm;Let;)J
 		ARG 1 state
 		ARG 2 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/EnderChestBlock.mapping
+++ b/mappings/net/minecraft/block/EnderChestBlock.mapping
@@ -35,7 +35,7 @@ CLASS bik net/minecraft/block/EnderChestBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/FallingBlock.mapping
+++ b/mappings/net/minecraft/block/FallingBlock.mapping
@@ -13,7 +13,7 @@ CLASS bin net/minecraft/block/FallingBlock
 		ARG 2 world
 		ARG 3 pos
 		ARG 4 rnd
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/FarmlandBlock.mapping
+++ b/mappings/net/minecraft/block/FarmlandBlock.mapping
@@ -21,7 +21,7 @@ CLASS bio net/minecraft/block/FarmlandBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/FenceBlock.mapping
+++ b/mappings/net/minecraft/block/FenceBlock.mapping
@@ -18,7 +18,7 @@ CLASS bip net/minecraft/block/FenceBlock
 		ARG 6 facing
 		ARG 7 hitX
 		ARG 8 hitY
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/FenceBlock.mapping
+++ b/mappings/net/minecraft/block/FenceBlock.mapping
@@ -1,4 +1,5 @@
 CLASS bip net/minecraft/block/FenceBlock
+	FIELD i SHAPES [Lcmx;
 	METHOD <init> (Lbgs$c;)V
 		ARG 1 settings
 	METHOD a getPlacementState (Laus;)Lbpm;

--- a/mappings/net/minecraft/block/FenceGateBlock.mapping
+++ b/mappings/net/minecraft/block/FenceGateBlock.mapping
@@ -32,7 +32,7 @@ CLASS biq net/minecraft/block/FenceGateBlock
 		ARG 3 pos
 		ARG 4 block
 		ARG 5 neighborPos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/FenceGateBlock.mapping
+++ b/mappings/net/minecraft/block/FenceGateBlock.mapping
@@ -12,7 +12,7 @@ CLASS biq net/minecraft/block/FenceGateBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
+	METHOD a getCollisionShape (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/FireBlock.mapping
+++ b/mappings/net/minecraft/block/FireBlock.mapping
@@ -24,7 +24,7 @@ CLASS bir net/minecraft/block/FireBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/FlowerPotBlock.mapping
+++ b/mappings/net/minecraft/block/FlowerPotBlock.mapping
@@ -16,7 +16,7 @@ CLASS biu net/minecraft/block/FlowerPotBlock
 		ARG 6 facing
 		ARG 7 hitX
 		ARG 8 hitY
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/FluidBlock.mapping
+++ b/mappings/net/minecraft/block/FluidBlock.mapping
@@ -28,7 +28,7 @@ CLASS bjv net/minecraft/block/FluidBlock
 	METHOD a getDroppedStacks (Lbpm;Lciv$a;)Ljava/util/List;
 		ARG 1 state
 		ARG 2 builder
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/GrassPathBlock.mapping
+++ b/mappings/net/minecraft/block/GrassPathBlock.mapping
@@ -16,7 +16,7 @@ CLASS bja net/minecraft/block/GrassPathBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/GrindstoneBlock.mapping
+++ b/mappings/net/minecraft/block/GrindstoneBlock.mapping
@@ -10,7 +10,7 @@ CLASS bjc net/minecraft/block/GrindstoneBlock
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos
-	METHOD a (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
+	METHOD a getCollisionShape (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/HorizontalConnectedBlock.mapping
+++ b/mappings/net/minecraft/block/HorizontalConnectedBlock.mapping
@@ -5,6 +5,9 @@ CLASS bhu net/minecraft/block/HorizontalConnectedBlock
 	FIELD d WEST Lbqe;
 	FIELD e WATERLOGGED Lbqe;
 	FIELD f FACING_PROPERTIES Ljava/util/Map;
+	FIELD g collisionShapes [Lcmx;
+	FIELD h boundingShapes [Lcmx;
+	METHOD a createShapes (FFFFF)[Lcmx;
 	METHOD a getBoundingShape (Lbpm;Lbbb;Let;)Lcmx;
 		ARG 1 state
 		ARG 2 view
@@ -14,7 +17,7 @@ CLASS bhu net/minecraft/block/HorizontalConnectedBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
+	METHOD a getCollisionShape (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos
@@ -25,9 +28,11 @@ CLASS bhu net/minecraft/block/HorizontalConnectedBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
+	METHOD a getDirectionMask (Ley;)I
 	METHOD a_ (Lbpm;Lbbb;Let;)Z
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos
 	METHOD h getFluidState (Lbpm;)Lcfd;
 		ARG 1 state
+	METHOD k getShapeIndex (Lbpm;)I

--- a/mappings/net/minecraft/block/KelpBlock.mapping
+++ b/mappings/net/minecraft/block/KelpBlock.mapping
@@ -21,7 +21,7 @@ CLASS bjn net/minecraft/block/KelpBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/KelpPlantBlock.mapping
+++ b/mappings/net/minecraft/block/KelpPlantBlock.mapping
@@ -17,7 +17,7 @@ CLASS bjo net/minecraft/block/KelpPlantBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/LadderBlock.mapping
+++ b/mappings/net/minecraft/block/LadderBlock.mapping
@@ -17,7 +17,7 @@ CLASS bjp net/minecraft/block/LadderBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/LanternBlock.mapping
+++ b/mappings/net/minecraft/block/LanternBlock.mapping
@@ -11,7 +11,7 @@ CLASS bjq net/minecraft/block/LanternBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/LeavesBlock.mapping
+++ b/mappings/net/minecraft/block/LeavesBlock.mapping
@@ -9,7 +9,7 @@ CLASS bjr net/minecraft/block/LeavesBlock
 		ARG 2 world
 		ARG 3 pos
 		ARG 4 rnd
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/LecternBlock.mapping
+++ b/mappings/net/minecraft/block/LecternBlock.mapping
@@ -9,7 +9,7 @@ CLASS bjs net/minecraft/block/LecternBlock
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos
-	METHOD a (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
+	METHOD a getCollisionShape (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/MagmaBlock.mapping
+++ b/mappings/net/minecraft/block/MagmaBlock.mapping
@@ -19,7 +19,7 @@ CLASS bjz net/minecraft/block/MagmaBlock
 		ARG 2 world
 		ARG 3 pos
 		ARG 4 oldState
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/MushroomBlock.mapping
+++ b/mappings/net/minecraft/block/MushroomBlock.mapping
@@ -9,7 +9,7 @@ CLASS bjh net/minecraft/block/MushroomBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/NoteBlock.mapping
+++ b/mappings/net/minecraft/block/NoteBlock.mapping
@@ -27,7 +27,7 @@ CLASS bkg net/minecraft/block/NoteBlock
 		ARG 3 pos
 		ARG 4 block
 		ARG 5 neighborPos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/ObserverBlock.mapping
+++ b/mappings/net/minecraft/block/ObserverBlock.mapping
@@ -24,7 +24,7 @@ CLASS bkh net/minecraft/block/ObserverBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/PaneBlock.mapping
+++ b/mappings/net/minecraft/block/PaneBlock.mapping
@@ -14,8 +14,9 @@ CLASS bjk net/minecraft/block/PaneBlock
 		ARG 4 world
 		ARG 5 pos
 		ARG 6 neighborPos
+	METHOD a connectsTo (Lbpm;Z)Z
 	METHOD a appendProperties (Lbpn$a;)V
 		ARG 1 builder
 	METHOD c getRenderLayer ()Lbbc;
-	METHOD f (Lbgs;)Z
+	METHOD f neverConnectsTo (Lbgs;)Z
 		ARG 0 block

--- a/mappings/net/minecraft/block/PaneBlock.mapping
+++ b/mappings/net/minecraft/block/PaneBlock.mapping
@@ -7,7 +7,7 @@ CLASS bjk net/minecraft/block/PaneBlock
 		ARG 1 state
 		ARG 2 neighbor
 		ARG 3 facing
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/PistonExtensionBlock.mapping
+++ b/mappings/net/minecraft/block/PistonExtensionBlock.mapping
@@ -24,7 +24,7 @@ CLASS bpf net/minecraft/block/PistonExtensionBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
+	METHOD a getCollisionShape (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/PistonHeadBlock.mapping
+++ b/mappings/net/minecraft/block/PistonHeadBlock.mapping
@@ -40,7 +40,7 @@ CLASS bph net/minecraft/block/PistonHeadBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/PlantBlock.mapping
+++ b/mappings/net/minecraft/block/PlantBlock.mapping
@@ -5,7 +5,7 @@ CLASS bgy net/minecraft/block/PlantBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/PortalBlock.mapping
+++ b/mappings/net/minecraft/block/PortalBlock.mapping
@@ -22,7 +22,7 @@ CLASS bke net/minecraft/block/PortalBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/RedstoneTorchWallBlock.mapping
+++ b/mappings/net/minecraft/block/RedstoneTorchWallBlock.mapping
@@ -27,7 +27,7 @@ CLASS bkx net/minecraft/block/RedstoneTorchWallBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/RedstoneWireBlock.mapping
+++ b/mappings/net/minecraft/block/RedstoneWireBlock.mapping
@@ -47,7 +47,7 @@ CLASS bku net/minecraft/block/RedstoneWireBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/RepeaterBlock.mapping
+++ b/mappings/net/minecraft/block/RepeaterBlock.mapping
@@ -17,7 +17,7 @@ CLASS bkz net/minecraft/block/RepeaterBlock
 		ARG 2 world
 		ARG 3 pos
 		ARG 4 rnd
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/SaplingBambooBlock.mapping
+++ b/mappings/net/minecraft/block/SaplingBambooBlock.mapping
@@ -27,7 +27,7 @@ CLASS bgc net/minecraft/block/SaplingBambooBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/ScaffoldingBlock.mapping
+++ b/mappings/net/minecraft/block/ScaffoldingBlock.mapping
@@ -10,7 +10,7 @@ CLASS ble net/minecraft/block/ScaffoldingBlock
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos
-	METHOD a (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
+	METHOD a getCollisionShape (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/ScaffoldingBlock.mapping
+++ b/mappings/net/minecraft/block/ScaffoldingBlock.mapping
@@ -24,7 +24,7 @@ CLASS ble net/minecraft/block/ScaffoldingBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/SeaPickleBlock.mapping
+++ b/mappings/net/minecraft/block/SeaPickleBlock.mapping
@@ -25,7 +25,7 @@ CLASS blf net/minecraft/block/SeaPickleBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/SeagrassBlock.mapping
+++ b/mappings/net/minecraft/block/SeagrassBlock.mapping
@@ -26,7 +26,7 @@ CLASS blg net/minecraft/block/SeagrassBlock
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/SignBlock.mapping
+++ b/mappings/net/minecraft/block/SignBlock.mapping
@@ -17,7 +17,7 @@ CLASS blj net/minecraft/block/SignBlock
 		ARG 6 facing
 		ARG 7 hitX
 		ARG 8 hitY
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/SlabBlock.mapping
+++ b/mappings/net/minecraft/block/SlabBlock.mapping
@@ -20,7 +20,7 @@ CLASS blm net/minecraft/block/SlabBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/SnowBlock.mapping
+++ b/mappings/net/minecraft/block/SnowBlock.mapping
@@ -24,7 +24,7 @@ CLASS blq net/minecraft/block/SnowBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/SnowBlock.mapping
+++ b/mappings/net/minecraft/block/SnowBlock.mapping
@@ -15,7 +15,7 @@ CLASS blq net/minecraft/block/SnowBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
+	METHOD a getCollisionShape (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/SnowyBlock.mapping
+++ b/mappings/net/minecraft/block/SnowyBlock.mapping
@@ -4,7 +4,7 @@ CLASS blr net/minecraft/block/SnowyBlock
 		ARG 1 settings
 	METHOD a getPlacementState (Laus;)Lbpm;
 		ARG 1 ctx
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/SoulSandBlock.mapping
+++ b/mappings/net/minecraft/block/SoulSandBlock.mapping
@@ -8,7 +8,7 @@ CLASS bls net/minecraft/block/SoulSandBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
+	METHOD a getCollisionShape (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/StairsBlock.mapping
+++ b/mappings/net/minecraft/block/StairsBlock.mapping
@@ -62,7 +62,7 @@ CLASS blz net/minecraft/block/StairsBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/StandingBannerBlock.mapping
+++ b/mappings/net/minecraft/block/StandingBannerBlock.mapping
@@ -15,7 +15,7 @@ CLASS bgd net/minecraft/block/StandingBannerBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/StandingSignBlock.mapping
+++ b/mappings/net/minecraft/block/StandingSignBlock.mapping
@@ -13,7 +13,7 @@ CLASS bma net/minecraft/block/StandingSignBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/StemAttachedBlock.mapping
+++ b/mappings/net/minecraft/block/StemAttachedBlock.mapping
@@ -13,7 +13,7 @@ CLASS bga net/minecraft/block/StemAttachedBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/SugarCaneBlock.mapping
+++ b/mappings/net/minecraft/block/SugarCaneBlock.mapping
@@ -10,7 +10,7 @@ CLASS bmh net/minecraft/block/SugarCaneBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/TallPlantBlock.mapping
+++ b/mappings/net/minecraft/block/TallPlantBlock.mapping
@@ -27,7 +27,7 @@ CLASS bic net/minecraft/block/TallPlantBlock
 	METHOD a getPosRandom (Lbpm;Let;)J
 		ARG 1 state
 		ARG 2 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/TorchBlock.mapping
+++ b/mappings/net/minecraft/block/TorchBlock.mapping
@@ -15,7 +15,7 @@ CLASS bmn net/minecraft/block/TorchBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/TrapdoorBlock.mapping
+++ b/mappings/net/minecraft/block/TrapdoorBlock.mapping
@@ -27,7 +27,7 @@ CLASS bmo net/minecraft/block/TrapdoorBlock
 		ARG 3 pos
 		ARG 4 block
 		ARG 5 neighborPos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/TripwireBlock.mapping
+++ b/mappings/net/minecraft/block/TripwireBlock.mapping
@@ -31,7 +31,7 @@ CLASS bmq net/minecraft/block/TripwireBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/TripwireHookBlock.mapping
+++ b/mappings/net/minecraft/block/TripwireHookBlock.mapping
@@ -33,7 +33,7 @@ CLASS bmr net/minecraft/block/TripwireHookBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/VineBlock.mapping
+++ b/mappings/net/minecraft/block/VineBlock.mapping
@@ -20,7 +20,7 @@ CLASS bmt net/minecraft/block/VineBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/WallBannerBlock.mapping
+++ b/mappings/net/minecraft/block/WallBannerBlock.mapping
@@ -15,7 +15,7 @@ CLASS bmu net/minecraft/block/WallBannerBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/WallBlock.mapping
+++ b/mappings/net/minecraft/block/WallBlock.mapping
@@ -17,7 +17,7 @@ CLASS bmv net/minecraft/block/WallBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 ePos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/WallBlock.mapping
+++ b/mappings/net/minecraft/block/WallBlock.mapping
@@ -12,7 +12,7 @@ CLASS bmv net/minecraft/block/WallBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
+	METHOD a getCollisionShape (Lbpm;Lbbb;Let;Lcmi;)Lcmx;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/WallMountedBlock.mapping
+++ b/mappings/net/minecraft/block/WallMountedBlock.mapping
@@ -7,7 +7,7 @@ CLASS bim net/minecraft/block/WallMountedBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/WallSignBlock.mapping
+++ b/mappings/net/minecraft/block/WallSignBlock.mapping
@@ -18,7 +18,7 @@ CLASS bmw net/minecraft/block/WallSignBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/block/WallTorchBlock.mapping
+++ b/mappings/net/minecraft/block/WallTorchBlock.mapping
@@ -24,7 +24,7 @@ CLASS bmy net/minecraft/block/WallTorchBlock
 	METHOD a applyRotation (Lbpm;Lblb;)Lbpm;
 		ARG 1 state
 		ARG 2 rotation
-	METHOD a getRenderingState (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
+	METHOD a getStateForNeighborUpdate (Lbpm;Ley;Lbpm;Lbbq;Let;Let;)Lbpm;
 		ARG 1 state
 		ARG 2 facing
 		ARG 3 neighborState

--- a/mappings/net/minecraft/util/BooleanBiFunction.mapping
+++ b/mappings/net/minecraft/util/BooleanBiFunction.mapping
@@ -15,3 +15,4 @@ CLASS cmh net/minecraft/util/BooleanBiFunction
 	FIELD n CAUSED_BY Lcmh;
 	FIELD o OR Lcmh;
 	FIELD p TRUE Lcmh;
+	METHOD apply (ZZ)Z

--- a/mappings/net/minecraft/util/shape/BitSetVoxelShapeContainer.mapping
+++ b/mappings/net/minecraft/util/shape/BitSetVoxelShapeContainer.mapping
@@ -17,7 +17,7 @@ CLASS cmg net/minecraft/util/shape/BitSetVoxelShapeContainer
 		ARG 7 xMax
 		ARG 8 yMax
 		ARG 9 zMax
-	METHOD a ()Z
+	METHOD a isEmpty ()Z
 	METHOD a getIndex (III)I
 		ARG 1 x
 		ARG 2 y

--- a/mappings/net/minecraft/util/shape/VoxelShape.mapping
+++ b/mappings/net/minecraft/util/shape/VoxelShape.mapping
@@ -19,7 +19,7 @@ CLASS cmx net/minecraft/util/shape/VoxelShape
 	METHOD a (Ley$a;Lclz;D)D
 		ARG 1 axis
 		ARG 2 box
-	METHOD a (Ley;)Lcmx;
+	METHOD a getFace (Ley;)Lcmx;
 		ARG 1 facing
 	METHOD b isEmpty ()Z
 	METHOD b getMinimum (Ley$a;)D

--- a/mappings/net/minecraft/util/shape/VoxelShapes.mapping
+++ b/mappings/net/minecraft/util/shape/VoxelShapes.mapping
@@ -15,6 +15,8 @@ CLASS cmu net/minecraft/util/shape/VoxelShapes
 	METHOD a lcm (II)J
 	METHOD a cube (Lclz;)Lcmx;
 		ARG 0 box
+	METHOD a union (Lcmx;Lcmx;)Lcmx;
+	METHOD a combine (Lcmx;Lcmx;Lcmh;)Lcmx;
 	METHOD a (Ley$a;Lclz;Ljava/util/stream/Stream;D)D
 		ARG 0 axis
 		ARG 1 box


### PR DESCRIPTION
Apologies for PR spam, just this one has a couple of changes I was unsure of, so it felt cleaner to split it into something separate:

 - I'm a bit conflicted on `.getCollisionShape` - it appears to be used both
for entity collision and determining if a block's side is a "full cube" (and so can have torches placed against or w/e)
 - I've renamed `getRenderingState` to `getStateForNeighborUpdate`, though am not 100% it's a good name - it may also perform side effects (mostly scheduling this block to be ticked next thread), so isn't quite a pure getter.