### PR TITLE
Remove duplicate field "TextFormat.color"

### DIFF
--- a/mappings/net/minecraft/text/TextFormat.mapping
+++ b/mappings/net/minecraft/text/TextFormat.mapping
@@ -4,7 +4,6 @@ CLASS c net/minecraft/text/TextFormat
 	FIELD C id I
 	FIELD D color Ljava/lang/Integer;
 	FIELD a BLACK Lc;
-	FIELD v color Lc;
 	FIELD x FORMAT_PATTERN Ljava/util/regex/Pattern;
 	FIELD z sectionSignCode C
 	METHOD a bySectionSignCode (C)Lc;


### PR DESCRIPTION
As it clashes with `TextFormat.color (Integer)`, when it should be called `TextFormat.RESET`. (#625).

(PR made manually on github - however the mapping format should be simple enough to not cause issues?)