### PR TITLE
Refactor chat components

### DIFF
--- a/mappings/net/minecraft/ChatFormat.mapping
+++ b/mappings/net/minecraft/ChatFormat.mapping
@@ -1,4 +1,4 @@
-CLASS c net/minecraft/text/TextFormat
+CLASS c net/minecraft/ChatFormat
 	FIELD A modifier Z
 	FIELD B code Ljava/lang/String;
 	FIELD C id I

--- a/mappings/net/minecraft/network/chat/BaseComponent.mapping
+++ b/mappings/net/minecraft/network/chat/BaseComponent.mapping
@@ -1,4 +1,4 @@
-CLASS jj net/minecraft/text/AbstractTextComponent
+CLASS jj net/minecraft/network/chat/BaseComponent
 	FIELD a siblings Ljava/util/List;
 	FIELD b style Lju;
 	METHOD equals (Ljava/lang/Object;)Z

--- a/mappings/net/minecraft/network/chat/ChatMessageType.mapping
+++ b/mappings/net/minecraft/network/chat/ChatMessageType.mapping
@@ -1,4 +1,4 @@
-CLASS jk net/minecraft/text/ChatMessageType
+CLASS jk net/minecraft/network/chat/ChatMessageType
 	FIELD d id B
 	FIELD e interruptsNarration Z
 	METHOD <init> (Ljava/lang/String;IBZ)V

--- a/mappings/net/minecraft/network/chat/ClickEvent.mapping
+++ b/mappings/net/minecraft/network/chat/ClickEvent.mapping
@@ -1,4 +1,4 @@
-CLASS jl net/minecraft/text/event/ClickEvent
+CLASS jl net/minecraft/network/chat/ClickEvent
 	CLASS jl$a Action
 		FIELD a OPEN_URL Ljl$a;
 		FIELD b OPEN_FILE Ljl$a;

--- a/mappings/net/minecraft/network/chat/Component.mapping
+++ b/mappings/net/minecraft/network/chat/Component.mapping
@@ -1,4 +1,4 @@
-CLASS jm net/minecraft/text/TextComponent
+CLASS jm net/minecraft/network/chat/Component
 	CLASS jm$a Serializer
 		FIELD a GSON Lcom/google/gson/Gson;
 		FIELD b POS_FIELD Ljava/lang/reflect/Field;

--- a/mappings/net/minecraft/network/chat/ComponentWithSelectors.mapping
+++ b/mappings/net/minecraft/network/chat/ComponentWithSelectors.mapping
@@ -1,0 +1,3 @@
+CLASS jo net/minecraft/network/chat/ComponentWithSelectors
+	METHOD a resolve (Lcd;Laif;)Ljm;
+		ARG 1 source

--- a/mappings/net/minecraft/network/chat/Components.mapping
+++ b/mappings/net/minecraft/network/chat/Components.mapping
@@ -1,4 +1,4 @@
-CLASS jn net/minecraft/text/TextFormatter
+CLASS jn net/minecraft/network/chat/Components
 	METHOD a resolveAndStyle (Lcd;Ljm;Laif;)Ljm;
 		ARG 0 source
 		ARG 1 component

--- a/mappings/net/minecraft/network/chat/HoverEvent.mapping
+++ b/mappings/net/minecraft/network/chat/HoverEvent.mapping
@@ -1,4 +1,4 @@
-CLASS jp net/minecraft/text/event/HoverEvent
+CLASS jp net/minecraft/network/chat/HoverEvent
 	CLASS jp$a Action
 		FIELD a SHOW_TEXT Ljp$a;
 		FIELD b SHOW_ITEM Ljp$a;

--- a/mappings/net/minecraft/network/chat/KeybindComponent.mapping
+++ b/mappings/net/minecraft/network/chat/KeybindComponent.mapping
@@ -1,4 +1,4 @@
-CLASS jq net/minecraft/text/KeybindTextComponent
+CLASS jq net/minecraft/network/chat/KeybindComponent
 	FIELD c keybind Ljava/lang/String;
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o

--- a/mappings/net/minecraft/network/chat/NbtComponent.mapping
+++ b/mappings/net/minecraft/network/chat/NbtComponent.mapping
@@ -1,4 +1,4 @@
-CLASS jr net/minecraft/text/NbtTextComponent
+CLASS jr net/minecraft/network/chat/NbtComponent
 	CLASS jr$a BlockPosArgument
 		FIELD e pos Ljava/lang/String;
 		FIELD f parsedPos Ldl;
@@ -7,7 +7,7 @@ CLASS jr net/minecraft/text/NbtTextComponent
 		METHOD equals (Ljava/lang/Object;)Z
 			ARG 1 o
 		METHOD k getPos ()Ljava/lang/String;
-	CLASS jr$b EntityNbtTextComponent
+	CLASS jr$b EntityNbtComponent
 		FIELD e selector Ljava/lang/String;
 		FIELD f parsedSelector Lec;
 		METHOD b parseSelector (Ljava/lang/String;)Lec;

--- a/mappings/net/minecraft/network/chat/ScoreComponent.mapping
+++ b/mappings/net/minecraft/network/chat/ScoreComponent.mapping
@@ -1,4 +1,4 @@
-CLASS js net/minecraft/text/ScoreTextComponent
+CLASS js net/minecraft/network/chat/ScoreComponent
 	FIELD b name Ljava/lang/String;
 	FIELD c selector Lec;
 	FIELD d objective Ljava/lang/String;

--- a/mappings/net/minecraft/network/chat/SelectorComponent.mapping
+++ b/mappings/net/minecraft/network/chat/SelectorComponent.mapping
@@ -1,4 +1,4 @@
-CLASS jt net/minecraft/text/SelectorTextComponent
+CLASS jt net/minecraft/network/chat/SelectorComponent
 	FIELD b LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD c pattern Ljava/lang/String;
 	METHOD equals (Ljava/lang/Object;)Z

--- a/mappings/net/minecraft/network/chat/Style.mapping
+++ b/mappings/net/minecraft/network/chat/Style.mapping
@@ -1,4 +1,4 @@
-CLASS ju net/minecraft/text/Style
+CLASS ju net/minecraft/network/chat/Style
 	CLASS ju$a Serializer
 		METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 			ARG 1 functionJson

--- a/mappings/net/minecraft/network/chat/TextComponent.mapping
+++ b/mappings/net/minecraft/network/chat/TextComponent.mapping
@@ -1,4 +1,4 @@
-CLASS jv net/minecraft/text/StringTextComponent
+CLASS jv net/minecraft/network/chat/TextComponent
 	FIELD b text Ljava/lang/String;
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o

--- a/mappings/net/minecraft/network/chat/TranslatableComponent.mapping
+++ b/mappings/net/minecraft/network/chat/TranslatableComponent.mapping
@@ -1,4 +1,4 @@
-CLASS jw net/minecraft/text/TranslatableTextComponent
+CLASS jw net/minecraft/network/chat/TranslatableComponent
 	FIELD b translatedText Ljava/util/List;
 	FIELD c PARAM_PATTERN Ljava/util/regex/Pattern;
 	FIELD d EMPTY_LANGUAGE Lhw;

--- a/mappings/net/minecraft/network/chat/TranslationException.mapping
+++ b/mappings/net/minecraft/network/chat/TranslationException.mapping
@@ -1,4 +1,4 @@
-CLASS jx net/minecraft/text/ComponentTranslationException
+CLASS jx net/minecraft/network/chat/TranslationException
 	METHOD <init> (Ljw;I)V
 		ARG 1 component
 	METHOD <init> (Ljw;Ljava/lang/String;)V

--- a/mappings/net/minecraft/text/TextComponentWithSelectors.mapping
+++ b/mappings/net/minecraft/text/TextComponentWithSelectors.mapping
@@ -1,3 +1,0 @@
-CLASS jo net/minecraft/text/TextComponentWithSelectors
-	METHOD a resolve (Lcd;Laif;)Ljm;
-		ARG 1 source


### PR DESCRIPTION
Closes #174, Succeeds #567 (partially).

This PR brings the naming of chat components in line with Mojang - in both
package and *chat* components.