### PR TITLE
Clean up static final fields in various datafixers

### DIFF
--- a/mappings/net/minecraft/datafixers/fixes/BiomesFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/BiomesFix.mapping
@@ -1,2 +1,2 @@
 CLASS zk net/minecraft/datafixers/fixes/BiomesFix
-	FIELD a biomes Ljava/util/Map;
+	FIELD a RENAMED_BIOMES Ljava/util/Map;

--- a/mappings/net/minecraft/datafixers/fixes/BlockEntityIdFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/BlockEntityIdFix.mapping
@@ -1,1 +1,2 @@
 CLASS zo net/minecraft/datafixers/fixes/BlockEntityIdFix
+	FIELD a RENAMED_BLOCK_ENTITIES Ljava/util/Map;

--- a/mappings/net/minecraft/datafixers/fixes/BlockEntitySignTextStrictJsonFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/BlockEntitySignTextStrictJsonFix.mapping
@@ -1,2 +1,3 @@
 CLASS zs net/minecraft/datafixers/fixes/BlockEntitySignTextStrictJsonFix
+	FIELD a GSON Lcom/google/gson/Gson;
 	METHOD a transform (Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;

--- a/mappings/net/minecraft/datafixers/fixes/BlockStateFlattening.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/BlockStateFlattening.mapping
@@ -1,11 +1,19 @@
 CLASS zv net/minecraft/datafixers/fixes/BlockStateFlattening
 	FIELD a LOGGER Lorg/apache/logging/log4j/Logger;
-	FIELD b states [Lcom/mojang/datafixers/Dynamic;
-	FIELD c stateObjToId Lit/unimi/dsi/fastutil/objects/Object2IntMap;
-	FIELD d stateStrToId Lit/unimi/dsi/fastutil/objects/Object2IntMap;
+	FIELD b NEW_IDS_TO_STATES [Lcom/mojang/datafixers/Dynamic;
+	FIELD c OLD_STATES_TO_NEW_IDS Lit/unimi/dsi/fastutil/objects/Object2IntMap;
+	FIELD d BLOCKS_TO_DEFAULT_IDS Lit/unimi/dsi/fastutil/objects/Object2IntMap;
 	METHOD a lookup (I)Ljava/lang/String;
+		ARG 0 stateId
 	METHOD a putStates (ILjava/lang/String;[Ljava/lang/String;)V
+		ARG 0 newId
+		ARG 1 newStateStr
+		ARG 2 oldStateStrings
 	METHOD a lookupState (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 0 oldState
 	METHOD a lookup (Ljava/lang/String;)Ljava/lang/String;
+		ARG 0 blockId
 	METHOD b lookupState (I)Lcom/mojang/datafixers/Dynamic;
+		ARG 0 stateId
 	METHOD b parseState (Ljava/lang/String;)Lcom/mojang/datafixers/Dynamic;
+		ARG 0 stateStr

--- a/mappings/net/minecraft/datafixers/fixes/EntityBlockStateFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityBlockStateFix.mapping
@@ -1,1 +1,4 @@
 CLASS aah net/minecraft/datafixers/fixes/EntityBlockStateFix
+	FIELD a BLOCK_NAME_TO_ID Ljava/util/Map;
+	METHOD a getNumericalBlockId (Ljava/lang/String;)I
+		ARG 0 blockId

--- a/mappings/net/minecraft/datafixers/fixes/EntityHealthFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityHealthFix.mapping
@@ -1,2 +1,2 @@
 CLASS aan net/minecraft/datafixers/fixes/EntityHealthFix
-	FIELD a entities Ljava/util/Set;
+	FIELD a ENTITIES Ljava/util/Set;

--- a/mappings/net/minecraft/datafixers/fixes/EntityIdFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityIdFix.mapping
@@ -1,1 +1,2 @@
 CLASS aaq net/minecraft/datafixers/fixes/EntityIdFix
+	FIELD a RENAMED_ENTITIES Ljava/util/Map;

--- a/mappings/net/minecraft/datafixers/fixes/EntityMinecartIdentifiersFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityMinecartIdentifiersFix.mapping
@@ -1,2 +1,2 @@
 CLASS aas net/minecraft/datafixers/fixes/EntityMinecartIdentifiersFix
-	FIELD a minecarts Ljava/util/List;
+	FIELD a MINECARTS Ljava/util/List;

--- a/mappings/net/minecraft/datafixers/fixes/EntityPaintingFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityPaintingFix.mapping
@@ -1,2 +1,2 @@
 CLASS aat net/minecraft/datafixers/fixes/EntityPaintingFix
-	FIELD a offsets [[I
+	FIELD a OFFSETS [[I

--- a/mappings/net/minecraft/datafixers/fixes/EntityPaintingMotiveFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityPaintingMotiveFix.mapping
@@ -1,3 +1,3 @@
 CLASS aau net/minecraft/datafixers/fixes/EntityPaintingMotiveFix
-	FIELD a paintings Ljava/util/Map;
+	FIELD a RENAMED_MOTIVES Ljava/util/Map;
 	METHOD a transform (Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;

--- a/mappings/net/minecraft/datafixers/fixes/EntityPufferfishRenameFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityPufferfishRenameFix.mapping
@@ -1,3 +1,3 @@
 CLASS aav net/minecraft/datafixers/fixes/EntityPufferfishRenameFix
-	FIELD a convert Ljava/util/Map;
+	FIELD a RENAMED_FISHES Ljava/util/Map;
 	METHOD a rename (Ljava/lang/String;)Ljava/lang/String;

--- a/mappings/net/minecraft/datafixers/fixes/ItemIdFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemIdFix.mapping
@@ -1,3 +1,4 @@
 CLASS abl net/minecraft/datafixers/fixes/ItemIdFix
-	FIELD a items Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
+	FIELD a NUMERICAL_ID_TO_STRING_ID_MAP Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
+	METHOD <clinit> ()V
 	METHOD a fromId (I)Ljava/lang/String;

--- a/mappings/net/minecraft/datafixers/fixes/ItemIdFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemIdFix.mapping
@@ -1,4 +1,3 @@
 CLASS abl net/minecraft/datafixers/fixes/ItemIdFix
 	FIELD a NUMERICAL_ID_TO_STRING_ID_MAP Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
-	METHOD <clinit> ()V
 	METHOD a fromId (I)Ljava/lang/String;

--- a/mappings/net/minecraft/datafixers/fixes/ItemInstanceSpawnEggFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemInstanceSpawnEggFix.mapping
@@ -1,2 +1,2 @@
 CLASS abt net/minecraft/datafixers/fixes/ItemInstanceSpawnEggFix
-	FIELD a entityEggs Ljava/util/Map;
+	FIELD a ENTITY_SPAWN_EGGS Ljava/util/Map;

--- a/mappings/net/minecraft/datafixers/fixes/ItemInstanceTheFlatteningFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemInstanceTheFlatteningFix.mapping
@@ -1,5 +1,9 @@
 CLASS abu net/minecraft/datafixers/fixes/ItemInstanceTheFlatteningFix
-	FIELD a damageMap Ljava/util/Map;
-	FIELD b itemNames Ljava/util/Set;
-	FIELD c damagedItems Ljava/util/Set;
+	FIELD a FLATTENING_MAP Ljava/util/Map;
+	FIELD b ORIGINAL_ITEM_NAMES Ljava/util/Set;
+	FIELD c DAMAGABLE_ITEMS Ljava/util/Set;
+	METHOD <clinit> ()V
+		ARG 0 map
 	METHOD a getItem (Ljava/lang/String;I)Ljava/lang/String;
+		ARG 0 originalName
+		ARG 1 damage

--- a/mappings/net/minecraft/datafixers/fixes/ItemInstanceTheFlatteningFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemInstanceTheFlatteningFix.mapping
@@ -2,8 +2,6 @@ CLASS abu net/minecraft/datafixers/fixes/ItemInstanceTheFlatteningFix
 	FIELD a FLATTENING_MAP Ljava/util/Map;
 	FIELD b ORIGINAL_ITEM_NAMES Ljava/util/Set;
 	FIELD c DAMAGABLE_ITEMS Ljava/util/Set;
-	METHOD <clinit> ()V
-		ARG 0 map
 	METHOD a getItem (Ljava/lang/String;I)Ljava/lang/String;
 		ARG 0 originalName
 		ARG 1 damage

--- a/mappings/net/minecraft/datafixers/fixes/ItemPotionFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemPotionFix.mapping
@@ -1,3 +1,2 @@
 CLASS abn net/minecraft/datafixers/fixes/ItemPotionFix
 	FIELD a ID_TO_POTIONS [Ljava/lang/String;
-	METHOD <clinit> ()V

--- a/mappings/net/minecraft/datafixers/fixes/ItemPotionFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemPotionFix.mapping
@@ -1,2 +1,3 @@
 CLASS abn net/minecraft/datafixers/fixes/ItemPotionFix
-	FIELD a potions [Ljava/lang/String;
+	FIELD a ID_TO_POTIONS [Ljava/lang/String;
+	METHOD <clinit> ()V

--- a/mappings/net/minecraft/datafixers/fixes/ItemShulkerBoxColorFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemShulkerBoxColorFix.mapping
@@ -1,2 +1,2 @@
 CLASS abp net/minecraft/datafixers/fixes/ItemShulkerBoxColorFix
-	FIELD a colorNames [Ljava/lang/String;
+	FIELD a COLORED_SHULKER_BOX_IDS [Ljava/lang/String;

--- a/mappings/net/minecraft/datafixers/fixes/ItemSpawnEggFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemSpawnEggFix.mapping
@@ -1,2 +1,2 @@
 CLASS abq net/minecraft/datafixers/fixes/ItemSpawnEggFix
-	FIELD a entities [Ljava/lang/String;
+	FIELD a DAMAGE_TO_ENTITY_IDS [Ljava/lang/String;

--- a/mappings/net/minecraft/datafixers/fixes/ItemStackEnchantmentFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemStackEnchantmentFix.mapping
@@ -1,3 +1,2 @@
 CLASS abr net/minecraft/datafixers/fixes/ItemStackEnchantmentFix
 	FIELD a ID_TO_ENCHANTMENTS_MAP Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
-	METHOD <clinit> ()V

--- a/mappings/net/minecraft/datafixers/fixes/ItemStackEnchantmentFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemStackEnchantmentFix.mapping
@@ -1,2 +1,3 @@
 CLASS abr net/minecraft/datafixers/fixes/ItemStackEnchantmentFix
-	FIELD a enchants Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
+	FIELD a ID_TO_ENCHANTMENTS_MAP Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
+	METHOD <clinit> ()V

--- a/mappings/net/minecraft/datafixers/fixes/LevelDataGeneratorOptionsFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/LevelDataGeneratorOptionsFix.mapping
@@ -1,2 +1,2 @@
 CLASS aby net/minecraft/datafixers/fixes/LevelDataGeneratorOptionsFix
-	FIELD a biomes Ljava/util/Map;
+	FIELD a NUMERICAL_IDS_TO_BIOME_IDS Ljava/util/Map;

--- a/mappings/net/minecraft/datafixers/fixes/LevelFlatGeneratorInfoFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/LevelFlatGeneratorInfoFix.mapping
@@ -1,3 +1,7 @@
 CLASS abz net/minecraft/datafixers/fixes/LevelFlatGeneratorInfoFix
-	FIELD b commas Lcom/google/common/base/Splitter;
+	FIELD a SPLIT_ON_SEMICOLON Lcom/google/common/base/Splitter;
+	FIELD b SPLIT_ON_COMMA Lcom/google/common/base/Splitter;
+	FIELD c SPLIT_ON_LOWER_X Lcom/google/common/base/Splitter;
+	FIELD d SPLIT_ON_ASTERISK Lcom/google/common/base/Splitter;
+	FIELD e SPLIT_ON_COLON Lcom/google/common/base/Splitter;
 	METHOD a transform (Ljava/lang/String;)Ljava/lang/String;

--- a/mappings/net/minecraft/datafixers/fixes/OptionsKeyLwjgl3Fix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/OptionsKeyLwjgl3Fix.mapping
@@ -1,2 +1,2 @@
 CLASS acf net/minecraft/datafixers/fixes/OptionsKeyLwjgl3Fix
-	FIELD a keys Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
+	FIELD a NUMERICAL_KEY_IDS_TO_KEY_NAMES Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;

--- a/mappings/net/minecraft/datafixers/fixes/StatsCounterFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/StatsCounterFix.mapping
@@ -1,6 +1,8 @@
 CLASS acq net/minecraft/datafixers/fixes/StatsCounterFix
-	FIELD a skip Ljava/util/Set;
-	FIELD b customMap Ljava/util/Map;
-	FIELD e entityMap Ljava/util/Map;
+	FIELD a SKIP Ljava/util/Set;
+	FIELD b RENAMED_GENERAL_STATS Ljava/util/Map;
+	FIELD c RENAMED_ITEM_STATS Ljava/util/Map;
+	FIELD d RENAMED_ENTITY_STATS Ljava/util/Map;
+	FIELD e RENAMED_ENTITIES Ljava/util/Map;
 	METHOD a getItem (Ljava/lang/String;)Ljava/lang/String;
 	METHOD b getBlock (Ljava/lang/String;)Ljava/lang/String;


### PR DESCRIPTION
This pull request:
  - Mainly upper-casing `static final` fields in datafixers.
    - For those `static final` fields that haven't been mapped, a new name is provided.
    - Many of `static final` fields are renamed. Comments are welcome.
  - For `BlockStateFlattening`, several param names are mapped. Comments are welcome.