### PR TITLE
Fix TextFormat.RESET being named as color

### DIFF
--- a/mappings/net/minecraft/text/TextFormat.mapping
+++ b/mappings/net/minecraft/text/TextFormat.mapping
@@ -4,7 +4,7 @@ CLASS c net/minecraft/text/TextFormat
 	FIELD C id I
 	FIELD D color Ljava/lang/Integer;
 	FIELD a BLACK Lc;
-	FIELD v color Lc;
+	FIELD v RESET Lc;
 	FIELD x FORMAT_PATTERN Ljava/util/regex/Pattern;
 	FIELD z sectionSignCode C
 	METHOD a bySectionSignCode (C)Lc;


### PR DESCRIPTION
In https://github.com/FabricMC/yarn/pull/607 it got mapped as `color` which conflicts with `TextFormat#color` and causes compilation errors.