### PR TITLE
Use eol=lf on *.mapping files to help Windows users

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.mapping text eol=lf


### PR DESCRIPTION
If a Windows user uses core.autocrlf=true in their git config then the .mapping files get checked out with CRLF line endings, but Enigma saves its mappings with LF endings leading to line ending mismatches. This avoids that.