### PR TITLE
Remove manual GameMode mapping

### DIFF
--- a/mappings/net/minecraft/world/GameMode.mapping
+++ b/mappings/net/minecraft/world/GameMode.mapping
@@ -1,5 +1,4 @@
 CLASS bhf net/minecraft/world/GameMode
-	FIELD a INVALID Lbhf;
 	FIELD f id I
 	FIELD g name Ljava/lang/String;
 	METHOD <init> (Ljava/lang/String;IILjava/lang/String;)V


### PR DESCRIPTION
The member does not need a mapping, it is inferred. The actual name is `NOT_SET`.

Enigma view to verify inference:

![enigma](https://i.imgur.com/ySC6hE0.png)