### PR TITLE
Forgot to add SetNbtLootFunction.mapping in #598

### DIFF
--- a/mappings/net/minecraft/world/loot/function/SetNbtLootFunction.mapping
+++ b/mappings/net/minecraft/world/loot/function/SetNbtLootFunction.mapping
@@ -1,4 +1,5 @@
 CLASS cpy net/minecraft/world/loot/function/SetNbtLootFunction
+	CLASS cpy$a Builder
 	FIELD a tag Lib;
 	METHOD <init> ([Lcqr;Lib;)V
 		ARG 1 conditions

--- a/mappings/net/minecraft/world/loot/function/SetNbtLootFunction.mapping
+++ b/mappings/net/minecraft/world/loot/function/SetNbtLootFunction.mapping
@@ -1,0 +1,9 @@
+CLASS cpy net/minecraft/world/loot/function/SetNbtLootFunction
+	FIELD a tag Lib;
+	METHOD <init> ([Lcqr;Lib;)V
+		ARG 1 conditions
+		ARG 2 tag
+	METHOD a builder (Lib;)Lcpn$a;
+		ARG 0 tag
+	METHOD a (Lib;[Lcqr;)Lcpo;
+		ARG 1 conditions


### PR DESCRIPTION
Unfortunatley, I noticed that only after the merge of #598.
When changing `SetTagLootFunction` to `SetNbtLootFunction`, I forgot to add the newly created `.mapping` file in the commit, hence the mapping for that file is missing completely in the current repro.
This pull request includes that file for the pre1 branch of this project.

Sorry about the trouble!