### PR TITLE
Screen naming

### DIFF
--- a/mappings/net/minecraft/client/gui/ContainerScreen.mapping
+++ b/mappings/net/minecraft/client/gui/ContainerScreen.mapping
@@ -1,7 +1,7 @@
 CLASS cwe net/minecraft/client/gui/ContainerScreen
 	FIELD a BACKGROUND_TEXTURE Lqi;
-	FIELD b containerWidth I
-	FIELD g containerHeight I
+	FIELD b width I
+	FIELD g height I
 	FIELD h container Latu;
 	FIELD i playerInventory Lary;
 	FIELD s name Lji;

--- a/mappings/net/minecraft/client/gui/Screen.mapping
+++ b/mappings/net/minecraft/client/gui/Screen.mapping
@@ -5,8 +5,8 @@ CLASS cvj net/minecraft/client/gui/Screen
 	FIELD j listeners Ljava/util/List;
 	FIELD k client Lcqx;
 	FIELD l itemRenderer Ldlx;
-	FIELD m width I
-	FIELD n height I
+	FIELD m windowWidth I
+	FIELD n windowHeight I
 	FIELD o buttons Ljava/util/List;
 	FIELD p labelWidgets Ljava/util/List;
 	FIELD r fontRenderer Lcrp;

--- a/mappings/net/minecraft/client/gui/Screen.mapping
+++ b/mappings/net/minecraft/client/gui/Screen.mapping
@@ -5,8 +5,8 @@ CLASS cvj net/minecraft/client/gui/Screen
 	FIELD j listeners Ljava/util/List;
 	FIELD k client Lcqx;
 	FIELD l itemRenderer Ldlx;
-	FIELD m windowWidth I
-	FIELD n windowHeight I
+	FIELD m screenWidth I
+	FIELD n screenHeight I
 	FIELD o buttons Ljava/util/List;
 	FIELD p labelWidgets Ljava/util/List;
 	FIELD r fontRenderer Lcrp;


### PR DESCRIPTION
Changes `Screen.width` and `Screen.height` to `Screen.windowWidth` and `Screen.windowHeight` to clear up their roles.

Changes `ContainerScreen.containerWidth` (and respective `height`) to `ContainerScreen.width` to remove redundancy.