### PR TITLE
Fix some strange settings names

### DIFF
--- a/mappings/net/minecraft/client/gui/menu/AddServerScreen.mapping
+++ b/mappings/net/minecraft/client/gui/menu/AddServerScreen.mapping
@@ -10,7 +10,7 @@ CLASS czb net/minecraft/client/gui/menu/AddServerScreen
 		ARG 2 serverEntry
 	METHOD a addAndClose ()V
 	METHOD a onClose (Ljava/lang/String;)V
-		ARG 1 unused
+		ARG 1 text
 	METHOD render (IIF)V
 		ARG 1 mouseX
 		ARG 2 mouseY

--- a/mappings/net/minecraft/client/gui/menu/CustomizeBuffetLevelScreen.mapping
+++ b/mappings/net/minecraft/client/gui/menu/CustomizeBuffetLevelScreen.mapping
@@ -11,8 +11,8 @@ CLASS cyv net/minecraft/client/gui/menu/CustomizeBuffetLevelScreen
 	FIELD a CHUNK_GENERATOR_TYPES Ljava/util/List;
 	FIELD b parent Ldcw;
 	FIELD c generatorOptionsTag Lib;
-	FIELD d biomSelectionList Lcyv$a;
-	FIELD e biomsListLength I
+	FIELD d biomeSelectionList Lcyv$a;
+	FIELD e biomeListLength I
 	FIELD f confirmButton Lcwo;
 	METHOD <init> (Ldcw;Lib;)V
 		ARG 1 parent

--- a/mappings/net/minecraft/client/gui/menu/SettingsScreen.mapping
+++ b/mappings/net/minecraft/client/gui/menu/SettingsScreen.mapping
@@ -10,7 +10,7 @@ CLASS czk net/minecraft/client/gui/menu/SettingsScreen
 		ARG 2 gameOptions
 	METHOD a getDifficultyButtonText (Lagx;)Ljava/lang/String;
 		ARG 1 difficulty
-	METHOD a tmp (Z)V
+	METHOD a lockDifficulty (Z)V
 		ARG 1 difficultyLocked
 	METHOD render (IIF)V
 		ARG 1 mouseX


### PR DESCRIPTION
#611 added two spelling mistakes of `biome` (as far as I can tell) and named a button callback `tmp` which seems unintentional.