### PR TITLE
Tweaked a few json helper names

### DIFF
--- a/mappings/net/minecraft/util/JsonHelper.mapping
+++ b/mappings/net/minecraft/util/JsonHelper.mapping
@@ -3,33 +3,49 @@ CLASS yp net/minecraft/util/JsonHelper
 	METHOD a deserialize (Lcom/google/gson/Gson;Ljava/io/Reader;Ljava/lang/Class;)Ljava/lang/Object;
 	METHOD a deserialize (Lcom/google/gson/Gson;Ljava/io/Reader;Ljava/lang/Class;Z)Ljava/lang/Object;
 		ARG 2 type
+		ARG 3 lenient
 	METHOD a deserialize (Lcom/google/gson/Gson;Ljava/io/Reader;Ljava/lang/reflect/Type;)Ljava/lang/Object;
 	METHOD a deserialize (Lcom/google/gson/Gson;Ljava/io/Reader;Ljava/lang/reflect/Type;Z)Ljava/lang/Object;
+		ARG 3 lenient
 	METHOD a deserialize (Lcom/google/gson/Gson;Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Object;
-		ARG 2 type
+		ARG 1 content
 	METHOD a deserialize (Lcom/google/gson/Gson;Ljava/lang/String;Ljava/lang/Class;Z)Ljava/lang/Object;
-		ARG 2 type
+		ARG 1 content
+		ARG 3 lenient
 	METHOD a deserialize (Lcom/google/gson/Gson;Ljava/lang/String;Ljava/lang/reflect/Type;)Ljava/lang/Object;
+		ARG 1 content
 	METHOD a deserialize (Lcom/google/gson/Gson;Ljava/lang/String;Ljava/lang/reflect/Type;Z)Ljava/lang/Object;
+		ARG 1 content
+		ARG 3 lenient
 	METHOD a isString (Lcom/google/gson/JsonElement;)Z
 		ARG 0 element
 	METHOD a asString (Lcom/google/gson/JsonElement;Ljava/lang/String;)Ljava/lang/String;
 		ARG 0 element
 		ARG 1 name
 	METHOD a deserialize (Lcom/google/gson/JsonElement;Ljava/lang/String;Lcom/google/gson/JsonDeserializationContext;Ljava/lang/Class;)Ljava/lang/Object;
+		ARG 0 element
+		ARG 1 name
+		ARG 2 context
 		ARG 3 type
-	METHOD a (Lcom/google/gson/JsonObject;Ljava/lang/String;)Z
+	METHOD a hasString (Lcom/google/gson/JsonObject;Ljava/lang/String;)Z
 		ARG 0 object
 		ARG 1 element
 	METHOD a getByte (Lcom/google/gson/JsonObject;Ljava/lang/String;B)B
+		ARG 0 object
+		ARG 1 element
+		ARG 2 defaultByte
 	METHOD a getFloat (Lcom/google/gson/JsonObject;Ljava/lang/String;F)F
 		ARG 0 object
 		ARG 1 element
+		ARG 2 defaultFloat
 	METHOD a getInt (Lcom/google/gson/JsonObject;Ljava/lang/String;I)I
 		ARG 0 object
 		ARG 1 element
 		ARG 2 defaultInt
 	METHOD a getLong (Lcom/google/gson/JsonObject;Ljava/lang/String;J)J
+		ARG 0 object
+		ARG 1 element
+		ARG 2 defaultLong
 	METHOD a getArray (Lcom/google/gson/JsonObject;Ljava/lang/String;Lcom/google/gson/JsonArray;)Lcom/google/gson/JsonArray;
 		ARG 0 object
 		ARG 1 name
@@ -59,8 +75,12 @@ CLASS yp net/minecraft/util/JsonHelper
 		ARG 2 defaultBoolean
 	METHOD a deserialize (Ljava/io/Reader;)Lcom/google/gson/JsonObject;
 	METHOD a deserialize (Ljava/io/Reader;Z)Lcom/google/gson/JsonObject;
+		ARG 1 lenient
 	METHOD a deserialize (Ljava/lang/String;)Lcom/google/gson/JsonObject;
+		ARG 0 content
 	METHOD a deserialize (Ljava/lang/String;Z)Lcom/google/gson/JsonObject;
+		ARG 0 content
+		ARG 1 lenient
 	METHOD b isNumber (Lcom/google/gson/JsonElement;)Z
 		ARG 0 element
 	METHOD b asItem (Lcom/google/gson/JsonElement;Ljava/lang/String;)Lawj;
@@ -69,19 +89,23 @@ CLASS yp net/minecraft/util/JsonHelper
 	METHOD c asBoolean (Lcom/google/gson/JsonElement;Ljava/lang/String;)Z
 		ARG 0 element
 		ARG 1 name
-	METHOD c isBoolean (Lcom/google/gson/JsonObject;Ljava/lang/String;)Z
+	METHOD c hasBoolean (Lcom/google/gson/JsonObject;Ljava/lang/String;)Z
 		ARG 0 object
 		ARG 1 element
 	METHOD d getType (Lcom/google/gson/JsonElement;)Ljava/lang/String;
 		ARG 0 element
-	METHOD d isArray (Lcom/google/gson/JsonObject;Ljava/lang/String;)Z
+		ARG 1 abbreviated
+		ARG 2 primitive
+	METHOD d hasArray (Lcom/google/gson/JsonObject;Ljava/lang/String;)Z
 		ARG 0 object
 		ARG 1 element
 	METHOD e asFloat (Lcom/google/gson/JsonElement;Ljava/lang/String;)F
 		ARG 0 element
 		ARG 1 name
 	METHOD f asLong (Lcom/google/gson/JsonElement;Ljava/lang/String;)J
-	METHOD f isPrimitive (Lcom/google/gson/JsonObject;Ljava/lang/String;)Z
+		ARG 0 element
+		ARG 1 name
+	METHOD f hasPrimitive (Lcom/google/gson/JsonObject;Ljava/lang/String;)Z
 		ARG 0 object
 		ARG 1 element
 	METHOD g asInt (Lcom/google/gson/JsonElement;Ljava/lang/String;)I
@@ -91,6 +115,8 @@ CLASS yp net/minecraft/util/JsonHelper
 		ARG 0 object
 		ARG 1 lement
 	METHOD h asByte (Lcom/google/gson/JsonElement;Ljava/lang/String;)B
+		ARG 0 element
+		ARG 1 name
 	METHOD h getString (Lcom/google/gson/JsonObject;Ljava/lang/String;)Ljava/lang/String;
 		ARG 0 object
 		ARG 1 element


### PR DESCRIPTION
Methods working on json objects renamed to `hasXxx` instead of `isXxx` (reserved for json elements).

Type\\Operation  | Check | Retrieve
-- | ----- | --------
`JsonElement` | `isXxx` | `asXxx`
`JsonObject` | `hasXxx` | `getXxx`

I made all methods follow the guide set in that form above so that new modders can understand the `JsonHelper` more easily.

Also added some mappings for string and boolean parameters and missing default values.