### PR TITLE
Add mappings for relative movement

### DIFF
--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -99,7 +99,11 @@ CLASS ahl net/minecraft/entity/Entity
 	METHOD a setSize (FF)V
 		ARG 1 width
 		ARG 2 height
-	METHOD a doRelativeMovement (FFFF)V
+	METHOD a applyVelocity (FFFF)V
+		ARG 1 sideVelocity
+		ARG 2 upVelocity
+		ARG 3 forwardVelocity
+		ARG 4 friction
 	METHOD a damage (Lagv;F)Z
 		ARG 1 source
 		ARG 2 amount

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -160,6 +160,7 @@ CLASS ahl net/minecraft/entity/Entity
 	METHOD a playSound (Lxx;FF)V
 		ARG 1 sound
 		ARG 2 volume
+	METHOD a isInFluid (Lyp;Z)Z
 	METHOD a toListTag ([D)Lib;
 	METHOD a toListTag ([F)Lib;
 	METHOD aA spawnSprintingParticles ()V
@@ -172,6 +173,7 @@ CLASS ahl net/minecraft/entity/Entity
 	METHOD aI getSavedEntityId ()Ljava/lang/String;
 	METHOD aJ isValid ()Z
 	METHOD aK isInsideWall ()Z
+	METHOD aL updateRiding ()V
 	METHOD aM getHeightOffset ()D
 	METHOD aN getMountedHeightOffset ()D
 	METHOD aP removeAllPassengers ()V
@@ -191,6 +193,7 @@ CLASS ahl net/minecraft/entity/Entity
 	METHOD ag moveToBoundingBoxCenter ()V
 	METHOD ah getSoundSwim ()Lxx;
 	METHOD ai getSoundSplash ()Lxx;
+	METHOD aj getSoundHighSpeedSplash ()Lxx;
 	METHOD ak checkBlockCollision ()V
 	METHOD am isSilent ()Z
 	METHOD an isUnaffectedByGravity ()Z

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -99,11 +99,10 @@ CLASS ahl net/minecraft/entity/Entity
 	METHOD a setSize (FF)V
 		ARG 1 width
 		ARG 2 height
-	METHOD a applyVelocity (FFFF)V
-		ARG 1 sideVelocity
-		ARG 2 upVelocity
-		ARG 3 forwardVelocity
-		ARG 4 friction
+	METHOD a addVelocity (FFFF)V
+		ARG 1 intendedMovementSideways
+		ARG 2 intendedMovementUp
+		ARG 3 intendedMovementForwards
 	METHOD a damage (Lagv;F)Z
 		ARG 1 source
 		ARG 2 amount

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -99,6 +99,7 @@ CLASS ahl net/minecraft/entity/Entity
 	METHOD a setSize (FF)V
 		ARG 1 width
 		ARG 2 height
+	METHOD a relativeVelocityToAxial (FFFF)V
 	METHOD a damage (Lagv;F)Z
 		ARG 1 source
 		ARG 2 amount

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -99,7 +99,7 @@ CLASS ahl net/minecraft/entity/Entity
 	METHOD a setSize (FF)V
 		ARG 1 width
 		ARG 2 height
-	METHOD a relativeVelocityToAxial (FFFF)V
+	METHOD a doRelativeMovement (FFFF)V
 	METHOD a damage (Lagv;F)Z
 		ARG 1 source
 		ARG 2 amount

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -17,9 +17,9 @@ CLASS ahu net/minecraft/entity/LivingEntity
 	FIELD bG lastAttackTime I
 	FIELD bJ absorptionAmount F
 	FIELD b LOGGER_LIVING Lorg/apache/logging/log4j/Logger;
-	FIELD bf velocityStrafe F
-	FIELD bg velocityVertical F
-	FIELD bh velocityWalk F
+	FIELD bf strafeVelocity F
+	FIELD bg verticalVelocity F
+	FIELD bh walkVelocity F
 	FIELD br activeItemStack Laxt;
 	FIELD bv POTION_SWIRLS_AMBIENT Lpw;
 	FIELD bw STUCK_ARROWS Lpw;
@@ -37,9 +37,9 @@ CLASS ahu net/minecraft/entity/LivingEntity
 	METHOD C pushAway (Lahl;)V
 	METHOD D canSee (Lahl;)Z
 	METHOD a moveRelative (FFF)V
-		ARG 1 velocityStrafe
-		ARG 2 velocityVertical
-		ARG 3 velocityWalk
+		ARG 1 strafeVelocity
+		ARG 2 verticalVelocity
+		ARG 3 walkVelocity
 	METHOD a swingHand (Lagg;)V
 	METHOD a setStackInHand (Lagg;Laxt;)V
 		ARG 1 hand

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -17,9 +17,9 @@ CLASS ahu net/minecraft/entity/LivingEntity
 	FIELD bG lastAttackTime I
 	FIELD bJ absorptionAmount F
 	FIELD b LOGGER_LIVING Lorg/apache/logging/log4j/Logger;
-	FIELD bf velocityWalk F
-	FIELD bg velocityVert F
-	FIELD bh velocityStrafe F
+	FIELD bf velocityStrafe F
+	FIELD bg velocityVertical F
+	FIELD bh velocityWalk F
 	FIELD br activeItemStack Laxt;
 	FIELD bv POTION_SWIRLS_AMBIENT Lpw;
 	FIELD bw STUCK_ARROWS Lpw;
@@ -37,6 +37,9 @@ CLASS ahu net/minecraft/entity/LivingEntity
 	METHOD C pushAway (Lahl;)V
 	METHOD D canSee (Lahl;)Z
 	METHOD a moveRelative (FFF)V
+		ARG 1 velocityStrafe
+		ARG 2 velocityVertical
+		ARG 3 velocityWalk
 	METHOD a swingHand (Lagg;)V
 	METHOD a setStackInHand (Lagg;Laxt;)V
 		ARG 1 hand

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -36,7 +36,7 @@ CLASS ahu net/minecraft/entity/LivingEntity
 	METHOD C updatePotionVisibility ()V
 	METHOD C pushAway (Lahl;)V
 	METHOD D canSee (Lahl;)Z
-	METHOD a updateVelocity (FFF)V
+	METHOD a travel (FFF)V
 		ARG 1 sideVelocity
 		ARG 2 upVelocity
 		ARG 3 forwardVelocity

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -65,6 +65,8 @@ CLASS ahu net/minecraft/entity/LivingEntity
 	METHOD cK getOffHandStack ()Laxt;
 	METHOD cL getSoundVolume ()F
 	METHOD cM getSoundPitch ()F
+	METHOD cO getJumpVelocity ()F
+	METHOD cP jump ()V
 	METHOD cT isSleeping ()Z
 	METHOD cV doPushLogic ()V
 	METHOD cW isUsingRiptide ()Z

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -99,7 +99,9 @@ CLASS ahu net/minecraft/entity/LivingEntity
 	METHOD e (FF)F
 		ARG 1 yaw
 	METHOD e getHurtSound (Lagv;)Lxx;
+	METHOD e attackLivingEntity (Lahu;)V
 	METHOD k updateMovement ()V
+	METHOD m damageShield (F)V
 	METHOD m setDespawnCounter (I)V
 	METHOD n getFallSound (I)Lxx;
 	METHOD o initAi ()V

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -17,6 +17,9 @@ CLASS ahu net/minecraft/entity/LivingEntity
 	FIELD bG lastAttackTime I
 	FIELD bJ absorptionAmount F
 	FIELD b LOGGER_LIVING Lorg/apache/logging/log4j/Logger;
+	FIELD bf velocityWalk F
+	FIELD bg velocityVert F
+	FIELD bh velocityStrafe F
 	FIELD br activeItemStack Laxt;
 	FIELD bv POTION_SWIRLS_AMBIENT Lpw;
 	FIELD bw STUCK_ARROWS Lpw;
@@ -33,6 +36,7 @@ CLASS ahu net/minecraft/entity/LivingEntity
 	METHOD C updatePotionVisibility ()V
 	METHOD C pushAway (Lahl;)V
 	METHOD D canSee (Lahl;)Z
+	METHOD a moveRelative (FFF)V
 	METHOD a swingHand (Lagg;)V
 	METHOD a setStackInHand (Lagg;Laxt;)V
 		ARG 1 hand

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -36,10 +36,10 @@ CLASS ahu net/minecraft/entity/LivingEntity
 	METHOD C updatePotionVisibility ()V
 	METHOD C pushAway (Lahl;)V
 	METHOD D canSee (Lahl;)Z
-	METHOD a moveRelative (FFF)V
-		ARG 1 strafeVelocity
-		ARG 2 verticalVelocity
-		ARG 3 walkVelocity
+	METHOD a updateVelocity (FFF)V
+		ARG 1 sideVelocity
+		ARG 2 upVelocity
+		ARG 3 forwardVelocity
 	METHOD a swingHand (Lagg;)V
 	METHOD a setStackInHand (Lagg;Laxt;)V
 		ARG 1 hand

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -22,6 +22,7 @@ CLASS ary net/minecraft/entity/player/PlayerEntity
 	FIELD b ABSORPTION_AMOUNT Lpw;
 	FIELD bO sleeping Z
 	FIELD bP sleepingPos Les;
+	FIELD bS isInWater Z
 	FIELD bT abilities Larw;
 	FIELD bU experience I
 	FIELD bV experienceLevel I
@@ -70,6 +71,7 @@ CLASS ary net/minecraft/entity/player/PlayerEntity
 	METHOD a canPlaceBlock (Les;Lew;Laxt;)Z
 		ARG 1 pos
 		ARG 2 side
+	METHOD a spawnParticles (Lfx;)V
 	METHOD a unlockRecipes (Ljava/util/Collection;)I
 		ARG 1 recipes
 	METHOD a addChatMessage (Ljg;Z)V
@@ -89,6 +91,7 @@ CLASS ary net/minecraft/entity/player/PlayerEntity
 	METHOD b lockRecipes (Ljava/util/Collection;)I
 		ARG 1 recipes
 	METHOD b incrementStat (Lye;)V
+	METHOD c collideWithEntity (Lahl;)V
 	METHOD c isUsingEffectiveTool (Lbqz;)Z
 	METHOD c getOfflinePlayerUuid (Ljava/lang/String;)Ljava/util/UUID;
 		ARG 0 nickname
@@ -100,14 +103,17 @@ CLASS ary net/minecraft/entity/player/PlayerEntity
 	METHOD dF canFoodHeal ()Z
 	METHOD dG canModifyWorld ()Z
 	METHOD dH getEnderChestInventory ()Lauz;
+	METHOD dI dropShoulderEntities ()V
 	METHOD dJ getScoreboard ()Lcog;
 	METHOD dL getReducedDebugInfo ()Z
 	METHOD dM getShoulderEntityLeft ()Lhv;
 	METHOD dN getShoulderEntityRight ()Lhv;
 	METHOD dQ getItemCooldownManager ()Laxp;
 	METHOD dR getLuck ()F
+	METHOD do updateInWater ()Z
 	METHOD dp updateSize ()V
 	METHOD dq getScore ()I
+	METHOD dr vanishCursedItems ()V
 	METHOD ds getWornArmorRatio ()F
 	METHOD du requestRespawn ()V
 	METHOD dw getGameProfile ()Lcom/mojang/authlib/GameProfile;
@@ -117,6 +123,9 @@ CLASS ary net/minecraft/entity/player/PlayerEntity
 	METHOD g createCooldownManager ()Laxp;
 	METHOD h setShoulderEntityLeft (Lhv;)V
 	METHOD i setShoulderEntityRight (Lhv;)V
+	METHOD j updateShoulderEntity (Lhv;)V
+	METHOD l updateTurtleHelmet ()V
+	METHOD n updateBubbleColumn ()V
 	METHOD n dropSelectedItem (Z)Laps;
 	METHOD p canConsume (Z)Z
 	METHOD q addExhaustion (F)V


### PR DESCRIPTION
- I've named the forward and side velocities for a LivingEntity `velocityWalk` and `velocityStrafe` based off their names in the controls, but falling is just as common as jumping so I changed that to `velocityVert`. That seems a bit clunky and I'd like ideas.
- `relativeVelocityToGlobal` is also a clunky name but I can't think of a more succinct way to phrase what it does.
- I considered naming `moveRelative` as `moveSelf` because it's only used with `MovementType.SELF` in LivingEntity, but I haven't checked subclasses so it might be overridden elsewhere.