### PR TITLE
Update bucket mappings

### DIFF
--- a/mappings/net/minecraft/item/BucketItem.mapping
+++ b/mappings/net/minecraft/item/BucketItem.mapping
@@ -1,12 +1,23 @@
 CLASS ava net/minecraft/item/BucketItem
+	FIELD a fluid Lcfc;
+	METHOD <init> (Lcfc;Lawj$a;)V
+		ARG 1 fluid
+		ARG 2 settings
 	METHOD a playEmptyingSound (Larb;Lbbq;Let;)V
 		ARG 1 player
 		ARG 2 world
 		ARG 3 pos
-	METHOD a getStackAfterUse (Lawo;Larb;)Lawo;
+	METHOD a getEmptiedStack (Lawo;Larb;)Lawo;
+		ARG 1 stack
+		ARG 2 player
+	METHOD a getFilledStack (Lawo;Larb;Lawj;)Lawo;
+		ARG 1 stack
+		ARG 2 player
+		ARG 3 filledBucket
 	METHOD a use (Lbbp;Larb;Lafo;)Lafr;
 		ARG 1 world
 		ARG 2 player
+		ARG 3 hand
 	METHOD a onEmptied (Lbbp;Lawo;Let;)V
 		ARG 1 world
 		ARG 2 stack


### PR DESCRIPTION
Mapped more unmapped members and renamed `getStackAfterUse` to `getEmptiedStack`.