### PR TITLE
ItemProvider -> ItemConvertible, StringRepresentable -> SnakeCaseIdentifiable

### DIFF
--- a/mappings/net/minecraft/item/ItemConvertible.mapping
+++ b/mappings/net/minecraft/item/ItemConvertible.mapping
@@ -1,0 +1,2 @@
+CLASS bhg net/minecraft/item/ItemConvertible
+	METHOD g asItem ()Lbbv;

--- a/mappings/net/minecraft/item/ItemProvider.mapping
+++ b/mappings/net/minecraft/item/ItemProvider.mapping
@@ -1,2 +1,0 @@
-CLASS bhg net/minecraft/item/ItemProvider
-	METHOD g getItem ()Lbbv;

--- a/mappings/net/minecraft/state/property/EnumPropertyValue.mapping
+++ b/mappings/net/minecraft/state/property/EnumPropertyValue.mapping
@@ -1,2 +1,0 @@
-CLASS zx net/minecraft/state/property/EnumPropertyValue
-	METHOD m getValueName ()Ljava/lang/String;

--- a/mappings/net/minecraft/state/property/EnumPropertyValue.mapping
+++ b/mappings/net/minecraft/state/property/EnumPropertyValue.mapping
@@ -1,0 +1,2 @@
+CLASS zx net/minecraft/state/property/EnumPropertyValue
+	METHOD m getValueName ()Ljava/lang/String;

--- a/mappings/net/minecraft/util/SnakeCaseIdentifiable.mapping
+++ b/mappings/net/minecraft/util/SnakeCaseIdentifiable.mapping
@@ -1,0 +1,2 @@
+CLASS zx net/minecraft/util/SnakeCaseIdentifiable
+	METHOD m toSnakeCase ()Ljava/lang/String;

--- a/mappings/net/minecraft/util/StringRepresentable.mapping
+++ b/mappings/net/minecraft/util/StringRepresentable.mapping
@@ -1,2 +1,0 @@
-CLASS zx net/minecraft/util/StringRepresentable
-	METHOD m asString ()Ljava/lang/String;


### PR DESCRIPTION
`ItemConvertible` reason:
1. This `ItemProvider` is implemented by `Item` and `Block` instead of some lambda that actually provides/supplies an item.
![image](https://user-images.githubusercontent.com/7806504/56778827-32181700-678d-11e9-8a17-fca58b2275f7.png)
2. Another name `HasItemForm`, which is very accurate, is also considered, but because of the ideal of interface naming in adjectives, I chose `ItemConvertible`, as [`convert` as a word means "change to a different form"](https://www.dictionary.com/browse/convert).

`EnumPropertyValue` reason:
1. This is only implemented by enum classes that can be used as state property values.
![image](https://user-images.githubusercontent.com/7806504/56778869-58d64d80-678d-11e9-8159-451ef3c80cb0.png)
2. This is really just used to get the enum value names in a lowercase form (or getting the proper string version of the value)
![image](https://user-images.githubusercontent.com/7806504/56778975-c84c3d00-678d-11e9-9734-4769f41ca0c2.png)
hence "get value name".
3. A few other usages are present, but they are only really used to be a shortcut for getting lowercase enum names for translation keys, etc.
![image](https://user-images.githubusercontent.com/7806504/56779017-f3369100-678d-11e9-8ef8-61e991fe0eeb.png)

