### PR TITLE
Identifier#path -> Identifier#value

### DIFF
--- a/mappings/net/minecraft/util/Identifier.mapping
+++ b/mappings/net/minecraft/util/Identifier.mapping
@@ -1,9 +1,9 @@
 CLASS qc net/minecraft/util/Identifier
 	CLASS qc$a DeSerializer
 	FIELD a namespace Ljava/lang/String;
-	FIELD b path Ljava/lang/String;
+	FIELD b value Ljava/lang/String;
 	FIELD c EXCEPTION_INVALID Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
-	METHOD a getPath ()Ljava/lang/String;
+	METHOD a getValue ()Ljava/lang/String;
 	METHOD a isValidChar (C)Z
 		ARG 0 chr
 	METHOD a parse (Lcom/mojang/brigadier/StringReader;)Lqc;


### PR DESCRIPTION
With the desire to generify what Mojang considers a location as an `Identifier`, it makes sense to treat the value component of the identifier pair as a `value` rather than a `path`.