### PR TITLE
Map two forgotten data-fixers

### DIFF
--- a/mappings/acu.mapping
+++ b/mappings/acu.mapping
@@ -1,2 +1,0 @@
-CLASS acu
-	METHOD a transform (Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;

--- a/mappings/net/minecraft/datafixers/fixes/AdvancementsFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/AdvancementsFix.mapping
@@ -1,1 +1,2 @@
 CLASS zh net/minecraft/datafixers/fixes/AdvancementsFix
+	FIELD a RENAMED_ADVANCEMENTS Ljava/util/Map;

--- a/mappings/net/minecraft/datafixers/fixes/CatTypeFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/CatTypeFix.mapping
@@ -1,0 +1,6 @@
+CLASS zx net/minecraft/datafixers/fixes/CatTypeFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a fixCatTypeData (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+	METHOD a transform (Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;

--- a/mappings/net/minecraft/datafixers/fixes/VillagerProfessionFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/VillagerProfessionFix.mapping
@@ -1,0 +1,7 @@
+CLASS acu net/minecraft/datafixers/fixes/VillagerProfessionFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)V
+		ARG 1 outputSchema
+	METHOD a (II)Ljava/lang/String;
+		ARG 0 professionId
+		ARG 1 careerId
+	METHOD a transform (Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;

--- a/mappings/zx.mapping
+++ b/mappings/zx.mapping
@@ -1,2 +1,0 @@
-CLASS zx
-	METHOD a transform (Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;


### PR DESCRIPTION
* `zx` -> `CatTypeFix`. A similar string is passed into its constructor.
* `acu` -> `VillagerProfessionFix`. A similar string is passed into its constructor.

Also:
* `zh.a` -> `AdvancementsFix.RENAMED_ADVANCEMENTS`. Based on its contents.

There is still one derived class of `DataFix` left (namely `abx`), but it currently crashes Enigma, so I didn't try to look into it.