### PR TITLE
Add *.sh to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ out/
 *.iws
 *.ipr
 *.jar
+
+*.sh


### PR DESCRIPTION
I use scripts to load Enigma and setup commits etc. Would be nice if Yarn itself ignored script files in Git. 