### PR TITLE
New Gui interfaces for 19w08a

### DIFF
--- a/mappings/net/minecraft/client/gui/GuiInputListener.mapping
+++ b/mappings/net/minecraft/client/gui/GuiInputListener.mapping
@@ -1,0 +1,6 @@
+CLASS csu net/minecraft/client/gui/GuiInputListener
+	METHOD a focusOn (Lcsv;)V
+	METHOD a setActive (Z)V
+		ARG 1 active
+	METHOD aa_ isActive ()Z
+	METHOD b getEntries ()Ljava/util/List;

--- a/mappings/net/minecraft/client/gui/Screen.mapping
+++ b/mappings/net/minecraft/client/gui/Screen.mapping
@@ -25,6 +25,7 @@ CLASS cvi net/minecraft/client/gui/Screen
 		ARG 1 text
 		ARG 2 x
 		ARG 3 y
+	METHOD a suggestMessage (Ljava/lang/String;Z)V
 	METHOD a openUri (Ljava/net/URI;)V
 	METHOD a drawTooltip (Ljava/util/List;II)V
 		ARG 1 text

--- a/mappings/net/minecraft/client/util/DrawProvider.mapping
+++ b/mappings/net/minecraft/client/util/DrawProvider.mapping
@@ -1,0 +1,2 @@
+CLASS css net/minecraft/client/util/DrawProvider
+	METHOD a draw (IIF)V


### PR DESCRIPTION
- Added GuiInputListener (extends `InputListener`)
  An interface for `focusOn`, `setActive`, `getEntries`
  I don't know about this one but `InputListener` is implemented in `MinecraftClient`, so I thought this is Screen specifc
- Added DrawProvider
  Basically an interface for `draw`
- Added `suggestMessage` in `Screen`

Please tell me if there are better names