### PR TITLE
More accurate coral block and egg material names

### DIFF
--- a/mappings/net/minecraft/block/CoralFanBlock.mapping
+++ b/mappings/net/minecraft/block/CoralFanBlock.mapping
@@ -1,4 +1,4 @@
-CLASS bnl net/minecraft/block/CoralTubeFanBlock
+CLASS bnl net/minecraft/block/CoralFanBlock
 	FIELD a deadCoralBlock Lbmm;
 	METHOD <init> (Lbmm;Lbmm$c;)V
 		ARG 1 deadCoralBlock

--- a/mappings/net/minecraft/block/Material.mapping
+++ b/mappings/net/minecraft/block/Material.mapping
@@ -35,7 +35,7 @@ CLASS clf net/minecraft/block/Material
 	FIELD L PISTON Lclf;
 	FIELD M UNUSED_PLANT Lclf;
 	FIELD N PUMPKIN Lclf;
-	FIELD O DRAGON_EGG Lclf;
+	FIELD O EGG Lclf;
 	FIELD P CAKE Lclf;
 	FIELD Q color Lclg;
 	FIELD R pistonBehavior Lclh;


### PR DESCRIPTION
Changed since only the blue coral is Tube Coral and Turtle Eggs use the same Material as Dragon Eggs.