### PR TITLE
ItemListWidget => EntryListWidget

### DIFF
--- a/mappings/net/minecraft/client/gui/Element.mapping
+++ b/mappings/net/minecraft/client/gui/Element.mapping
@@ -6,6 +6,8 @@ CLASS cxk net/minecraft/client/gui/Element
 	METHOD b mouseMoved (DD)V
 		ARG 1 mouseX
 		ARG 3 mouseY
+	METHOD changeFocus (Z)Z
+		ARG 1 lookForwards
 	METHOD charTyped (CI)Z
 		ARG 1 chr
 		ARG 2 keyCode
@@ -31,4 +33,6 @@ CLASS cxk net/minecraft/client/gui/Element
 		ARG 3 mouseY
 		ARG 5 button
 	METHOD mouseScrolled (DDD)Z
+		ARG 1 mouseX
+		ARG 3 mouseY
 		ARG 5 amount

--- a/mappings/net/minecraft/client/gui/menu/AlwaysSelectedEntryListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/menu/AlwaysSelectedEntryListWidget.mapping
@@ -1,0 +1,2 @@
+CLASS cwy net/minecraft/client/gui/menu/AlwaysSelectedEntryListWidget
+	CLASS cwy$a Entry

--- a/mappings/net/minecraft/client/gui/menu/AlwaysSelectedItemListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/menu/AlwaysSelectedItemListWidget.mapping
@@ -1,2 +1,0 @@
-CLASS cwy net/minecraft/client/gui/menu/AlwaysSelectedItemListWidget
-	CLASS cwy$a Item

--- a/mappings/net/minecraft/client/gui/widget/ElementListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ElementListWidget.mapping
@@ -1,5 +1,5 @@
 CLASS cws net/minecraft/client/gui/widget/ElementListWidget
-	CLASS cws$a ElementItem
+	CLASS cws$a Entry
 		FIELD a focused Lcxk;
 		FIELD b dragging Z
 		METHOD setDragging (Z)V

--- a/mappings/net/minecraft/client/gui/widget/EntryListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/EntryListWidget.mapping
@@ -1,6 +1,5 @@
-CLASS cwk net/minecraft/client/gui/widget/ItemListWidget
-	CLASS cwk$a Item
-		FIELD list parent Lcwk;
+CLASS cwk net/minecraft/client/gui/widget/EntryListWidget
+	CLASS cwk$a Entry
 		METHOD isMouseOver (DD)Z
 			ARG 1 mouseX
 			ARG 3 mouseY
@@ -12,23 +11,18 @@ CLASS cwk net/minecraft/client/gui/widget/ItemListWidget
 			ARG 7 mouseY
 			ARG 8 hovering
 			ARG 9 delta
-	CLASS cwk$b Items
-		FIELD b items Ljava/util/List;
+	CLASS cwk$b Entries
+		FIELD b entries Ljava/util/List;
 		METHOD add (ILjava/lang/Object;)V
-			ARG 1 value
+			ARG 1 index
+			ARG 2 entry
 		METHOD get (I)Ljava/lang/Object;
 			ARG 1 index
 		METHOD remove (I)Ljava/lang/Object;
 			ARG 1 index
 		METHOD set (ILjava/lang/Object;)Ljava/lang/Object;
-			ARG 1 value
-	FIELD centerListVertically verticallyCenter Z
-	FIELD children items Ljava/util/List;
-	FIELD minecraft client Lcvi;
-	FIELD renderHeader renderSelection Z
-	FIELD renderSelection visible Z
-	FIELD scrollAmount scroll D
-	FIELD selected selectedItem Lcwk$a;
+			ARG 1 index
+			ARG 2 entry
 	FIELD x0 left I
 	FIELD x1 right I
 	FIELD y0 top I
@@ -40,24 +34,27 @@ CLASS cwk net/minecraft/client/gui/widget/ItemListWidget
 		ARG 4 top
 		ARG 5 bottom
 		ARG 6 itemHeight
-	METHOD addEntry addItem (Lcwk$a;)I
+	METHOD addEntry (Lcwk$a;)I
 		ARG 1 entry
-	METHOD clearEntries clearItems ()V
-	METHOD getEntry getItem (I)Lcwk$a;
+	METHOD centerScrollOn (Lcwk$a;)V
+		ARG 1 entry
+	METHOD clickedHeader (II)V
+		ARG 1 x
+		ARG 2 y
+	METHOD ensureVisible (Lcwk$a;)V
+		ARG 1 entry
+	METHOD getEntry (I)Lcwk$a;
 		ARG 1 index
-	METHOD getEntryAtPosition getItemAtPosition (DD)Lcwk$a;
+	METHOD getEntryAtPosition (DD)Lcwk$a;
 		ARG 1 x
 		ARG 3 y
-	METHOD getMaxPosition getMaxScrollPosition ()I
+	METHOD getMaxPosition getMaxPosition ()I
 	METHOD getRowTop (I)I
 		ARG 1 index
-	METHOD getRowWidth getItemWidth ()I
-	METHOD getScrollAmount getScroll ()D
-	METHOD getSelected getSelectedItem ()Lcwk$a;
 	METHOD isMouseOver (DD)Z
 		ARG 1 mouseX
 		ARG 3 mouseY
-	METHOD isSelectedItem isSelected (I)Z
+	METHOD isSelectedItem (I)Z
 		ARG 1 index
 	METHOD keyPressed (III)Z
 		ARG 1 keyCode
@@ -79,30 +76,49 @@ CLASS cwk net/minecraft/client/gui/widget/ItemListWidget
 		ARG 5 button
 	METHOD mouseScrolled (DDD)Z
 		ARG 5 amount
+	METHOD moveSelection (I)V
+		ARG 1 amount
+	METHOD remove (I)Lcwk$a;
+		ARG 1 index
+	METHOD removeEntry (Lcwk$a;)Z
+		ARG 1 entry
 	METHOD render (IIF)V
 		ARG 1 mouseX
 		ARG 2 mouseY
 		ARG 3 delta
-	METHOD renderBackground drawBackground ()V
 	METHOD renderDecorations (II)V
 		ARG 1 mouseX
 		ARG 2 mouseY
+	METHOD renderHeader (IILcum;)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 tessellator
+	METHOD renderHoleBackground (IIII)V
+		ARG 1 top
+		ARG 2 bottom
+		ARG 3 alphaTop
+		ARG 4 alphaBottom
 	METHOD renderList (IIIIF)V
 		ARG 1 x
 		ARG 2 y
 		ARG 3 mouseX
 		ARG 4 mouseY
 		ARG 5 delta
+	METHOD replaceEntries (Ljava/util/Collection;)V
+		ARG 1 newEntries
 	METHOD scroll (I)V
 		ARG 1 amount
 	METHOD setLeftPos (I)V
 		ARG 1 left
 	METHOD setRenderHeader (ZI)V
-		ARG 1 renderSelection
+		ARG 1 renderHeader
 		ARG 2 headerHeight
-	METHOD setScrollAmount capYPosition (D)V
-	METHOD setSelected selectItem (Lcwk$a;)V
-		ARG 1 item
+	METHOD setRenderSelection (Z)V
+		ARG 1 renderSelection
+	METHOD setScrollAmount (D)V
+		ARG 1 amount
+	METHOD setSelected (Lcwk$a;)V
+		ARG 1 entry
 	METHOD updateSize (IIII)V
 		ARG 1 width
 		ARG 2 height


### PR DESCRIPTION
Right now there are 20 Yarn mappings for things which don't have any Intermediaries (ie straight Notch -> Yarn):
```
In cwk (net/minecraft/client/gui/widget/ItemListWidget)
	Extra mapped methods:
		getEntry(I)Lcwk$a; => getItem
		getScrollAmount()D => getScroll
		clearEntries()V => clearItems
		getRowWidth()I => getItemWidth
		isSelectedItem(I)Z => isSelected
		renderBackground()V => drawBackground
		setScrollAmount(D)V => capYPosition
		setSelected(Lcwk$a;)V => selectItem
		getMaxPosition()I => getMaxScrollPosition
		getEntryAtPosition(DD)Lcwk$a; => getItemAtPosition
		getSelected()Lcwk$a; => getSelectedItem
		addEntry(Lcwk$a;)I => addItem
	Extra mapped fields:
		Lcwk$a; selected => selectedItem
		Z renderSelection => visible
		Lcvi; minecraft => client
		D scrollAmount => scroll
		Z centerListVertically => verticallyCenter
		Ljava/util/List; children => items
		Z renderHeader => renderSelection

In cwk$a (net/minecraft/client/gui/widget/ItemListWidget$Item)
	Extra mapped fields:
		Lcwk; list => parent
```
In removing these to go back to the (non-obf'd) Notch names it seems reasonable to conclude Mojang use `Entry` rather than `Item` for `ItemListWidget`. Thus renaming it to better fit the method names felt appropriate given the method names need to change anyway.