### PR TITLE
Unmap mojang named methods and fields

### DIFF
--- a/mappings/net/minecraft/client/gui/ContainerScreen.mapping
+++ b/mappings/net/minecraft/client/gui/ContainerScreen.mapping
@@ -1,8 +1,8 @@
 CLASS czc net/minecraft/client/gui/ContainerScreen
 	FIELD A lastClickedButton I
 	FIELD a BACKGROUND_TEXTURE Lqq;
-	FIELD b width I
-	FIELD c height I
+	FIELD b containerWidth I
+	FIELD c containerHeight I
 	FIELD d container Laxa;
 	FIELD e playerInventory Lauu;
 	FIELD f left I

--- a/mappings/net/minecraft/client/gui/DrawableHelper.mapping
+++ b/mappings/net/minecraft/client/gui/DrawableHelper.mapping
@@ -1,39 +1,35 @@
 CLASS cuu net/minecraft/client/gui/DrawableHelper
-	FIELD BACKGROUND_LOCATION OPTIONS_BG Lqq;
-	FIELD GUI_ICONS_LOCATION ICONS Lqq;
-	FIELD STATS_ICON_LOCATION STAT_ICONS Lqq;
-	FIELD blitOffset zOffset F
-	METHOD blit drawTexturedRect (FFIIII)V
+	METHOD blit (FFIIII)V
 		ARG 1 x
 		ARG 2 y
 		ARG 3 u
 		ARG 4 v
 		ARG 5 width
 		ARG 6 height
-	METHOD blit drawTexturedRect (IIFFIIFF)V
+	METHOD blit (IIFFIIFF)V
 		ARG 0 x
 		ARG 1 y
 		ARG 4 width
 		ARG 5 height
-	METHOD blit drawTexturedRect (IIFFIIIIFF)V
+	METHOD blit (IIFFIIIIFF)V
 		ARG 0 x
 		ARG 1 y
 		ARG 6 width
 		ARG 7 height
-	METHOD blit drawTexturedRect (IIIIII)V
+	METHOD blit (IIIIII)V
 		ARG 1 x
 		ARG 2 y
 		ARG 3 u
 		ARG 4 v
 		ARG 5 width
 		ARG 6 height
-	METHOD blit drawTexturedRect (IILdtc;II)V
+	METHOD blit (IILdtc;II)V
 		ARG 1 x
 		ARG 2 y
 		ARG 3 sprite
 		ARG 4 width
 		ARG 5 height
-	METHOD drawCenteredString drawStringCentered (Lcus;Ljava/lang/String;III)V
+	METHOD drawCenteredString (Lcus;Ljava/lang/String;III)V
 		ARG 1 fontRenderer
 		ARG 2 str
 		ARG 3 x
@@ -45,25 +41,25 @@ CLASS cuu net/minecraft/client/gui/DrawableHelper
 		ARG 3 x
 		ARG 4 y
 		ARG 5 color
-	METHOD fill drawRect (IIIII)V
+	METHOD fill (IIIII)V
 		ARG 0 left
 		ARG 1 top
 		ARG 2 right
 		ARG 3 bottom
 		ARG 4 color
-	METHOD fillGradient drawGradientRect (IIIIII)V
+	METHOD fillGradient (IIIIII)V
 		ARG 1 top
 		ARG 2 left
 		ARG 3 right
 		ARG 4 bottom
 		ARG 5 color1
 		ARG 6 color2
-	METHOD hLine drawHorizontalLine (IIII)V
+	METHOD hLine (IIII)V
 		ARG 1 left
 		ARG 2 right
 		ARG 3 top
 		ARG 4 color
-	METHOD vLine drawVerticalLine (IIII)V
+	METHOD vLine (IIII)V
 		ARG 1 left
 		ARG 2 top
 		ARG 3 bottom

--- a/mappings/net/minecraft/client/gui/MultiInputListener.mapping
+++ b/mappings/net/minecraft/client/gui/MultiInputListener.mapping
@@ -6,9 +6,7 @@ CLASS cvz net/minecraft/client/gui/MultiInputListener
 	METHOD b focusNext ()V
 	METHOD b getFocused (I)Lcwa;
 	METHOD c focusPrevious ()V
-	METHOD children getInputListeners ()Ljava/util/List;
-	METHOD isDragging isActive ()Z
-	METHOD setDragging setActive (Z)V
+	METHOD setDragging (Z)V
 		ARG 1 active
 	METHOD setFocused (Lcwa;)V
 		ARG 1 focused

--- a/mappings/net/minecraft/client/gui/Screen.mapping
+++ b/mappings/net/minecraft/client/gui/Screen.mapping
@@ -1,12 +1,4 @@
 CLASS cyi net/minecraft/client/gui/Screen
-	FIELD ALLOWED_PROTOCOLS PROTOCOLS Ljava/util/Set;
-	FIELD children listeners Ljava/util/List;
-	FIELD clickedLink uri Ljava/net/URI;
-	FIELD font fontRenderer Lcus;
-	FIELD height screenHeight I
-	FIELD labels labelWidgets Ljava/util/List;
-	FIELD minecraft client Lcua;
-	FIELD width screenWidth I
 	METHOD addButton (Lcvb;)Lcvb;
 		ARG 1 button
 	METHOD confirmResult (ZI)V

--- a/mappings/net/minecraft/client/gui/Screen.mapping
+++ b/mappings/net/minecraft/client/gui/Screen.mapping
@@ -11,53 +11,53 @@ CLASS cyi net/minecraft/client/gui/Screen
 		ARG 1 button
 	METHOD confirmResult (ZI)V
 		ARG 1 result
-	METHOD getTooltipFromItem getStackTooltip (Lbaz;)Ljava/util/List;
-	METHOD handleComponentClicked handleTextComponentClick (Ljm;)Z
-	METHOD hasAltDown isAltPressed ()Z
-	METHOD hasControlDown isControlPressed ()Z
-	METHOD hasShiftDown isShiftPressed ()Z
-	METHOD init onInitialized ()V
-	METHOD init initialize (Lcua;II)V
+	METHOD getTooltipFromItem (Lbaz;)Ljava/util/List;
+	METHOD handleComponentClicked (Ljm;)Z
+	METHOD hasAltDown ()Z
+	METHOD hasControlDown ()Z
+	METHOD hasShiftDown ()Z
+	METHOD init ()V
+	METHOD init (Lcua;II)V
 		ARG 1 client
 		ARG 2 width
 		ARG 3 height
-	METHOD isCopy isCopyShortcutPressed (I)Z
+	METHOD isCopy (I)Z
 		ARG 0 code
-	METHOD isCut isCutShortcutPressed (I)Z
+	METHOD isCut (I)Z
 		ARG 0 code
-	METHOD isPaste isPasteShortcutPressed (I)Z
+	METHOD isPaste (I)Z
 		ARG 0 code
-	METHOD isSelectAll isSelectAllShortcutPressed (I)Z
+	METHOD isSelectAll (I)Z
 		ARG 0 code
-	METHOD onClose close ()V
-	METHOD openLink openUri (Ljava/net/URI;)V
-	METHOD removed onClosed ()V
-	METHOD renderBackground drawBackground ()V
-	METHOD renderBackground drawBackground (I)V
+	METHOD onClose ()V
+	METHOD openLink (Ljava/net/URI;)V
+	METHOD removed ()V
+	METHOD renderBackground ()V
+	METHOD renderBackground (I)V
 		ARG 1 alpha
-	METHOD renderComponentHoverEffect drawTextComponentHover (Ljm;II)V
+	METHOD renderComponentHoverEffect (Ljm;II)V
 		ARG 1 component
 		ARG 2 x
 		ARG 3 y
-	METHOD renderDirtBackground drawTextureBackground (I)V
+	METHOD renderDirtBackground (I)V
 		ARG 1 alpha
-	METHOD renderTooltip drawStackTooltip (Lbaz;II)V
+	METHOD renderTooltip (Lbaz;II)V
 		ARG 1 stack
 		ARG 2 x
 		ARG 3 y
-	METHOD renderTooltip drawTooltip (Ljava/lang/String;II)V
+	METHOD renderTooltip (Ljava/lang/String;II)V
 		ARG 1 text
 		ARG 2 x
 		ARG 3 y
-	METHOD renderTooltip drawTooltip (Ljava/util/List;II)V
+	METHOD renderTooltip (Ljava/util/List;II)V
 		ARG 1 text
 		ARG 2 x
 		ARG 3 y
-	METHOD resize onScaleChanged (Lcua;II)V
+	METHOD resize (Lcua;II)V
 		ARG 1 client
 		ARG 2 width
 		ARG 3 height
 	METHOD sendMessage (Ljava/lang/String;Z)V
 		ARG 1 message
-	METHOD shouldCloseOnEsc doesEscapeKeyClose ()Z
-	METHOD tick update ()V
+	METHOD shouldCloseOnEsc ()Z
+	METHOD tick ()V

--- a/mappings/net/minecraft/client/gui/ScreenComponent.mapping
+++ b/mappings/net/minecraft/client/gui/ScreenComponent.mapping
@@ -1,2 +1,1 @@
 CLASS cvy net/minecraft/client/gui/ScreenComponent
-	FIELD isDragging active Z

--- a/mappings/net/minecraft/client/gui/menu/RealmsButton.mapping
+++ b/mappings/net/minecraft/client/gui/menu/RealmsButton.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/realms/RealmsAbstractButtonProxy net/minecraft/client/gui/menu/RealmsButton
-	METHOD active isEnabled ()Z
-	METHOD active setEnabled (Z)V
+	METHOD active ()Z
+	METHOD active (Z)V
 		ARG 1 enabled
-	METHOD getButton getRealmsProxy ()Lnet/minecraft/realms/AbstractRealmsButton;
+	METHOD getButton ()Lnet/minecraft/realms/AbstractRealmsButton;
 	METHOD setVisible (Z)V
 		ARG 1 visible

--- a/mappings/net/minecraft/client/gui/menu/RealmsScreen.mapping
+++ b/mappings/net/minecraft/client/gui/menu/RealmsScreen.mapping
@@ -1,13 +1,11 @@
 CLASS net/minecraft/realms/RealmsScreenProxy net/minecraft/client/gui/menu/RealmsScreen
-	FIELD LOGGER LOGGER_REALMS Lorg/apache/logging/log4j/Logger;
-	FIELD screen realmsScreen Lnet/minecraft/realms/RealmsScreen;
-	METHOD buttons getButtons ()Ljava/util/List;
-	METHOD buttonsAdd addButton (Lnet/minecraft/realms/AbstractRealmsButton;)V
-	METHOD buttonsClear clearWidgets ()V
-	METHOD childrenClear clearListeners ()V
+	METHOD buttons ()Ljava/util/List;
+	METHOD buttonsAdd (Lnet/minecraft/realms/AbstractRealmsButton;)V
+	METHOD buttonsClear ()V
+	METHOD childrenClear ()V
 	METHOD confirmResult (ZI)V
 		ARG 1 result
-	METHOD drawCenteredString drawStringCentered (Ljava/lang/String;III)V
+	METHOD drawCenteredString (Ljava/lang/String;III)V
 		ARG 1 text
 		ARG 2 x
 		ARG 3 y
@@ -16,12 +14,12 @@ CLASS net/minecraft/realms/RealmsScreenProxy net/minecraft/client/gui/menu/Realm
 		ARG 2 x
 		ARG 3 y
 		ARG 4 color
-	METHOD fontDrawShadow drawString (Ljava/lang/String;III)V
+	METHOD fontDrawShadow (Ljava/lang/String;III)V
 		ARG 1 text
 		ARG 2 x
 		ARG 3 y
-	METHOD fontLineHeight getFontHeight ()I
-	METHOD fontSplit wrapStringToList (Ljava/lang/String;I)Ljava/util/List;
-	METHOD fontWidth getStringWidth (Ljava/lang/String;)I
-	METHOD getScreen getRealmsScreen ()Lnet/minecraft/realms/RealmsScreen;
-	METHOD hasWidget containsWidget (Lnet/minecraft/realms/RealmsGuiEventListener;)Z
+	METHOD fontLineHeight ()I
+	METHOD fontSplit (Ljava/lang/String;I)Ljava/util/List;
+	METHOD fontWidth (Ljava/lang/String;)I
+	METHOD getScreen ()Lnet/minecraft/realms/RealmsScreen;
+	METHOD hasWidget (Lnet/minecraft/realms/RealmsGuiEventListener;)Z

--- a/mappings/net/minecraft/client/gui/widget/AbstractListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/AbstractListWidget.mapping
@@ -1,11 +1,4 @@
 CLASS cvs net/minecraft/client/gui/widget/AbstractListWidget
-	FIELD itemHeight entryHeight I
-	FIELD minecraft client Lcua;
-	FIELD x0 x I
-	FIELD x1 right I
-	FIELD y0 y I
-	FIELD y1 bottom I
-	FIELD yo scrollY D
 	METHOD <init> (Lcua;IIIII)V
 		ARG 1 client
 		ARG 2 width
@@ -13,37 +6,37 @@ CLASS cvs net/minecraft/client/gui/widget/AbstractListWidget
 		ARG 4 y
 		ARG 5 bottom
 		ARG 6 entryHeight
-	METHOD capYPosition clampScrollY ()V
-	METHOD getItemAtPosition getSelectedEntry (DD)I
-	METHOD getItemCount getEntryCount ()I
-	METHOD getItemHeight getEntryHeight ()I
-	METHOD getMaxPosition getMaxScrollPosition ()I
-	METHOD getMaxScroll getMaxScrollY ()I
-	METHOD getRowWidth getEntryWidth ()I
-	METHOD getScroll getScrollY ()I
-	METHOD isMouseInList isSelected (DD)Z
+	METHOD capYPosition ()V
+	METHOD getItemAtPosition (DD)I
+	METHOD getItemCount ()I
+	METHOD getItemHeight ()I
+	METHOD getMaxPosition ()I
+	METHOD getMaxScroll ()I
+	METHOD getRowWidth ()I
+	METHOD getScroll ()I
+	METHOD isMouseInList (DD)Z
 		ARG 1 mouseX
 		ARG 3 mouseY
-	METHOD isSelectedItem isSelectedEntry (I)Z
+	METHOD isSelectedItem (I)Z
 		ARG 1 index
-	METHOD renderBackground drawBackground ()V
-	METHOD renderHoleBackground renderCoverBackground (IIII)V
-	METHOD renderItem drawEntry (IIIIIIF)V
+	METHOD renderBackground ()V
+	METHOD renderHoleBackground (IIII)V
+	METHOD renderItem (IIIIIIF)V
 		ARG 1 index
 		ARG 2 y
-	METHOD renderList drawEntries (IIIIF)V
+	METHOD renderList (IIIIF)V
 		ARG 1 x
 		ARG 2 y
 		ARG 3 mouseX
 		ARG 4 mouseY
 	METHOD scroll (I)V
 		ARG 1 amount
-	METHOD selectItem selectEntry (IIDD)Z
+	METHOD selectItem (IIDD)Z
 		ARG 1 index
 		ARG 2 button
 		ARG 3 mouseX
 		ARG 5 mouseY
-	METHOD setLeftPos setX (I)V
+	METHOD setLeftPos (I)V
 	METHOD updateItemPosition (IIIF)V
 		ARG 1 index
 	METHOD updateSize (IIII)V

--- a/mappings/net/minecraft/client/gui/widget/ButtonWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ButtonWidget.mapping
@@ -1,2 +1,1 @@
 CLASS cve net/minecraft/client/gui/widget/ButtonWidget
-	METHOD onPress onPressed ()V

--- a/mappings/net/minecraft/client/gui/widget/ClickableScrolledSelectionList.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ClickableScrolledSelectionList.mapping
@@ -1,3 +1,2 @@
 CLASS net/minecraft/realms/RealmsClickableScrolledSelectionListProxy net/minecraft/client/gui/widget/ClickableScrolledSelectionList
-	METHOD getWidth width ()I
 	METHOD yo getScrollY ()D

--- a/mappings/net/minecraft/client/gui/widget/RealmsButtonWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/RealmsButtonWidget.mapping
@@ -1,5 +1,4 @@
 CLASS net/minecraft/realms/RealmsButtonProxy net/minecraft/client/gui/widget/RealmsButtonWidget
-	FIELD button realmsButton Lnet/minecraft/realms/RealmsButton;
 	METHOD <init> (Lnet/minecraft/realms/RealmsButton;IILjava/lang/String;IILcve$a;)V
 		ARG 1 button
 		ARG 2 x
@@ -7,6 +6,6 @@ CLASS net/minecraft/realms/RealmsButtonProxy net/minecraft/client/gui/widget/Rea
 		ARG 4 text
 		ARG 5 width
 		ARG 6 height
-	METHOD getHeight getY ()I
-	METHOD getSuperYImage getTexId (Z)I
+	METHOD getHeight ()I
+	METHOD getSuperYImage (Z)I
 	METHOD y getHeight ()I

--- a/mappings/net/minecraft/client/gui/widget/SliderWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/SliderWidget.mapping
@@ -1,6 +1,4 @@
 CLASS cvc net/minecraft/client/gui/widget/SliderWidget
-	FIELD options gameOptions Lcue;
-	FIELD value progress D
 	METHOD <init> (IIIID)V
 		ARG 1 x
 		ARG 2 y
@@ -13,7 +11,7 @@ CLASS cvc net/minecraft/client/gui/widget/SliderWidget
 		ARG 4 width
 		ARG 5 height
 		ARG 6 progress
-	METHOD applyValue onProgressChanged ()V
-	METHOD setValueFromMouse changeProgress (D)V
+	METHOD applyValue ()V
+	METHOD setValueFromMouse (D)V
 		ARG 1 mouseX
-	METHOD updateMessage updateText ()V
+	METHOD updateMessage ()V

--- a/mappings/net/minecraft/resource/ResourceReloadListener.mapping
+++ b/mappings/net/minecraft/resource/ResourceReloadListener.mapping
@@ -2,7 +2,7 @@ CLASS ww net/minecraft/resource/ResourceReloadListener
 	CLASS ww$a Helper
 		METHOD a waitForAll (Ljava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
 			ARG 1 passedObject
-	METHOD reload apply (Lww$a;Lxb;Lafx;Lafx;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;)Ljava/util/concurrent/CompletableFuture;
+	METHOD reload (Lww$a;Lxb;Lafx;Lafx;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 helper
 		ARG 3 prepareProfiler
 		ARG 4 applyProfiler


### PR DESCRIPTION
We might give these intermediary names in future snapshots, for now this should prevent any issues.

This shouldn't break current as they are given the mojang name and not the yarn name.