### PR TITLE
Some ray tracing shenanagins 

### DIFF
--- a/mappings/bbw.mapping
+++ b/mappings/bbw.mapping
@@ -1,4 +1,0 @@
-CLASS bbw
-	CLASS bbw$b
-		FIELD a NONE Lbbw$b;
-		FIELD d predicate Ljava/util/function/Predicate;

--- a/mappings/net/minecraft/block/AbstractButtonBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractButtonBlock.mapping
@@ -1,7 +1,7 @@
 CLASS bhs net/minecraft/block/AbstractButtonBlock
 	METHOD a getTickRate (Lbcm;)I
 		ARG 1 world
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/AbstractPressurePlateBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractPressurePlateBlock.mapping
@@ -21,7 +21,7 @@ CLASS bhe net/minecraft/block/AbstractPressurePlateBlock
 	METHOD a setRedstoneOutput (Lbqi;I)Lbqi;
 		ARG 1 state
 		ARG 2 rsOut
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/AbstractRailBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractRailBlock.mapping
@@ -5,7 +5,7 @@ CLASS bhf net/minecraft/block/AbstractRailBlock
 	METHOD a isRail (Lbci;Let;)Z
 		ARG 0 world
 		ARG 1 pos
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/AbstractRedstoneGateBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractRedstoneGateBlock.mapping
@@ -12,7 +12,7 @@ CLASS bit net/minecraft/block/AbstractRedstoneGateBlock
 	METHOD a getInputLevel (Lbcm;Let;Ley;)I
 		ARG 1 view
 		ARG 2 pos
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/AirBlock.mapping
+++ b/mappings/net/minecraft/block/AirBlock.mapping
@@ -1,7 +1,7 @@
 CLASS bgr net/minecraft/block/AirBlock
 	METHOD <init> (Lbhl$c;)V
 		ARG 1 settings
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/AnvilBlock.mapping
+++ b/mappings/net/minecraft/block/AnvilBlock.mapping
@@ -19,7 +19,7 @@ CLASS bgs net/minecraft/block/AnvilBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/AttachedStemBlock.mapping
+++ b/mappings/net/minecraft/block/AttachedStemBlock.mapping
@@ -7,7 +7,7 @@ CLASS bgt net/minecraft/block/AttachedStemBlock
 		ARG 1 floor
 		ARG 2 view
 		ARG 3 pos
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/BambooBlock.mapping
+++ b/mappings/net/minecraft/block/BambooBlock.mapping
@@ -18,7 +18,7 @@ CLASS bgu net/minecraft/block/BambooBlock
 		ARG 2 player
 		ARG 3 world
 		ARG 4 pos
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/BedBlock.mapping
+++ b/mappings/net/minecraft/block/BedBlock.mapping
@@ -35,7 +35,7 @@ CLASS bhh net/minecraft/block/BedBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/BeetrootsBlock.mapping
+++ b/mappings/net/minecraft/block/BeetrootsBlock.mapping
@@ -2,7 +2,7 @@ CLASS bhi net/minecraft/block/BeetrootsBlock
 	METHOD <init> (Lbhl$c;)V
 		ARG 1 settings
 	METHOD a getGrowthAmount (Lbci;)I
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/BellBlock.mapping
+++ b/mappings/net/minecraft/block/BellBlock.mapping
@@ -5,7 +5,7 @@ CLASS bhj net/minecraft/block/BellBlock
 		ARG 1 ctx
 	METHOD a createBlockEntity (Lbbt;)Lbom;
 		ARG 1 view
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -177,7 +177,7 @@ CLASS bhl net/minecraft/block/Block
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/BlockState.mapping
+++ b/mappings/net/minecraft/block/BlockState.mapping
@@ -29,7 +29,7 @@ CLASS bqi net/minecraft/block/BlockState
 		ARG 1 view
 		ARG 2 pos
 		ARG 3 env
-	METHOD a getBoundingShape (Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 view
 	METHOD a getCullShape (Lbbt;Let;Ley;)Lcnr;
 		ARG 1 view
@@ -158,6 +158,7 @@ CLASS bqi net/minecraft/block/BlockState
 		ARG 1 view
 		ARG 2 pos
 	METHOD k emitsRedstonePower ()Z
+	METHOD k getOutlineShape (Lbbt;Let;)Lcnr;
 	METHOD l hasComparatorOutput ()Z
 	METHOD l getCollisionShape (Lbbt;Let;)Lcnr;
 		ARG 1 view

--- a/mappings/net/minecraft/block/BrewingStandBlock.mapping
+++ b/mappings/net/minecraft/block/BrewingStandBlock.mapping
@@ -15,7 +15,7 @@ CLASS bho net/minecraft/block/BrewingStandBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/BubbleColumnBlock.mapping
+++ b/mappings/net/minecraft/block/BubbleColumnBlock.mapping
@@ -3,7 +3,7 @@ CLASS bhp net/minecraft/block/BubbleColumnBlock
 		ARG 1 settings
 	METHOD a getTickRate (Lbcm;)I
 		ARG 1 world
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/CactusBlock.mapping
+++ b/mappings/net/minecraft/block/CactusBlock.mapping
@@ -6,7 +6,7 @@ CLASS bht net/minecraft/block/CactusBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/CakeBlock.mapping
+++ b/mappings/net/minecraft/block/CakeBlock.mapping
@@ -6,7 +6,7 @@ CLASS bhu net/minecraft/block/CakeBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/CampfireBlock.mapping
+++ b/mappings/net/minecraft/block/CampfireBlock.mapping
@@ -24,7 +24,7 @@ CLASS bhv net/minecraft/block/CampfireBlock
 		ARG 4 fluidState
 	METHOD a getLuminance (Lbqi;)I
 		ARG 1 state
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/CarpetBlock.mapping
+++ b/mappings/net/minecraft/block/CarpetBlock.mapping
@@ -1,6 +1,6 @@
 CLASS boc net/minecraft/block/CarpetBlock
 	FIELD b color Lavz;
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/CarrotsBlock.mapping
+++ b/mappings/net/minecraft/block/CarrotsBlock.mapping
@@ -1,7 +1,7 @@
 CLASS bhw net/minecraft/block/CarrotsBlock
 	METHOD <init> (Lbhl$c;)V
 		ARG 1 settings
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/CauldronBlock.mapping
+++ b/mappings/net/minecraft/block/CauldronBlock.mapping
@@ -6,7 +6,7 @@ CLASS bhz net/minecraft/block/CauldronBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/ChestBlock.mapping
+++ b/mappings/net/minecraft/block/ChestBlock.mapping
@@ -22,7 +22,7 @@ CLASS bia net/minecraft/block/ChestBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/CocoaBlock.mapping
+++ b/mappings/net/minecraft/block/CocoaBlock.mapping
@@ -12,7 +12,7 @@ CLASS bid net/minecraft/block/CocoaBlock
 		ARG 2 random
 		ARG 3 pos
 		ARG 4 state
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/ComposterBlock.mapping
+++ b/mappings/net/minecraft/block/ComposterBlock.mapping
@@ -50,7 +50,7 @@ CLASS big net/minecraft/block/ComposterBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/ConduitBlock.mapping
+++ b/mappings/net/minecraft/block/ConduitBlock.mapping
@@ -16,7 +16,7 @@ CLASS bii net/minecraft/block/ConduitBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/ConnectedPlantBlock.mapping
+++ b/mappings/net/minecraft/block/ConnectedPlantBlock.mapping
@@ -7,7 +7,7 @@ CLASS ble net/minecraft/block/ConnectedPlantBlock
 	FIELD f DOWN Lbra;
 	FIELD g FACING_PROPERTIES Ljava/util/Map;
 	FIELD i FACINGS [Ley;
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/CoralBlock.mapping
+++ b/mappings/net/minecraft/block/CoralBlock.mapping
@@ -1,5 +1,5 @@
 CLASS bil net/minecraft/block/CoralBlock
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/CoralDeadBlock.mapping
+++ b/mappings/net/minecraft/block/CoralDeadBlock.mapping
@@ -2,7 +2,7 @@ CLASS bha net/minecraft/block/CoralDeadBlock
 	FIELD a shape Lcnr;
 	METHOD <init> (Lbhl$c;)V
 		ARG 1 settings
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/CoralDeadFanBlock.mapping
+++ b/mappings/net/minecraft/block/CoralDeadFanBlock.mapping
@@ -1,7 +1,7 @@
 CLASS bgz net/minecraft/block/CoralDeadFanBlock
 	METHOD <init> (Lbhl$c;)V
 		ARG 1 settings
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/CoralDeadWallFanBlock.mapping
+++ b/mappings/net/minecraft/block/CoralDeadWallFanBlock.mapping
@@ -3,7 +3,7 @@ CLASS bhc net/minecraft/block/CoralDeadWallFanBlock
 		ARG 1 settings
 	METHOD a getPlacementState (Lavh;)Lbqi;
 		ARG 1 ctx
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/CoralParentBlock.mapping
+++ b/mappings/net/minecraft/block/CoralParentBlock.mapping
@@ -4,7 +4,7 @@ CLASS bhb net/minecraft/block/CoralParentBlock
 		ARG 1 settings
 	METHOD a getPlacementState (Lavh;)Lbqi;
 		ARG 1 ctx
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/CropBlock.mapping
+++ b/mappings/net/minecraft/block/CropBlock.mapping
@@ -20,7 +20,7 @@ CLASS bio net/minecraft/block/CropBlock
 		ARG 1 floor
 		ARG 2 view
 		ARG 3 pos
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/DaylightDetectorBlock.mapping
+++ b/mappings/net/minecraft/block/DaylightDetectorBlock.mapping
@@ -3,7 +3,7 @@ CLASS biq net/minecraft/block/DaylightDetectorBlock
 		ARG 1 settings
 	METHOD a createBlockEntity (Lbbt;)Lbom;
 		ARG 1 view
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/DeadBushBlock.mapping
+++ b/mappings/net/minecraft/block/DeadBushBlock.mapping
@@ -5,7 +5,7 @@ CLASS bir net/minecraft/block/DeadBushBlock
 		ARG 1 floor
 		ARG 2 view
 		ARG 3 pos
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/DoorBlock.mapping
+++ b/mappings/net/minecraft/block/DoorBlock.mapping
@@ -26,7 +26,7 @@ CLASS biw net/minecraft/block/DoorBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/DragonEggBlock.mapping
+++ b/mappings/net/minecraft/block/DragonEggBlock.mapping
@@ -8,7 +8,7 @@ CLASS biy net/minecraft/block/DragonEggBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/EnchantingTableBlock.mapping
+++ b/mappings/net/minecraft/block/EnchantingTableBlock.mapping
@@ -14,7 +14,7 @@ CLASS bja net/minecraft/block/EnchantingTableBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/EndPortalBlock.mapping
+++ b/mappings/net/minecraft/block/EndPortalBlock.mapping
@@ -7,7 +7,7 @@ CLASS bjc net/minecraft/block/EndPortalBlock
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/EndPortalFrameBlock.mapping
+++ b/mappings/net/minecraft/block/EndPortalFrameBlock.mapping
@@ -10,7 +10,7 @@ CLASS bjd net/minecraft/block/EndPortalFrameBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/EndRodBlock.mapping
+++ b/mappings/net/minecraft/block/EndRodBlock.mapping
@@ -3,7 +3,7 @@ CLASS bje net/minecraft/block/EndRodBlock
 		ARG 1 settings
 	METHOD a getPlacementState (Lavh;)Lbqi;
 		ARG 1 ctx
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/EnderChestBlock.mapping
+++ b/mappings/net/minecraft/block/EnderChestBlock.mapping
@@ -11,7 +11,7 @@ CLASS bjf net/minecraft/block/EnderChestBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/FarmlandBlock.mapping
+++ b/mappings/net/minecraft/block/FarmlandBlock.mapping
@@ -13,7 +13,7 @@ CLASS bjj net/minecraft/block/FarmlandBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/FenceGateBlock.mapping
+++ b/mappings/net/minecraft/block/FenceGateBlock.mapping
@@ -8,7 +8,7 @@ CLASS bjl net/minecraft/block/FenceGateBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/FernBlock.mapping
+++ b/mappings/net/minecraft/block/FernBlock.mapping
@@ -11,7 +11,7 @@ CLASS bnf net/minecraft/block/FernBlock
 		ARG 2 random
 		ARG 3 pos
 		ARG 4 state
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/FireBlock.mapping
+++ b/mappings/net/minecraft/block/FireBlock.mapping
@@ -8,7 +8,7 @@ CLASS bjm net/minecraft/block/FireBlock
 		ARG 1 world
 	METHOD a registerFlammable (Lbhl;II)V
 		ARG 1 block
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/FlowerBlock.mapping
+++ b/mappings/net/minecraft/block/FlowerBlock.mapping
@@ -1,6 +1,6 @@
 CLASS bjo net/minecraft/block/FlowerBlock
 	METHOD Z_ getOffsetType ()Lbhl$b;
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/FlowerPotBlock.mapping
+++ b/mappings/net/minecraft/block/FlowerPotBlock.mapping
@@ -3,7 +3,7 @@ CLASS bjp net/minecraft/block/FlowerPotBlock
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/FluidBlock.mapping
+++ b/mappings/net/minecraft/block/FluidBlock.mapping
@@ -8,7 +8,7 @@ CLASS bkq net/minecraft/block/FluidBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/GrassPathBlock.mapping
+++ b/mappings/net/minecraft/block/GrassPathBlock.mapping
@@ -8,7 +8,7 @@ CLASS bjv net/minecraft/block/GrassPathBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/GrindstoneBlock.mapping
+++ b/mappings/net/minecraft/block/GrindstoneBlock.mapping
@@ -1,7 +1,7 @@
 CLASS bjx net/minecraft/block/GrindstoneBlock
 	METHOD <init> (Lbhl$c;)V
 		ARG 1 settings
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/HopperBlock.mapping
+++ b/mappings/net/minecraft/block/HopperBlock.mapping
@@ -16,7 +16,7 @@ CLASS bka net/minecraft/block/HopperBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/HorizontalConnectedBlock.mapping
+++ b/mappings/net/minecraft/block/HorizontalConnectedBlock.mapping
@@ -13,7 +13,7 @@ CLASS bip net/minecraft/block/HorizontalConnectedBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/KelpBlock.mapping
+++ b/mappings/net/minecraft/block/KelpBlock.mapping
@@ -13,7 +13,7 @@ CLASS bki net/minecraft/block/KelpBlock
 		ARG 2 pos
 		ARG 3 state
 		ARG 4 fluidState
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/LadderBlock.mapping
+++ b/mappings/net/minecraft/block/LadderBlock.mapping
@@ -3,7 +3,7 @@ CLASS bkk net/minecraft/block/LadderBlock
 		ARG 1 settings
 	METHOD a getPlacementState (Lavh;)Lbqi;
 		ARG 1 ctx
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/LanternBlock.mapping
+++ b/mappings/net/minecraft/block/LanternBlock.mapping
@@ -3,7 +3,7 @@ CLASS bkl net/minecraft/block/LanternBlock
 		ARG 1 settings
 	METHOD a getPlacementState (Lavh;)Lbqi;
 		ARG 1 ctx
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/LecternBlock.mapping
+++ b/mappings/net/minecraft/block/LecternBlock.mapping
@@ -5,7 +5,7 @@ CLASS bkn net/minecraft/block/LecternBlock
 		ARG 1 ctx
 	METHOD a createBlockEntity (Lbbt;)Lbom;
 		ARG 1 view
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/LeverBlock.mapping
+++ b/mappings/net/minecraft/block/LeverBlock.mapping
@@ -1,7 +1,7 @@
 CLASS bkp net/minecraft/block/LeverBlock
 	METHOD <init> (Lbhl$c;)V
 		ARG 1 settings
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/MushroomPlantBlock.mapping
+++ b/mappings/net/minecraft/block/MushroomPlantBlock.mapping
@@ -14,7 +14,7 @@ CLASS bkx net/minecraft/block/MushroomPlantBlock
 		ARG 1 floor
 		ARG 2 view
 		ARG 3 pos
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/NetherWartBlock.mapping
+++ b/mappings/net/minecraft/block/NetherWartBlock.mapping
@@ -9,7 +9,7 @@ CLASS bla net/minecraft/block/NetherWartBlock
 		ARG 1 floor
 		ARG 2 view
 		ARG 3 pos
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/PistonBlock.mapping
+++ b/mappings/net/minecraft/block/PistonBlock.mapping
@@ -17,7 +17,7 @@ CLASS bqc net/minecraft/block/PistonBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/PistonExtensionBlock.mapping
+++ b/mappings/net/minecraft/block/PistonExtensionBlock.mapping
@@ -20,7 +20,7 @@ CLASS bqb net/minecraft/block/PistonExtensionBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/PistonHeadBlock.mapping
+++ b/mappings/net/minecraft/block/PistonHeadBlock.mapping
@@ -15,7 +15,7 @@ CLASS bqd net/minecraft/block/PistonHeadBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/PortalBlock.mapping
+++ b/mappings/net/minecraft/block/PortalBlock.mapping
@@ -5,7 +5,7 @@ CLASS bkz net/minecraft/block/PortalBlock
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/PotatoesBlock.mapping
+++ b/mappings/net/minecraft/block/PotatoesBlock.mapping
@@ -1,7 +1,7 @@
 CLASS blh net/minecraft/block/PotatoesBlock
 	METHOD <init> (Lbhl$c;)V
 		ARG 1 settings
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/RedstoneTorchWallBlock.mapping
+++ b/mappings/net/minecraft/block/RedstoneTorchWallBlock.mapping
@@ -3,7 +3,7 @@ CLASS bls net/minecraft/block/RedstoneTorchWallBlock
 		ARG 1 settings
 	METHOD a getPlacementState (Lavh;)Lbqi;
 		ARG 1 ctx
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/RedstoneWireBlock.mapping
+++ b/mappings/net/minecraft/block/RedstoneWireBlock.mapping
@@ -7,7 +7,7 @@ CLASS blp net/minecraft/block/RedstoneWireBlock
 	METHOD a getRenderConnectionType (Lbbt;Let;Ley;)Lbrn;
 		ARG 1 view
 		ARG 2 pos
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/SaplingBambooBlock.mapping
+++ b/mappings/net/minecraft/block/SaplingBambooBlock.mapping
@@ -20,7 +20,7 @@ CLASS bgv net/minecraft/block/SaplingBambooBlock
 		ARG 2 player
 		ARG 3 world
 		ARG 4 pos
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/SaplingBlock.mapping
+++ b/mappings/net/minecraft/block/SaplingBlock.mapping
@@ -9,7 +9,7 @@ CLASS bly net/minecraft/block/SaplingBlock
 		ARG 2 random
 		ARG 3 pos
 		ARG 4 state
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/ScaffoldingBlock.mapping
+++ b/mappings/net/minecraft/block/ScaffoldingBlock.mapping
@@ -6,7 +6,7 @@ CLASS blz net/minecraft/block/ScaffoldingBlock
 	METHOD a (Lbqi;Lavh;)Z
 		ARG 1 state
 		ARG 2 ctx
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/SeaPickleBlock.mapping
+++ b/mappings/net/minecraft/block/SeaPickleBlock.mapping
@@ -21,7 +21,7 @@ CLASS bma net/minecraft/block/SeaPickleBlock
 		ARG 1 floor
 		ARG 2 view
 		ARG 3 pos
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/SeagrassBlock.mapping
+++ b/mappings/net/minecraft/block/SeagrassBlock.mapping
@@ -26,7 +26,7 @@ CLASS bmb net/minecraft/block/SeagrassBlock
 		ARG 1 floor
 		ARG 2 view
 		ARG 3 pos
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/ShulkerBoxBlock.mapping
+++ b/mappings/net/minecraft/block/ShulkerBoxBlock.mapping
@@ -26,7 +26,7 @@ CLASS bmd net/minecraft/block/ShulkerBoxBlock
 		ARG 2 pos
 		ARG 3 state
 		ARG 4 player
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/SignBlock.mapping
+++ b/mappings/net/minecraft/block/SignBlock.mapping
@@ -4,7 +4,7 @@ CLASS bme net/minecraft/block/SignBlock
 	METHOD a canMobSpawnInside ()Z
 	METHOD a createBlockEntity (Lbbt;)Lbom;
 		ARG 1 view
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/SkullBlock.mapping
+++ b/mappings/net/minecraft/block/SkullBlock.mapping
@@ -9,7 +9,7 @@ CLASS bmg net/minecraft/block/SkullBlock
 		FIELD f DRAGON Lbmg$b;
 	METHOD a getPlacementState (Lavh;)Lbqi;
 		ARG 1 ctx
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/SlabBlock.mapping
+++ b/mappings/net/minecraft/block/SlabBlock.mapping
@@ -16,7 +16,7 @@ CLASS bmh net/minecraft/block/SlabBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/SnowBlock.mapping
+++ b/mappings/net/minecraft/block/SnowBlock.mapping
@@ -11,7 +11,7 @@ CLASS bml net/minecraft/block/SnowBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/StairsBlock.mapping
+++ b/mappings/net/minecraft/block/StairsBlock.mapping
@@ -23,7 +23,7 @@ CLASS bmu net/minecraft/block/StairsBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/StandingBannerBlock.mapping
+++ b/mappings/net/minecraft/block/StandingBannerBlock.mapping
@@ -1,7 +1,7 @@
 CLASS bgw net/minecraft/block/StandingBannerBlock
 	METHOD a getPlacementState (Lavh;)Lbqi;
 		ARG 1 ctx
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/StemBlock.mapping
+++ b/mappings/net/minecraft/block/StemBlock.mapping
@@ -16,7 +16,7 @@ CLASS bmw net/minecraft/block/StemBlock
 		ARG 1 floor
 		ARG 2 view
 		ARG 3 pos
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/StonecutterBlock.mapping
+++ b/mappings/net/minecraft/block/StonecutterBlock.mapping
@@ -1,7 +1,7 @@
 CLASS bmz net/minecraft/block/StonecutterBlock
 	METHOD <init> (Lbhl$c;)V
 		ARG 1 settings
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/StructureVoidBlock.mapping
+++ b/mappings/net/minecraft/block/StructureVoidBlock.mapping
@@ -1,7 +1,7 @@
 CLASS bnb net/minecraft/block/StructureVoidBlock
 	METHOD <init> (Lbhl$c;)V
 		ARG 1 settings
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/SugarCaneBlock.mapping
+++ b/mappings/net/minecraft/block/SugarCaneBlock.mapping
@@ -2,7 +2,7 @@ CLASS bnc net/minecraft/block/SugarCaneBlock
 	FIELD a AGE Lbri;
 	METHOD <init> (Lbhl$c;)V
 		ARG 1 settings
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/SweetBerryBushBlock.mapping
+++ b/mappings/net/minecraft/block/SweetBerryBushBlock.mapping
@@ -17,7 +17,7 @@ CLASS bnd net/minecraft/block/SweetBerryBushBlock
 		ARG 2 random
 		ARG 3 pos
 		ARG 4 state
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/TallSeagrassBlock.mapping
+++ b/mappings/net/minecraft/block/TallSeagrassBlock.mapping
@@ -23,7 +23,7 @@ CLASS bng net/minecraft/block/TallSeagrassBlock
 		ARG 1 floor
 		ARG 2 view
 		ARG 3 pos
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/TorchBlock.mapping
+++ b/mappings/net/minecraft/block/TorchBlock.mapping
@@ -2,7 +2,7 @@ CLASS bni net/minecraft/block/TorchBlock
 	FIELD d BOUNDING_SHAPE Lcnr;
 	METHOD <init> (Lbhl$c;)V
 		ARG 1 settings
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/TrapdoorBlock.mapping
+++ b/mappings/net/minecraft/block/TrapdoorBlock.mapping
@@ -8,7 +8,7 @@ CLASS bnj net/minecraft/block/TrapdoorBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/TripwireBlock.mapping
+++ b/mappings/net/minecraft/block/TripwireBlock.mapping
@@ -6,7 +6,7 @@ CLASS bnl net/minecraft/block/TripwireBlock
 		ARG 2 pos
 		ARG 3 state
 		ARG 4 player
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/TripwireHookBlock.mapping
+++ b/mappings/net/minecraft/block/TripwireHookBlock.mapping
@@ -10,7 +10,7 @@ CLASS bnm net/minecraft/block/TripwireHookBlock
 		ARG 3 state
 		ARG 4 placer
 		ARG 5 itemStack
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/TurtleEggBlock.mapping
+++ b/mappings/net/minecraft/block/TurtleEggBlock.mapping
@@ -22,7 +22,7 @@ CLASS bnn net/minecraft/block/TurtleEggBlock
 	METHOD a (Lbqi;Lavh;)Z
 		ARG 1 state
 		ARG 2 ctx
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/VineBlock.mapping
+++ b/mappings/net/minecraft/block/VineBlock.mapping
@@ -6,7 +6,7 @@ CLASS bno net/minecraft/block/VineBlock
 	METHOD a (Lbqi;Lavh;)Z
 		ARG 1 state
 		ARG 2 ctx
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/WallBannerBlock.mapping
+++ b/mappings/net/minecraft/block/WallBannerBlock.mapping
@@ -1,7 +1,7 @@
 CLASS bnp net/minecraft/block/WallBannerBlock
 	METHOD a getPlacementState (Lavh;)Lbqi;
 		ARG 1 ctx
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/WallBlock.mapping
+++ b/mappings/net/minecraft/block/WallBlock.mapping
@@ -8,7 +8,7 @@ CLASS bnq net/minecraft/block/WallBlock
 		ARG 2 view
 		ARG 3 pos
 		ARG 4 env
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/WallSignBlock.mapping
+++ b/mappings/net/minecraft/block/WallSignBlock.mapping
@@ -4,7 +4,7 @@ CLASS bnr net/minecraft/block/WallSignBlock
 		ARG 1 settings
 	METHOD a getPlacementState (Lavh;)Lbqi;
 		ARG 1 ctx
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/WallSkullBlock.mapping
+++ b/mappings/net/minecraft/block/WallSkullBlock.mapping
@@ -1,7 +1,7 @@
 CLASS bns net/minecraft/block/WallSkullBlock
 	METHOD a getPlacementState (Lavh;)Lbqi;
 		ARG 1 ctx
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/WallTorchBlock.mapping
+++ b/mappings/net/minecraft/block/WallTorchBlock.mapping
@@ -5,7 +5,7 @@ CLASS bnt net/minecraft/block/WallTorchBlock
 		ARG 1 settings
 	METHOD a getPlacementState (Lavh;)Lbqi;
 		ARG 1 ctx
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/block/WaterlilyBlock.mapping
+++ b/mappings/net/minecraft/block/WaterlilyBlock.mapping
@@ -5,7 +5,7 @@ CLASS bnu net/minecraft/block/WaterlilyBlock
 		ARG 1 floor
 		ARG 2 view
 		ARG 3 pos
-	METHOD a canCollideWith (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	METHOD a getOutlineShape (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos

--- a/mappings/net/minecraft/fluid/BaseFluid.mapping
+++ b/mappings/net/minecraft/fluid/BaseFluid.mapping
@@ -11,5 +11,6 @@ CLASS cfu net/minecraft/fluid/BaseFluid
 	METHOD a appendProperties (Lbqj$a;)V
 	METHOD a getState (Z)Lcfw;
 		ARG 1 still
+	METHOD b getShape (Lcfw;Lbbt;Let;)Lcnr;
 	METHOD e getFlowing ()Lcfv;
 	METHOD f getStill ()Lcfv;

--- a/mappings/net/minecraft/fluid/EmptyFluid.mapping
+++ b/mappings/net/minecraft/fluid/EmptyFluid.mapping
@@ -3,5 +3,6 @@ CLASS cft net/minecraft/fluid/EmptyFluid
 	METHOD a toBlockState (Lcfw;)Lbqi;
 	METHOD b getBucketItem ()Lawx;
 	METHOD b isStill (Lcfw;)Z
+	METHOD b getShape (Lcfw;Lbbt;Let;)Lcnr;
 	METHOD c isEmpty ()Z
 	METHOD d getBlastResistance ()F

--- a/mappings/net/minecraft/fluid/Fluid.mapping
+++ b/mappings/net/minecraft/fluid/Fluid.mapping
@@ -10,6 +10,7 @@ CLASS cfv net/minecraft/fluid/Fluid
 	METHOD b getBucketItem ()Lawx;
 	METHOD b onRandomTick (Lbci;Let;Lcfw;Ljava/util/Random;)V
 	METHOD b isStill (Lcfw;)Z
+	METHOD b getShape (Lcfw;Lbbt;Let;)Lcnr;
 	METHOD c isEmpty ()Z
 	METHOD d getBlastResistance ()F
 	METHOD e setDefaultState (Lcfw;)V

--- a/mappings/net/minecraft/fluid/FluidState.mapping
+++ b/mappings/net/minecraft/fluid/FluidState.mapping
@@ -8,6 +8,7 @@ CLASS cfw net/minecraft/fluid/FluidState
 	METHOD b onRandomTick (Lbci;Let;Ljava/util/Random;)V
 	METHOD c getFluid ()Lcfv;
 	METHOD d isStill ()Z
+	METHOD d getShape (Lbbt;Let;)Lcnr;
 	METHOD e isEmpty ()Z
 	METHOD g hasRandomTicks ()Z
 	METHOD h getBlockState ()Lbqi;

--- a/mappings/net/minecraft/world/BlockView.mapping
+++ b/mappings/net/minecraft/world/BlockView.mapping
@@ -1,6 +1,9 @@
 CLASS bbt net/minecraft/world/BlockView
 	METHOD H getMaxLightLevel ()I
 	METHOD I getHeight ()I
+	METHOD a rayTrace (Lbbw;)Lcmt;
+	METHOD a rayTrace (Lbbw;Ljava/util/function/BiFunction;Ljava/util/function/Function;)Ljava/lang/Object;
+	METHOD a rayTraceBlock (Lcmx;Lcmx;Let;Lcnr;Lbqi;)Lcmt;
 	METHOD b getBlockState (Let;)Lbqi;
 		ARG 1 pos
 	METHOD c getFluidState (Let;)Lcfw;

--- a/mappings/net/minecraft/world/RayTraceContext.mapping
+++ b/mappings/net/minecraft/world/RayTraceContext.mapping
@@ -1,0 +1,19 @@
+CLASS bbw net/minecraft/world/RayTraceContext
+	CLASS bbw$a ShapeType
+		FIELD c provider Lbbw$c;
+		METHOD get (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	CLASS bbw$b FluidHandling
+		FIELD a NONE Lbbw$b;
+		FIELD d predicate Ljava/util/function/Predicate;
+		METHOD a handled (Lcfw;)Z
+	CLASS bbw$c ShapeProvider
+		METHOD get (Lbqi;Lbbt;Let;Lcnc;)Lcnr;
+	FIELD a start Lcmx;
+	FIELD b end Lcmx;
+	FIELD c shapeType Lbbw$a;
+	FIELD d fluid Lbbw$b;
+	FIELD e entityPosition Lcnc;
+	METHOD a getEnd ()Lcmx;
+	METHOD a getBlockShape (Lbqi;Lbbt;Let;)Lcnr;
+	METHOD a getFluidShape (Lcfw;Lbbt;Let;)Lcnr;
+	METHOD b getStart ()Lcmx;


### PR DESCRIPTION
 - Maps some ray tracing methods on `BlockView`.
 - Maps `bbw` to `RayTraceContext`, and most entries on there.
 - Possibly more contentious, rename `getBoundingShape` to `getOutlineShape`. This matches the `OUTLINE` enum value within `bbw` and, given the name is wrong anyway (`canCollideWith`), this seems like a opportune time to change it.