### PR TITLE
VoxelShape.getIncludedPoints -> getPointPositions

### DIFF
--- a/mappings/net/minecraft/util/shape/VoxelShape.mapping
+++ b/mappings/net/minecraft/util/shape/VoxelShape.mapping
@@ -16,11 +16,11 @@ CLASS csr net/minecraft/util/shape/VoxelShape
 		ARG 1 axisCycle
 		ARG 2 box
 		ARG 3 maxDist
-	METHOD a getIncludedPoints (Lfa$a;)Lit/unimi/dsi/fastutil/doubles/DoubleList;
+	METHOD a getPointPositions (Lfa$a;)Lit/unimi/dsi/fastutil/doubles/DoubleList;
 		ARG 1 axis
 	METHOD a getCoordIndex (Lfa$a;D)I
 		ARG 2 coord
-	METHOD a getCoord (Lfa$a;I)D
+	METHOD a getPointPosition (Lfa$a;I)D
 		ARG 1 axis
 		ARG 2 index
 	METHOD a (Lfa$a;Lcrs;D)D


### PR DESCRIPTION
It's a list of positions for each layer separator (which Mojang calls "points", see `ArrayVoxelShape`), not sure where the "included" came from.