### PR TITLE
Drop verbose 'Inv' wording from Inventrory methods.

### DIFF
--- a/mappings/afg.mapping
+++ b/mappings/afg.mapping
@@ -1,2 +1,0 @@
-CLASS afg
-	METHOD U_ clearInv ()V

--- a/mappings/net/minecraft/block/entity/AbstractFurnaceBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/AbstractFurnaceBlockEntity.mapping
@@ -8,17 +8,22 @@ CLASS bni net/minecraft/block/entity/AbstractFurnaceBlockEntity
 	FIELD m recipesUsed Ljava/util/Map;
 	METHOD B isBurning ()Z
 	METHOD R_ getName ()Ljd;
-	METHOD U_ clearInv ()V
-	METHOD Z_ getInvSize ()I
-	METHOD a getInvStack (I)Lawo;
-	METHOD a takeInvStack (II)Lawo;
+	METHOD U_ onPasted ()V
+	METHOD Z_ getSize ()I
+	METHOD a getStack (I)Lawo;
 		ARG 1 slot
-	METHOD a setInvStack (ILawo;)V
+	METHOD a takeStack (II)Lawo;
 		ARG 1 slot
-	METHOD a canInsertInvStack (ILawo;Ley;)Z
+		ARG 2 amount
+	METHOD a setStack (ILawo;)V
 		ARG 1 slot
 		ARG 2 stack
-	METHOD a canPlayerUseInv (Larb;)Z
+	METHOD a canInsertStack (ILawo;Ley;)Z
+		ARG 1 slot
+		ARG 2 stack
+		ARG 3 face
+	METHOD a canPlayerUse (Larb;)Z
+		ARG 1 player
 	METHOD a provideRecipeInputs (Lard;)V
 	METHOD a getItemBurnTime (Lawo;)I
 	METHOD a setLastRecipe (Layw;)V
@@ -27,17 +32,22 @@ CLASS bni net/minecraft/block/entity/AbstractFurnaceBlockEntity
 		ARG 1 world
 		ARG 2 player
 		ARG 3 recipe
-	METHOD a getInvAvailableSlots (Ley;)[I
+	METHOD a getAvailableSlots (Ley;)[I
+		ARG 1 face
 	METHOD a fromTag (Lhs;)V
 	METHOD a setCustomName (Ljd;)V
-	METHOD b removeInvStack (I)Lawo;
-	METHOD b setInvProperty (II)V
-		ARG 1 pos
-	METHOD b isValidInvStack (ILawo;)Z
+	METHOD b removeStack (I)Lawo;
 		ARG 1 slot
-	METHOD b canExtractInvStack (ILawo;Ley;)Z
+	METHOD b setProperty (II)V
+		ARG 1 index
+		ARG 2 value
+	METHOD b isValidStack (ILawo;)Z
 		ARG 1 slot
 		ARG 2 stack
+	METHOD b canExtractStack (ILawo;Ley;)Z
+		ARG 1 slot
+		ARG 2 stack
+		ARG 3 face
 	METHOD b unlockLastRecipe (Larb;)V
 		ARG 1 player
 	METHOD b canUseAsFuel (Lawo;)Z
@@ -45,14 +55,15 @@ CLASS bni net/minecraft/block/entity/AbstractFurnaceBlockEntity
 	METHOD b canAcceptRecipeOutput (Layw;)Z
 		ARG 1 recipe
 	METHOD b toTag (Lhs;)Lhs;
-	METHOD c isInvEmpty ()Z
-	METHOD c getInvProperty (I)I
+	METHOD c isEmpty ()Z
+	METHOD c getProperty (I)I
+		ARG 1 index
 	METHOD c craftRecipe (Layw;)V
 		ARG 1 recipe
 	METHOD e tick ()V
 	METHOD f getCustomName ()Ljd;
 	METHOD g getLastRecipe ()Layw;
-	METHOD i getInvPropertyCount ()I
+	METHOD i getPropertyCount ()I
 	METHOD p getBurnTimeMap ()Ljava/util/Map;
 	METHOD q getCookTime ()I
 	METHOD r getDefaultName ()Ljd;

--- a/mappings/net/minecraft/block/entity/BarrelBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BarrelBlockEntity.mapping
@@ -1,22 +1,26 @@
 CLASS bnl net/minecraft/block/entity/BarrelBlockEntity
 	FIELD a inventory Lfh;
 	METHOD R_ getName ()Ljd;
-	METHOD U_ clearInv ()V
-	METHOD Z_ getInvSize ()I
-	METHOD a getInvStack (I)Lawo;
-	METHOD a takeInvStack (II)Lawo;
+	METHOD U_ onPasted ()V
+	METHOD Z_ getSize ()I
+	METHOD a getStack (I)Lawo;
 		ARG 1 slot
-	METHOD a setInvStack (ILawo;)V
+	METHOD a takeStack (II)Lawo;
 		ARG 1 slot
+		ARG 2 amount
+	METHOD a setStack (ILawo;)V
+		ARG 1 slot
+		ARG 2 stack
 	METHOD a createContainer (Lara;Larb;)Lasw;
 		ARG 1 playerInv
 	METHOD a setInvStackList (Lfh;)V
 		ARG 1 list
 	METHOD a fromTag (Lhs;)V
 	METHOD a setCustomName (Ljd;)V
-	METHOD b removeInvStack (I)Lawo;
+	METHOD b removeStack (I)Lawo;
+		ARG 1 slot
 	METHOD b toTag (Lhs;)Lhs;
-	METHOD c isInvEmpty ()Z
+	METHOD c isEmpty ()Z
 	METHOD f getCustomName ()Ljd;
 	METHOD m getContainerId ()Ljava/lang/String;
 	METHOD p getInvStackList ()Lfh;

--- a/mappings/net/minecraft/block/entity/BeaconBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BeaconBlockEntity.mapping
@@ -7,41 +7,52 @@ CLASS bnm net/minecraft/block/entity/BeaconBlockEntity
 	FIELD n stack Lawo;
 	FIELD o customName Ljd;
 	METHOD R_ getName ()Ljd;
-	METHOD U_ clearInv ()V
-	METHOD Z_ getInvSize ()I
-	METHOD a getInvStack (I)Lawo;
-	METHOD a takeInvStack (II)Lawo;
+	METHOD U_ onPasted ()V
+	METHOD Z_ getSize ()I
+	METHOD a getStack (I)Lawo;
 		ARG 1 slot
-	METHOD a setInvStack (ILawo;)V
+	METHOD a takeStack (II)Lawo;
 		ARG 1 slot
-	METHOD a canInsertInvStack (ILawo;Ley;)Z
+		ARG 2 amount
+	METHOD a setStack (ILawo;)V
 		ARG 1 slot
 		ARG 2 stack
+	METHOD a canInsertStack (ILawo;Ley;)Z
+		ARG 1 slot
+		ARG 2 stack
+		ARG 3 face
 	METHOD a createContainer (Lara;Larb;)Lasw;
 		ARG 1 playerInv
-	METHOD a canPlayerUseInv (Larb;)Z
-	METHOD a getInvAvailableSlots (Ley;)[I
+	METHOD a canPlayerUse (Larb;)Z
+		ARG 1 player
+	METHOD a getAvailableSlots (Ley;)[I
+		ARG 1 face
 	METHOD a fromTag (Lhs;)V
 	METHOD a setCustomName (Ljd;)V
-	METHOD aa_ getInvMaxStackAmount ()I
+	METHOD aa_ getMaxStackAmount ()I
 	METHOD ai_ toUpdatePacket ()Lke;
 	METHOD aj_ toInitialChunkDataTag ()Lhs;
-	METHOD b removeInvStack (I)Lawo;
-	METHOD b setInvProperty (II)V
-		ARG 1 pos
-	METHOD b isValidInvStack (ILawo;)Z
+	METHOD b removeStack (I)Lawo;
 		ARG 1 slot
-	METHOD b canExtractInvStack (ILawo;Ley;)Z
+	METHOD b setProperty (II)V
+		ARG 1 index
+		ARG 2 value
+	METHOD b isValidStack (ILawo;)Z
 		ARG 1 slot
 		ARG 2 stack
+	METHOD b canExtractStack (ILawo;Ley;)Z
+		ARG 1 slot
+		ARG 2 stack
+		ARG 3 face
 	METHOD b toTag (Lhs;)Lhs;
-	METHOD c isInvEmpty ()Z
-	METHOD c getInvProperty (I)I
+	METHOD c isEmpty ()Z
+	METHOD c getProperty (I)I
+		ARG 1 index
 	METHOD e tick ()V
 	METHOD e getPotionEffectById (I)Lagn;
 		ARG 0 id
 	METHOD f getCustomName ()Ljd;
-	METHOD i getInvPropertyCount ()I
+	METHOD i getPropertyCount ()I
 	METHOD m getContainerId ()Ljava/lang/String;
 	METHOD s getLevel ()I
 	METHOD t getSquaredRenderDistance ()D

--- a/mappings/net/minecraft/block/entity/BlastFurnaceBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BlastFurnaceBlockEntity.mapping
@@ -1,7 +1,8 @@
 CLASS bnp net/minecraft/block/entity/BlastFurnaceBlockEntity
 	METHOD a createContainer (Lara;Larb;)Lasw;
 		ARG 1 playerInv
-	METHOD a canPlayerUseInv (Larb;)Z
+	METHOD a canPlayerUse (Larb;)Z
+		ARG 1 player
 	METHOD a getItemBurnTime (Lawo;)I
 	METHOD m getContainerId ()Ljava/lang/String;
 	METHOD q getCookTime ()I

--- a/mappings/net/minecraft/block/entity/BrewingStandBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BrewingStandBlockEntity.mapping
@@ -7,36 +7,47 @@ CLASS bns net/minecraft/block/entity/BrewingStandBlockEntity
 	FIELD k customName Ljd;
 	FIELD l fuel I
 	METHOD R_ getName ()Ljd;
-	METHOD U_ clearInv ()V
-	METHOD Z_ getInvSize ()I
-	METHOD a getInvStack (I)Lawo;
-	METHOD a takeInvStack (II)Lawo;
+	METHOD U_ onPasted ()V
+	METHOD Z_ getSize ()I
+	METHOD a getStack (I)Lawo;
 		ARG 1 slot
-	METHOD a setInvStack (ILawo;)V
+	METHOD a takeStack (II)Lawo;
 		ARG 1 slot
-	METHOD a canInsertInvStack (ILawo;Ley;)Z
+		ARG 2 amount
+	METHOD a setStack (ILawo;)V
 		ARG 1 slot
 		ARG 2 stack
+	METHOD a canInsertStack (ILawo;Ley;)Z
+		ARG 1 slot
+		ARG 2 stack
+		ARG 3 face
 	METHOD a createContainer (Lara;Larb;)Lasw;
 		ARG 1 playerInv
-	METHOD a canPlayerUseInv (Larb;)Z
-	METHOD a getInvAvailableSlots (Ley;)[I
+	METHOD a canPlayerUse (Larb;)Z
+		ARG 1 player
+	METHOD a getAvailableSlots (Ley;)[I
+		ARG 1 face
 	METHOD a fromTag (Lhs;)V
 	METHOD a setCustomName (Ljd;)V
-	METHOD b removeInvStack (I)Lawo;
-	METHOD b setInvProperty (II)V
-		ARG 1 pos
-	METHOD b isValidInvStack (ILawo;)Z
+	METHOD b removeStack (I)Lawo;
 		ARG 1 slot
-	METHOD b canExtractInvStack (ILawo;Ley;)Z
+	METHOD b setProperty (II)V
+		ARG 1 index
+		ARG 2 value
+	METHOD b isValidStack (ILawo;)Z
 		ARG 1 slot
 		ARG 2 stack
+	METHOD b canExtractStack (ILawo;Ley;)Z
+		ARG 1 slot
+		ARG 2 stack
+		ARG 3 face
 	METHOD b toTag (Lhs;)Lhs;
-	METHOD c isInvEmpty ()Z
-	METHOD c getInvProperty (I)I
+	METHOD c isEmpty ()Z
+	METHOD c getProperty (I)I
+		ARG 1 index
 	METHOD e tick ()V
 	METHOD f getCustomName ()Ljd;
-	METHOD i getInvPropertyCount ()I
+	METHOD i getPropertyCount ()I
 	METHOD m getContainerId ()Ljava/lang/String;
 	METHOD q canCraft ()Z
 	METHOD r craft ()V

--- a/mappings/net/minecraft/block/entity/ChestBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/ChestBlockEntity.mapping
@@ -1,7 +1,7 @@
 CLASS bnt net/minecraft/block/entity/ChestBlockEntity
 	FIELD j inventory Lfh;
 	METHOD R_ getName ()Ljd;
-	METHOD Z_ getInvSize ()I
+	METHOD Z_ getSize ()I
 	METHOD a getAnimationProgress (F)F
 	METHOD a createContainer (Lara;Larb;)Lasw;
 		ARG 1 playerInv
@@ -9,9 +9,11 @@ CLASS bnt net/minecraft/block/entity/ChestBlockEntity
 		ARG 1 list
 	METHOD a fromTag (Lhs;)V
 	METHOD b toTag (Lhs;)Lhs;
-	METHOD b_ onInvOpen (Larb;)V
-	METHOD c isInvEmpty ()Z
-	METHOD c_ onInvClose (Larb;)V
+	METHOD b_ onOpened (Larb;)V
+		ARG 1 player
+	METHOD c isEmpty ()Z
+	METHOD c_ onClosed (Larb;)V
+		ARG 1 player
 	METHOD e tick ()V
 	METHOD m getContainerId ()Ljava/lang/String;
 	METHOD p getInvStackList ()Lfh;

--- a/mappings/net/minecraft/block/entity/DispenserBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/DispenserBlockEntity.mapping
@@ -2,13 +2,13 @@ CLASS bny net/minecraft/block/entity/DispenserBlockEntity
 	FIELD a RANDOM Ljava/util/Random;
 	FIELD b inventory Lfh;
 	METHOD R_ getName ()Ljd;
-	METHOD Z_ getInvSize ()I
+	METHOD Z_ getSize ()I
 	METHOD a createContainer (Lara;Larb;)Lasw;
 		ARG 1 playerInv
 	METHOD a setInvStackList (Lfh;)V
 		ARG 1 list
 	METHOD a fromTag (Lhs;)V
 	METHOD b toTag (Lhs;)Lhs;
-	METHOD c isInvEmpty ()Z
+	METHOD c isEmpty ()Z
 	METHOD m getContainerId ()Ljava/lang/String;
 	METHOD p getInvStackList ()Lfh;

--- a/mappings/net/minecraft/block/entity/FurnaceBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/FurnaceBlockEntity.mapping
@@ -1,6 +1,7 @@
 CLASS boc net/minecraft/block/entity/FurnaceBlockEntity
 	METHOD a createContainer (Lara;Larb;)Lasw;
-	METHOD a canPlayerUseInv (Larb;)Z
+	METHOD a canPlayerUse (Larb;)Z
+		ARG 1 player
 	METHOD m getContainerId ()Ljava/lang/String;
 	METHOD q getCookTime ()I
 	METHOD r getDefaultName ()Ljd;

--- a/mappings/net/minecraft/block/entity/HopperBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/HopperBlockEntity.mapping
@@ -6,11 +6,13 @@ CLASS boe net/minecraft/block/entity/HopperBlockEntity
 	METHOD F getHopperY ()D
 	METHOD G getHopperZ ()D
 	METHOD R_ getName ()Ljd;
-	METHOD Z_ getInvSize ()I
-	METHOD a takeInvStack (II)Lawo;
+	METHOD Z_ getSize ()I
+	METHOD a takeStack (II)Lawo;
 		ARG 1 slot
-	METHOD a setInvStack (ILawo;)V
+		ARG 2 amount
+	METHOD a setStack (ILawo;)V
 		ARG 1 slot
+		ARG 2 stack
 	METHOD a canInsert (Lafi;Lawo;ILey;)Z
 		ARG 0 inv
 		ARG 1 stack
@@ -44,12 +46,12 @@ CLASS boe net/minecraft/block/entity/HopperBlockEntity
 	METHOD b getInputInventory (Lbod;)Lafi;
 		ARG 0 hopper
 	METHOD b toTag (Lhs;)Lhs;
-	METHOD c isInvEmpty ()Z
+	METHOD c isEmpty ()Z
 	METHOD d setCooldown (I)V
 		ARG 1 cooldown
 	METHOD e tick ()V
 	METHOD m getContainerId ()Ljava/lang/String;
 	METHOD p getInvStackList ()Lfh;
-	METHOD q isEmpty ()Z
+	METHOD q isEmpty_ ()Z
 	METHOD r isFull ()Z
 	METHOD s tryInsert ()Z

--- a/mappings/net/minecraft/block/entity/JukeboxBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/JukeboxBlockEntity.mapping
@@ -1,6 +1,6 @@
 CLASS bog net/minecraft/block/entity/JukeboxBlockEntity
 	FIELD a record Lawo;
-	METHOD U_ clearInv ()V
+	METHOD U_ onPasted ()V
 	METHOD a setRecord (Lawo;)V
 	METHOD a fromTag (Lhs;)V
 	METHOD b toTag (Lhs;)Lhs;

--- a/mappings/net/minecraft/block/entity/LootableContainerBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/LootableContainerBlockEntity.mapping
@@ -2,19 +2,24 @@ CLASS bok net/minecraft/block/entity/LootableContainerBlockEntity
 	FIELD g lootTableId Lqc;
 	FIELD h lootTableSeed J
 	FIELD i customName Ljd;
-	METHOD U_ clearInv ()V
-	METHOD a getInvStack (I)Lawo;
-	METHOD a takeInvStack (II)Lawo;
+	METHOD U_ onPasted ()V
+	METHOD a getStack (I)Lawo;
 		ARG 1 slot
-	METHOD a setInvStack (ILawo;)V
+	METHOD a takeStack (II)Lawo;
 		ARG 1 slot
-	METHOD a canPlayerUseInv (Larb;)Z
+		ARG 2 amount
+	METHOD a setStack (ILawo;)V
+		ARG 1 slot
+		ARG 2 stack
+	METHOD a canPlayerUse (Larb;)Z
+		ARG 1 player
 	METHOD a setInvStackList (Lfh;)V
 		ARG 1 list
 	METHOD a setCustomName (Ljd;)V
 	METHOD a setLootTable (Lqc;J)V
 		ARG 1 id
-	METHOD b removeInvStack (I)Lawo;
+	METHOD b removeStack (I)Lawo;
+		ARG 1 slot
 	METHOD d checkLootInteraction (Larb;)V
 	METHOD d deserializeLootTable (Lhs;)Z
 	METHOD e serializeLootTable (Lhs;)Z

--- a/mappings/net/minecraft/block/entity/PasteCallback.mapping
+++ b/mappings/net/minecraft/block/entity/PasteCallback.mapping
@@ -1,0 +1,4 @@
+CLASS afg net/minecraft/block/entity/PasteCallback
+	METHOD U_ onPasted ()V
+	METHOD a tryOnPasted (Ljava/lang/Object;)V
+		ARG 0 obj

--- a/mappings/net/minecraft/block/entity/ShulkerBoxBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/ShulkerBoxBlockEntity.mapping
@@ -8,24 +8,29 @@ CLASS bol net/minecraft/block/entity/ShulkerBoxBlockEntity
 	FIELD l prevAnimationProgress F
 	FIELD m color Lavl;
 	METHOD R_ getName ()Ljd;
-	METHOD Z_ getInvSize ()I
+	METHOD Z_ getSize ()I
 	METHOD a getAnimationProgress (F)F
-	METHOD a canInsertInvStack (ILawo;Ley;)Z
+	METHOD a canInsertStack (ILawo;Ley;)Z
 		ARG 1 slot
 		ARG 2 stack
+		ARG 3 face
 	METHOD a createContainer (Lara;Larb;)Lasw;
 		ARG 1 playerInv
-	METHOD a getInvAvailableSlots (Ley;)[I
+	METHOD a getAvailableSlots (Ley;)[I
+		ARG 1 face
 	METHOD a setInvStackList (Lfh;)V
 		ARG 1 list
 	METHOD a fromTag (Lhs;)V
-	METHOD b canExtractInvStack (ILawo;Ley;)Z
+	METHOD b canExtractStack (ILawo;Ley;)Z
 		ARG 1 slot
 		ARG 2 stack
+		ARG 3 face
 	METHOD b toTag (Lhs;)Lhs;
-	METHOD b_ onInvOpen (Larb;)V
-	METHOD c isInvEmpty ()Z
-	METHOD c_ onInvClose (Larb;)V
+	METHOD b_ onOpened (Larb;)V
+		ARG 1 player
+	METHOD c isEmpty ()Z
+	METHOD c_ onClosed (Larb;)V
+		ARG 1 player
 	METHOD e tick ()V
 	METHOD m getContainerId ()Ljava/lang/String;
 	METHOD p getInvStackList ()Lfh;

--- a/mappings/net/minecraft/block/entity/SmokerBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/SmokerBlockEntity.mapping
@@ -1,7 +1,8 @@
 CLASS boo net/minecraft/block/entity/SmokerBlockEntity
 	METHOD a createContainer (Lara;Larb;)Lasw;
 		ARG 1 playerInv
-	METHOD a canPlayerUseInv (Larb;)Z
+	METHOD a canPlayerUse (Larb;)Z
+		ARG 1 player
 	METHOD a getItemBurnTime (Lawo;)I
 	METHOD m getContainerId ()Ljava/lang/String;
 	METHOD q getCookTime ()I

--- a/mappings/net/minecraft/client/gui/container/LoomGui.mapping
+++ b/mappings/net/minecraft/client/gui/container/LoomGui.mapping
@@ -24,7 +24,8 @@ CLASS cvh net/minecraft/client/gui/container/LoomGui
 	METHOD a draw (IIF)V
 		ARG 1 mouseX
 		ARG 2 mouseY
-	METHOD a onInvChange (Lafi;)V
+	METHOD a onChanged (Lafi;)V
+		ARG 1 inv
 	METHOD c drawForeground (II)V
 		ARG 1 mouseX
 		ARG 2 mouseY

--- a/mappings/net/minecraft/client/network/ClientBasicInventory.mapping
+++ b/mappings/net/minecraft/client/network/ClientBasicInventory.mapping
@@ -8,9 +8,11 @@ CLASS ddp net/minecraft/client/network/ClientBasicInventory
 	METHOD a createContainer (Lara;Larb;)Lasw;
 		ARG 1 playerInv
 	METHOD ac_ hasContainerLock ()Z
-	METHOD b setInvProperty (II)V
-		ARG 1 pos
-	METHOD c getInvProperty (I)I
-	METHOD i getInvPropertyCount ()I
+	METHOD b setProperty (II)V
+		ARG 1 index
+		ARG 2 value
+	METHOD c getProperty (I)I
+		ARG 1 index
+	METHOD i getPropertyCount ()I
 	METHOD k getContainerLock ()Laft;
 	METHOD m getContainerId ()Ljava/lang/String;

--- a/mappings/net/minecraft/container/DoubleLockableContainer.mapping
+++ b/mappings/net/minecraft/container/DoubleLockableContainer.mapping
@@ -6,31 +6,41 @@ CLASS afh net/minecraft/container/DoubleLockableContainer
 		ARG 2 first
 	METHOD R_ getName ()Ljd;
 	METHOD S_ hasCustomName ()Z
-	METHOD U_ clearInv ()V
-	METHOD Z_ getInvSize ()I
-	METHOD a getInvStack (I)Lawo;
-	METHOD a takeInvStack (II)Lawo;
+	METHOD U_ onPasted ()V
+	METHOD Z_ getSize ()I
+	METHOD a getStack (I)Lawo;
 		ARG 1 slot
-	METHOD a setInvStack (ILawo;)V
+	METHOD a takeStack (II)Lawo;
 		ARG 1 slot
+		ARG 2 amount
+	METHOD a setStack (ILawo;)V
+		ARG 1 slot
+		ARG 2 stack
 	METHOD a isPart (Lafi;)Z
 	METHOD a setContainerLock (Laft;)V
 	METHOD a createContainer (Lara;Larb;)Lasw;
 		ARG 1 playerInv
-	METHOD a canPlayerUseInv (Larb;)Z
-	METHOD aa_ getInvMaxStackAmount ()I
+	METHOD a canPlayerUse (Larb;)Z
+		ARG 1 player
+	METHOD aa_ getMaxStackAmount ()I
 	METHOD ac_ hasContainerLock ()Z
-	METHOD b removeInvStack (I)Lawo;
-	METHOD b setInvProperty (II)V
-		ARG 1 pos
-	METHOD b isValidInvStack (ILawo;)Z
+	METHOD b removeStack (I)Lawo;
 		ARG 1 slot
-	METHOD b_ onInvOpen (Larb;)V
-	METHOD c isInvEmpty ()Z
-	METHOD c getInvProperty (I)I
-	METHOD c_ onInvClose (Larb;)V
+	METHOD b setProperty (II)V
+		ARG 1 index
+		ARG 2 value
+	METHOD b isValidStack (ILawo;)Z
+		ARG 1 slot
+		ARG 2 stack
+	METHOD b_ onOpened (Larb;)V
+		ARG 1 player
+	METHOD c isEmpty ()Z
+	METHOD c getProperty (I)I
+		ARG 1 index
+	METHOD c_ onClosed (Larb;)V
+		ARG 1 player
 	METHOD f getCustomName ()Ljd;
 	METHOD h markDirty ()V
-	METHOD i getInvPropertyCount ()I
+	METHOD i getPropertyCount ()I
 	METHOD k getContainerLock ()Laft;
 	METHOD m getContainerId ()Ljava/lang/String;

--- a/mappings/net/minecraft/container/LoomContainer.mapping
+++ b/mappings/net/minecraft/container/LoomContainer.mapping
@@ -1,7 +1,8 @@
 CLASS ats net/minecraft/container/LoomContainer
 	CLASS ats$1
-		METHOD b setInvProperty (II)V
-			ARG 1 value
+		METHOD b setProperty (II)V
+			ARG 1 index
+			ARG 2 value
 		METHOD h markDirty ()V
 	CLASS ats$2
 		METHOD a canInsert (Lawo;)Z

--- a/mappings/net/minecraft/entity/passive/HorseBaseEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/HorseBaseEntity.mapping
@@ -10,7 +10,8 @@ CLASS ana net/minecraft/entity/passive/HorseBaseEntity
 	METHOD I_ canJump ()Z
 	METHOD N getLimitPerChunk ()I
 	METHOD W_ update ()V
-	METHOD a onInvChange (Lafi;)V
+	METHOD a onChanged (Lafi;)V
+		ARG 1 inv
 	METHOD a damage (Lage;F)Z
 		ARG 1 source
 		ARG 2 amount

--- a/mappings/net/minecraft/entity/passive/HorseEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/HorseEntity.mapping
@@ -9,7 +9,8 @@ CLASS anc net/minecraft/entity/passive/HorseEntity
 	FIELD bV textureLayers [Ljava/lang/String;
 	METHOD D getAmbientSound ()Lxm;
 	METHOD W_ update ()V
-	METHOD a onInvChange (Lafi;)V
+	METHOD a onChanged (Lafi;)V
+		ARG 1 inv
 	METHOD a createChild (Lags;)Lags;
 	METHOD a interactMob (Larb;Lafo;)Z
 		ARG 1 player

--- a/mappings/net/minecraft/entity/passive/LlamaEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/LlamaEntity.mapping
@@ -7,7 +7,8 @@ CLASS ane net/minecraft/entity/passive/LlamaEntity
 	FIELD bN ATTR_STRENGTH Lpr;
 	FIELD bP ATTR_VARIANT Lpr;
 	METHOD D getAmbientSound ()Lxm;
-	METHOD a onInvChange (Lafi;)V
+	METHOD a onChanged (Lafi;)V
+		ARG 1 inv
 	METHOD a createChild (Lags;)Lags;
 	METHOD a attack (Lahe;F)V
 		ARG 1 target

--- a/mappings/net/minecraft/entity/player/PlayerInventory.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerInventory.mapping
@@ -7,28 +7,33 @@ CLASS ara net/minecraft/entity/player/PlayerInventory
 	FIELD g cursorStack Lawo;
 	FIELD h changeCount I
 	METHOD R_ getName ()Ljd;
-	METHOD U_ clearInv ()V
-	METHOD Z_ getInvSize ()I
-	METHOD a getInvStack (I)Lawo;
-	METHOD a takeInvStack (II)Lawo;
+	METHOD U_ onPasted ()V
+	METHOD Z_ getSize ()I
+	METHOD a getStack (I)Lawo;
 		ARG 1 slot
-	METHOD a setInvStack (ILawo;)V
+	METHOD a takeStack (II)Lawo;
 		ARG 1 slot
+		ARG 2 amount
+	METHOD a setStack (ILawo;)V
+		ARG 1 slot
+		ARG 2 stack
 	METHOD a clone (Lara;)V
-	METHOD a canPlayerUseInv (Larb;)Z
+	METHOD a canPlayerUse (Larb;)Z
+		ARG 1 player
 	METHOD a populateRecipeFinder (Lard;)V
 	METHOD a addPickBlock (Lawo;)V
 	METHOD a canStackAddMore (Lawo;Lawo;)Z
 		ARG 1 existingStack
 	METHOD a getBlockBreakingSpeed (Lbpm;)F
 	METHOD a serialize (Lhy;)Lhy;
-	METHOD b removeInvStack (I)Lawo;
+	METHOD b removeStack (I)Lawo;
+		ARG 1 slot
 	METHOD b getSlotWithStack (Lawo;)I
 	METHOD b areItemsEqual (Lawo;Lawo;)Z
 		ARG 1 stack1
 	METHOD b isUsingEffectiveTool (Lbpm;)Z
 	METHOD b deserialize (Lhy;)V
-	METHOD c isInvEmpty ()Z
+	METHOD c isEmpty ()Z
 	METHOD c insertStack (ILawo;)Z
 		ARG 1 slot
 	METHOD d swapSlotWithHotbar (I)V

--- a/mappings/net/minecraft/entity/vehicle/ChestMinecartEntity.mapping
+++ b/mappings/net/minecraft/entity/vehicle/ChestMinecartEntity.mapping
@@ -1,5 +1,5 @@
 CLASS asm net/minecraft/entity/vehicle/ChestMinecartEntity
-	METHOD Z_ getInvSize ()I
+	METHOD Z_ getSize ()I
 	METHOD a dropItems (Lage;)V
 	METHOD a createContainer (Lara;Larb;)Lasw;
 		ARG 1 playerInv

--- a/mappings/net/minecraft/entity/vehicle/HopperMinecartEntity.mapping
+++ b/mappings/net/minecraft/entity/vehicle/HopperMinecartEntity.mapping
@@ -10,7 +10,7 @@ CLASS asp net/minecraft/entity/vehicle/HopperMinecartEntity
 	METHOD H updateLogic ()Z
 	METHOD I isCoolingDown ()Z
 	METHOD W_ update ()V
-	METHOD Z_ getInvSize ()I
+	METHOD Z_ getSize ()I
 	METHOD a onActivatorRail (IIIZ)V
 		ARG 1 x
 		ARG 2 y

--- a/mappings/net/minecraft/entity/vehicle/StorageMinecartEntity.mapping
+++ b/mappings/net/minecraft/entity/vehicle/StorageMinecartEntity.mapping
@@ -4,27 +4,32 @@ CLASS asj net/minecraft/entity/vehicle/StorageMinecartEntity
 	FIELD d lootSeed J
 	METHOD <init> (Lagz;Lbbp;)V
 		ARG 1 type
-	METHOD U_ clearInv ()V
+	METHOD U_ onPasted ()V
 	METHOD X invalidate ()V
-	METHOD a getInvStack (I)Lawo;
-	METHOD a takeInvStack (II)Lawo;
+	METHOD a getStack (I)Lawo;
 		ARG 1 slot
-	METHOD a setInvStack (ILawo;)V
+	METHOD a takeStack (II)Lawo;
 		ARG 1 slot
+		ARG 2 amount
+	METHOD a setStack (ILawo;)V
+		ARG 1 slot
+		ARG 2 stack
 	METHOD a setContainerLock (Laft;)V
 	METHOD a dropItems (Lage;)V
-	METHOD a canPlayerUseInv (Larb;)Z
+	METHOD a canPlayerUse (Larb;)Z
+		ARG 1 player
 	METHOD a changeDimension (Lbsg;)Lagv;
 	METHOD a readCustomDataFromTag (Lhs;)V
 	METHOD a setLootTable (Lqc;J)V
 		ARG 1 id
 	METHOD ac_ hasContainerLock ()Z
-	METHOD b removeInvStack (I)Lawo;
+	METHOD b removeStack (I)Lawo;
+		ARG 1 slot
 	METHOD b interact (Larb;Lafo;)Z
 		ARG 1 player
 	METHOD b writeCustomDataToTag (Lhs;)V
 	METHOD b setInWorld (Z)V
-	METHOD c isInvEmpty ()Z
+	METHOD c isEmpty ()Z
 	METHOD g getLootTableId ()Lqc;
 	METHOD h markDirty ()V
 	METHOD k getContainerLock ()Laft;

--- a/mappings/net/minecraft/inventory/BasicInventory.mapping
+++ b/mappings/net/minecraft/inventory/BasicInventory.mapping
@@ -5,19 +5,24 @@ CLASS afx net/minecraft/inventory/BasicInventory
 	FIELD d listeners Ljava/util/List;
 	FIELD e customName Ljd;
 	METHOD R_ getName ()Ljd;
-	METHOD U_ clearInv ()V
-	METHOD Z_ getInvSize ()I
-	METHOD a getInvStack (I)Lawo;
-	METHOD a takeInvStack (II)Lawo;
+	METHOD U_ onPasted ()V
+	METHOD Z_ getSize ()I
+	METHOD a getStack (I)Lawo;
 		ARG 1 slot
-	METHOD a setInvStack (ILawo;)V
+	METHOD a takeStack (II)Lawo;
 		ARG 1 slot
+		ARG 2 amount
+	METHOD a setStack (ILawo;)V
+		ARG 1 slot
+		ARG 2 stack
 	METHOD a addListener (Lafk;)V
-	METHOD a canPlayerUseInv (Larb;)Z
+	METHOD a canPlayerUse (Larb;)Z
+		ARG 1 player
 	METHOD a provideRecipeInputs (Lard;)V
 	METHOD a setCustomName (Ljd;)V
-	METHOD b removeInvStack (I)Lawo;
+	METHOD b removeStack (I)Lawo;
+		ARG 1 slot
 	METHOD b removeListener (Lafk;)V
-	METHOD c isInvEmpty ()Z
+	METHOD c isEmpty ()Z
 	METHOD f getCustomName ()Ljd;
 	METHOD h markDirty ()V

--- a/mappings/net/minecraft/inventory/CraftingInventory.mapping
+++ b/mappings/net/minecraft/inventory/CraftingInventory.mapping
@@ -7,17 +7,22 @@ CLASS atg net/minecraft/inventory/CraftingInventory
 		ARG 1 container
 		ARG 2 width
 	METHOD R_ getName ()Ljd;
-	METHOD U_ clearInv ()V
-	METHOD Z_ getInvSize ()I
-	METHOD a getInvStack (I)Lawo;
-	METHOD a takeInvStack (II)Lawo;
+	METHOD U_ onPasted ()V
+	METHOD Z_ getSize ()I
+	METHOD a getStack (I)Lawo;
 		ARG 1 slot
-	METHOD a setInvStack (ILawo;)V
+	METHOD a takeStack (II)Lawo;
 		ARG 1 slot
-	METHOD a canPlayerUseInv (Larb;)Z
+		ARG 2 amount
+	METHOD a setStack (ILawo;)V
+		ARG 1 slot
+		ARG 2 stack
+	METHOD a canPlayerUse (Larb;)Z
+		ARG 1 player
 	METHOD a provideRecipeInputs (Lard;)V
-	METHOD ab_ getInvWidth ()I
-	METHOD b removeInvStack (I)Lawo;
-	METHOD c isInvEmpty ()Z
+	METHOD ab_ getWidth ()I
+	METHOD b removeStack (I)Lawo;
+		ARG 1 slot
+	METHOD c isEmpty ()Z
 	METHOD h markDirty ()V
-	METHOD n getInvHeight ()I
+	METHOD n getHeight ()I

--- a/mappings/net/minecraft/inventory/CraftingResultInventory.mapping
+++ b/mappings/net/minecraft/inventory/CraftingResultInventory.mapping
@@ -2,17 +2,22 @@ CLASS atz net/minecraft/inventory/CraftingResultInventory
 	FIELD a stack Lfh;
 	FIELD b lastRecipe Layw;
 	METHOD R_ getName ()Ljd;
-	METHOD U_ clearInv ()V
-	METHOD Z_ getInvSize ()I
-	METHOD a getInvStack (I)Lawo;
-	METHOD a takeInvStack (II)Lawo;
+	METHOD U_ onPasted ()V
+	METHOD Z_ getSize ()I
+	METHOD a getStack (I)Lawo;
 		ARG 1 slot
-	METHOD a setInvStack (ILawo;)V
+	METHOD a takeStack (II)Lawo;
 		ARG 1 slot
-	METHOD a canPlayerUseInv (Larb;)Z
+		ARG 2 amount
+	METHOD a setStack (ILawo;)V
+		ARG 1 slot
+		ARG 2 stack
+	METHOD a canPlayerUse (Larb;)Z
+		ARG 1 player
 	METHOD a setLastRecipe (Layw;)V
 		ARG 1 recipe
-	METHOD b removeInvStack (I)Lawo;
-	METHOD c isInvEmpty ()Z
+	METHOD b removeStack (I)Lawo;
+		ARG 1 slot
+	METHOD c isEmpty ()Z
 	METHOD g getLastRecipe ()Layw;
 	METHOD h markDirty ()V

--- a/mappings/net/minecraft/inventory/EnderChestInventory.mapping
+++ b/mappings/net/minecraft/inventory/EnderChestInventory.mapping
@@ -1,8 +1,11 @@
 CLASS atw net/minecraft/inventory/EnderChestInventory
 	FIELD a currentBlockEntity Lbob;
-	METHOD a canPlayerUseInv (Larb;)Z
+	METHOD a canPlayerUse (Larb;)Z
+		ARG 1 player
 	METHOD a setCurrentBlockEntity (Lbob;)V
 	METHOD a readTags (Lhy;)V
-	METHOD b_ onInvOpen (Larb;)V
-	METHOD c_ onInvClose (Larb;)V
+	METHOD b_ onOpened (Larb;)V
+		ARG 1 player
+	METHOD c_ onClosed (Larb;)V
+		ARG 1 player
 	METHOD j getTags ()Lhy;

--- a/mappings/net/minecraft/inventory/Inventory.mapping
+++ b/mappings/net/minecraft/inventory/Inventory.mapping
@@ -1,21 +1,32 @@
 CLASS afi net/minecraft/inventory/Inventory
-	METHOD Z_ getInvSize ()I
-	METHOD a getInvStack (I)Lawo;
-	METHOD a takeInvStack (II)Lawo;
+	METHOD Z_ getSize ()I
+	METHOD a getStack (I)Lawo;
 		ARG 1 slot
-	METHOD a setInvStack (ILawo;)V
+	METHOD a takeStack (II)Lawo;
 		ARG 1 slot
-	METHOD a canPlayerUseInv (Larb;)Z
-	METHOD aa_ getInvMaxStackAmount ()I
-	METHOD ab_ getInvWidth ()I
-	METHOD b removeInvStack (I)Lawo;
-	METHOD b setInvProperty (II)V
-	METHOD b isValidInvStack (ILawo;)Z
+		ARG 2 amount
+	METHOD a setStack (ILawo;)V
 		ARG 1 slot
-	METHOD b_ onInvOpen (Larb;)V
-	METHOD c isInvEmpty ()Z
-	METHOD c getInvProperty (I)I
-	METHOD c_ onInvClose (Larb;)V
+		ARG 2 stack
+	METHOD a canPlayerUse (Larb;)Z
+		ARG 1 player
+	METHOD aa_ getMaxStackAmount ()I
+	METHOD ab_ getWidth ()I
+	METHOD b removeStack (I)Lawo;
+		ARG 1 slot
+	METHOD b setProperty (II)V
+		ARG 1 index
+		ARG 2 value
+	METHOD b isValidStack (ILawo;)Z
+		ARG 1 slot
+		ARG 2 stack
+	METHOD b_ onOpened (Larb;)V
+		ARG 1 player
+	METHOD c isEmpty ()Z
+	METHOD c getProperty (I)I
+		ARG 1 index
+	METHOD c_ onClosed (Larb;)V
+		ARG 1 player
 	METHOD h markDirty ()V
-	METHOD i getInvPropertyCount ()I
-	METHOD n getInvHeight ()I
+	METHOD i getPropertyCount ()I
+	METHOD n getHeight ()I

--- a/mappings/net/minecraft/inventory/InventoryListener.mapping
+++ b/mappings/net/minecraft/inventory/InventoryListener.mapping
@@ -1,2 +1,3 @@
 CLASS afk net/minecraft/inventory/InventoryListener
-	METHOD a onInvChange (Lafi;)V
+	METHOD a onChanged (Lafi;)V
+		ARG 1 inv

--- a/mappings/net/minecraft/inventory/SidedInventory.mapping
+++ b/mappings/net/minecraft/inventory/SidedInventory.mapping
@@ -1,8 +1,11 @@
 CLASS aga net/minecraft/inventory/SidedInventory
-	METHOD a canInsertInvStack (ILawo;Ley;)Z
+	METHOD a canInsertStack (ILawo;Ley;)Z
 		ARG 1 slot
 		ARG 2 stack
-	METHOD a getInvAvailableSlots (Ley;)[I
-	METHOD b canExtractInvStack (ILawo;Ley;)Z
+		ARG 3 face
+	METHOD a getAvailableSlots (Ley;)[I
+		ARG 1 face
+	METHOD b canExtractStack (ILawo;Ley;)Z
 		ARG 1 slot
 		ARG 2 stack
+		ARG 3 face

--- a/mappings/net/minecraft/village/VillagerInventory.mapping
+++ b/mappings/net/minecraft/village/VillagerInventory.mapping
@@ -4,16 +4,21 @@ CLASS att net/minecraft/village/VillagerInventory
 	FIELD c villagerRecipe Lbau;
 	FIELD d recipeIndex I
 	METHOD R_ getName ()Ljd;
-	METHOD U_ clearInv ()V
-	METHOD Z_ getInvSize ()I
-	METHOD a getInvStack (I)Lawo;
-	METHOD a takeInvStack (II)Lawo;
+	METHOD U_ onPasted ()V
+	METHOD Z_ getSize ()I
+	METHOD a getStack (I)Lawo;
 		ARG 1 slot
-	METHOD a setInvStack (ILawo;)V
+	METHOD a takeStack (II)Lawo;
 		ARG 1 slot
-	METHOD a canPlayerUseInv (Larb;)Z
-	METHOD b removeInvStack (I)Lawo;
-	METHOD c isInvEmpty ()Z
+		ARG 2 amount
+	METHOD a setStack (ILawo;)V
+		ARG 1 slot
+		ARG 2 stack
+	METHOD a canPlayerUse (Larb;)Z
+		ARG 1 player
+	METHOD b removeStack (I)Lawo;
+		ARG 1 slot
+	METHOD c isEmpty ()Z
 	METHOD d setRecipeIndex (I)V
 	METHOD e needRecipeUpdate (I)Z
 	METHOD h markDirty ()V


### PR DESCRIPTION
Drops 'Inv' from all Inventory methods. What else am i getting a stack on? A carrot?
Named `afg`(`class_3829`) -> `PasteCallback`, its only ever called by things that 'paste' a BlockEntity in world and its not specific to Inventories, although its only implemented by `Inventory` inheritors and `JukeboxBlockEntity`, still not 100% on the name imo, feedback would be nice.
![](https://ss.covers1624.net/9998b)