### PR TITLE
DimensionalPersistentStateManager -> PersistentStateManager

### DIFF
--- a/mappings/net/minecraft/server/world/ServerChunkManager.mapping
+++ b/mappings/net/minecraft/server/world/ServerChunkManager.mapping
@@ -10,7 +10,7 @@ CLASS uq net/minecraft/server/world/ServerChunkManager
 	FIELD i genQueue Ljava/util/Queue;
 	FIELD j players Luo;
 	FIELD k threadedAnvilChunkStorage Luf;
-	FIELD l dimensionalPersistentStateManager Lcjb;
+	FIELD l persistentStateManager Lcjb;
 	FIELD m maxWatchDistance I
 	FIELD n lastMobSpawningTime J
 	FIELD o spawnMonsters Z
@@ -60,6 +60,6 @@ CLASS uq net/minecraft/server/world/ServerChunkManager
 	METHOD d doesNotGenerateChunks (Lut;)Z
 		ARG 1 player
 	METHOD g getLoadedChunkCount ()I
-	METHOD h getDimensionalPersistentStateManager ()Lcjb;
+	METHOD h getPersistentStateManager ()Lcjb;
 	METHOD k update ()Z
 	METHOD l doMobSpawning ()V

--- a/mappings/net/minecraft/server/world/ServerWorld.mapping
+++ b/mappings/net/minecraft/server/world/ServerWorld.mapping
@@ -10,7 +10,7 @@ CLASS ur net/minecraft/server/world/ServerWorld
 	FIELD z LOGGER Lorg/apache/logging/log4j/Logger;
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;Ljava/util/concurrent/Executor;Lcjd;Lcjc;Lbti;Laff;Lvc;)V
 		ARG 1 server
-	METHOD B getDimensionalPersistentStateManager ()Lcjb;
+	METHOD B getPersistentStateManager ()Lcjb;
 	METHOD a init (Lbcv;)V
 		ARG 1 levelInfo
 	METHOD a save (Lzc;ZZ)V

--- a/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
+++ b/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
@@ -9,7 +9,7 @@ CLASS uf net/minecraft/server/world/ThreadedAnvilChunkStorage
 	FIELD g genQueueAdder Ljava/util/concurrent/Executor;
 	FIELD h playersWatchingChunkProvider Lue$d;
 	FIELD i chunkGenerator Lbse;
-	FIELD j dimensionalPersistentStateManagerFactory Ljava/util/function/Supplier;
+	FIELD j persistentStateManagerFactory Ljava/util/function/Supplier;
 	FIELD k posToHolderCopy Lit/unimi/dsi/fastutil/longs/Long2ObjectLinkedOpenHashMap;
 	FIELD m posToHolderCopyOutdated Z
 	FIELD n chunkTaskPrioritySystem Luh;

--- a/mappings/net/minecraft/world/PersistentStateManager.mapping
+++ b/mappings/net/minecraft/world/PersistentStateManager.mapping
@@ -1,4 +1,4 @@
-CLASS cjb net/minecraft/world/dimension/DimensionalPersistentStateManager
+CLASS cjb net/minecraft/world/PersistentStateManager
 	FIELD a LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD b keyToState Ljava/util/Map;
 	METHOD a save ()V

--- a/mappings/net/minecraft/world/chunk/storage/VersionedRegionFileCache.mapping
+++ b/mappings/net/minecraft/world/chunk/storage/VersionedRegionFileCache.mapping
@@ -5,7 +5,7 @@ CLASS btc net/minecraft/world/chunk/storage/VersionedRegionFileCache
 		ARG 1 dataFixer
 	METHOD a updateChunkTag (Lbti;Ljava/util/function/Supplier;Lhr;)Lhr;
 		ARG 1 dimensionType
-		ARG 2 dimensionalPersistentStateManagerFactory
+		ARG 2 persistentStateManagerFactory
 		ARG 3 tag
 	METHOD a getDataVersion (Lhr;)I
 		ARG 0 tag


### PR DESCRIPTION
PersistentStateManager used to be a class managing shared persistent data between worlds, and DimensionalPersistentStateManager was for persistent data belonging to a single world.

As of 19w04a the class we knew as PersistentStateManager was removed in favor of using the DimensionalPersistentStateManager of the overworld as a shared persistent data manager.

At this point the mouthful "dimensional persistent state manager" is no longer necessary to distinguish the class from something else.