### PR TITLE
Pass over DataFixers

### DIFF
--- a/mappings/net/minecraft/datafixers/fixes/AddTrappedChestFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/AddTrappedChestFix.mapping
@@ -1,2 +1,5 @@
 CLASS aea net/minecraft/datafixers/fixes/AddTrappedChestFix
 	FIELD a LOGGER Lorg/apache/logging/log4j/Logger;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/AdvancementsFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/AdvancementsFix.mapping
@@ -1,2 +1,5 @@
 CLASS aai net/minecraft/datafixers/fixes/AdvancementsFix
 	FIELD a RENAMED_ADVANCEMENTS Ljava/util/Map;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/BedBlockEntityFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/BedBlockEntityFix.mapping
@@ -1,1 +1,4 @@
 CLASS aaj net/minecraft/datafixers/fixes/BedBlockEntityFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/BedItemColorFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/BedItemColorFix.mapping
@@ -1,1 +1,4 @@
 CLASS aak net/minecraft/datafixers/fixes/BedItemColorFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/BiomesFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/BiomesFix.mapping
@@ -1,2 +1,5 @@
 CLASS aal net/minecraft/datafixers/fixes/BiomesFix
 	FIELD a RENAMED_BIOMES Ljava/util/Map;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/BlockEntityBannerColorFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/BlockEntityBannerColorFix.mapping
@@ -1,1 +1,10 @@
 CLASS aam net/minecraft/datafixers/fixes/BlockEntityBannerColorFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a fixBannerColor (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 tag
+	METHOD d (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 0 tag
+	METHOD e (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 0 tag

--- a/mappings/net/minecraft/datafixers/fixes/BlockEntityBlockStateFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/BlockEntityBlockStateFix.mapping
@@ -1,1 +1,4 @@
 CLASS aan net/minecraft/datafixers/fixes/BlockEntityBlockStateFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/BlockEntityCustomNameToComponentFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/BlockEntityCustomNameToComponentFix.mapping
@@ -1,1 +1,4 @@
 CLASS aao net/minecraft/datafixers/fixes/BlockEntityCustomNameToComponentFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/BlockEntityIdFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/BlockEntityIdFix.mapping
@@ -1,2 +1,5 @@
 CLASS aap net/minecraft/datafixers/fixes/BlockEntityIdFix
 	FIELD a RENAMED_BLOCK_ENTITIES Ljava/util/Map;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/BlockEntityJukeboxFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/BlockEntityJukeboxFix.mapping
@@ -1,1 +1,4 @@
 CLASS aaq net/minecraft/datafixers/fixes/BlockEntityJukeboxFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/BlockEntityKeepPacked.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/BlockEntityKeepPacked.mapping
@@ -1,2 +1,6 @@
 CLASS aar net/minecraft/datafixers/fixes/BlockEntityKeepPacked
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
 	METHOD a keepPacked (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 0 tag

--- a/mappings/net/minecraft/datafixers/fixes/BlockEntityShulkerBoxColorFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/BlockEntityShulkerBoxColorFix.mapping
@@ -1,1 +1,4 @@
 CLASS aas net/minecraft/datafixers/fixes/BlockEntityShulkerBoxColorFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/BlockEntitySignTextStrictJsonFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/BlockEntitySignTextStrictJsonFix.mapping
@@ -5,3 +5,9 @@ CLASS aat net/minecraft/datafixers/fixes/BlockEntitySignTextStrictJsonFix
 			ARG 2 unused
 			ARG 3 context
 	FIELD a GSON Lcom/google/gson/Gson;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a fix (Lcom/mojang/datafixers/Dynamic;Ljava/lang/String;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 tag
+		ARG 2 lineName

--- a/mappings/net/minecraft/datafixers/fixes/BlockNameFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/BlockNameFix.mapping
@@ -2,8 +2,10 @@ CLASS aav net/minecraft/datafixers/fixes/BlockNameFix
 	FIELD a name Ljava/lang/String;
 	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)V
 		ARG 1 oldSchema
+		ARG 2 name
 	METHOD a create (Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;Ljava/util/function/Function;)Lcom/mojang/datafixers/DataFix;
 		ARG 0 oldSchema
 		ARG 1 name
 		ARG 2 rename
 	METHOD a rename (Ljava/lang/String;)Ljava/lang/String;
+		ARG 1 oldName

--- a/mappings/net/minecraft/datafixers/fixes/BlockNameFlatteningFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/BlockNameFlatteningFix.mapping
@@ -1,1 +1,4 @@
 CLASS aau net/minecraft/datafixers/fixes/BlockNameFlatteningFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/BlockStateStructureTemplateFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/BlockStateStructureTemplateFix.mapping
@@ -1,1 +1,4 @@
 CLASS aax net/minecraft/datafixers/fixes/BlockStateStructureTemplateFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/CatTypeFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/CatTypeFix.mapping
@@ -3,3 +3,4 @@ CLASS aay net/minecraft/datafixers/fixes/CatTypeFix
 		ARG 1 outputSchema
 		ARG 2 changesType
 	METHOD a fixCatTypeData (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 tag

--- a/mappings/net/minecraft/datafixers/fixes/ChoiceFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ChoiceFix.mapping
@@ -7,4 +7,5 @@ CLASS adf net/minecraft/datafixers/fixes/ChoiceFix
 		ARG 2 changesType
 		ARG 3 name
 		ARG 4 type
+		ARG 5 choiceName
 	METHOD a transform (Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;

--- a/mappings/net/minecraft/datafixers/fixes/ChunkLightRemoveFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ChunkLightRemoveFix.mapping
@@ -1,1 +1,4 @@
 CLASS aaz net/minecraft/datafixers/fixes/ChunkLightRemoveFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/ChunkPalettedStorageFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ChunkPalettedStorageFix.mapping
@@ -65,6 +65,9 @@ CLASS aba net/minecraft/datafixers/fixes/ChunkPalettedStorageFix
 	FIELD s bed Ljava/util/Map;
 	FIELD t banner Ljava/util/Map;
 	FIELD u air Lcom/mojang/datafixers/Dynamic;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
 	METHOD a getName (Lcom/mojang/datafixers/Dynamic;)Ljava/lang/String;
 	METHOD a getProperty (Lcom/mojang/datafixers/Dynamic;Ljava/lang/String;)Ljava/lang/String;
 	METHOD a buildBed (Ljava/util/Map;ILjava/lang/String;)V

--- a/mappings/net/minecraft/datafixers/fixes/ChunkStatusFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ChunkStatusFix.mapping
@@ -1,1 +1,4 @@
 CLASS abb net/minecraft/datafixers/fixes/ChunkStatusFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/ChunkStatusFix2.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ChunkStatusFix2.mapping
@@ -1,2 +1,5 @@
 CLASS abc net/minecraft/datafixers/fixes/ChunkStatusFix2
 	FIELD a statusMap Ljava/util/Map;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/ChunkStructuresTemplateRenameFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ChunkStructuresTemplateRenameFix.mapping
@@ -1,2 +1,5 @@
 CLASS abd net/minecraft/datafixers/fixes/ChunkStructuresTemplateRenameFix
 	FIELD a structures Lcom/google/common/collect/ImmutableMap;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/ChunkToProtoChunkFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ChunkToProtoChunkFix.mapping
@@ -1,1 +1,4 @@
 CLASS abe net/minecraft/datafixers/fixes/ChunkToProtoChunkFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/ColorlessShulkerEntityFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ColorlessShulkerEntityFix.mapping
@@ -1,1 +1,4 @@
 CLASS abf net/minecraft/datafixers/fixes/ColorlessShulkerEntityFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/DecorationEntityFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/DecorationEntityFix.mapping
@@ -1,0 +1,9 @@
+CLASS abu net/minecraft/datafixers/fixes/DecorationEntityFix
+	FIELD a OFFSETS [[I
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a fixDecorationPosition (Lcom/mojang/datafixers/Dynamic;ZZ)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 tag
+		ARG 2 isPainting
+		ARG 3 isItemFrame

--- a/mappings/net/minecraft/datafixers/fixes/EntityArmorStandSilentFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityArmorStandSilentFix.mapping
@@ -1,1 +1,6 @@
 CLASS abh net/minecraft/datafixers/fixes/EntityArmorStandSilentFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a fixSilent (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 tag

--- a/mappings/net/minecraft/datafixers/fixes/EntityBlockStateFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityBlockStateFix.mapping
@@ -1,4 +1,14 @@
 CLASS abi net/minecraft/datafixers/fixes/EntityBlockStateFix
 	FIELD a BLOCK_NAME_TO_ID Ljava/util/Map;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a mergeIdAndData (Lcom/mojang/datafixers/Typed;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/mojang/datafixers/Typed;
+		ARG 2 oldIdKey
+		ARG 3 oldDataKey
+		ARG 4 newStateKey
+	METHOD a useFunction (Lcom/mojang/datafixers/Typed;Ljava/lang/String;Ljava/util/function/Function;)Lcom/mojang/datafixers/Typed;
+		ARG 2 entityId
+		ARG 3 function
 	METHOD a getNumericalBlockId (Ljava/lang/String;)I
 		ARG 0 blockId

--- a/mappings/net/minecraft/datafixers/fixes/EntityCatSplitFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityCatSplitFix.mapping
@@ -1,1 +1,4 @@
 CLASS abj net/minecraft/datafixers/fixes/EntityCatSplitFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/EntityCodSalmonFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityCodSalmonFix.mapping
@@ -1,3 +1,6 @@
 CLASS abk net/minecraft/datafixers/fixes/EntityCodSalmonFix
 	FIELD a ENTITIES Ljava/util/Map;
 	FIELD b SPAWN_EGGS Ljava/util/Map;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/EntityCustomNameToComponentFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityCustomNameToComponentFix.mapping
@@ -1,2 +1,6 @@
 CLASS abl net/minecraft/datafixers/fixes/EntityCustomNameToComponentFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
 	METHOD a fixCustomName (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 0 tag

--- a/mappings/net/minecraft/datafixers/fixes/EntityElderGuardianSplitFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityElderGuardianSplitFix.mapping
@@ -1,1 +1,4 @@
 CLASS abm net/minecraft/datafixers/fixes/EntityElderGuardianSplitFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/EntityEquipmentToArmorAndHandFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityEquipmentToArmorAndHandFix.mapping
@@ -1,1 +1,5 @@
 CLASS abn net/minecraft/datafixers/fixes/EntityEquipmentToArmorAndHandFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a fixEquipment (Lcom/mojang/datafixers/types/Type;)Lcom/mojang/datafixers/TypeRewriteRule;

--- a/mappings/net/minecraft/datafixers/fixes/EntityHealthFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityHealthFix.mapping
@@ -1,2 +1,7 @@
 CLASS abo net/minecraft/datafixers/fixes/EntityHealthFix
 	FIELD a ENTITIES Ljava/util/Set;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a fixHealth (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 tag

--- a/mappings/net/minecraft/datafixers/fixes/EntityHorseSaddleFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityHorseSaddleFix.mapping
@@ -1,1 +1,4 @@
 CLASS abp net/minecraft/datafixers/fixes/EntityHorseSaddleFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/EntityHorseSplitFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityHorseSplitFix.mapping
@@ -1,1 +1,4 @@
 CLASS abq net/minecraft/datafixers/fixes/EntityHorseSplitFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/EntityIdFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityIdFix.mapping
@@ -1,2 +1,5 @@
 CLASS abr net/minecraft/datafixers/fixes/EntityIdFix
 	FIELD a RENAMED_ENTITIES Ljava/util/Map;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/EntityItemFrameDirectionFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityItemFrameDirectionFix.mapping
@@ -1,1 +1,6 @@
 CLASS abs net/minecraft/datafixers/fixes/EntityItemFrameDirectionFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a updateDirection (B)B
+	METHOD a fixDirection (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;

--- a/mappings/net/minecraft/datafixers/fixes/EntityMinecartIdentifiersFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityMinecartIdentifiersFix.mapping
@@ -1,2 +1,5 @@
 CLASS abt net/minecraft/datafixers/fixes/EntityMinecartIdentifiersFix
 	FIELD a MINECARTS Ljava/util/List;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/EntityPaintingFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityPaintingFix.mapping
@@ -1,2 +1,0 @@
-CLASS abu net/minecraft/datafixers/fixes/EntityPaintingFix
-	FIELD a OFFSETS [[I

--- a/mappings/net/minecraft/datafixers/fixes/EntityPaintingMotiveFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityPaintingMotiveFix.mapping
@@ -1,2 +1,5 @@
 CLASS abv net/minecraft/datafixers/fixes/EntityPaintingMotiveFix
 	FIELD a RENAMED_MOTIVES Ljava/util/Map;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/EntityPufferfishRenameFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityPufferfishRenameFix.mapping
@@ -1,2 +1,5 @@
 CLASS abw net/minecraft/datafixers/fixes/EntityPufferfishRenameFix
 	FIELD a RENAMED_FISHES Ljava/util/Map;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/EntityRavagerRenameFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityRavagerRenameFix.mapping
@@ -1,2 +1,5 @@
 CLASS abx net/minecraft/datafixers/fixes/EntityRavagerRenameFix
 	FIELD a ITEMS Ljava/util/Map;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/EntityRedundantChanceTagsFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityRedundantChanceTagsFix.mapping
@@ -1,1 +1,4 @@
 CLASS aby net/minecraft/datafixers/fixes/EntityRedundantChanceTagsFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/EntityRenameFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityRenameFix.mapping
@@ -2,5 +2,7 @@ CLASS adw net/minecraft/datafixers/fixes/EntityRenameFix
 	FIELD a name Ljava/lang/String;
 	METHOD <init> (Ljava/lang/String;Lcom/mojang/datafixers/schemas/Schema;Z)V
 		ARG 1 name
-		ARG 2 oldSchema
+		ARG 2 outputSchema
+		ARG 3 changesType
 	METHOD a rename (Ljava/lang/String;)Ljava/lang/String;
+		ARG 1 oldName

--- a/mappings/net/minecraft/datafixers/fixes/EntityRidingToPassengerFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityRidingToPassengerFix.mapping
@@ -1,1 +1,4 @@
 CLASS aca net/minecraft/datafixers/fixes/EntityRidingToPassengerFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/EntityShulkerColorFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityShulkerColorFix.mapping
@@ -1,1 +1,4 @@
 CLASS acb net/minecraft/datafixers/fixes/EntityShulkerColorFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/EntitySimpleTransformFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntitySimpleTransformFix.mapping
@@ -4,3 +4,4 @@ CLASS adv net/minecraft/datafixers/fixes/EntitySimpleTransformFix
 		ARG 2 oldSchema
 	METHOD a transform (Ljava/lang/String;Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/util/Pair;
 		ARG 1 choice
+		ARG 2 tag

--- a/mappings/net/minecraft/datafixers/fixes/EntitySkeletonSplitFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntitySkeletonSplitFix.mapping
@@ -1,1 +1,4 @@
 CLASS acc net/minecraft/datafixers/fixes/EntitySkeletonSplitFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/EntityStringUuidFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityStringUuidFix.mapping
@@ -1,1 +1,4 @@
 CLASS acd net/minecraft/datafixers/fixes/EntityStringUuidFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/EntityTheRenameningBlock.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityTheRenameningBlock.mapping
@@ -2,3 +2,6 @@ CLASS ace net/minecraft/datafixers/fixes/EntityTheRenameningBlock
 	FIELD a ENTITIES Ljava/util/Map;
 	FIELD b BLOCKS Ljava/util/Map;
 	FIELD c ITEMS Ljava/util/Map;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/EntityTippedArrowFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityTippedArrowFix.mapping
@@ -1,1 +1,4 @@
 CLASS acf net/minecraft/datafixers/fixes/EntityTippedArrowFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/EntityTransformFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityTransformFix.mapping
@@ -2,7 +2,8 @@ CLASS abz net/minecraft/datafixers/fixes/EntityTransformFix
 	FIELD a name Ljava/lang/String;
 	METHOD <init> (Ljava/lang/String;Lcom/mojang/datafixers/schemas/Schema;Z)V
 		ARG 1 name
-		ARG 2 oldSchema
+		ARG 2 outputSchema
+		ARG 3 changesType
 	METHOD a makeTyped (Ljava/lang/Object;Lcom/mojang/datafixers/types/DynamicOps;Lcom/mojang/datafixers/types/Type;)Lcom/mojang/datafixers/Typed;
 	METHOD a transform (Ljava/lang/String;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/util/Pair;
 		ARG 1 choice

--- a/mappings/net/minecraft/datafixers/fixes/EntityWolfColorFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityWolfColorFix.mapping
@@ -1,1 +1,6 @@
 CLASS acg net/minecraft/datafixers/fixes/EntityWolfColorFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a fixCollarColor (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 tag

--- a/mappings/net/minecraft/datafixers/fixes/EntityZombieSplitFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityZombieSplitFix.mapping
@@ -1,1 +1,4 @@
 CLASS ach net/minecraft/datafixers/fixes/EntityZombieSplitFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/EntityZombieVillagerTypeFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/EntityZombieVillagerTypeFix.mapping
@@ -1,3 +1,9 @@
 CLASS aci net/minecraft/datafixers/fixes/EntityZombieVillagerTypeFix
 	FIELD a RANDOM Ljava/util/Random;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
 	METHOD a clampType (I)I
+		ARG 1 type
+	METHOD a fixZombieType (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 tag

--- a/mappings/net/minecraft/datafixers/fixes/FixChoiceTypes.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/FixChoiceTypes.mapping
@@ -4,3 +4,4 @@ CLASS aah net/minecraft/datafixers/fixes/FixChoiceTypes
 	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;Lcom/mojang/datafixers/DSL$TypeReference;)V
 		ARG 1 ouputSchema
 		ARG 2 name
+		ARG 3 types

--- a/mappings/net/minecraft/datafixers/fixes/FixItemName.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/FixItemName.mapping
@@ -2,6 +2,7 @@ CLASS acr net/minecraft/datafixers/fixes/FixItemName
 	FIELD a name Ljava/lang/String;
 	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)V
 		ARG 1 outputSchema
+		ARG 2 name
 	METHOD a create (Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;Ljava/util/function/Function;)Lcom/mojang/datafixers/DataFix;
 		ARG 0 outputSchema
 		ARG 1 name

--- a/mappings/net/minecraft/datafixers/fixes/HangingEntityFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/HangingEntityFix.mapping
@@ -1,4 +1,4 @@
-CLASS abu net/minecraft/datafixers/fixes/DecorationEntityFix
+CLASS abu net/minecraft/datafixers/fixes/HangingEntityFix
 	FIELD a OFFSETS [[I
 	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
 		ARG 1 outputSchema

--- a/mappings/net/minecraft/datafixers/fixes/HeightmapRenamingFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/HeightmapRenamingFix.mapping
@@ -1,1 +1,6 @@
 CLASS ack net/minecraft/datafixers/fixes/HeightmapRenamingFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a renameHeightmapTags (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 tag

--- a/mappings/net/minecraft/datafixers/fixes/IglooMetadataRemovalFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/IglooMetadataRemovalFix.mapping
@@ -1,3 +1,10 @@
 CLASS acl net/minecraft/datafixers/fixes/IglooMetadataRemovalFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a removeMetadata (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 0 tag
 	METHOD b removeIgloos (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 0 tag
 	METHOD c isIgloo (Lcom/mojang/datafixers/Dynamic;)Z
+		ARG 0 tag

--- a/mappings/net/minecraft/datafixers/fixes/ItemBannerColorFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemBannerColorFix.mapping
@@ -1,1 +1,4 @@
 CLASS acm net/minecraft/datafixers/fixes/ItemBannerColorFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/ItemCustomNameToComponentFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemCustomNameToComponentFix.mapping
@@ -1,1 +1,6 @@
 CLASS acn net/minecraft/datafixers/fixes/ItemCustomNameToComponentFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a fixCustomName (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 tag

--- a/mappings/net/minecraft/datafixers/fixes/ItemIdFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemIdFix.mapping
@@ -1,3 +1,7 @@
 CLASS aco net/minecraft/datafixers/fixes/ItemIdFix
 	FIELD a NUMERICAL_ID_TO_STRING_ID_MAP Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
 	METHOD a fromId (I)Ljava/lang/String;
+		ARG 0 id

--- a/mappings/net/minecraft/datafixers/fixes/ItemInstanceMapIdFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemInstanceMapIdFix.mapping
@@ -1,1 +1,4 @@
 CLASS acv net/minecraft/datafixers/fixes/ItemInstanceMapIdFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/ItemInstanceSpawnEggFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemInstanceSpawnEggFix.mapping
@@ -1,2 +1,5 @@
 CLASS acw net/minecraft/datafixers/fixes/ItemInstanceSpawnEggFix
 	FIELD a ENTITY_SPAWN_EGGS Ljava/util/Map;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/ItemInstanceTheFlatteningFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemInstanceTheFlatteningFix.mapping
@@ -2,6 +2,9 @@ CLASS acx net/minecraft/datafixers/fixes/ItemInstanceTheFlatteningFix
 	FIELD a FLATTENING_MAP Ljava/util/Map;
 	FIELD b ORIGINAL_ITEM_NAMES Ljava/util/Set;
 	FIELD c DAMAGABLE_ITEMS Ljava/util/Set;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
 	METHOD a getItem (Ljava/lang/String;I)Ljava/lang/String;
 		ARG 0 originalName
 		ARG 1 damage

--- a/mappings/net/minecraft/datafixers/fixes/ItemLoreToComponentFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemLoreToComponentFix.mapping
@@ -1,1 +1,8 @@
 CLASS acp net/minecraft/datafixers/fixes/ItemLoreToComponentFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a componentize (Ljava/lang/String;)Ljava/lang/String;
+		ARG 0 string
+	METHOD a fixLoreTags (Ljava/util/stream/Stream;)Ljava/util/stream/Stream;
+		ARG 0 tags

--- a/mappings/net/minecraft/datafixers/fixes/ItemOminousBannerRenameFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemOminousBannerRenameFix.mapping
@@ -1,1 +1,6 @@
 CLASS aag net/minecraft/datafixers/fixes/ItemOminousBannerRenameFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a fixBannerName (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 tag

--- a/mappings/net/minecraft/datafixers/fixes/ItemPotionFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemPotionFix.mapping
@@ -1,2 +1,5 @@
 CLASS acq net/minecraft/datafixers/fixes/ItemPotionFix
 	FIELD a ID_TO_POTIONS [Ljava/lang/String;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/ItemShulkerBoxColorFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemShulkerBoxColorFix.mapping
@@ -1,2 +1,5 @@
 CLASS acs net/minecraft/datafixers/fixes/ItemShulkerBoxColorFix
 	FIELD a COLORED_SHULKER_BOX_IDS [Ljava/lang/String;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/ItemSpawnEggFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemSpawnEggFix.mapping
@@ -1,2 +1,5 @@
 CLASS act net/minecraft/datafixers/fixes/ItemSpawnEggFix
 	FIELD a DAMAGE_TO_ENTITY_IDS [Ljava/lang/String;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/ItemStackEnchantmentFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemStackEnchantmentFix.mapping
@@ -1,2 +1,7 @@
 CLASS acu net/minecraft/datafixers/fixes/ItemStackEnchantmentFix
 	FIELD a ID_TO_ENCHANTMENTS_MAP Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a fixEnchantments (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 tag

--- a/mappings/net/minecraft/datafixers/fixes/ItemWaterPotionFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemWaterPotionFix.mapping
@@ -1,1 +1,4 @@
 CLASS acy net/minecraft/datafixers/fixes/ItemWaterPotionFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/ItemWrittenBookPagesStrictJsonFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemWrittenBookPagesStrictJsonFix.mapping
@@ -1,1 +1,6 @@
 CLASS acz net/minecraft/datafixers/fixes/ItemWrittenBookPagesStrictJsonFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a fixBookPages (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 tag

--- a/mappings/net/minecraft/datafixers/fixes/LevelDataGeneratorOptionsFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/LevelDataGeneratorOptionsFix.mapping
@@ -1,2 +1,12 @@
 CLASS adb net/minecraft/datafixers/fixes/LevelDataGeneratorOptionsFix
 	FIELD a NUMERICAL_IDS_TO_BIOME_IDS Ljava/util/Map;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a parseFlatLayer (Ljava/lang/String;)Lcom/mojang/datafixers/util/Pair;
+		ARG 0 layer
+	METHOD a fixGeneratorOptions (Ljava/lang/String;Lcom/mojang/datafixers/types/DynamicOps;)Lcom/mojang/datafixers/Dynamic;
+		ARG 0 generatorOptions
+		ARG 1 ops
+	METHOD b parseFlatLayers (Ljava/lang/String;)Ljava/util/List;
+		ARG 0 layers

--- a/mappings/net/minecraft/datafixers/fixes/LevelFlatGeneratorInfoFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/LevelFlatGeneratorInfoFix.mapping
@@ -4,4 +4,10 @@ CLASS adc net/minecraft/datafixers/fixes/LevelFlatGeneratorInfoFix
 	FIELD c SPLIT_ON_LOWER_X Lcom/google/common/base/Splitter;
 	FIELD d SPLIT_ON_ASTERISK Lcom/google/common/base/Splitter;
 	FIELD e SPLIT_ON_COLON Lcom/google/common/base/Splitter;
-	METHOD a transform (Ljava/lang/String;)Ljava/lang/String;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a fixGeneratorOptions (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 tag
+	METHOD a fixFlatGeneratorOptions (Ljava/lang/String;)Ljava/lang/String;
+		ARG 1 generatorOptions

--- a/mappings/net/minecraft/datafixers/fixes/MapIdFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/MapIdFix.mapping
@@ -1,1 +1,4 @@
 CLASS add net/minecraft/datafixers/fixes/MapIdFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/MobSpawnerEntityIdentifiersFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/MobSpawnerEntityIdentifiersFix.mapping
@@ -1,1 +1,6 @@
 CLASS ade net/minecraft/datafixers/fixes/MobSpawnerEntityIdentifiersFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a fixSpawner (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 tag

--- a/mappings/net/minecraft/datafixers/fixes/NewVillageFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/NewVillageFix.mapping
@@ -1,1 +1,4 @@
 CLASS adg net/minecraft/datafixers/fixes/NewVillageFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/ObjectiveDisplayNameFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ObjectiveDisplayNameFix.mapping
@@ -1,1 +1,4 @@
 CLASS adh net/minecraft/datafixers/fixes/ObjectiveDisplayNameFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/ObjectiveRenderTypeFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ObjectiveRenderTypeFix.mapping
@@ -1,1 +1,6 @@
 CLASS adi net/minecraft/datafixers/fixes/ObjectiveRenderTypeFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a parseLegacyRenderType (Ljava/lang/String;)Lcta$a;
+		ARG 0 oldName

--- a/mappings/net/minecraft/datafixers/fixes/OminousBannerBlockEntityRenameFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/OminousBannerBlockEntityRenameFix.mapping
@@ -1,2 +1,5 @@
 CLASS aaf net/minecraft/datafixers/fixes/OminousBannerBlockEntityRenameFix
-	METHOD a convertOutdatedTranslationKey (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a fixBannerName (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;

--- a/mappings/net/minecraft/datafixers/fixes/OminousBannerItemRenameFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/OminousBannerItemRenameFix.mapping
@@ -1,4 +1,4 @@
-CLASS aag net/minecraft/datafixers/fixes/ItemOminousBannerRenameFix
+CLASS aag net/minecraft/datafixers/fixes/OminousBannerItemRenameFix
 	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
 		ARG 1 outputSchema
 		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/OptionsAddTextBackgroundFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/OptionsAddTextBackgroundFix.mapping
@@ -1,1 +1,6 @@
 CLASS adj net/minecraft/datafixers/fixes/OptionsAddTextBackgroundFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a convertToTextBackgroundOpacity (Ljava/lang/String;)D
+		ARG 1 chatOpacity

--- a/mappings/net/minecraft/datafixers/fixes/OptionsForceVBOFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/OptionsForceVBOFix.mapping
@@ -1,1 +1,4 @@
 CLASS adk net/minecraft/datafixers/fixes/OptionsForceVBOFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/OptionsKeyLwjgl3Fix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/OptionsKeyLwjgl3Fix.mapping
@@ -1,2 +1,5 @@
 CLASS adl net/minecraft/datafixers/fixes/OptionsKeyLwjgl3Fix
 	FIELD a NUMERICAL_KEY_IDS_TO_KEY_NAMES Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/OptionsKeyTranslationFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/OptionsKeyTranslationFix.mapping
@@ -1,1 +1,4 @@
 CLASS adm net/minecraft/datafixers/fixes/OptionsKeyTranslationFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/OptionsLowerCaseLanguageFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/OptionsLowerCaseLanguageFix.mapping
@@ -1,1 +1,4 @@
 CLASS adn net/minecraft/datafixers/fixes/OptionsLowerCaseLanguageFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/PointOfInterestReorganizationFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/PointOfInterestReorganizationFix.mapping
@@ -1,2 +1,6 @@
 CLASS adt net/minecraft/datafixers/fixes/PointOfInterestReorganizationFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
 	METHOD a reorganize (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 0 tag

--- a/mappings/net/minecraft/datafixers/fixes/RecipeFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/RecipeFix.mapping
@@ -1,2 +1,5 @@
 CLASS ado net/minecraft/datafixers/fixes/RecipeFix
 	FIELD a recipes Ljava/util/Map;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/RecipeRenamingFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/RecipeRenamingFix.mapping
@@ -1,2 +1,5 @@
 CLASS adp net/minecraft/datafixers/fixes/RecipeRenamingFix
 	FIELD a recipes Ljava/util/Map;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/SavedDataVillageCropFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/SavedDataVillageCropFix.mapping
@@ -1,1 +1,17 @@
 CLASS adu net/minecraft/datafixers/fixes/SavedDataVillageCropFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 tag
+	METHOD a fixCropId (Lcom/mojang/datafixers/Dynamic;Ljava/lang/String;)Lcom/mojang/datafixers/Dynamic;
+		ARG 0 tag
+		ARG 1 cropId
+	METHOD a fixVillageChildren (Ljava/util/stream/Stream;)Ljava/util/stream/Stream;
+		ARG 0 villageChildren
+	METHOD b (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 0 tag
+	METHOD c fixSmallPlotCropIds (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 0 tag
+	METHOD d fixLargePlotCropIds (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 0 tag

--- a/mappings/net/minecraft/datafixers/fixes/StatsCounterFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/StatsCounterFix.mapping
@@ -4,5 +4,8 @@ CLASS adx net/minecraft/datafixers/fixes/StatsCounterFix
 	FIELD c RENAMED_ITEM_STATS Ljava/util/Map;
 	FIELD d RENAMED_ENTITY_STATS Ljava/util/Map;
 	FIELD e RENAMED_ENTITIES Ljava/util/Map;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
 	METHOD a getItem (Ljava/lang/String;)Ljava/lang/String;
 	METHOD b getBlock (Ljava/lang/String;)Ljava/lang/String;

--- a/mappings/net/minecraft/datafixers/fixes/TeamDisplayNameFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/TeamDisplayNameFix.mapping
@@ -1,1 +1,4 @@
 CLASS adz net/minecraft/datafixers/fixes/TeamDisplayNameFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/VillagerProfessionFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/VillagerProfessionFix.mapping
@@ -1,6 +1,6 @@
 CLASS aeb net/minecraft/datafixers/fixes/VillagerProfessionFix
 	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)V
 		ARG 1 outputSchema
-	METHOD a (II)Ljava/lang/String;
+	METHOD a convertProfessionId (II)Ljava/lang/String;
 		ARG 0 professionId
 		ARG 1 careerId

--- a/mappings/net/minecraft/datafixers/fixes/VillagerTradeFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/VillagerTradeFix.mapping
@@ -1,1 +1,5 @@
 CLASS aed net/minecraft/datafixers/fixes/VillagerTradeFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType
+	METHOD a fixPumpkinTrade (Lcom/mojang/datafixers/OpticFinder;Lcom/mojang/datafixers/Typed;)Lcom/mojang/datafixers/Typed;

--- a/mappings/net/minecraft/datafixers/fixes/WriteAndReadFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/WriteAndReadFix.mapping
@@ -2,5 +2,6 @@ CLASS aee net/minecraft/datafixers/fixes/WriteAndReadFix
 	FIELD a name Ljava/lang/String;
 	FIELD b type Lcom/mojang/datafixers/DSL$TypeReference;
 	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;Lcom/mojang/datafixers/DSL$TypeReference;)V
-		ARG 1 outSchema
+		ARG 1 outputSchema
 		ARG 2 name
+		ARG 3 type

--- a/mappings/net/minecraft/datafixers/fixes/ZombieVillagerXpRebuildFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ZombieVillagerXpRebuildFix.mapping
@@ -1,1 +1,4 @@
 CLASS aef net/minecraft/datafixers/fixes/ZombieVillagerXpRebuildFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 outputSchema
+		ARG 2 changesType


### PR DESCRIPTION
This PR maps a bunch of things in `net/minecraft/datafixers/fixers`, mostly focusing on missing parameter names and method names. Hopefully clearer names in this area help people understand DataFixer better.

Some highlights:

* Constructor parameters changed to `outputSchema` and `changesType`.
  * Obvious change since this is what DataFixerUpper calls them. There's just lots of these parameters.
* `EntityPaintingFix` -> `HangingEntityFix`
  * It applies to paintings *and* item frames, not just paintings.
* `ItemOminousBannerRenameFix` -> `OminousBannerItemRenameFix`
  * Suffixy.
  * Matched the other one.
* `OminousBannerBlockEntityRenameFix#convertOutdatedTranslationKey` -> `fixBannerName`
  * Felt wordy? Idk.
  * It's a fixer, so of course it's converting something outdated.
  * (see also `OminousBannerItemRenameFix`'s method that I named myself to the same thing.)
* Parameters:
  * `Dynamic<?>` -> `tag` in most cases
    * Realistically we are talking about nbt tags in 90% of cases where a dynamic appears.
  * `DynamicOps<?>` -> `ops`
    * What DataFixerUpper calls them.

Some questions:

* Parameters: What to call "Typed"s? I can't find any Typed names in DataFixerUpper.
* `LeavesFix`, `SwimStatsRenameFix`, `VillagerXpRebuildFix`
  * These don't wanna decompile for me!
* `SavedDataVillageCropFix#a, b`
  * Maybe I've been staring at Yarn too long but I can't figure these ones out.
  * Seem to be "plumbing" functions.