### PR TITLE
DefaultedList -> NonNullList

### DIFF
--- a/mappings/net/minecraft/util/DefaultedList.mapping
+++ b/mappings/net/minecraft/util/DefaultedList.mapping
@@ -1,16 +1,23 @@
 CLASS fj net/minecraft/util/DefaultedList
-	FIELD a underlying Ljava/util/List;
+	FIELD a delegate Ljava/util/List;
 	FIELD b defaultValue Ljava/lang/Object;
 	METHOD <init> (Ljava/util/List;Ljava/lang/Object;)V
-		ARG 1 underlying
-	METHOD a create ()Lfj;
-	METHOD a create (ILjava/lang/Object;)Lfj;
+		ARG 1 delegate
+		ARG 2 defaultValue
+	METHOD a of ()Lfj;
+	METHOD a withExpectedSize (ILjava/lang/Object;)Lfj;
 		ARG 0 size
 		ARG 1 defaultValue
-	METHOD a create (Ljava/lang/Object;[Ljava/lang/Object;)Lfj;
+	METHOD a of (Ljava/lang/Object;[Ljava/lang/Object;)Lfj;
 		ARG 0 defaultValue
 		ARG 1 values
 	METHOD add (ILjava/lang/Object;)V
-		ARG 1 value
+		ARG 1 index
+		ARG 2 element
+	METHOD get (I)Ljava/lang/Object;
+		ARG 1 index
+	METHOD remove (I)Ljava/lang/Object;
+		ARG 1 index
 	METHOD set (ILjava/lang/Object;)Ljava/lang/Object;
 		ARG 1 index
+		ARG 2 element

--- a/mappings/net/minecraft/util/NonNullList.mapping
+++ b/mappings/net/minecraft/util/NonNullList.mapping
@@ -1,15 +1,15 @@
 CLASS fj net/minecraft/util/NonNullList
 	FIELD a delegate Ljava/util/List;
-	FIELD b defaultValue Ljava/lang/Object;
+	FIELD b fallback Ljava/lang/Object;
 	METHOD <init> (Ljava/util/List;Ljava/lang/Object;)V
 		ARG 1 delegate
-		ARG 2 defaultValue
+		ARG 2 fallback
 	METHOD a of ()Lfj;
 	METHOD a ofSize (ILjava/lang/Object;)Lfj;
 		ARG 0 size
-		ARG 1 defaultValue
+		ARG 1 fallback
 	METHOD a copyOf (Ljava/lang/Object;[Ljava/lang/Object;)Lfj;
-		ARG 0 defaultValue
+		ARG 0 fallback
 		ARG 1 values
 	METHOD add (ILjava/lang/Object;)V
 		ARG 1 index

--- a/mappings/net/minecraft/util/NonNullList.mapping
+++ b/mappings/net/minecraft/util/NonNullList.mapping
@@ -1,16 +1,16 @@
 CLASS fj net/minecraft/util/NonNullList
 	FIELD a delegate Ljava/util/List;
-	FIELD b fallback Ljava/lang/Object;
+	FIELD b initialElement Ljava/lang/Object;
 	METHOD <init> (Ljava/util/List;Ljava/lang/Object;)V
 		ARG 1 delegate
-		ARG 2 fallback
+		ARG 2 initialElement
 	METHOD a of ()Lfj;
 	METHOD a ofSize (ILjava/lang/Object;)Lfj;
 		ARG 0 size
-		ARG 1 fallback
+		ARG 1 initialElement
 	METHOD a copyOf (Ljava/lang/Object;[Ljava/lang/Object;)Lfj;
-		ARG 0 fallback
-		ARG 1 values
+		ARG 0 initialElement
+		ARG 1 elements
 	METHOD add (ILjava/lang/Object;)V
 		ARG 1 index
 		ARG 2 element

--- a/mappings/net/minecraft/util/NonNullList.mapping
+++ b/mappings/net/minecraft/util/NonNullList.mapping
@@ -1,14 +1,14 @@
-CLASS fj net/minecraft/util/DefaultedList
+CLASS fj net/minecraft/util/NonNullList
 	FIELD a delegate Ljava/util/List;
 	FIELD b defaultValue Ljava/lang/Object;
 	METHOD <init> (Ljava/util/List;Ljava/lang/Object;)V
 		ARG 1 delegate
 		ARG 2 defaultValue
 	METHOD a of ()Lfj;
-	METHOD a withExpectedSize (ILjava/lang/Object;)Lfj;
+	METHOD a ofSize (ILjava/lang/Object;)Lfj;
 		ARG 0 size
 		ARG 1 defaultValue
-	METHOD a of (Ljava/lang/Object;[Ljava/lang/Object;)Lfj;
+	METHOD a copyOf (Ljava/lang/Object;[Ljava/lang/Object;)Lfj;
 		ARG 0 defaultValue
 		ARG 1 values
 	METHOD add (ILjava/lang/Object;)V


### PR DESCRIPTION
The list implementation does not always have a default value. It has two perceived states.
- Fixed size, returning a default value for absent elements.
- Variable size, always returning an element, with no default defined.
Effectively, this implementation is just to ensure there is never a null return value, not to ensure there is a default value. The default value just happens to exist as a way to handle absent values in fixed size delegate lists.

The constructors have been updated to be more contextual too.

I'm not sure if the semantics of resizing should be more explicit in the constructors. Essentially, all but the no-args constructor produce a fixed-size list (Backed by an instance of `Arrays$ArrayList`).