### PR TITLE
Change BucketInteractable to less specific FluidDrainable

### DIFF
--- a/mappings/net/minecraft/block/BubbleColumnBlock.mapping
+++ b/mappings/net/minecraft/block/BubbleColumnBlock.mapping
@@ -31,7 +31,7 @@ CLASS bgw net/minecraft/block/BubbleColumnBlock
 		ARG 6 neighborPos
 	METHOD a appendProperties (Lbpn$a;)V
 		ARG 1 builder
-	METHOD b getBucketFluid (Lbbq;Let;Lbpm;)Lcfc;
+	METHOD b tryDrainFluid (Lbbq;Let;Lbpm;)Lcfc;
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state

--- a/mappings/net/minecraft/block/BucketInteractable.mapping
+++ b/mappings/net/minecraft/block/BucketInteractable.mapping
@@ -1,5 +1,0 @@
-CLASS bgx net/minecraft/block/BucketInteractable
-	METHOD b getBucketFluid (Lbbq;Let;Lbpm;)Lcfc;
-		ARG 1 world
-		ARG 2 pos
-		ARG 3 state

--- a/mappings/net/minecraft/block/FluidBlock.mapping
+++ b/mappings/net/minecraft/block/FluidBlock.mapping
@@ -41,7 +41,7 @@ CLASS bjv net/minecraft/block/FluidBlock
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos
-	METHOD b getBucketFluid (Lbbq;Let;Lbpm;)Lcfc;
+	METHOD b tryDrainFluid (Lbbq;Let;Lbpm;)Lcfc;
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state

--- a/mappings/net/minecraft/block/FluidDrainable.mapping
+++ b/mappings/net/minecraft/block/FluidDrainable.mapping
@@ -1,0 +1,5 @@
+CLASS bgx net/minecraft/block/FluidDrainable
+	METHOD b tryDrainFluid (Lbbq;Let;Lbpm;)Lcfc;
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 state

--- a/mappings/net/minecraft/block/Waterloggable.mapping
+++ b/mappings/net/minecraft/block/Waterloggable.mapping
@@ -9,7 +9,7 @@ CLASS blk net/minecraft/block/Waterloggable
 		ARG 2 pos
 		ARG 3 state
 		ARG 4 fluidState
-	METHOD b getBucketFluid (Lbbq;Let;Lbpm;)Lcfc;
+	METHOD b tryDrainFluid (Lbbq;Let;Lbpm;)Lcfc;
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state


### PR DESCRIPTION
Since Sponges also make use of `class_2263`, it seems better suited for it to be named something that is applicable to more than just Buckets. 

The `FluidDrainable` name felt appropriate since in `Waterloggable` the `class_2263` implementation essentially performs the opposite task of the `FluidFillable` implementation. 