### PR TITLE
Map a shader effect class and an exception

### DIFF
--- a/mappings/net/minecraft/client/gl/PostProcessShader.mapping
+++ b/mappings/net/minecraft/client/gl/PostProcessShader.mapping
@@ -12,4 +12,6 @@ CLASS dek net/minecraft/client/gl/PostProcessShader
 		ARG 1 time
 	METHOD a setProjectionMatrix (Lcop;)V
 		ARG 1 projectionMatrix
+	METHOD a addAuxTarget (Ljava/lang/String;Ljava/lang/Object;II)V
 	METHOD b getProgram ()Lddw;
+	METHOD close ()V

--- a/mappings/net/minecraft/client/gl/ShaderEffect.mapping
+++ b/mappings/net/minecraft/client/gl/ShaderEffect.mapping
@@ -1,0 +1,80 @@
+CLASS dej net/minecraft/client/gl/ShaderEffect
+	FIELD a mainTarget Lcnr;
+	FIELD b resourceManager Lwj;
+	FIELD c name Ljava/lang/String;
+	FIELD d passes Ljava/util/List;
+	FIELD e targetsByName Ljava/util/Map;
+	FIELD f defaultSizedTargets Ljava/util/List;
+	FIELD g projectionMatrix Lcop;
+	FIELD h width I
+	FIELD i height I
+	FIELD j time F
+	FIELD k lastTickDelta F
+	METHOD <init> (Ldnp;Lwj;Lcnr;Lqc;)V
+		ARG 3 framebuffer
+		ARG 4 location
+	METHOD a getName ()Ljava/lang/String;
+	METHOD a render (F)V
+		ARG 1 tickDelta
+	METHOD a setupDimensions (II)V
+		ARG 1 targetsWidth
+		ARG 2 targetsHeight
+	METHOD a parseTarget (Lcom/google/gson/JsonElement;)V
+		ARG 1 jsonTarget
+		ARG 2 jsonTargetObject
+		ARG 3 name
+		ARG 4 width
+		ARG 5 height
+	METHOD a parsePass (Ldnp;Lcom/google/gson/JsonElement;)V
+		ARG 2 jsonPass
+		ARG 3 jsonPassObject
+		ARG 4 passName
+		ARG 5 inTargetName
+		ARG 6 outTargetName
+		ARG 7 inTarget
+		ARG 8 outTarget
+		ARG 9 pass
+		ARG 10 auxTargets
+		ARG 11 i
+		ARG 12 uniformIndex
+		ARG 14 auxTargetJson
+		ARG 15 targetName
+		ARG 16 targetId
+		ARG 17 auxTarget
+		ARG 18 textureLocation
+		ARG 19 textureResource
+		ARG 20 texture
+		ARG 21 textureWidth
+		ARG 22 textureHeight
+		ARG 23 bilinear
+	METHOD a parseEffect (Ldnp;Lqc;)V
+		ARG 2 location
+		ARG 3 resource
+		ARG 4 jsonShaderEffect
+		ARG 5 jsonTargets
+		ARG 6 i
+		ARG 10 exception
+	METHOD a getSecondaryTarget (Ljava/lang/String;)Lcnr;
+		ARG 1 name
+	METHOD a addTarget (Ljava/lang/String;II)V
+		ARG 1 name
+		ARG 2 width
+		ARG 3 height
+		ARG 4 target
+	METHOD a addPass (Ljava/lang/String;Lcnr;Lcnr;)Ldek;
+		ARG 1 programName
+		ARG 2 source
+		ARG 3 dest
+		ARG 4 parsedPass
+	METHOD b setupProjectionMatrix ()V
+	METHOD b parseUniform (Lcom/google/gson/JsonElement;)V
+		ARG 1 jsonUniform
+		ARG 2 jsonUniformObject
+		ARG 3 uniformName
+		ARG 4 uniform
+		ARG 6 i
+		ARG 7 jsonValues
+		ARG 11 exception
+	METHOD b getTarget (Ljava/lang/String;)Lcnr;
+		ARG 1 name
+	METHOD close ()V

--- a/mappings/net/minecraft/client/gl/ShaderParseException.mapping
+++ b/mappings/net/minecraft/client/gl/ShaderParseException.mapping
@@ -1,0 +1,22 @@
+CLASS qg net/minecraft/client/gl/ShaderParseException
+	CLASS qg$a JsonStackTrace
+		FIELD a fileName Ljava/lang/String;
+		FIELD b faultyElements Ljava/util/List;
+		METHOD a add (Ljava/lang/String;)V
+			ARG 1 element
+		METHOD b joinStackTrace ()Ljava/lang/String;
+	FIELD a traces Ljava/util/List;
+	FIELD b message Ljava/lang/String;
+	METHOD <init> (Ljava/lang/String;)V
+		ARG 1 message
+	METHOD <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+		ARG 1 message
+		ARG 2 cause
+	METHOD a wrap (Ljava/lang/Exception;)Lqg;
+		ARG 0 cause
+		ARG 1 message
+	METHOD a addFaultyElement (Ljava/lang/String;)V
+		ARG 1 jsonKey
+	METHOD b addFaultyFile (Ljava/lang/String;)V
+		ARG 1 path
+	METHOD getMessage ()Ljava/lang/String;


### PR DESCRIPTION
Note: I did not really know where to put those so I put them in the same package as `net.minecraft.client.gl.PostProcessShader`. However there are a few other classes related to post process shader stuff, so I would suggest adding a dedicated `shader` package. If the sentiment is shared, I can do it in this PR.