### PR TITLE
Finish mapping entity attributes

### DIFF
--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -14,12 +14,12 @@ CLASS dip net/minecraft/client/network/ClientPlayerEntity
 	METHOD B getStats ()Lyq;
 	METHOD D getRecipeBook ()Lctg;
 	METHOD F hasJumpingMount ()Z
+	METHOD I isRiding ()Z
 	METHOD a setClientPermissionLevel (I)V
 	METHOD a onRecipeDisplayed (Lbcz;)V
 	METHOD f sendChatMessage (Ljava/lang/String;)V
 	METHOD g setServerBrand (Ljava/lang/String;)V
 		ARG 1 serverBrand
-	METHOD l isRiding ()Z
 	METHOD t updateHealth (F)V
 	METHOD x startRidingJump ()V
 	METHOD z openRidingInventory ()V

--- a/mappings/net/minecraft/entity/ExperienceOrbEntity.mapping
+++ b/mappings/net/minecraft/entity/ExperienceOrbEntity.mapping
@@ -2,7 +2,7 @@ CLASS aic net/minecraft/entity/ExperienceOrbEntity
 	FIELD c xpAge I
 	FIELD e health I
 	FIELD f amount I
-	FIELD g target Laum;
+	FIELD g target Laun;
 	METHOD <init> (Lbfx;DDDI)V
 		ARG 1 world
 		ARG 2 x

--- a/mappings/net/minecraft/entity/attribute/AbstractEntityAttribute.mapping
+++ b/mappings/net/minecraft/entity/attribute/AbstractEntityAttribute.mapping
@@ -2,8 +2,12 @@ CLASS aiy net/minecraft/entity/attribute/AbstractEntityAttribute
 	FIELD a parent Laiv;
 	FIELD b id Ljava/lang/String;
 	FIELD c defaultValue D
+	FIELD d tracked Z
 	METHOD <init> (Laiv;Ljava/lang/String;D)V
 		ARG 1 parent
 		ARG 2 id
+		ARG 3 defaultValue
+	METHOD a setTracked (Z)Laiy;
+		ARG 1 tracked
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o

--- a/mappings/net/minecraft/entity/attribute/AbstractEntityAttributeContainer.mapping
+++ b/mappings/net/minecraft/entity/attribute/AbstractEntityAttributeContainer.mapping
@@ -1,8 +1,15 @@
 CLASS aiz net/minecraft/entity/attribute/AbstractEntityAttributeContainer
 	FIELD a instancesByKey Ljava/util/Map;
 	FIELD b instancesById Ljava/util/Map;
+	FIELD c attributeHierarchy Lcom/google/common/collect/Multimap;
 	METHOD a values ()Ljava/util/Collection;
 	METHOD a get (Laiv;)Laiw;
+		ARG 1 attribute
+	METHOD a add (Laiw;)V
+		ARG 1 instance
 	METHOD a get (Ljava/lang/String;)Laiw;
+		ARG 1 name
 	METHOD b register (Laiv;)Laiw;
+		ARG 1 attribute
 	METHOD c createInstance (Laiv;)Laiw;
+		ARG 1 attribute

--- a/mappings/net/minecraft/entity/attribute/ClampedEntityAttribute.mapping
+++ b/mappings/net/minecraft/entity/attribute/ClampedEntityAttribute.mapping
@@ -6,5 +6,8 @@ CLASS ajc net/minecraft/entity/attribute/ClampedEntityAttribute
 		ARG 1 parent
 		ARG 2 id
 		ARG 3 defaultValue
+		ARG 5 minValue
+		ARG 7 maxValue
 	METHOD a setName (Ljava/lang/String;)Lajc;
+		ARG 1 name
 	METHOD g getName ()Ljava/lang/String;

--- a/mappings/net/minecraft/entity/attribute/EntityAttribute.mapping
+++ b/mappings/net/minecraft/entity/attribute/EntityAttribute.mapping
@@ -1,4 +1,7 @@
 CLASS aiv net/minecraft/entity/attribute/EntityAttribute
 	METHOD a getId ()Ljava/lang/String;
+	METHOD a clamp (D)D
+		ARG 1 value
 	METHOD b getDefaultValue ()D
+	METHOD c isTracked ()Z
 	METHOD d getParent ()Laiv;

--- a/mappings/net/minecraft/entity/attribute/EntityAttributeContainer.mapping
+++ b/mappings/net/minecraft/entity/attribute/EntityAttributeContainer.mapping
@@ -1,2 +1,5 @@
 CLASS ajb net/minecraft/entity/attribute/EntityAttributeContainer
 	FIELD d instancesByName Ljava/util/Map;
+	FIELD e trackedAttributes Ljava/util/Set;
+	METHOD b getTrackedAttributes ()Ljava/util/Set;
+	METHOD c buildTrackedAttributesCollection ()Ljava/util/Collection;

--- a/mappings/net/minecraft/entity/attribute/EntityAttributeInstance.mapping
+++ b/mappings/net/minecraft/entity/attribute/EntityAttributeInstance.mapping
@@ -1,12 +1,19 @@
 CLASS aiw net/minecraft/entity/attribute/EntityAttributeInstance
 	METHOD a getAttribute ()Laiv;
 	METHOD a setBaseValue (D)V
+		ARG 1 baseValue
+	METHOD a getModifiers (Laix$a;)Ljava/util/Collection;
 	METHOD a hasModifier (Laix;)Z
+		ARG 1 modifier
 	METHOD a getModifier (Ljava/util/UUID;)Laix;
+		ARG 1 uuid
 	METHOD b getBaseValue ()D
 	METHOD b addModifier (Laix;)V
+		ARG 1 modifier
 	METHOD b removeModifier (Ljava/util/UUID;)V
+		ARG 1 uuid
 	METHOD c getModifiers ()Ljava/util/Collection;
 	METHOD c removeModifier (Laix;)V
+		ARG 1 modifier
 	METHOD d clearModifiers ()V
 	METHOD e getValue ()D

--- a/mappings/net/minecraft/entity/attribute/EntityAttributeInstanceImpl.mapping
+++ b/mappings/net/minecraft/entity/attribute/EntityAttributeInstanceImpl.mapping
@@ -1,4 +1,15 @@
 CLASS aja net/minecraft/entity/attribute/EntityAttributeInstanceImpl
 	FIELD a container Laiz;
 	FIELD b attribute Laiv;
+	FIELD c modifiersByOperation Ljava/util/Map;
+	FIELD d modifiersByName Ljava/util/Map;
+	FIELD e modifiersByUuid Ljava/util/Map;
 	FIELD f baseValue D
+	FIELD g needsRefresh Z
+	FIELD h cachedValue D
+	METHOD <init> (Laiz;Laiv;)V
+		ARG 1 container
+		ARG 2 attribute
+	METHOD b getAllModifiers (Laix$a;)Ljava/util/Collection;
+	METHOD f invalidateCache ()V
+	METHOD g computeValue ()D

--- a/mappings/net/minecraft/entity/attribute/EntityAttributeModifier.mapping
+++ b/mappings/net/minecraft/entity/attribute/EntityAttributeModifier.mapping
@@ -2,7 +2,11 @@ CLASS aix net/minecraft/entity/attribute/EntityAttributeModifier
 	CLASS aix$a Operation
 		FIELD d VALUES [Laix$a;
 		FIELD e id I
+		METHOD <init> (Ljava/lang/String;II)V
+			ARG 3 id
 		METHOD a getId ()I
+		METHOD a fromId (I)Laix$a;
+			ARG 0 id
 	FIELD a amount D
 	FIELD b operation Laix$a;
 	FIELD c nameGetter Ljava/util/function/Supplier;
@@ -11,8 +15,17 @@ CLASS aix net/minecraft/entity/attribute/EntityAttributeModifier
 	METHOD <init> (Ljava/lang/String;DLaix$a;)V
 		ARG 1 name
 		ARG 2 amount
+	METHOD <init> (Ljava/util/UUID;Ljava/lang/String;DLaix$a;)V
+		ARG 1 uuid
+		ARG 2 name
+		ARG 3 amount
+	METHOD <init> (Ljava/util/UUID;Ljava/util/function/Supplier;DLaix$a;)V
+		ARG 1 uuid
+		ARG 2 nameGetter
+		ARG 3 amount
 	METHOD a getId ()Ljava/util/UUID;
 	METHOD a setSerialize (Z)Laix;
+		ARG 1 serialize
 	METHOD b getName ()Ljava/lang/String;
 	METHOD c getOperation ()Laix$a;
 	METHOD d getAmount ()D

--- a/mappings/net/minecraft/entity/attribute/EntityAttributes.mapping
+++ b/mappings/net/minecraft/entity/attribute/EntityAttributes.mapping
@@ -13,9 +13,13 @@ CLASS ati net/minecraft/entity/attribute/EntityAttributes
 	FIELD l LOGGER Lorg/apache/logging/log4j/Logger;
 	METHOD a toTag (Laiw;)Lia;
 		ARG 0 instance
+	METHOD a fromTag (Laiw;Lia;)V
+		ARG 0 instance
 	METHOD a toTag (Laix;)Lia;
 		ARG 0 modifier
 	METHOD a toTag (Laiz;)Lih;
+		ARG 0 container
+	METHOD a fromTag (Laiz;Lih;)V
 		ARG 0 container
 	METHOD a createFromTag (Lia;)Laix;
 		ARG 0 tag


### PR DESCRIPTION
Adds mappings for every field/method/argument in the `net.minecraft.entity.attribute` package. Also fixes two lost mappings.