### PR TITLE
rename PumpkinFeature to WildCropFeature

### DIFF
--- a/mappings/net/minecraft/world/gen/feature/PumpkinFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/PumpkinFeature.mapping
@@ -1,5 +1,0 @@
-CLASS byu net/minecraft/world/gen/feature/PumpkinFeature
-	FIELD a pumpkin Lbue;
-	METHOD <init> (Ljava/util/function/Function;Lbue;)V
-		ARG 1 configDeserializer
-		ARG 2 pumpkin

--- a/mappings/net/minecraft/world/gen/feature/WildCropFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/WildCropFeature.mapping
@@ -1,0 +1,5 @@
+CLASS byu net/minecraft/world/gen/feature/WildCropFeature
+	FIELD a crop Lbue;
+	METHOD <init> (Ljava/util/function/Function;Lbue;)V
+		ARG 1 configDeserializer
+		ARG 2 crop


### PR DESCRIPTION
PumpkinFeature is now used for sweet berries as well, so it feels like it would be better to have it just be for any crop that grows in the wild.