### PR TITLE
Increase max memory for Enigma

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -196,6 +196,7 @@ task yarn(dependsOn: setupYarn) {
 			fork: true,
 			spawn: true
 		) {
+			jvmarg(value: "-Xmx2048m")
 			arg(value: mergedFile.getAbsolutePath())
 			arg(value: mappingsDir.getAbsolutePath())
 		}


### PR DESCRIPTION
Export source is now crashing with the default memory limit. Increasing it to 2GB fixes the problem and makes it faster than it ever was.