### PR TITLE
FoodItemSetting saturation -> saturationModifier

### DIFF
--- a/mappings/net/minecraft/item/FoodItemSetting.mapping
+++ b/mappings/net/minecraft/item/FoodItemSetting.mapping
@@ -1,13 +1,13 @@
 CLASS awp net/minecraft/item/FoodItemSetting
 	CLASS awp$a Builder
 		FIELD a hunger I
-		FIELD b saturation F
+		FIELD b saturationModifier F
 		FIELD c wolfFood Z
 		FIELD d alwaysEdible Z
 		FIELD e eatenFast Z
 		FIELD f statusEffectChances Ljava/util/List;
 		METHOD a wolfFood ()Lawp$a;
-		METHOD a saturation (F)Lawp$a;
+		METHOD a saturationModifier (F)Lawp$a;
 			ARG 1 amount
 		METHOD a hunger (I)Lawp$a;
 			ARG 1 amount
@@ -17,20 +17,20 @@ CLASS awp net/minecraft/item/FoodItemSetting
 		METHOD c eatenFast ()Lawp$a;
 		METHOD d build ()Lawp;
 	FIELD a hunger I
-	FIELD b saturation F
+	FIELD b saturationModifier F
 	FIELD c wolfFood Z
 	FIELD d alwaysEdible Z
 	FIELD e eatenFast Z
 	FIELD f statusEffectChances Ljava/util/List;
 	METHOD <init> (IFZZZLjava/util/List;)V
 		ARG 1 hunger
-		ARG 2 saturation
+		ARG 2 saturationModifier
 		ARG 3 isWolfFood
 		ARG 4 isAlwaysEdible
 		ARG 5 isEatenFaster
 		ARG 6 statusEffects
 	METHOD a getHunger ()I
-	METHOD b getSaturation ()F
+	METHOD b getSaturationModifier ()F
 	METHOD c isWolfFood ()Z
 	METHOD d isAlwaysEdible ()Z
 	METHOD e isEatenFast ()Z


### PR DESCRIPTION
Saturation restored is calculated by `hungerRestored * saturationModifier * 2` (see `HungerManager.add(IF)V`), so saturation is an incorrect name for the fields/methods.

19w11b version of #257 