### PR TITLE
Map ItemColorMap

### DIFF
--- a/mappings/net/minecraft/client/render/item/ItemColorMap.mapping
+++ b/mappings/net/minecraft/client/render/item/ItemColorMap.mapping
@@ -1,1 +1,8 @@
 CLASS cpw net/minecraft/client/render/item/ItemColorMap
+	FIELD a mappers Lfc;
+	METHOD a create (Lcpt;)Lcpw;
+	METHOD a getRenderColor (Lawo;I)I
+		ARG 1 item
+	METHOD a register (Lcpv;[Lbbo;)V
+		ARG 1 mapper
+


### PR DESCRIPTION
Absurdly small PR, sorry. It appears that cpw causes Enigma to crash, so this one was done manually -  I've confirmed that it builds and tiny-remapper handles it correctly though.

It just uses the same names as `BlockColorMap`, as that seemed the most sane.