### PR TITLE
ItemStack cleanup + amount->size

### DIFF
--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -116,7 +116,7 @@ CLASS axs net/minecraft/item/Item
 		ARG 1 stack
 	METHOD h getTranslatedNameTrimmed (Laxx;)Lji;
 		ARG 1 stack
-	METHOD i getMaxAmount ()I
+	METHOD i getMaxStackSize ()I
 	METHOD i getRarity (Laxx;)Layk;
 		ARG 1 stack
 	METHOD j getDurability ()I

--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -2,7 +2,7 @@ CLASS axx net/minecraft/item/ItemStack
 	FIELD a EMPTY Laxx;
 	FIELD b MODIFIER_FORMAT Ljava/text/DecimalFormat;
 	FIELD c LOGGER Lorg/apache/logging/log4j/Logger;
-	FIELD d amount I
+	FIELD d size I
 	FIELD e updateCooldown I
 	FIELD f item Laxs;
 	FIELD g tag Lhx;
@@ -12,42 +12,61 @@ CLASS axx net/minecraft/item/ItemStack
 	FIELD k lastCheckedCanHarvestResult Z
 	FIELD l lastCheckedCanPlaceBlock Lbri;
 	FIELD m lastCheckedCanPlaceResult Z
+	METHOD <init> (Lbde;)V
+		ARG 1 provider
 	METHOD <init> (Lbde;I)V
-		ARG 1 container
+		ARG 1 provider
+		ARG 2 size
+	METHOD <init> (Lhx;)V
+		ARG 1 tag
 	METHOD A getRepairCost ()I
 	METHOD B toTextComponent ()Lji;
+		ARG 1 style
 	METHOD C getUpdateCooldown ()I
-	METHOD D getAmount ()I
+	METHOD D getSize ()I
 	METHOD E createModifierFormat ()Ljava/text/DecimalFormat;
 	METHOD F updateEmptyFlag ()V
 	METHOD a isEmpty ()Z
 	METHOD a split (I)Laxx;
-		ARG 1 amount
+		ARG 1 size
 	METHOD a applyDamage (ILahv;)V
+		ARG 1 amount
+		ARG 2 entity
 	METHOD a applyDamage (ILjava/util/Random;Luw;)Z
 		ARG 1 amount
+		ARG 2 random
+		ARG 3 entity
 	METHOD a getAttributeModifiers (Lahr;)Lcom/google/common/collect/Multimap;
+		ARG 1 slot
 	METHOD a onEntityDamaged (Lahv;Larz;)V
 		ARG 1 attacker
+		ARG 2 entity
 	METHOD a setHoldingItemFrame (Lapi;)V
+		ARG 1 entity
 	METHOD a interactWithEntity (Larz;Lahv;Lagg;)Z
 		ARG 1 user
 		ARG 2 target
+		ARG 3 hand
 	METHOD a getTooltipText (Larz;Lazh;)Ljava/util/List;
 		ARG 1 player
+		ARG 2 context
 	METHOD a isEqualIgnoreTags (Laxx;)Z
+		ARG 1 stack
 	METHOD a areTagsEqual (Laxx;Laxx;)Z
-		ARG 0 a
-		ARG 1 b
+		ARG 0 left
+		ARG 1 right
 	METHOD a useOnBlock (Lazk;)Lagh;
+		ARG 1 context
 	METHOD a addEnchantment (Lbbh;I)V
 		ARG 1 enchantment
+		ARG 2 level
 	METHOD a update (Lbdf;Lahm;IZ)V
 		ARG 1 world
 		ARG 2 owner
 		ARG 3 invSlot
 	METHOD a onItemFinishedUsing (Lbdf;Lahv;)Laxx;
 		ARG 1 world
+		ARG 2 entity
 	METHOD a onItemStopUsing (Lbdf;Lahv;I)V
 		ARG 1 world
 		ARG 2 user
@@ -58,53 +77,77 @@ CLASS axx net/minecraft/item/ItemStack
 	METHOD a use (Lbdf;Larz;Lagg;)Lagi;
 		ARG 1 world
 		ARG 2 player
+		ARG 3 hand
 	METHOD a onBlockBroken (Lbdf;Lbre;Les;Larz;)V
 		ARG 1 world
 		ARG 2 state
 		ARG 3 pos
+		ARG 4 entity
 	METHOD a getBlockBreakingSpeed (Lbre;)F
+		ARG 1 state
 	METHOD a areBlocksEqual (Lbri;Lbri;)Z
 		ARG 0 first
 		ARG 1 second
 	METHOD a fromTag (Lhx;)Laxx;
 		ARG 0 tag
-	METHOD a getOrCreateSubCompoundTag (Ljava/lang/String;)Lhx;
+	METHOD a getOrCreateSubTag (Ljava/lang/String;)Lhx;
+		ARG 1 key
 	METHOD a addAttributeModifier (Ljava/lang/String;Laim;Lahr;)V
 		ARG 1 attributeName
 		ARG 2 modifier
-	METHOD a setChildTag (Ljava/lang/String;Lio;)V
-		ARG 1 tagName
+		ARG 3 slot
+	METHOD a setSubTag (Ljava/lang/String;Lio;)V
+		ARG 1 key
+		ARG 2 tag
 	METHOD a setDisplayName (Lji;)Laxx;
+		ARG 1 name
 	METHOD a getCustomCanHarvest (Lys;Lbri;)Z
+		ARG 1 manager
+		ARG 2 position
 	METHOD b getItem ()Laxs;
 	METHOD b setDamage (I)V
+		ARG 1 damage
 	METHOD b isEqualIgnoreDurability (Laxx;)Z
+		ARG 1 stack
 	METHOD b areEqual (Laxx;Laxx;)Z
-		ARG 0 a
-		ARG 1 b
+		ARG 0 left
+		ARG 1 right
 	METHOD b isEffectiveOn (Lbre;)Z
+		ARG 1 state
 	METHOD b toTag (Lhx;)Lhx;
-	METHOD b getSubCompoundTag (Ljava/lang/String;)Lhx;
+		ARG 1 nbt
+	METHOD b getSubTag (Ljava/lang/String;)Lhx;
+		ARG 1 key
 	METHOD b getCustomCanPlace (Lys;Lbri;)Z
-	METHOD c getMaxAmount ()I
+		ARG 1 manager
+		ARG 2 position
+	METHOD c getMaxSize ()I
 	METHOD c setRepairCost (I)V
+		ARG 1 cost
 	METHOD c isEqual (Laxx;)Z
+		ARG 1 stack
 	METHOD c areEqualIgnoreTags (Laxx;Laxx;)Z
-		ARG 0 a
-		ARG 1 b
+		ARG 0 left
+		ARG 1 right
 	METHOD c setTag (Lhx;)V
+		ARG 1 tag
 	METHOD c removeSubTag (Ljava/lang/String;)V
+		ARG 1 key
 	METHOD d canStack ()Z
 	METHOD d setUpdateCooldown (I)V
+		ARG 1 updateCooldown
 	METHOD d areEqualIgnoreDurability (Laxx;Laxx;)Z
-		ARG 0 a
-		ARG 1 b
+		ARG 0 left
+		ARG 1 right
 	METHOD e hasDurability ()Z
-	METHOD e setAmount (I)V
+	METHOD e setSize (I)V
+		ARG 1 size
 	METHOD f isDamaged ()Z
-	METHOD f addAmount (I)V
+	METHOD f incSize (I)V
+		ARG 1 amount
 	METHOD g getDamage ()I
-	METHOD g subtractAmount (I)V
+	METHOD g decSize (I)V
+		ARG 1 amount
 	METHOD h getDurability ()I
 	METHOD i copy ()Laxx;
 	METHOD j getTranslationKey ()Ljava/lang/String;
@@ -113,7 +156,7 @@ CLASS axx net/minecraft/item/ItemStack
 	METHOD n hasTag ()Z
 	METHOD o getTag ()Lhx;
 	METHOD p getOrCreateTag ()Lhx;
-	METHOD q getEnchantmentList ()Lid;
+	METHOD q getEnchantmentsTag ()Lid;
 	METHOD r getDisplayName ()Lji;
 	METHOD s removeDisplayName ()V
 	METHOD t hasDisplayName ()Z


### PR DESCRIPTION
It was settled that `ItemStack` is a name that will remain unchanged in Yarn, and as such, I have updated method names accordingly. It makes no sense to refer to the size of a stack as a count or amount. A stack with a count or amount attribute implies that there are multiple stacks, not multiple objects in a single stack. The only reason Mojang refers to it as a `Count` in NBT is that it is not represented as a stack in their source. However, we are stuck with `ItemStack` and should adapt accordingly.