### PR TITLE
Move some client only Vecmath classes to better location.

### DIFF
--- a/mappings/net/minecraft/client/util/Quaternion.mapping
+++ b/mappings/net/minecraft/client/util/Quaternion.mapping
@@ -1,2 +1,0 @@
-CLASS coq net/minecraft/client/util/Quaternion
-	FIELD a components [F

--- a/mappings/net/minecraft/client/util/math/Matrix4f.mapping
+++ b/mappings/net/minecraft/client/util/math/Matrix4f.mapping
@@ -1,0 +1,32 @@
+CLASS cop net/minecraft/client/util/math/Matrix4f
+	FIELD a components [F
+	METHOD <init> (Lcop;)V
+		ARG 1 other
+	METHOD <init> ([FZ)V
+		ARG 2 transpose
+	METHOD a setIdentity ()V
+	METHOD a multiply (F)V
+		ARG 1 value
+	METHOD a get (II)F
+		ARG 1 row
+		ARG 2 col
+	METHOD a set (IIF)V
+		ARG 1 row
+		ARG 2 col
+		ARG 3 value
+	METHOD a multiply (Lcop;)V
+		ARG 1 other
+	METHOD a setFromBuffer (Ljava/nio/FloatBuffer;)V
+		ARG 1 buffer
+	METHOD a setFromBuffer (Ljava/nio/FloatBuffer;Z)V
+		ARG 1 buffer
+		ARG 2 transpose
+	METHOD b add (Lcop;)V
+		ARG 1 value
+	METHOD b putIntoBuffer (Ljava/nio/FloatBuffer;)V
+		ARG 1 buffer
+	METHOD b putIntoBuffer (Ljava/nio/FloatBuffer;Z)V
+		ARG 1 buffer
+		ARG 2 transpose
+	METHOD c subtract (Lcop;)V
+		ARG 1 value

--- a/mappings/net/minecraft/client/util/math/Quaternion.mapping
+++ b/mappings/net/minecraft/client/util/math/Quaternion.mapping
@@ -1,0 +1,4 @@
+CLASS coq net/minecraft/client/util/math/Quaternion
+	FIELD a components [F
+	METHOD a (F)F
+	METHOD b (F)F

--- a/mappings/net/minecraft/client/util/math/Vector3f.mapping
+++ b/mappings/net/minecraft/client/util/math/Vector3f.mapping
@@ -1,4 +1,4 @@
-CLASS cos net/minecraft/sortme/Vector3f
+CLASS cos net/minecraft/client/util/math/Vector3f
 	FIELD a components [F
 	METHOD <init> (FFF)V
 		ARG 1 x

--- a/mappings/net/minecraft/client/util/math/Vector4f.mapping
+++ b/mappings/net/minecraft/client/util/math/Vector4f.mapping
@@ -1,14 +1,18 @@
-CLASS cot net/minecraft/sortme/Vector4f
+CLASS cot net/minecraft/client/util/math/Vector4f
 	FIELD a components [F
 	METHOD <init> (FFFF)V
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
+		ARG 4 w
 	METHOD a x ()F
-	METHOD a (FFFF)V
+	METHOD a set (FFFF)V
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
+		ARG 4 w
+	METHOD a multiply (Lcop;)V
+	METHOD a multiply (Lcos;)V
 	METHOD b y ()F
 	METHOD c z ()F
 	METHOD d w ()F

--- a/mappings/net/minecraft/sortme/Matrix4f.mapping
+++ b/mappings/net/minecraft/sortme/Matrix4f.mapping
@@ -1,2 +1,0 @@
-CLASS cop net/minecraft/sortme/Matrix4f
-	FIELD a components [F


### PR DESCRIPTION
Moves `Vector3f`, `Vector4f`, `Matrix4f` and `Quaternion` to `net/minecraft/client/util/math`, plus some names.