### PR TITLE
Item-related name tweaks

### DIFF
--- a/mappings/net/minecraft/item/ArmorMaterial.mapping
+++ b/mappings/net/minecraft/item/ArmorMaterial.mapping
@@ -1,0 +1,7 @@
+CLASS auj net/minecraft/item/ArmorMaterial
+	METHOD a getDurability (Laha;)I
+	METHOD b getEquipSound ()Lxm;
+	METHOD b getProtectionAmount (Laha;)I
+	METHOD c getRepairIngredient ()Layt;
+	METHOD d getName ()Ljava/lang/String;
+	METHOD e getToughness ()F

--- a/mappings/net/minecraft/item/ArmorMaterials.mapping
+++ b/mappings/net/minecraft/item/ArmorMaterials.mapping
@@ -1,11 +1,14 @@
 CLASS auk net/minecraft/item/ArmorMaterials
+	FIELD g DURABILITY_MULTIPLIERS [I
 	FIELD h name Ljava/lang/String;
+	FIELD i durability I
 	FIELD j protectionAmounts [I
 	FIELD l equipSound Lxm;
 	FIELD m toughness F
 	FIELD n repairIngredientSupplier Lyt;
-	METHOD b ()Lxm;
-	METHOD b (Laha;)I
-	METHOD c ()Layt;
-	METHOD d ()Ljava/lang/String;
-	METHOD e ()F
+	METHOD a getDurability (Laha;)I
+	METHOD b getEquipSound ()Lxm;
+	METHOD b getProtectionAmount (Laha;)I
+	METHOD c getRepairIngredient ()Layt;
+	METHOD d getName ()Ljava/lang/String;
+	METHOD e getToughness ()F

--- a/mappings/net/minecraft/item/BannerPatternItem.mapping
+++ b/mappings/net/minecraft/item/BannerPatternItem.mapping
@@ -1,5 +1,5 @@
 CLASS aup net/minecraft/item/BannerPatternItem
-	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a buildTooltip (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/BannerPatternItem.mapping
+++ b/mappings/net/minecraft/item/BannerPatternItem.mapping
@@ -1,5 +1,5 @@
 CLASS aup net/minecraft/item/BannerPatternItem
-	METHOD a addInformation (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/EnchantedBookItem.mapping
+++ b/mappings/net/minecraft/item/EnchantedBookItem.mapping
@@ -4,7 +4,7 @@ CLASS avr net/minecraft/item/EnchantedBookItem
 	METHOD a addEnchantment (Lawo;Lazv;)V
 		ARG 0 stack
 		ARG 1 enchantmentInfo
-	METHOD a addInformation (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/EnchantedBookItem.mapping
+++ b/mappings/net/minecraft/item/EnchantedBookItem.mapping
@@ -4,7 +4,7 @@ CLASS avr net/minecraft/item/EnchantedBookItem
 	METHOD a addEnchantment (Lawo;Lazv;)V
 		ARG 0 stack
 		ARG 1 enchantmentInfo
-	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a buildTooltip (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/FilledMapItem.mapping
+++ b/mappings/net/minecraft/item/FilledMapItem.mapping
@@ -7,7 +7,7 @@ CLASS awt net/minecraft/item/FilledMapItem
 	METHOD a createMapPacket (Lawo;Lbbp;Larb;)Ljr;
 		ARG 1 stack
 		ARG 2 world
-	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a buildTooltip (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/FilledMapItem.mapping
+++ b/mappings/net/minecraft/item/FilledMapItem.mapping
@@ -7,7 +7,7 @@ CLASS awt net/minecraft/item/FilledMapItem
 	METHOD a createMapPacket (Lawo;Lbbp;Larb;)Ljr;
 		ARG 1 stack
 		ARG 2 world
-	METHOD a addInformation (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/FireworkChargeItem.mapping
+++ b/mappings/net/minecraft/item/FireworkChargeItem.mapping
@@ -1,7 +1,7 @@
 CLASS avz net/minecraft/item/FireworkChargeItem
 	METHOD a getColorTextComponent (I)Ljd;
 		ARG 0 colorRGB
-	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a buildTooltip (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/FireworkChargeItem.mapping
+++ b/mappings/net/minecraft/item/FireworkChargeItem.mapping
@@ -1,7 +1,7 @@
 CLASS avz net/minecraft/item/FireworkChargeItem
 	METHOD a getColorTextComponent (I)Ljd;
 		ARG 0 colorRGB
-	METHOD a addInformation (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/FireworksItem.mapping
+++ b/mappings/net/minecraft/item/FireworksItem.mapping
@@ -1,5 +1,5 @@
 CLASS avy net/minecraft/item/FireworksItem
-	METHOD a addInformation (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/FireworksItem.mapping
+++ b/mappings/net/minecraft/item/FireworksItem.mapping
@@ -1,5 +1,5 @@
 CLASS avy net/minecraft/item/FireworksItem
-	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a buildTooltip (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/FishBucketItem.mapping
+++ b/mappings/net/minecraft/item/FishBucketItem.mapping
@@ -1,5 +1,5 @@
 CLASS awa net/minecraft/item/FishBucketItem
-	METHOD a addInformation (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/FishBucketItem.mapping
+++ b/mappings/net/minecraft/item/FishBucketItem.mapping
@@ -1,5 +1,5 @@
 CLASS awa net/minecraft/item/FishBucketItem
-	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a buildTooltip (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -2,12 +2,12 @@ CLASS awj net/minecraft/item/Item
 	CLASS awj$a Settings
 		FIELD a fullStackSize I
 		FIELD b durability I
-		FIELD c recipeReplacement Lawj;
+		FIELD c recipeRemainder Lawj;
 		FIELD d itemGroup Lavg;
 		FIELD e rarity Laxb;
 		METHOD a stackSize (I)Lawj$a;
 		METHOD a itemGroup (Lavg;)Lawj$a;
-		METHOD a recipeReplacement (Lawj;)Lawj$a;
+		METHOD a recipeRemainder (Lawj;)Lawj$a;
 		METHOD a rarity (Laxb;)Lawj$a;
 		METHOD b durabilityIfNotSet (I)Lawj$a;
 		METHOD c durability (I)Lawj$a;
@@ -25,7 +25,7 @@ CLASS awj net/minecraft/item/Item
 	FIELD l rarity Laxb;
 	FIELD m fullStackSize I
 	FIELD n durability I
-	FIELD o recipeReplacement Lawj;
+	FIELD o recipeRemainder Lawj;
 	FIELD p translationKey Ljava/lang/String;
 	METHOD a getTranslationKey ()Ljava/lang/String;
 	METHOD a getAttributeModifiers (Laha;)Lcom/google/common/collect/Multimap;
@@ -60,7 +60,7 @@ CLASS awj net/minecraft/item/Item
 		ARG 2 world
 		ARG 3 state
 		ARG 4 pos
-	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a buildTooltip (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip
@@ -103,7 +103,7 @@ CLASS awj net/minecraft/item/Item
 	METHOD l getTextComponent ()Ljd;
 	METHOD m getOrCreateTranslationKey ()Ljava/lang/String;
 	METHOD n requiresClientSync ()Z
-	METHOD o getRecipeReplacement ()Lawj;
-	METHOD p hasRecipeReplacement ()Z
+	METHOD o getRecipeRemainder ()Lawj;
+	METHOD p hasRecipeRemainder ()Z
 	METHOD q getItemGroup ()Lavg;
 	METHOD r getDefaultStack ()Lawo;

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -2,7 +2,7 @@ CLASS awj net/minecraft/item/Item
 	CLASS awj$a Settings
 		FIELD a fullStackSize I
 		FIELD b durability I
-		FIELD c containerItem Lawj;
+		FIELD c recipeReplacement Lawj;
 		FIELD d itemGroup Lavg;
 		FIELD e rarity Laxb;
 		METHOD a stackSize (I)Lawj$a;

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -7,7 +7,7 @@ CLASS awj net/minecraft/item/Item
 		FIELD e rarity Laxb;
 		METHOD a stackSize (I)Lawj$a;
 		METHOD a itemGroup (Lavg;)Lawj$a;
-		METHOD a containerItem (Lawj;)Lawj$a;
+		METHOD a recipeReplacement (Lawj;)Lawj$a;
 		METHOD a rarity (Laxb;)Lawj$a;
 		METHOD b durabilityIfNotSet (I)Lawj$a;
 		METHOD c durability (I)Lawj$a;
@@ -25,7 +25,7 @@ CLASS awj net/minecraft/item/Item
 	FIELD l rarity Laxb;
 	FIELD m fullStackSize I
 	FIELD n durability I
-	FIELD o containerItem Lawj;
+	FIELD o recipeReplacement Lawj;
 	FIELD p translationKey Ljava/lang/String;
 	METHOD a getTranslationKey ()Ljava/lang/String;
 	METHOD a getAttributeModifiers (Laha;)Lcom/google/common/collect/Multimap;
@@ -60,7 +60,7 @@ CLASS awj net/minecraft/item/Item
 		ARG 2 world
 		ARG 3 state
 		ARG 4 pos
-	METHOD a addInformation (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip
@@ -103,7 +103,7 @@ CLASS awj net/minecraft/item/Item
 	METHOD l getTextComponent ()Ljd;
 	METHOD m getOrCreateTranslationKey ()Ljava/lang/String;
 	METHOD n requiresClientSync ()Z
-	METHOD o getContainerItem ()Lawj;
-	METHOD p hasContainerItem ()Z
+	METHOD o getRecipeReplacement ()Lawj;
+	METHOD p hasRecipeReplacement ()Z
 	METHOD q getItemGroup ()Lavg;
 	METHOD r getDefaultStack ()Lawo;

--- a/mappings/net/minecraft/item/ItemContainer.mapping
+++ b/mappings/net/minecraft/item/ItemContainer.mapping
@@ -1,2 +1,0 @@
-CLASS bbo net/minecraft/item/ItemContainer
-	METHOD h getItem ()Lawj;

--- a/mappings/net/minecraft/item/ItemProvider.mapping
+++ b/mappings/net/minecraft/item/ItemProvider.mapping
@@ -1,0 +1,2 @@
+CLASS bbo net/minecraft/item/ItemProvider
+	METHOD h getItem ()Lawj;

--- a/mappings/net/minecraft/item/LingeringPotionItem.mapping
+++ b/mappings/net/minecraft/item/LingeringPotionItem.mapping
@@ -1,5 +1,5 @@
 CLASS aws net/minecraft/item/LingeringPotionItem
-	METHOD a addInformation (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/LingeringPotionItem.mapping
+++ b/mappings/net/minecraft/item/LingeringPotionItem.mapping
@@ -1,5 +1,5 @@
 CLASS aws net/minecraft/item/LingeringPotionItem
-	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a buildTooltip (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/PotionItem.mapping
+++ b/mappings/net/minecraft/item/PotionItem.mapping
@@ -3,7 +3,7 @@ CLASS awz net/minecraft/item/PotionItem
 	METHOD a onItemFinishedUsing (Lawo;Lbbp;Lahe;)Lawo;
 		ARG 1 stack
 		ARG 2 world
-	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a buildTooltip (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/PotionItem.mapping
+++ b/mappings/net/minecraft/item/PotionItem.mapping
@@ -3,7 +3,7 @@ CLASS awz net/minecraft/item/PotionItem
 	METHOD a onItemFinishedUsing (Lawo;Lbbp;Lahe;)Lawo;
 		ARG 1 stack
 		ARG 2 world
-	METHOD a addInformation (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/RecordItem.mapping
+++ b/mappings/net/minecraft/item/RecordItem.mapping
@@ -1,11 +1,12 @@
 CLASS axc net/minecraft/item/RecordItem
 	FIELD a SOUND_ITEM_MAP Ljava/util/Map;
 	FIELD c sound Lxm;
-	METHOD a addInformation (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip
 	METHOD a useOnBlock (Layb;)Lafq;
 	METHOD a bySound (Lxm;)Laxc;
 		ARG 0 sound
+	METHOD e getDescription ()Ljd;
 	METHOD f getSound ()Lxm;

--- a/mappings/net/minecraft/item/RecordItem.mapping
+++ b/mappings/net/minecraft/item/RecordItem.mapping
@@ -1,7 +1,7 @@
 CLASS axc net/minecraft/item/RecordItem
 	FIELD a SOUND_ITEM_MAP Ljava/util/Map;
 	FIELD c sound Lxm;
-	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a buildTooltip (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/ShieldItem.mapping
+++ b/mappings/net/minecraft/item/ShieldItem.mapping
@@ -1,7 +1,7 @@
 CLASS axj net/minecraft/item/ShieldItem
 	METHOD a canRepair (Lawo;Lawo;)Z
 		ARG 1 tool
-	METHOD a addInformation (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/ShieldItem.mapping
+++ b/mappings/net/minecraft/item/ShieldItem.mapping
@@ -1,7 +1,7 @@
 CLASS axj net/minecraft/item/ShieldItem
 	METHOD a canRepair (Lawo;Lawo;)Z
 		ARG 1 tool
-	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a buildTooltip (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/TippedArrowItem.mapping
+++ b/mappings/net/minecraft/item/TippedArrowItem.mapping
@@ -1,6 +1,6 @@
 CLASS axx net/minecraft/item/TippedArrowItem
 	METHOD a addStacksForDisplay (Lavg;Lfh;)V
-	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a buildTooltip (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/TippedArrowItem.mapping
+++ b/mappings/net/minecraft/item/TippedArrowItem.mapping
@@ -1,6 +1,6 @@
 CLASS axx net/minecraft/item/TippedArrowItem
 	METHOD a addStacksForDisplay (Lavg;Lfh;)V
-	METHOD a addInformation (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/WrittenBookItem.mapping
+++ b/mappings/net/minecraft/item/WrittenBookItem.mapping
@@ -1,5 +1,5 @@
 CLASS aye net/minecraft/item/WrittenBookItem
-	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a buildTooltip (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/WrittenBookItem.mapping
+++ b/mappings/net/minecraft/item/WrittenBookItem.mapping
@@ -1,5 +1,5 @@
 CLASS aye net/minecraft/item/WrittenBookItem
-	METHOD a addInformation (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/block/AirBlockItem.mapping
+++ b/mappings/net/minecraft/item/block/AirBlockItem.mapping
@@ -1,7 +1,7 @@
 CLASS auh net/minecraft/item/block/AirBlockItem
 	FIELD a block Lbgs;
 	METHOD a getTranslationKey ()Ljava/lang/String;
-	METHOD a addInformation (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/block/AirBlockItem.mapping
+++ b/mappings/net/minecraft/item/block/AirBlockItem.mapping
@@ -1,7 +1,7 @@
 CLASS auh net/minecraft/item/block/AirBlockItem
 	FIELD a block Lbgs;
 	METHOD a getTranslationKey ()Ljava/lang/String;
-	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a buildTooltip (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/block/BannerItem.mapping
+++ b/mappings/net/minecraft/item/block/BannerItem.mapping
@@ -2,7 +2,7 @@ CLASS auo net/minecraft/item/block/BannerItem
 	METHOD <init> (Lbgs;Lbgs;Lawj$a;)V
 		ARG 1 standingBlock
 		ARG 2 wallBlock
-	METHOD a addInformation (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/block/BannerItem.mapping
+++ b/mappings/net/minecraft/item/block/BannerItem.mapping
@@ -2,7 +2,7 @@ CLASS auo net/minecraft/item/block/BannerItem
 	METHOD <init> (Lbgs;Lbgs;Lawj$a;)V
 		ARG 1 standingBlock
 		ARG 2 wallBlock
-	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a buildTooltip (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/block/BlockItem.mapping
+++ b/mappings/net/minecraft/item/block/BlockItem.mapping
@@ -4,7 +4,7 @@ CLASS aur net/minecraft/item/block/BlockItem
 	METHOD a place (Laus;)Lafq;
 	METHOD a setBlockState (Laus;Lbpm;)Z
 	METHOD a addStacksForDisplay (Lavg;Lfh;)V
-	METHOD a addInformation (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip

--- a/mappings/net/minecraft/item/block/BlockItem.mapping
+++ b/mappings/net/minecraft/item/block/BlockItem.mapping
@@ -4,7 +4,7 @@ CLASS aur net/minecraft/item/block/BlockItem
 	METHOD a place (Laus;)Lafq;
 	METHOD a setBlockState (Laus;Lbpm;)Z
 	METHOD a addStacksForDisplay (Lavg;Lfh;)V
-	METHOD a getTooltipText (Lawo;Lbbp;Ljava/util/List;Laxy;)V
+	METHOD a buildTooltip (Lawo;Lbbp;Ljava/util/List;Laxy;)V
 		ARG 1 stack
 		ARG 2 world
 		ARG 3 tooltip


### PR DESCRIPTION
* ItemContainer is also used on Blocks, which don't really *contain* items, so ItemProvider is a more idiomatic name.
* Container items have nothing to do with containers bar the fact they're occasionally a bucket or bottle; their real purpose is to be used as recipe replacements, so they have been named accordingly.
* addInformation is a bad name. The only method which calls it is getTooltipText.

~~Let's defeat Lord Voldemap together~~