### PR TITLE
drawBoxOutline -> buildBoxOutline

### DIFF
--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -95,7 +95,7 @@ CLASS dee net/minecraft/client/render/WorldRenderer
 		ARG 9 blue
 		ARG 10 alpha
 	METHOD a renderStars (Lcou;)V
-	METHOD a drawBoxOutline (Lcou;DDDDDDFFFF)V
+	METHOD a buildBoxOutline (Lcou;DDDDDDFFFF)V
 		ARG 0 buffer
 		ARG 1 minX
 		ARG 3 minY


### PR DESCRIPTION
Another oversight in my original PR. This method does not draw the box, it merely appends the data to the builder. `buildBoxOutline` is equivalent semantics to `buildBox` in this class.