### PR TITLE
Remap registries

### DIFF
--- a/mappings/net/minecraft/util/IndexedIterable.mapping
+++ b/mappings/net/minecraft/util/IndexedIterable.mapping
@@ -1,0 +1,3 @@
+CLASS ey net/minecraft/util/IndexedIterable
+	METHOD a get (I)Ljava/lang/Object;
+		ARG 1 index

--- a/mappings/net/minecraft/util/IntIterable.mapping
+++ b/mappings/net/minecraft/util/IntIterable.mapping
@@ -1,2 +1,0 @@
-CLASS ey net/minecraft/util/IntIterable
-	METHOD a getInt (I)Ljava/lang/Object;

--- a/mappings/net/minecraft/util/registry/DefaultMappedRegistry.mapping
+++ b/mappings/net/minecraft/util/registry/DefaultMappedRegistry.mapping
@@ -1,4 +1,0 @@
-CLASS ev net/minecraft/util/registry/DefaultMappedRegistry
-	FIELD M defaultId Lqh;
-	FIELD N defaultValue Ljava/lang/Object;
-	METHOD a getDefaultId ()Lqh;

--- a/mappings/net/minecraft/util/registry/DefaultedRegistry.mapping
+++ b/mappings/net/minecraft/util/registry/DefaultedRegistry.mapping
@@ -1,0 +1,6 @@
+CLASS ev net/minecraft/util/registry/DefaultedRegistry
+	FIELD M defaultId Lqh;
+	FIELD N defaultValue Ljava/lang/Object;
+	METHOD <init> (Ljava/lang/String;)V
+		ARG 1 defaultId
+	METHOD a getDefaultId ()Lqh;

--- a/mappings/net/minecraft/util/registry/IdRegistry.mapping
+++ b/mappings/net/minecraft/util/registry/IdRegistry.mapping
@@ -1,6 +1,0 @@
-CLASS fd net/minecraft/util/registry/IdRegistry
-	FIELD M nextId I
-	FIELD a ID_LOGGER Lorg/apache/logging/log4j/Logger;
-	FIELD b idStore Lyw;
-	FIELD c objectMap Lcom/google/common/collect/BiMap;
-	FIELD d randomValueArray [Ljava/lang/Object;

--- a/mappings/net/minecraft/util/registry/ModifiableRegistry.mapping
+++ b/mappings/net/minecraft/util/registry/ModifiableRegistry.mapping
@@ -1,7 +1,0 @@
-CLASS fl net/minecraft/util/registry/ModifiableRegistry
-	METHOD a set (ILqh;Ljava/lang/Object;)Ljava/lang/Object;
-		ARG 1 rawId
-		ARG 2 id
-	METHOD a register (Lqh;Ljava/lang/Object;)Ljava/lang/Object;
-		ARG 1 id
-	METHOD c isEmpty ()Z

--- a/mappings/net/minecraft/util/registry/MutableRegistry.mapping
+++ b/mappings/net/minecraft/util/registry/MutableRegistry.mapping
@@ -1,0 +1,9 @@
+CLASS fl net/minecraft/util/registry/MutableRegistry
+	METHOD a set (ILqh;Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 1 rawId
+		ARG 2 id
+		ARG 3 entry
+	METHOD a set (Lqh;Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 1 id
+		ARG 2 entry
+	METHOD c isEmpty ()Z

--- a/mappings/net/minecraft/util/registry/Registry.mapping
+++ b/mappings/net/minecraft/util/registry/Registry.mapping
@@ -11,6 +11,7 @@ CLASS fh net/minecraft/util/registry/Registry
 	FIELD J STAT_TYPE Lfh;
 	FIELD K VILLAGER_TYPE Lev;
 	FIELD L VILLAGER_PROFESSION Lev;
+	FIELD a DEFAULT_ENTRIES Ljava/util/Map;
 	FIELD e LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD f REGISTRIES Lfl;
 	FIELD g SOUND_EVENT Lfh;
@@ -33,18 +34,40 @@ CLASS fh net/minecraft/util/registry/Registry
 	FIELD x DIMENSION Lfh;
 	FIELD y MOTIVE Lev;
 	FIELD z CUSTOM_STAT Lfh;
-	METHOD a set (Lfh;ILjava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	METHOD a register (Lfh;ILjava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 0 registry
+		ARG 1 rawId
+		ARG 2 id
+		ARG 3 entry
 	METHOD a register (Lfh;Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 0 registry
+		ARG 1 id
+		ARG 2 entry
 	METHOD a register (Lfh;Lqh;Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 0 registry
+		ARG 1 id
+		ARG 2 entry
 	METHOD a getRawId (Ljava/lang/Object;)I
-	METHOD a registerRegistry (Ljava/lang/String;Lfl;)Lfh;
+		ARG 1 entry
+	METHOD a create (Ljava/lang/String;Lfl;)Lfh;
 		ARG 0 id
 		ARG 1 registry
-	METHOD a registerRegistry (Ljava/lang/String;Lfl;Ljava/util/function/Supplier;)Lfl;
+	METHOD a create (Ljava/lang/String;Lfl;Ljava/util/function/Supplier;)Lfl;
+		ARG 0 id
+		ARG 1 registry
+		ARG 2 defaultEntry
+	METHOD a putDefaultEntry (Ljava/lang/String;Ljava/util/function/Supplier;)V
+		ARG 0 id
+		ARG 1 defaultEntry
 	METHOD a getRandom (Ljava/util/Random;)Ljava/lang/Object;
+		ARG 1 rand
 	METHOD a get (Lqh;)Ljava/lang/Object;
-	METHOD b keys ()Ljava/util/Set;
+		ARG 1 id
+	METHOD b getIds ()Ljava/util/Set;
 	METHOD b getId (Ljava/lang/Object;)Lqh;
-	METHOD b getOptional (Lqh;)Ljava/util/Optional;
-	METHOD c contains (Lqh;)Z
+		ARG 1 entry
+	METHOD b getOrEmpty (Lqh;)Ljava/util/Optional;
+		ARG 1 id
+	METHOD c containsId (Lqh;)Z
+		ARG 1 id
 	METHOD d stream ()Ljava/util/stream/Stream;

--- a/mappings/net/minecraft/util/registry/SimpleRegistry.mapping
+++ b/mappings/net/minecraft/util/registry/SimpleRegistry.mapping
@@ -1,0 +1,6 @@
+CLASS fd net/minecraft/util/registry/SimpleRegistry
+	FIELD M nextId I
+	FIELD a LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD b indexedEntries Lyw;
+	FIELD c entries Lcom/google/common/collect/BiMap;
+	FIELD d randomEntries [Ljava/lang/Object;


### PR DESCRIPTION
```
IndexedIterable extends Iterable
| get(int) # indexed getter, used for raw id lookups

Registry implements IndexedIterable
|  register(registry, int, identifier, entry) # registers entry and id to raw id
|  register(registry, identifier, entry) # registers entry to id
|  register(registry, string, entry) # registers entry to id
|  create(string, registry, supplier) # creates a new registry (defaulted)
|  create(string, registry) # creates a new registry
|
|  getRawId(entry)
|  getRandom(rand)
|  get(identifier)
|  getIds()
|  getId(entry)
|  getOrEmpty(identifier)
|  containsId(identifier)
|  stream()

MutableRegistry extends Registry
|  set(int, identifier, entry)
|  set(identifier, entry)
|  isEmpty()

SimpleRegistry extends MutableRegistry

DefaultedRegistry extends SimpleRegistry
|  getDefaultId()
```
