### PR TITLE
Rename ICrashCallable to CrashCallable

### DIFF
--- a/mappings/net/minecraft/util/crash/CrashCallable.mapping
+++ b/mappings/net/minecraft/util/crash/CrashCallable.mapping
@@ -1,0 +1,1 @@
+CLASS f net/minecraft/util/crash/CrashCallable

--- a/mappings/net/minecraft/util/crash/ICrashCallable.mapping
+++ b/mappings/net/minecraft/util/crash/ICrashCallable.mapping
@@ -1,1 +1,0 @@
-CLASS f net/minecraft/util/crash/ICrashCallable


### PR DESCRIPTION
Drops the `I` prefix from `ICrashCallable`.