### PR TITLE
BufferBuilder.vertexes -> vertexCount

### DIFF
--- a/mappings/net/minecraft/client/render/BufferBuilder.mapping
+++ b/mappings/net/minecraft/client/render/BufferBuilder.mapping
@@ -10,7 +10,7 @@ CLASS cqc net/minecraft/client/render/BufferBuilder
 	FIELD c bufInt Ljava/nio/IntBuffer;
 	FIELD d bufShort Ljava/nio/ShortBuffer;
 	FIELD e bufFloat Ljava/nio/FloatBuffer;
-	FIELD f vertexes I
+	FIELD f vertexCount I
 	FIELD g currentElement Lcqj;
 	FIELD h currentElementId I
 	FIELD i colorDisabled Z


### PR DESCRIPTION
I wanted to correct "vertexes" to the more correct "vertices" which is used elsewhere, before I realized it should be "vertexCount" or similar, as the field does not contain the vertices but the amount of vertices in the buffer. This properly matches getVertexCount.