### PR TITLE
Hotfix for #696

### DIFF
--- a/mappings/net/minecraft/block/entity/Hopper.mapping
+++ b/mappings/net/minecraft/block/entity/Hopper.mapping
@@ -5,5 +5,5 @@ CLASS bub net/minecraft/block/entity/Hopper
 	METHOD A getHopperY ()D
 	METHOD B getHopperZ ()D
 	METHOD O_ getInputAreaShape ()Lcsr;
-	METHOD w getWorld ()Lbhi;
+	METHOD w getHopperWorld ()Lbhi;
 	METHOD z getHopperX ()D


### PR DESCRIPTION
A conflict has arisen! Yarn/Tiny does not support shared implementations due to the uniqueness of names in obfuscation. I guarantee Mojang shares an implementation here (literally returns what super of `Entity#getWorld` does (`this.world`), but declared for the `Hopper#getWorld` implementation). So we need to make `Hopper#getWorld` unique. Maybe we could look into supporting shared implementations in the future?