### PR TITLE
Mapped frustrums and some method arguments

### DIFF
--- a/mappings/net/minecraft/client/render/BufferBuilder.mapping
+++ b/mappings/net/minecraft/client/render/BufferBuilder.mapping
@@ -2,6 +2,9 @@ CLASS ctz net/minecraft/client/render/BufferBuilder
 	CLASS ctz$a State
 		FIELD b rawBuffer [I
 		FIELD c format Lcuf;
+		METHOD <init> (Lctz;[ILcuf;)V
+			ARG 2 rawBuffer
+			ARG 3 format
 		METHOD a getRawBuffer ()[I
 		METHOD b getVertexCount ()I
 		METHOD c getFormat ()Lcuf;
@@ -55,6 +58,9 @@ CLASS ctz net/minecraft/client/render/BufferBuilder
 	METHOD a restoreState (Lctz$a;)V
 	METHOD a getDistanceSq (Ljava/nio/FloatBuffer;FFFII)F
 		ARG 0 buffer
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
 	METHOD a putVertexData ([I)V
 	METHOD b clear ()V
 	METHOD b vertex (DDD)Lctz;

--- a/mappings/net/minecraft/client/render/Frustum.mapping
+++ b/mappings/net/minecraft/client/render/Frustum.mapping
@@ -1,7 +1,7 @@
 CLASS dnb net/minecraft/client/render/Frustum
 	FIELD a sides [[F
-	FIELD b projectionMatrixArray [F
-	FIELD c modelViewMatrixArray [F
+	FIELD b projectionMatrix [F
+	FIELD c modelViewMatrix [F
 	FIELD d mvpMatrix [F
 	METHOD a getDistanceFromPlane ([FDDD)D
 		ARG 1 plane

--- a/mappings/net/minecraft/client/render/Frustum.mapping
+++ b/mappings/net/minecraft/client/render/Frustum.mapping
@@ -1,5 +1,8 @@
 CLASS dnb net/minecraft/client/render/Frustum
 	FIELD a sides [[F
+	FIELD b projectionMatrixArray [F
+	FIELD c modelViewMatrixArray [F
+	FIELD d mvpMatrix [F
 	METHOD a getDistanceFromPlane ([FDDD)D
 		ARG 1 plane
 		ARG 2 x

--- a/mappings/net/minecraft/client/render/RenderTickCounter.mapping
+++ b/mappings/net/minecraft/client/render/RenderTickCounter.mapping
@@ -4,3 +4,8 @@ CLASS cvh net/minecraft/client/render/RenderTickCounter
 	FIELD c lastFrameDuration F
 	FIELD d prevTimeMillis J
 	FIELD e timeScale F
+	METHOD <init> (FJ)V
+		ARG 1 tps
+		ARG 2 timeMillis
+	METHOD a beginRenderTick (J)V
+		ARG 1 timeMillis

--- a/mappings/net/minecraft/client/render/Tessellator.mapping
+++ b/mappings/net/minecraft/client/render/Tessellator.mapping
@@ -2,6 +2,8 @@ CLASS cuc net/minecraft/client/render/Tessellator
 	FIELD a buffer Lctz;
 	FIELD b renderer Lcua;
 	FIELD c INSTANCE Lcuc;
+	METHOD <init> (I)V
+		ARG 1 bufferCapacity
 	METHOD a getInstance ()Lcuc;
 	METHOD b draw ()V
 	METHOD c getBufferBuilder ()Lctz;

--- a/mappings/net/minecraft/client/render/VertexFormat.mapping
+++ b/mappings/net/minecraft/client/render/VertexFormat.mapping
@@ -13,8 +13,10 @@ CLASS cuf net/minecraft/client/render/VertexFormat
 	METHOD b getUvOffset (I)I
 	METHOD c getNormalOffset ()I
 	METHOD c getElement (I)Lcug;
+		ARG 1 index
 	METHOD d hasColorElement ()Z
 	METHOD d getElementOffset (I)I
+		ARG 1 element
 	METHOD e getColorOffset ()I
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o

--- a/mappings/net/minecraft/client/render/VertexFormatElement.mapping
+++ b/mappings/net/minecraft/client/render/VertexFormatElement.mapping
@@ -10,6 +10,10 @@ CLASS cug net/minecraft/client/render/VertexFormatElement
 		FIELD h size I
 		FIELD i name Ljava/lang/String;
 		FIELD j glId I
+		METHOD <init> (Ljava/lang/String;IILjava/lang/String;I)V
+			ARG 3 size
+			ARG 4 name
+			ARG 5 glId
 		METHOD a getSize ()I
 		METHOD b getName ()Ljava/lang/String;
 		METHOD c getGlId ()I
@@ -22,6 +26,8 @@ CLASS cug net/minecraft/client/render/VertexFormatElement
 		FIELD f BLEND_WEIGHT Lcug$b;
 		FIELD g PADDING Lcug$b;
 		FIELD h name Ljava/lang/String;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
+			ARG 3 name
 		METHOD a getName ()Ljava/lang/String;
 	FIELD a LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD b format Lcug$a;
@@ -32,6 +38,7 @@ CLASS cug net/minecraft/client/render/VertexFormatElement
 		ARG 1 index
 		ARG 2 format
 		ARG 3 type
+		ARG 4 count
 	METHOD a getFormat ()Lcug$a;
 	METHOD a isValidType (ILcug$b;)Z
 		ARG 1 index


### PR DESCRIPTION
This PR maps fields from `Frustrum` and `GlMatrixFrustrum`, with the exception of one matrix buffer which uses have been stripped. Also some arguments in the same package.