### PR TITLE
Cleanup ItemGroup mappings

### DIFF
--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -32,7 +32,7 @@ CLASS axo net/minecraft/item/Item
 	METHOD a getAttributeModifiers (Lahq;)Lcom/google/common/collect/Multimap;
 		ARG 1 equiptmentSlot
 	METHOD a isInItemGroup (Lawk;)Z
-	METHOD a addStacksForDisplay (Lawk;Lfe;)V
+	METHOD a appendItemsForGroup (Lawk;Lfe;)V
 	METHOD a getRawIdByItem (Laxo;)I
 		ARG 0 item
 	METHOD a isTool (Laxt;)Z

--- a/mappings/net/minecraft/item/ItemGroup.mapping
+++ b/mappings/net/minecraft/item/ItemGroup.mapping
@@ -49,28 +49,39 @@ CLASS awk net/minecraft/item/ItemGroup
 	FIELD l MATERIALS Lawk;
 	FIELD m HOTBAR Lawk;
 	FIELD n INVENTORY Lawk;
-	FIELD o id I
-	FIELD p unlocalizedName Ljava/lang/String;
+	FIELD o index I
+	FIELD p id Ljava/lang/String;
+	FIELD q name Ljava/lang/String;
 	FIELD r texture Ljava/lang/String;
-	FIELD s useScrollBar Z
+	FIELD s scrollbar Z
 	FIELD t tooltip Z
-	FIELD u enchantmentTypes [Lbbe;
-	FIELD v stack Laxt;
-	METHOD a getId ()I
-	METHOD a containsEnchantmentType (Lbbe;)Z
-	METHOD a getStacksForDisplay (Lfe;)V
+	FIELD u enchantments [Lbbe;
+	FIELD v icon Laxt;
+	METHOD <init> (ILjava/lang/String;)V
+		ARG 1 index
+		ARG 2 id
+	METHOD a getIndex ()I
+	METHOD a containsEnchantments (Lbbe;)Z
+		ARG 1 target
+	METHOD a appendItems (Lfe;)V
+		ARG 1 stacks
 	METHOD a setTexture (Ljava/lang/String;)Lawk;
-	METHOD a setEnchantmentTypes ([Lbbe;)Lawk;
-	METHOD b getUntranslatedName ()Ljava/lang/String;
+		ARG 1 texture
+	METHOD a setEnchantments ([Lbbe;)Lawk;
+		ARG 1 targets
+	METHOD b getId ()Ljava/lang/String;
+	METHOD b setName (Ljava/lang/String;)Lawk;
+		ARG 1 name
+	METHOD c getName ()Ljava/lang/String;
 	METHOD d getTranslationKey ()Ljava/lang/String;
-	METHOD e getIconItemStack ()Laxt;
-	METHOD f getIconItem ()Laxt;
+	METHOD e getIcon ()Laxt;
+	METHOD f createIcon ()Laxt;
 	METHOD g getTexture ()Ljava/lang/String;
 	METHOD h hasTooltip ()Z
-	METHOD i disableTooltip ()Lawk;
-	METHOD j useScrollBar ()Z
-	METHOD k setNotUseScrollBar ()Lawk;
+	METHOD i setNoTooltip ()Lawk;
+	METHOD j hasScrollbar ()Z
+	METHOD k setNoScrollbar ()Lawk;
 	METHOD l getColumn ()I
 	METHOD m isTopRow ()Z
-	METHOD n isTabRightAligned ()Z
-	METHOD o getEnchantmentTypes ()[Lbbe;
+	METHOD n isLastColumn ()Z
+	METHOD o getEnchantments ()[Lbbe;

--- a/mappings/net/minecraft/item/ItemGroup.mapping
+++ b/mappings/net/minecraft/item/ItemGroup.mapping
@@ -83,5 +83,5 @@ CLASS awk net/minecraft/item/ItemGroup
 	METHOD k setNoScrollbar ()Lawk;
 	METHOD l getColumn ()I
 	METHOD m isTopRow ()Z
-	METHOD n isLastColumn ()Z
+	METHOD n isInLastColumn ()Z
 	METHOD o getEnchantments ()[Lbbe;

--- a/mappings/net/minecraft/item/ItemGroup.mapping
+++ b/mappings/net/minecraft/item/ItemGroup.mapping
@@ -83,5 +83,5 @@ CLASS awk net/minecraft/item/ItemGroup
 	METHOD k setNoScrollbar ()Lawk;
 	METHOD l getColumn ()I
 	METHOD m isTopRow ()Z
-	METHOD n isInLastColumn ()Z
+	METHOD n isSpecial ()Z
 	METHOD o getEnchantments ()[Lbbe;


### PR DESCRIPTION
`id` -> `index`
`unlocalizedName` -> `id`
`field_7926` -> `name`
`useScrollBar` -> `scrollbar`
`enchantmentTypes` -> `enchantments`
`stack` -> `icon`
`getId` -> `getIndex`
`containsEnchantmentType` -> `containsEnchantments`
`getStacksForDisplay` -> `appendItems`
`setEnchantmentTypes` -> `setEnchantments`
`getUntranslatedName` -> `getId`
`method_7751` -> `getName`
`method_7739` -> `setName`
`getIconItemStack` -> `getIcon`
`getIconItem` -> `createIcon`
`disableTooltip` -> `setNoTooltip`
`useScrollBar` -> `hasScrollbar`
`setNotUseScrollBar` -> `setNoScrollbar`
`isTabRightAligned` -> `isSpecial`
`getEnchantmentTypes` -> `getEnchantments`
