### PR TITLE
Fix TextFieldWidget constructor parameters

### DIFF
--- a/mappings/net/minecraft/client/gui/widget/TextFieldWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/TextFieldWidget.mapping
@@ -1,6 +1,6 @@
 CLASS cse net/minecraft/client/gui/widget/TextFieldWidget
 	FIELD A renderTextProvider Ljava/util/function/BiFunction;
-	FIELD a fontRenderer Lcrp;
+	FIELD a textRenderer Lcrp;
 	FIELD b x I
 	FIELD g y I
 	FIELD h width I
@@ -18,13 +18,17 @@ CLASS cse net/minecraft/client/gui/widget/TextFieldWidget
 	FIELD y changedListener Ljava/util/function/Consumer;
 	FIELD z textPredicate Ljava/util/function/Predicate;
 	METHOD <init> (Lcrp;IIII)V
-		ARG 3 x
-		ARG 4 y
-		ARG 5 width
+		ARG 1 textRenderer
+		ARG 2 x
+		ARG 3 y
+		ARG 4 width
+		ARG 5 height
 	METHOD <init> (Lcrp;IIIILcse;)V
-		ARG 3 x
-		ARG 4 y
-		ARG 5 width
+		ARG 1 textRenderer
+		ARG 2 x
+		ARG 3 y
+		ARG 4 width
+		ARG 5 height
 	METHOD a tick ()V
 	METHOD a setText (Ljava/lang/String;)V
 		ARG 1 text


### PR DESCRIPTION
When ID was removed the parameters weren't shifted down to account for it
Also does `fontRenderer` => `textRenderer` to account for the class rename