### PR TITLE
Coordinates and positions

### DIFF
--- a/mappings/dj.mapping
+++ b/mappings/dj.mapping
@@ -1,3 +1,0 @@
-CLASS dj
-	METHOD equals (Ljava/lang/Object;)Z
-		ARG 1 o

--- a/mappings/dp.mapping
+++ b/mappings/dp.mapping
@@ -1,3 +1,0 @@
-CLASS dp
-	METHOD equals (Ljava/lang/Object;)Z
-		ARG 1 o

--- a/mappings/dq.mapping
+++ b/mappings/dq.mapping
@@ -1,3 +1,0 @@
-CLASS dq
-	METHOD equals (Ljava/lang/Object;)Z
-		ARG 1 o

--- a/mappings/net/minecraft/command/arguments/CoordinateArgument.mapping
+++ b/mappings/net/minecraft/command/arguments/CoordinateArgument.mapping
@@ -1,0 +1,20 @@
+CLASS dp net/minecraft/command/arguments/CoordinateArgument
+	FIELD a MISSING_COORDINATE Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
+	FIELD b MISSING_BLOCK_POSITION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
+	FIELD c relative Z
+	FIELD d value D
+	METHOD <init> (ZD)V
+		ARG 1 relative
+		ARG 2 value
+	METHOD a isRelative ()Z
+	METHOD a toActualCoordinate (D)D
+		ARG 1 offset
+	METHOD a parse (Lcom/mojang/brigadier/StringReader;)Ldp;
+		ARG 0 reader
+	METHOD a parse (Lcom/mojang/brigadier/StringReader;Z)Ldp;
+		ARG 0 reader
+		ARG 1 center
+	METHOD b isRelative (Lcom/mojang/brigadier/StringReader;)Z
+		ARG 0 reader
+	METHOD equals (Ljava/lang/Object;)Z
+		ARG 1 o

--- a/mappings/net/minecraft/command/arguments/CoordinateArgument.mapping
+++ b/mappings/net/minecraft/command/arguments/CoordinateArgument.mapping
@@ -7,7 +7,7 @@ CLASS dp net/minecraft/command/arguments/CoordinateArgument
 		ARG 1 relative
 		ARG 2 value
 	METHOD a isRelative ()Z
-	METHOD a toActualCoordinate (D)D
+	METHOD a toAbsoluteCoordinate (D)D
 		ARG 1 offset
 	METHOD a parse (Lcom/mojang/brigadier/StringReader;)Ldp;
 		ARG 0 reader

--- a/mappings/net/minecraft/command/arguments/DefaultPosArgument.mapping
+++ b/mappings/net/minecraft/command/arguments/DefaultPosArgument.mapping
@@ -7,7 +7,7 @@ CLASS dq net/minecraft/command/arguments/DefaultPosArgument
 		ARG 2 y
 		ARG 3 z
 	METHOD a isXRelative ()Z
-	METHOD a toActualPos (Lca;)Lcms;
+	METHOD a toAbsolutePos (Lca;)Lcms;
 		ARG 1 source
 	METHOD a parse (Lcom/mojang/brigadier/StringReader;)Ldq;
 		ARG 0 reader
@@ -15,7 +15,7 @@ CLASS dq net/minecraft/command/arguments/DefaultPosArgument
 		ARG 0 reader
 		ARG 1 centerHorizontally
 	METHOD b isYRelative ()Z
-	METHOD b toActualRotation (Lca;)Lcmr;
+	METHOD b toAbsoluteRotation (Lca;)Lcmr;
 		ARG 1 source
 	METHOD c isZRelative ()Z
 	METHOD d zero ()Ldq;

--- a/mappings/net/minecraft/command/arguments/DefaultPosArgument.mapping
+++ b/mappings/net/minecraft/command/arguments/DefaultPosArgument.mapping
@@ -1,0 +1,23 @@
+CLASS dq net/minecraft/command/arguments/DefaultPosArgument
+	FIELD a x Ldp;
+	FIELD b y Ldp;
+	FIELD c z Ldp;
+	METHOD <init> (Ldp;Ldp;Ldp;)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+	METHOD a isXRelative ()Z
+	METHOD a toActualPos (Lca;)Lcms;
+		ARG 1 source
+	METHOD a parse (Lcom/mojang/brigadier/StringReader;)Ldq;
+		ARG 0 reader
+	METHOD a parse (Lcom/mojang/brigadier/StringReader;Z)Ldq;
+		ARG 0 reader
+		ARG 1 centerHorizontally
+	METHOD b isYRelative ()Z
+	METHOD b toActualRotation (Lca;)Lcmr;
+		ARG 1 source
+	METHOD c isZRelative ()Z
+	METHOD d zero ()Ldq;
+	METHOD equals (Ljava/lang/Object;)Z
+		ARG 1 o

--- a/mappings/net/minecraft/command/arguments/LookingPosArgument.mapping
+++ b/mappings/net/minecraft/command/arguments/LookingPosArgument.mapping
@@ -7,7 +7,7 @@ CLASS dj net/minecraft/command/arguments/LookingPosArgument
 		ARG 3 y
 		ARG 5 z
 	METHOD a isXRelative ()Z
-	METHOD a toActualPos (Lca;)Lcms;
+	METHOD a toAbsolutePos (Lca;)Lcms;
 		ARG 1 source
 	METHOD a parse (Lcom/mojang/brigadier/StringReader;)Ldj;
 		ARG 0 reader
@@ -15,7 +15,7 @@ CLASS dj net/minecraft/command/arguments/LookingPosArgument
 		ARG 0 reader
 		ARG 1 startingCursorPos
 	METHOD b isYRelative ()Z
-	METHOD b toActualRotation (Lca;)Lcmr;
+	METHOD b toAbsoluteRotation (Lca;)Lcmr;
 		ARG 1 source
 	METHOD c isZRelative ()Z
 	METHOD equals (Ljava/lang/Object;)Z

--- a/mappings/net/minecraft/command/arguments/LookingPosArgument.mapping
+++ b/mappings/net/minecraft/command/arguments/LookingPosArgument.mapping
@@ -1,0 +1,22 @@
+CLASS dj net/minecraft/command/arguments/LookingPosArgument
+	FIELD a x D
+	FIELD b y D
+	FIELD c z D
+	METHOD <init> (DDD)V
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
+	METHOD a isXRelative ()Z
+	METHOD a toActualPos (Lca;)Lcms;
+		ARG 1 source
+	METHOD a parse (Lcom/mojang/brigadier/StringReader;)Ldj;
+		ARG 0 reader
+	METHOD a readCoordinate (Lcom/mojang/brigadier/StringReader;I)D
+		ARG 0 reader
+		ARG 1 startingCursorPos
+	METHOD b isYRelative ()Z
+	METHOD b toActualRotation (Lca;)Lcmr;
+		ARG 1 source
+	METHOD c isZRelative ()Z
+	METHOD equals (Ljava/lang/Object;)Z
+		ARG 1 o

--- a/mappings/net/minecraft/command/arguments/PosArgument.mapping
+++ b/mappings/net/minecraft/command/arguments/PosArgument.mapping
@@ -1,0 +1,10 @@
+CLASS di net/minecraft/command/arguments/PosArgument
+	METHOD a isXRelative ()Z
+	METHOD a toActualPos (Lca;)Lcms;
+		ARG 1 source
+	METHOD b isYRelative ()Z
+	METHOD b toActualRotation (Lca;)Lcmr;
+		ARG 1 source
+	METHOD c isZRelative ()Z
+	METHOD c toActualBlockPos (Lca;)Let;
+		ARG 1 source

--- a/mappings/net/minecraft/command/arguments/PosArgument.mapping
+++ b/mappings/net/minecraft/command/arguments/PosArgument.mapping
@@ -1,10 +1,10 @@
 CLASS di net/minecraft/command/arguments/PosArgument
 	METHOD a isXRelative ()Z
-	METHOD a toActualPos (Lca;)Lcms;
+	METHOD a toAbsolutePos (Lca;)Lcms;
 		ARG 1 source
 	METHOD b isYRelative ()Z
-	METHOD b toActualRotation (Lca;)Lcmr;
+	METHOD b toAbsoluteRotation (Lca;)Lcmr;
 		ARG 1 source
 	METHOD c isZRelative ()Z
-	METHOD c toActualBlockPos (Lca;)Let;
+	METHOD c toAbsoluteBlockPos (Lca;)Let;
 		ARG 1 source

--- a/mappings/net/minecraft/command/arguments/RotationArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/RotationArgumentType.mapping
@@ -3,3 +3,5 @@ CLASS dk net/minecraft/command/arguments/RotationArgumentType
 	FIELD b EXAMPLES Ljava/util/Collection;
 	METHOD a create ()Ldk;
 	METHOD a getRotationArgument (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Ldi;
+		ARG 0 context
+		ARG 1 argumentName

--- a/mappings/net/minecraft/server/command/TeleportCommand.mapping
+++ b/mappings/net/minecraft/server/command/TeleportCommand.mapping
@@ -1,2 +1,6 @@
 CLASS tf net/minecraft/server/command/TeleportCommand
+	METHOD a (Lca;Ljava/util/Collection;Lut;Ldi;Ldi;Ltf$a;)I
+		ARG 2 world
+		ARG 3 pos
+		ARG 4 rotation
 	METHOD a register (Lcom/mojang/brigadier/CommandDispatcher;)V


### PR DESCRIPTION
The `toActual*` names mean (almost always) the contained position offset with the caller position. (The only exception is `DefaultPosArgument` when it's not relative).