### PR TITLE
Add naming conventions

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -2,23 +2,34 @@
 
 ## General
 
-Use `UpperCamelCase` for class names. Use `lowerCamelCase` for method names, variable names, and names of fields that are not static and final. Always use `UPPER_SNAKE_CASE` for names of fields that are both static and final.
+Use `UpperCamelCase` for class names. Use `lowerCamelCase` for method names, variable names, and names of fields that are not static and
+final. Always use `UPPER_SNAKE_CASE` for names of fields that are both static and final.
 
-Method names should always be verbal phrases (`tick`, `getCarversForStep`). Non-boolean field and variable names and class names should be noun phrases (`ChunkRegion`, `color`). Boolean field and variable names should always be adjectival phrases or present-tense verbal phrases (`powered`, `canOpen`), avoiding the `is` and `has` prefixes when possible (`colored`, not `isColored` or `hasColor`).
+Method names should always be verbal phrases (`tick`, `getCarversForStep`). Non-boolean field and variable names and class names should
+be noun phrases (`ChunkRegion`, `color`). Boolean field and variable names should always be adjectival phrases or present-tense verbal
+phrases (`powered`, `canOpen`), avoiding the `is` and `has` prefixes when possible (`colored`, not `isColored` or `hasColor`).
 
-To make code as easy to read as possible, keep names in the natural language order. For example, a class representing a "chest block entity" should be named `ChestBlockEntity`, not `BlockEntityChest`. Though prefix naming may be helpful for grouping classes together in an IDE's tree view, reading and writing code is done much more often than browsing files.
+To make code as easy to read as possible, keep names in the natural language order. For example, a class representing a "chest block
+entity" should be named `ChestBlockEntity`, not `BlockEntityChest`. Though prefix naming may be helpful for grouping classes together in
+an IDE's tree view, reading and writing code is done much more often than browsing files.
 
 Use American English (`color`, not `colour`) for consistency throughout Yarn and with known Mojang names.
 
-Omit words that are redundant because of method parameter or the owner class's name. For example, use `getChunk(BlockPos pos)` rather than `getChunkAtPosition(BlockPos pos)`, and `create` rather than `createAchievement` for a method is in the `Achievement` class. Don't avoid overloading methods or shadowing fields.
+Omit words that are redundant because of method parameter or the owner class's name. For example, use `getChunk(BlockPos pos)` rather
+than `getChunkAtPosition(BlockPos pos)`, and `create` rather than `createAchievement` for a method is in the `Achievement` class. Don't
+avoid overloading methods or shadowing fields.
 
-Names should be as descriptive as possible, so don't omit important words. When naming something always look at all its usages (including overriding methods and inheriting classes).
+Names should be as descriptive as possible, so don't omit important words. When naming something always look at all its usages
+(including overriding methods and inheriting classes).
 
-Consistency is important as it makes code more readable and names easier to memorize. When possible, use terms that are present in other Yarn names, in libraries used by Minecraft, or in vanilla strings. See the "Common names" and "Mojang names" for more information.
+Consistency is important as it makes code more readable and names easier to memorize. When possible, use terms that are present in other
+Yarn names, in libraries used by Minecraft, or in vanilla strings. See the "Common names" and "Mojang names" for more information.
 
 ## Acronym and abbreviations
 
-Try to avoid acronyms and abbreviations unless it's a common one that everyone knows, and other yarn names involving the same word all use its abbreviated form. Full names are easier to read quickly and remember ("Which words were abbreviated?") and they often don't take more time to type thanks to IDE autocompletion. The common abbreviations you *should* use are:
+Try to avoid acronyms and abbreviations unless it's a common one that everyone knows, and other yarn names involving the same word all
+use its abbreviated form. Full names are easier to read quickly and remember ("Which words were abbreviated?") and they often don't take
+more time to type thanks to IDE autocompletion. The common abbreviations you *should* use are:
 
  - "id" for "identifier"
  - "pos" for "position"
@@ -26,13 +37,19 @@ Try to avoid acronyms and abbreviations unless it's a common one that everyone k
  - "init" for "initialize"
  - Any abbreviations used by Java or libraries ("json", "html", etc.)
 
-Treat acronyms as single words rather than capitalising every letter. This improves readability (compare `JsonObject` and `JSONObject`) and is consistent with Mojang naming (a known name is `NbtIo`).
+Treat acronyms as single words rather than capitalising every letter. This improves readability (compare `JsonObject` and `JSONObject`)
+and is consistent with Mojang naming (a known name is `NbtIo`).
 
 ## Mojang names
 
-Always use names that match names in strings in the vanilla code, unless that string is outdated or inaccurate. This avoids confusion, especially from new modders who may not understand what an class exception message is referring to.
+Always use names that match names in strings in the vanilla code, unless that string is outdated or inaccurate. This avoids confusion,
+especially from new modders who may not understand what an class exception message is referring to.
 
-Even if a known Mojang name doesn't appear in any strings, it's a good idea to use it, since the official name is a good indicator of the the class's actual purpose and what changes Mojang may do to it in the future. For example, don't name a class that Mojang calls `BedrockBlock` `NoSpawningBlock`, even if its only purpose is to disable mob spawning, because Mojang may decide to override more methods in that class, breaking mods that were using it in an unexpected way. Additionally, using a known Mojang name it less likely that the name will have to be changed in the future.
+Even if a known Mojang name doesn't appear in any strings, it's a good idea to use it, since the official name is a good indicator of
+the the class's actual purpose and what changes Mojang may do to it in the future. For example, don't name a class that Mojang calls
+`BedrockBlock` `NoSpawningBlock`, even if its only purpose is to disable mob spawning, because Mojang may decide to override more
+methods in that class, breaking mods that were using it in an unexpected way. Additionally, using a known Mojang name it less likely
+that the name will have to be changed in the future.
 
 There are however three exceptions to this rule:
  - Use "world" for what Mojang calls "level" (see https://github.com/FabricMC/yarn/issues/89)
@@ -41,11 +58,13 @@ There are however three exceptions to this rule:
 
 ## Packages
 
-Package names should always be singular, to respect Java conventions. Try to respect the Mojang package structure to avoid visibility problems in the future.
+Package names should always be singular, to respect Java conventions. Try to respect the Mojang package structure to avoid visibility
+problems in the future.
 
 ## Common names
 
-This section lists common names that are used throughout Yarn. There's no particular reason these are the names are being used instead of others, but you should use them for consistency.
+This section lists common names that are used throughout Yarn. There's no particular reason these are the names are being used instead
+of others, but you should use them for consistency.
 
 ### Ticks and updates
 
@@ -53,23 +72,29 @@ Use the term "tick" for updates done once per tick. Use "update" for other kind 
 
 ### Value last tick
 
-When a field (or getter) is the value that something had last tick (for interpolation, for example), prefix the field with the `last` prefix, (`lastX`, `lastWidth`, etc.).
+When a field (or getter) is the value that something had last tick (for interpolation, for example), prefix the field with the `last`
+prefix, (`lastX`, `lastWidth`, etc.).
 
 ### Getters, setters, and creators
 
-Use the word "get" for getters and other methods that calculate some property with no side effects other than possibly caching the value in a private field only used by that method.
+Use the word "get" for getters and other methods that calculate some property with no side effects other than possibly caching the value
+in a private field only used by that method.
 
 Use the word "set" for methods that set some property.
 
-Use the word "create" for methods that create a new instance of some object. Use the term "get or create" for methods that create a new instance only if one does not already exist. Don't use "get or create" for lazy initialization, though. 
+Use the word "create" for methods that create a new instance of some object. Use the term "get or create" for methods that create a new
+instance only if one does not already exist. Don't use "get or create" for lazy initialization, though. 
 
 ### Serializing and deserializing
 
-Use "serializer" for naming classes whose purpose is serializing or deserializing some type of object (ex. `RecipeSerializer`). Use the words "serialize" and "deserialize" only when refering to serializing or deserializing some object other.
+Use "serializer" for naming classes whose purpose is serializing or deserializing some type of object (ex. `RecipeSerializer`). Use the
+words "serialize" and "deserialize" only when refering to serializing or deserializing some object other.
 
-Use "from" for static methods that create an object of the method owner's type (`fromJson`, `fromNbt`, `fromString`, etc.). Use "to" for methods that convert an object to another type (`toString`, `toLong`, `toNbt`, etc.).
+Use "from" for static methods that create an object of the method owner's type (`fromJson`, `fromNbt`, `fromString`, etc.). Use "to" for
+methods that convert an object to another type (`toString`, `toLong`, `toNbt`, etc.).
 
-Use "read" for non-static methods that load data into a class. Use "write" for methods that save data to an *existing* object passed as a parameter.
+Use "read" for non-static methods that load data into a class. Use "write" for methods that save data to an *existing* object passed as
+a parameter.
 
 ### Factories and builders
 
@@ -77,7 +102,8 @@ Use the word "factory" (rather than "provider", etc.) for factories. Use "builde
 
 ### Collections
 
-Use a plural name for collections and maps rather than the words "list", "set", "array", etc., unless it's a collection of collection or there are several collections of different types containing the same objects (`entities`, `entityLists`, etc.).
+Use a plural name for collections and maps rather than the words "list", "set", "array", etc., unless it's a collection of collection or
+there are several collections of different types containing the same objects (`entities`, `entityLists`, etc.).
 
 When it's enough, name maps based on the value type. Otherwise, name it in the "`valuesByKeys`" format.
 
@@ -85,4 +111,6 @@ When it's enough, name maps based on the value type. Otherwise, name it in the "
 
 Avoid naming methods based on implementation details.
 
-Avoid including Java-related information in names. For example, don't prefix class names with `I`, `Enum`, or `Abstract` and don't prefix methods with `private`. Instead, try to find meaningful names to describe differences between classes. In the case of abstract classes, this may involve renaming subclasses to more specific names.
+Avoid including Java-related information in names. For example, don't prefix class names with `I`, `Enum`, or `Abstract` and don't
+prefix methods with `private`. Instead, try to find meaningful names to describe differences between classes. In the case of abstract
+classes, this may involve renaming subclasses to more specific names.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -17,8 +17,8 @@ classes together in an IDE's tree view, reading and writing code is done much mo
 Use American English (`color`, not `colour`) for consistency throughout Yarn and with known Mojang names.
 
 Omit words that are redundant because of method parameter or the owner class's name. For example, use `getChunk(BlockPos pos)`
-rather than `getChunkAtPosition(BlockPos pos)`, and `create` rather than `createAchievement` for a method is in the `Achievement`
-class. Don't avoid overloading methods or shadowing fields.
+rather than `getChunkAtPosition(BlockPos pos)`, and `create` rather than `createAchievement` for a method is in the
+`Achievement` class. Don't avoid overloading methods or shadowing fields.
 
 Names should be as descriptive as possible, so don't omit important words. When naming something always look at all its usages
 (including overriding methods and inheriting classes).

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -5,10 +5,10 @@
 Use `UpperCamelCase` for class names. Use `lowerCamelCase` for method names, variable names, and names of fields that are not
 static and final. Always use `UPPER_SNAKE_CASE` for names of fields that are both static and final.
 
-Method names should always be verbal phrases (`tick`, `getCarversForStep`). Non-boolean field and variable names and class names
-should be noun phrases (`ChunkRegion`, `color`). Boolean field and variable names should always be adjectival phrases or present
-tense verbal phrases (`powered`, `canOpen`), avoiding the `is` and `has` prefixes when possible (`colored`, not `isColored` or
-`hasColor`).
+Method names should always be verbal phrases (`tick`, `getCarversForStep`), except for builder methods. Class names and
+non-boolean field and variable names should be noun phrases (`ChunkRegion`, `color`). Boolean field and variable names should
+always be adjectival phrases or present tense verbal phrases (`powered`, `canOpen`), avoiding the `is` and `has` prefixes when
+possible (`colored`, not `isColored` or `hasColor`).
 
 To make code as easy to read as possible, keep names in the natural language order. For example, a class representing a "chest
 block entity" should be named `ChestBlockEntity`, not `BlockEntityChest`. Though prefix naming may be helpful for grouping
@@ -16,22 +16,22 @@ classes together in an IDE's tree view, reading and writing code is done much mo
 
 Use American English (`color`, not `colour`) for consistency throughout Yarn and with known Mojang names.
 
-Omit words that are redundant because of method parameter or the owner class's name. For example, use `getChunk(BlockPos pos)`
-rather than `getChunkAtPosition(BlockPos pos)`, and `create` rather than `createAchievement` for a method is in the
-`Achievement` class. Don't avoid overloading methods or shadowing fields.
+Omit words that are unnecessary thanks to parameter names or owner class names. For example, use `getChunk(BlockPos pos)`
+rather than `getChunkAtPosition(BlockPos pos)`, and `create` rather than `createBox` for a method is in the `Box` class.
+Don't avoid overloading methods or shadowing fields.
 
 Names should be as descriptive as possible, so don't omit important words. When naming something always look at all its usages
 (including overriding methods and inheriting classes).
 
 Consistency is important as it makes code more readable and names easier to memorize. When possible, use terms that are present
-in other Yarn names, in libraries used by Minecraft, or in vanilla strings. See the "Common names" and "Mojang names" for more
-information.
+in other Yarn names, in libraries used by Minecraft, or in vanilla strings. See the "Common names" and "Mojang names" sections
+for more information.
 
-## Acronym and abbreviations
+## Abbreviations
 
-Try to avoid acronyms and abbreviations unless it's a common one that everyone knows, and other yarn names involving the same
-word all use its abbreviated form. Full names are easier to read quickly and remember ("Which words were abbreviated?") and
-they often don't take more time to type thanks to IDE autocompletion. The common abbreviations you *should* use are:
+Avoid abbreviations unless it's a common one everyone knows and other yarn names involving the same word use its abbreviated
+form. Full names are easier to read quickly and remember ("Which words were abbreviated?") and they often don't take more
+time to type thanks to IDE autocompletion. Common abbreviations you should use are:
 
  - "id" for "identifier"
  - "pos" for "position"
@@ -40,18 +40,18 @@ they often don't take more time to type thanks to IDE autocompletion. The common
  - Any abbreviations used by Java or libraries ("json", "html", etc.)
 
 Treat acronyms as single words rather than capitalising every letter. This improves readability (compare `JsonObject` and
-`JSONObject`) and is consistent with Mojang naming (a known name is `NbtIo`).
+`JSONObject`) and it's consistent with Mojang naming (a known name is `NbtIo`).
 
 ## Mojang names
 
-Always use names that match names in strings in the vanilla code, unless that string is outdated or inaccurate. This avoids
-confusion, especially from new modders who may not understand what an class exception message is referring to.
+Use names that match names in strings in the vanilla code, unless that string is outdated or inaccurate. This avoids confusion,
+especially from new modders who may not understand what an class exception message is referring to.
 
-Even if a known Mojang name doesn't appear in any strings, it's a good idea to use it, since the official name is a good
-indicator of the the class's actual purpose and what changes Mojang may do to it in the future. For example, don't name a class
-that Mojang calls `BedrockBlock` `NoSpawningBlock`, even if its only purpose is to disable mob spawning, because Mojang may
-decide to override more methods in that class, breaking mods that were using it in an unexpected way. Additionally, using a
-known Mojang name it less likely that the name will have to be changed in the future.
+Even if a known Mojang name doesn't appear in any strings, it's a good idea to use it since the official name is a good
+indicator of the the class's actual purpose and makes it less likely the name will have to be changed in the future. For
+example, don't name a class that Mojang calls `BedrockBlock` `NoSpawningBlock`, even if its only purpose is to disable mob
+spawning, because Mojang may decide to override more methods in that class, breaking mods that were using it in an unexpected
+way.
 
 There are however three exceptions to this rule:
  - Use "world" for what Mojang calls "level" (see https://github.com/FabricMC/yarn/issues/89)
@@ -60,7 +60,7 @@ There are however three exceptions to this rule:
 
 ## Packages
 
-Package names should always be singular, to respect Java conventions. Try to respect the Mojang package structure to avoid
+Package names should always be singular to respect Java conventions. Try to respect the Mojang package structure to avoid
 visibility problems in the future.
 
 ## Common names
@@ -70,27 +70,28 @@ instead of others, but you should use them for consistency.
 
 ### Ticks and updates
 
-Use the term "tick" for updates done once per tick. Use "update" for other kind of updates.
+Use "tick" for updates done once per tick. Use "update" for other kind of updates.
 
 ### Value last tick
 
-When a field (or getter) is the value that something had last tick (for interpolation, for example), prefix the field with the
-`last` prefix, (`lastX`, `lastWidth`, etc.).
+Use the word "last" for the value that something had last tick (`lastX`, `lastWidth`, etc.).
 
-### Getters, setters, and creators
+### Getters, setters, with-ers, and creators
 
-Use the word "get" for getters and other methods that calculate some property with no side effects other than possibly caching
-the value in a private field only used by that method.
+Use "get" for getters and other methods that calculate some property with no side effects other than caching a value in a
+private field.
 
-Use the word "set" for methods that set some property.
+Use "set" for methods that set some property.
 
-Use the word "create" for methods that create a new instance of some object. Use the term "get or create" for methods that
-create a new instance only if one does not already exist. Don't use "get or create" for lazy initialization, though. 
+Use "with" for methods that return a copy of an object with a different value for some property.
+
+Use "create" for methods that create a new instance of some object. Use "get or create" for methods that create a new
+instance only if one does not already exist. Don't use "get or create" for lazy initialization, though. 
 
 ### Serializing and deserializing
 
-Use "serializer" for naming classes whose purpose is serializing or deserializing some type of object (ex. `RecipeSerializer`).
-Use the words "serialize" and "deserialize" only when refering to serializing or deserializing some object other.
+Use "serializer" for objects whose purpose is serializing or deserializing some type of object (`RecipeSerializer`). Use
+"serialize" and "deserialize" for methods only when serializing or deserializing an object other than the one the method is in.
 
 Use "from" for static methods that create an object of the method owner's type (`fromJson`, `fromNbt`, `fromString`, etc.). Use
 "to" for methods that convert an object to another type (`toString`, `toLong`, `toNbt`, etc.).
@@ -100,7 +101,10 @@ passed as a parameter.
 
 ### Factories and builders
 
-Use the word "factory" (rather than "provider", etc.) for factories. Use "builder" for builders.
+Use "factory" for objects whose purpose is creating other objects.
+
+Use "builder" for objects whose purpose is helping with the creation of an immutable object. Name builder methods the same
+as the field they're setting, without any prefix.
 
 ### Collections
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -3,7 +3,7 @@
 ## General
 
 Use `UpperCamelCase` for class names. Use `lowerCamelCase` for method names, variable names, and names of fields that are not
-static and final. Always use `UPPER_SNAKE_CASE` for names of fields that are both static and final.
+both static and final. Always use `UPPER_SNAKE_CASE` for names of fields that are both static and final.
 
 Method names should always be verbal phrases (`tick`, `getCarversForStep`), except for builder methods and "withX" methods.
 Class names and non-boolean field and variable names should be noun phrases (`ChunkRegion`, `color`). Boolean field and

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -117,7 +117,7 @@ There are however three exceptions to this rule:
 
 ## Things to avoid
 
-Don't naming methods based on implementation details. Names should describe what methods do, now how they work.
+Don't name methods based on implementation details. Names should describe what methods do, now how they work.
 
 Avoid including Java-related information in names. For example, don't prefix class names with `I`, `Enum`, or `Abstract` and
 don't prefix methods with `private`. Instead, try to find meaningful names to describe differences between classes. In the

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,12 +1,11 @@
-# Naming conventions
+il# Naming conventions
 
 ## General
 
 Use `UpperCamelCase` for class names. Use `lowerCamelCase` for method names, variable names, and names of fields that are not
 both static and final. Use `UPPER_SNAKE_CASE` for names of fields that are both static and final.
 
-Method names should always be verb phrases (`tick`, `getCarversForStep`), except for builder methods and "withX" methods.
-Class names and non-boolean field and variable names should be noun phrases (`ChunkRegion`, `color`). Boolean field and
+Method names should generally be verb phrases (`tick`, `getCarversForStep`), except for "withX", "toX", "fromX", "of" and builder methods. Class names and non-boolean field and variable names should be noun phrases (`ChunkRegion`, `color`). Boolean field and
 variable names should always be adjective phrases or present tense verb phrases (`powered`, `canOpen`), avoiding the `is`
 and `has` prefixes when possible (`colored`, not `isColored` or `hasColor`).
 
@@ -35,7 +34,7 @@ time to type thanks to IDE autocompletion. Common abbreviations you should use a
 
  - "id" for "identifier"
  - "pos" for "position"
- - "NBT" for "named binary tag"
+ - "nbt" for "named binary tag"
  - "init" for "initialize"
  - Any abbreviations used by Java or libraries ("json", "html", etc.)
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -5,10 +5,10 @@
 Use `UpperCamelCase` for class names. Use `lowerCamelCase` for method names, variable names, and names of fields that are not
 static and final. Always use `UPPER_SNAKE_CASE` for names of fields that are both static and final.
 
-Method names should always be verbal phrases (`tick`, `getCarversForStep`), except for builder methods. Class names and
-non-boolean field and variable names should be noun phrases (`ChunkRegion`, `color`). Boolean field and variable names should
-always be adjectival phrases or present tense verbal phrases (`powered`, `canOpen`), avoiding the `is` and `has` prefixes when
-possible (`colored`, not `isColored` or `hasColor`).
+Method names should always be verbal phrases (`tick`, `getCarversForStep`), except for builder methods and "withX" methods.
+Class names and non-boolean field and variable names should be noun phrases (`ChunkRegion`, `color`). Boolean field and
+variable names should always be adjectival phrases or present tense verbal phrases (`powered`, `canOpen`), avoiding the `is`
+and `has` prefixes when possible (`colored`, not `isColored` or `hasColor`).
 
 To make code as easy to read as possible, keep names in the natural language order. For example, a class representing a "chest
 block entity" should be named `ChestBlockEntity`, not `BlockEntityChest`. Though prefix naming may be helpful for grouping
@@ -76,14 +76,16 @@ Use "tick" for updates done once per tick. Use "update" for other kind of update
 
 Use the word "last" for the value that something had last tick (`lastX`, `lastWidth`, etc.).
 
-### Getters, setters, with-ers, and creators
+### Getters, setters, withers, and creators
 
 Use "get" for getters and other methods that calculate some property with no side effects other than caching a value in a
 private field.
 
-Use "set" for methods that set some property.
+Use "set" for methods that set some property. Name the parameter the same as the property (`setColor(color)`, not
+`setColor(newColor)`).
 
-Use "with" for methods that return a copy of an object with a different value for some property.
+Use "with" for methods that return a copy of an object with a different value for some property. Name the parameter the same
+as the property.
 
 Use "create" for methods that create a new instance of some object. Use "get or create" for methods that create a new
 instance only if one does not already exist. Don't use "get or create" for lazy initialization, though. 
@@ -93,8 +95,8 @@ instance only if one does not already exist. Don't use "get or create" for lazy 
 Use "serializer" for objects whose purpose is serializing or deserializing some type of object (`RecipeSerializer`). Use
 "serialize" and "deserialize" for methods only when serializing or deserializing an object other than the one the method is in.
 
-Use "from" for static methods that create an object of the method owner's type (`fromJson`, `fromNbt`, `fromString`, etc.). Use
-"to" for methods that convert an object to another type (`toString`, `toLong`, `toNbt`, etc.).
+Use "from" for static methods that create an object of the method owner's type (`fromJson`, `fromNbt`, `fromString`). Use "to"
+for methods that convert an object to another type (`toString`, `toLong`, `toNbt`).
 
 Use "read" for non-static methods that load data into a class. Use "write" for methods that save data to an *existing* object
 passed as a parameter.
@@ -109,7 +111,7 @@ as the field they're setting, without any prefix.
 ### Collections
 
 Use a plural name for collections and maps rather than the words "list", "set", "array", etc., unless it's a collection of
-collection or there are several collections of different types containing the same objects (`entities`, `entityLists`, etc.).
+collection or there are several collections of different types containing the same objects (`entities`, `entityLists`).
 
 When it's enough, name maps based on the value type. Otherwise, name it in the "`valuesByKeys`" format.
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,4 +1,4 @@
-il# Naming conventions
+# Naming conventions
 
 ## General
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -5,9 +5,10 @@
 Use `UpperCamelCase` for class names. Use `lowerCamelCase` for method names, variable names, and names of fields that are not
 both static and final. Use `UPPER_SNAKE_CASE` for names of fields that are both static and final.
 
-Method names should generally be verb phrases (`tick`, `getCarversForStep`), except for "withX", "toX", "fromX", "of" and builder methods. Class names and non-boolean field and variable names should be noun phrases (`ChunkRegion`, `color`). Boolean field and
-variable names should always be adjective phrases or present tense verb phrases (`powered`, `canOpen`), avoiding the `is`
-and `has` prefixes when possible (`colored`, not `isColored` or `hasColor`).
+Method names should generally be verb phrases (`tick`, `getCarversForStep`), except for "withX", "toX", "fromX", "of" and
+builder methods. Class names and non-boolean field and variable names should be noun phrases (`ChunkRegion`, `color`).
+Boolean field and variable names should always be adjective phrases or present tense verb phrases (`powered`, `canOpen`),
+avoiding the `is` and `has` prefixes when possible (`colored`, not `isColored` or `hasColor`).
 
 To make code as easy to read as possible, keep names in the natural language order. For example, a class representing a chest
 block entity should be named `ChestBlockEntity` rather than `BlockEntityChest`. Though prefix naming may be helpful for
@@ -23,8 +24,8 @@ Omit words that are made redundant by parameter names or owner class names. For 
 than `getChunkAtPosition(BlockPos pos)` and `Box.create` rather than `Box.createBox`. Don't avoid overloading methods or
 shadowing fields.
 
-However, it's more important for a name to be descriptive rather than short, so don't omit important words. When naming something
-always look at all its usages, including overriding methods and inheriting classes.
+However, it's more important for a name to be descriptive rather than short, so don't omit important words. When naming
+something always look at all its usages, including overriding methods and inheriting classes.
 
 It's important to be concise especially with names used in many places throughout the code, while more obscure names can be
 longer and more descriptive.
@@ -65,8 +66,8 @@ Use the word "last" for the value that something had last tick (`lastX`, `lastWi
 
 ### Getters, setters, withers, and creators
 
-Use "get" for non-boolean getters and other methods that calculate some property with no side effects other than caching a value in a
-private field. For boolean getters, use "is".
+Use "get" for non-boolean getters and other methods that calculate some property with no side effects other than caching a value
+in a private field. For boolean getters, use "is".
 
 Use "set" for methods that set some property. Name the parameter the same as the property (`setColor(color)`, not
 `setColor(newColor)`).

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,14 +1,20 @@
-# Naming Conventions
+# Naming conventions
 
-## Casing
+## General
 
-Use `UpperCamelCase` for class names. Use `lowerCamelCase` for method, variable, and fields that are not static and final. Use `UPPER_SNAKE_CASE` for all fields that are both static and final.
+Use `UpperCamelCase` for class names. Use `lowerCamelCase` for method names, variable names, and names of fields that are not static and final. Always use `UPPER_SNAKE_CASE` for names of fields that are both static and final.
 
-## Word order
+Method names should always be verbal phrases (`tick`, `getCarversForStep`). Non-boolean field and variable names and class names should be noun phrases (`ChunkRegion`, `color`). Boolean field and variable names should always be adjectival phrases or present-tense verbal phrases (`powered`, `canOpen`), avoiding the `is` and `has` prefixes when possible (`colored`, not `isColored` or `hasColor`).
 
-To make code as easy to read as possible, keep names in the natural English language order. For example, a class representing a "chest block entity" should be named `ChestBlockEntity`, not `BlockEntityChest`. Though using prefix naming may be helpful for grouping classes together in the IDE's tree view, reading and writing code is done much more often than browsing files.
+To make code as easy to read as possible, keep names in the natural language order. For example, a class representing a "chest block entity" should be named `ChestBlockEntity`, not `BlockEntityChest`. Though prefix naming may be helpful for grouping classes together in an IDE's tree view, reading and writing code is done much more often than browsing files.
 
-Avoid redundant words, but don't omit important words: the purpose of names is to give as much information about what the class, field, or method does.
+Use American English (`color`, not `colour`) for consistency throughout Yarn and with known Mojang names.
+
+Omit words that are redundant because of method parameter or the owner class's name. For example, use `getChunk(BlockPos pos)` rather than `getChunkAtPosition(BlockPos pos)`, and `create` rather than `createAchievement` for a method is in the `Achievement` class. Don't avoid overloading methods or shadowing fields.
+
+Names should be as descriptive as possible, so don't omit important words. When naming something always look at all its usages (including overriding methods and inheriting classes).
+
+Consistency is important as it makes code more readable and names easier to memorize. When possible, use terms that are present in other Yarn names, in libraries used by Minecraft, or in vanilla strings. See the "Common names" and "Mojang names" for more information.
 
 ## Acronym and abbreviations
 
@@ -24,24 +30,59 @@ Treat acronyms as single words rather than capitalising every letter. This impro
 
 ## Mojang names
 
-Always use names that match names in strings in the original code, unless that string is outdated or inaccurate. This 
+Always use names that match names in strings in the vanilla code, unless that string is outdated or inaccurate. This avoids confusion, especially from new modders who may not understand what an class exception message is referring to.
 
-Even if a known Mojang name doesn't appear in any strings, it's a good idea to use cit, since the official name gives more information about the class's purpose and what Mojang may decide to do with it in the future.
+Even if a known Mojang name doesn't appear in any strings, it's a good idea to use it, since the official name is a good indicator of the the class's actual purpose and what changes Mojang may do to it in the future. For example, don't name a class that Mojang calls `BedrockBlock` `NoSpawningBlock`, even if its only purpose is to disable mob spawning, because Mojang may decide to override more methods in that class, breaking mods that were using it in an unexpected way. Additionally, using a known Mojang name it less likely that the name will have to be changed in the future.
 
-However, there are three exceptions to this rule (all have open issues suggesting a change to the official Mojang name):
- - Use "container" for what Mojang calls "menu"
- - Use "inventory" for what Mojang calls "container"
- - Use "world" for what Mojang calls "level"
+There are however three exceptions to this rule:
+ - Use "world" for what Mojang calls "level" (see https://github.com/FabricMC/yarn/issues/89)
+ - Use "container" for what Mojang calls "menu" (see https://github.com/FabricMC/yarn/issues/386)
+ - Use "inventory" for what Mojang calls "container" (no issue yet, requires renaming "container" first)
+
+## Packages
+
+Package names should always be singular, to respect Java conventions. Try to respect the Mojang package structure to avoid visibility problems in the future.
 
 ## Common names
 
+This section lists common names that are used throughout Yarn. There's no particular reason these are the names are being used instead of others, but you should use them for consistency.
+
+### Ticks and updates
+
+Use the term "tick" for updates done once per tick. Use "update" for other kind of updates.
+
+### Value last tick
+
+When a field (or getter) is the value that something had last tick (for interpolation, for example), prefix the field with the `last` prefix, (`lastX`, `lastWidth`, etc.).
+
+### Getters, setters, and creators
+
+Use the word "get" for getters and other methods that calculate some property with no side effects other than possibly caching the value in a private field only used by that method.
+
+Use the word "set" for methods that set some property.
+
+Use the word "create" for methods that create a new instance of some object. Use the term "get or create" for methods that create a new instance only if one does not already exist. Don't use "get or create" for lazy initialization, though. 
+
+### Serializing and deserializing
+
+Use "serializer" for naming classes whose purpose is serializing or deserializing some type of object (ex. `RecipeSerializer`). Use the words "serialize" and "deserialize" only when refering to serializing or deserializing some object other.
+
+Use "from" for static methods that create an object of the method owner's type (`fromJson`, `fromNbt`, `fromString`, etc.). Use "to" for methods that convert an object to another type (`toString`, `toLong`, `toNbt`, etc.).
+
+Use "read" for non-static methods that load data into a class. Use "write" for methods that save data to an *existing* object passed as a parameter.
+
+### Factories and builders
+
+Use the word "factory" (rather than "provider", etc.) for factories. Use "builder" for builders.
 
 ### Collections
 
-Use a plural name for collections and maps (ex. rather than the words "list", "set", "array", etc., unless it's a collection of collections (ex, `entityLists` for an array of entity lists) or there are several collections of different types containing the same objects.
+Use a plural name for collections and maps rather than the words "list", "set", "array", etc., unless it's a collection of collection or there are several collections of different types containing the same objects (`entities`, `entityLists`, etc.).
 
-When it's enough, name maps based on the value type. Otherwise, name it `valuesByKeys`.
+When it's enough, name maps based on the value type. Otherwise, name it in the "`valuesByKeys`" format.
 
-## Other conventions
+## Information that should not be present in names
+
+Avoid naming methods based on implementation details.
 
 Avoid including Java-related information in names. For example, don't prefix class names with `I`, `Enum`, or `Abstract` and don't prefix methods with `private`. Instead, try to find meaningful names to describe differences between classes. In the case of abstract classes, this may involve renaming subclasses to more specific names.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -26,6 +26,9 @@ shadowing fields.
 However, it's more important for a name to be descriptive rather than short, so don't omit important words. When naming something
 always look at all its usages, including overriding methods and inheriting classes.
 
+It's important to be concise especially with names used in many places throughout the code, while more obscure names can be
+longer and more descriptive.
+
 ## Abbreviations
 
 Avoid abbreviations unless it's a common one everyone knows and other yarn names involving the same word use its abbreviated
@@ -62,8 +65,8 @@ Use the word "last" for the value that something had last tick (`lastX`, `lastWi
 
 ### Getters, setters, withers, and creators
 
-Use "get" for getters and other methods that calculate some property with no side effects other than caching a value in a
-private field.
+Use "get" for non-boolean getters and other methods that calculate some property with no side effects other than caching a value in a
+private field. For boolean getters, use "is".
 
 Use "set" for methods that set some property. Name the parameter the same as the property (`setColor(color)`, not
 `setColor(newColor)`).
@@ -99,6 +102,13 @@ collection or there are several collections of different types containing the sa
 
 When it's enough, name maps based on the value type. Otherwise, name it in the "`valuesByKeys`" format.
 
+### Coordinates
+
+Coordinates can be named `x`, `y`, and `z` when it's clear what they represent. If clarification is needed, add a word in
+front of the coordinate (`velocityX`, not `xVelocity`).
+
+Name screen coordinates `x` and `y`, rather than `left` and `top`.
+
 ## Mojang names
 
 Use names that match names in strings in the vanilla code, unless that string is outdated or inaccurate. This avoids confusion,
@@ -119,6 +129,6 @@ There are however three exceptions to this rule:
 
 Don't name methods based on implementation details. Names should describe what methods do, now how they work.
 
-Avoid including Java-related information in names. For example, don't prefix class names with `I`, `Enum`, or `Abstract` and
+Avoid including Java-related information in names. For example, don't prefix class names with `I`, or `Enum` and
 don't prefix methods with `private`. Instead, try to find meaningful names to describe differences between classes. In the
 case of abstract classes, this may involve renaming subclasses to more specific names.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -3,29 +3,29 @@
 ## General
 
 Use `UpperCamelCase` for class names. Use `lowerCamelCase` for method names, variable names, and names of fields that are not
-both static and final. Always use `UPPER_SNAKE_CASE` for names of fields that are both static and final.
+both static and final. Use `UPPER_SNAKE_CASE` for names of fields that are both static and final.
 
-Method names should always be verbal phrases (`tick`, `getCarversForStep`), except for builder methods and "withX" methods.
+Method names should always be verb phrases (`tick`, `getCarversForStep`), except for builder methods and "withX" methods.
 Class names and non-boolean field and variable names should be noun phrases (`ChunkRegion`, `color`). Boolean field and
-variable names should always be adjectival phrases or present tense verbal phrases (`powered`, `canOpen`), avoiding the `is`
+variable names should always be adjective phrases or present tense verb phrases (`powered`, `canOpen`), avoiding the `is`
 and `has` prefixes when possible (`colored`, not `isColored` or `hasColor`).
 
-To make code as easy to read as possible, keep names in the natural language order. For example, a class representing a "chest
-block entity" should be named `ChestBlockEntity`, not `BlockEntityChest`. Though prefix naming may be helpful for grouping
-classes together in an IDE's tree view, reading and writing code is done much more often than browsing files.
+To make code as easy to read as possible, keep names in the natural language order. For example, a class representing a chest
+block entity should be named `ChestBlockEntity` rather than `BlockEntityChest`. Though prefix naming may be helpful for
+grouping classes together in an IDE's tree view, reading and writing code is done much more often than browsing files.
 
-Use American English (`color`, not `colour`) for consistency throughout Yarn and with known Mojang names.
+## Spelling
 
-Omit words that are unnecessary thanks to parameter names or owner class names. For example, use `getChunk(BlockPos pos)`
-rather than `getChunkAtPosition(BlockPos pos)`, and `create` rather than `createBox` for a method is in the `Box` class.
-Don't avoid overloading methods or shadowing fields.
+Use American English for consistency throughout Yarn and with known Mojang names.
 
-Names should be as descriptive as possible, so don't omit important words. When naming something always look at all its usages
-(including overriding methods and inheriting classes).
+## Conciseness
 
-Consistency is important as it makes code more readable and names easier to memorize. When possible, use terms that are present
-in other Yarn names, in libraries used by Minecraft, or in vanilla strings. See the "Common names" and "Mojang names" sections
-for more information.
+Omit words that are made redundant by parameter names or owner class names. For example, use `getChunk(BlockPos pos)` rather
+than `getChunkAtPosition(BlockPos pos)` and `Box.create` rather than `Box.createBox`. Don't avoid overloading methods or
+shadowing fields.
+
+However, it's more important for a name to be descriptive rather than short, so don't omit important words. When naming something
+always look at all its usages, including overriding methods and inheriting classes.
 
 ## Abbreviations
 
@@ -42,31 +42,16 @@ time to type thanks to IDE autocompletion. Common abbreviations you should use a
 Treat acronyms as single words rather than capitalising every letter. This improves readability (compare `JsonObject` and
 `JSONObject`) and it's consistent with Mojang naming (a known name is `NbtIo`).
 
-## Mojang names
-
-Use names that match names in strings in the vanilla code, unless that string is outdated or inaccurate. This avoids confusion,
-especially from new modders who may not understand what an class exception message is referring to.
-
-Even if a known Mojang name doesn't appear in any strings, it's a good idea to use it since the official name is a good
-indicator of the the class's actual purpose and makes it less likely the name will have to be changed in the future. For
-example, don't name a class that Mojang calls `BedrockBlock` `NoSpawningBlock`, even if its only purpose is to disable mob
-spawning, because Mojang may decide to override more methods in that class, breaking mods that were using it in an unexpected
-way.
-
-There are however three exceptions to this rule:
- - Use "world" for what Mojang calls "level" (see https://github.com/FabricMC/yarn/issues/89)
- - Use "container" for what Mojang calls "menu" (see https://github.com/FabricMC/yarn/issues/386)
- - Use "inventory" for what Mojang calls "container" (no issue yet, requires renaming "container" first)
-
 ## Packages
 
 Package names should always be singular to respect Java conventions. Try to respect the Mojang package structure to avoid
 visibility problems in the future.
 
-## Common names
+## Consistency
 
-This section lists common names that are used throughout Yarn. There's no particular reason these are the names are being used
-instead of others, but you should use them for consistency.
+Consistency is important as it makes code more readable and names easier to memorize. When possible, use terms that are present
+in other Yarn names, in libraries used by Minecraft, or in vanilla strings. The rest of this section lists common names and
+name patterns you should use.
 
 ### Ticks and updates
 
@@ -90,7 +75,7 @@ as the property.
 Use "create" for methods that create a new instance of some object. Use "get or create" for methods that create a new
 instance only if one does not already exist. Don't use "get or create" for lazy initialization, though. 
 
-### Serializing and deserializing
+### Serialization
 
 Use "serializer" for objects whose purpose is serializing or deserializing some type of object (`RecipeSerializer`). Use
 "serialize" and "deserialize" for methods only when serializing or deserializing an object other than the one the method is in.
@@ -115,9 +100,25 @@ collection or there are several collections of different types containing the sa
 
 When it's enough, name maps based on the value type. Otherwise, name it in the "`valuesByKeys`" format.
 
-## Information that should not be present in names
+## Mojang names
 
-Avoid naming methods based on implementation details.
+Use names that match names in strings in the vanilla code, unless that string is outdated or inaccurate. This avoids confusion,
+especially from new modders who may not understand what an class exception message is referring to.
+
+Even if a known Mojang name doesn't appear in any strings, it's a good idea to use it since the official name is a good
+indicator of the the class's actual purpose and makes it less likely the name will have to be changed in the future. For
+example, don't name a class that Mojang calls `BedrockBlock` `NoSpawningBlock`, even if its only purpose is to disable mob
+spawning, because Mojang may decide to override more methods in that class, breaking mods that were using it in an unexpected
+way.
+
+There are however three exceptions to this rule:
+ - Use "world" for what Mojang calls "level" (see https://github.com/FabricMC/yarn/issues/89)
+ - Use "container" for what Mojang calls "menu" (see https://github.com/FabricMC/yarn/issues/386)
+ - Use "inventory" for what Mojang calls "container" (no issue yet, requires renaming "container" first)
+
+## Things to avoid
+
+Don't naming methods based on implementation details. Names should describe what methods do, now how they work.
 
 Avoid including Java-related information in names. For example, don't prefix class names with `I`, `Enum`, or `Abstract` and
 don't prefix methods with `private`. Instead, try to find meaningful names to describe differences between classes. In the

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,30 @@
+# Naming Conventions
+
+## Casing
+
+Use `UpperCamelCase` for class names. Use `lowerCamelCase` for method, variable, and fields that are not static and final. Use `UPPER_SNAKE_CASE` for all fields that are both static and final.
+
+## Word order
+
+To make code as easy to read as possible, keep names in the natural English language order. For example, a class representing a "chest block entity" should be named `ChestBlockEntity`, not `BlockEntityChest`. Though using prefix naming may be helpful for grouping classes together in the IDE's tree view, reading and writing code is done much more often than browsing files.
+
+## Acronym and abbreviations
+
+Try to avoid acronyms and abbreviations unless it's a common one that everyone knows, and other yarn names involving the same word all use its abbreviated form. Full names are easier to read quickly and remember ("Which words were abbreviated?") and they often don't take more time to type due to IDE autocompletion.
+
+Treat acronyms as single words rather than capitalising every letter. This improves readability (compare `JsonObject` and `JSONObject`) and is consistent with Mojang naming (a known name is `NbtIo`).
+
+## Mojang names
+
+Always use names that match names in strings in the original code, unless that string is outdated or inaccurate. This 
+
+Even if a known Mojang name doesn't appear in any strings, it's a good idea to use cit, since the official name gives more information about the class's purpose and what Mojang may decide to do with it in the future.
+
+However, there are three exceptions to this rule (all have open issues suggesting a change to the official Mojang name):
+ - Use "container" for what Mojang calls "menu"
+ - Use "inventory" for what Mojang calls "container"
+ - Use "world" for what Mojang calls "level"
+
+## Other conventions
+
+Avoid including Java-related information in names. For example, don't prefix class names with `I`, `Enum`, or `Abstract` and don't prefix methods with `private`. Instead, try to find meaningful names to describe differences between classes. In the case of abstract classes, this may involve renaming subclasses to more specific names.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -2,34 +2,36 @@
 
 ## General
 
-Use `UpperCamelCase` for class names. Use `lowerCamelCase` for method names, variable names, and names of fields that are not static and
-final. Always use `UPPER_SNAKE_CASE` for names of fields that are both static and final.
+Use `UpperCamelCase` for class names. Use `lowerCamelCase` for method names, variable names, and names of fields that are not
+static and final. Always use `UPPER_SNAKE_CASE` for names of fields that are both static and final.
 
-Method names should always be verbal phrases (`tick`, `getCarversForStep`). Non-boolean field and variable names and class names should
-be noun phrases (`ChunkRegion`, `color`). Boolean field and variable names should always be adjectival phrases or present-tense verbal
-phrases (`powered`, `canOpen`), avoiding the `is` and `has` prefixes when possible (`colored`, not `isColored` or `hasColor`).
+Method names should always be verbal phrases (`tick`, `getCarversForStep`). Non-boolean field and variable names and class names
+should be noun phrases (`ChunkRegion`, `color`). Boolean field and variable names should always be adjectival phrases or present
+tense verbal phrases (`powered`, `canOpen`), avoiding the `is` and `has` prefixes when possible (`colored`, not `isColored` or
+`hasColor`).
 
-To make code as easy to read as possible, keep names in the natural language order. For example, a class representing a "chest block
-entity" should be named `ChestBlockEntity`, not `BlockEntityChest`. Though prefix naming may be helpful for grouping classes together in
-an IDE's tree view, reading and writing code is done much more often than browsing files.
+To make code as easy to read as possible, keep names in the natural language order. For example, a class representing a "chest
+block entity" should be named `ChestBlockEntity`, not `BlockEntityChest`. Though prefix naming may be helpful for grouping
+classes together in an IDE's tree view, reading and writing code is done much more often than browsing files.
 
 Use American English (`color`, not `colour`) for consistency throughout Yarn and with known Mojang names.
 
-Omit words that are redundant because of method parameter or the owner class's name. For example, use `getChunk(BlockPos pos)` rather
-than `getChunkAtPosition(BlockPos pos)`, and `create` rather than `createAchievement` for a method is in the `Achievement` class. Don't
-avoid overloading methods or shadowing fields.
+Omit words that are redundant because of method parameter or the owner class's name. For example, use `getChunk(BlockPos pos)`
+rather than `getChunkAtPosition(BlockPos pos)`, and `create` rather than `createAchievement` for a method is in the `Achievement`
+class. Don't avoid overloading methods or shadowing fields.
 
 Names should be as descriptive as possible, so don't omit important words. When naming something always look at all its usages
 (including overriding methods and inheriting classes).
 
-Consistency is important as it makes code more readable and names easier to memorize. When possible, use terms that are present in other
-Yarn names, in libraries used by Minecraft, or in vanilla strings. See the "Common names" and "Mojang names" for more information.
+Consistency is important as it makes code more readable and names easier to memorize. When possible, use terms that are present
+in other Yarn names, in libraries used by Minecraft, or in vanilla strings. See the "Common names" and "Mojang names" for more
+information.
 
 ## Acronym and abbreviations
 
-Try to avoid acronyms and abbreviations unless it's a common one that everyone knows, and other yarn names involving the same word all
-use its abbreviated form. Full names are easier to read quickly and remember ("Which words were abbreviated?") and they often don't take
-more time to type thanks to IDE autocompletion. The common abbreviations you *should* use are:
+Try to avoid acronyms and abbreviations unless it's a common one that everyone knows, and other yarn names involving the same
+word all use its abbreviated form. Full names are easier to read quickly and remember ("Which words were abbreviated?") and
+they often don't take more time to type thanks to IDE autocompletion. The common abbreviations you *should* use are:
 
  - "id" for "identifier"
  - "pos" for "position"
@@ -37,19 +39,19 @@ more time to type thanks to IDE autocompletion. The common abbreviations you *sh
  - "init" for "initialize"
  - Any abbreviations used by Java or libraries ("json", "html", etc.)
 
-Treat acronyms as single words rather than capitalising every letter. This improves readability (compare `JsonObject` and `JSONObject`)
-and is consistent with Mojang naming (a known name is `NbtIo`).
+Treat acronyms as single words rather than capitalising every letter. This improves readability (compare `JsonObject` and
+`JSONObject`) and is consistent with Mojang naming (a known name is `NbtIo`).
 
 ## Mojang names
 
-Always use names that match names in strings in the vanilla code, unless that string is outdated or inaccurate. This avoids confusion,
-especially from new modders who may not understand what an class exception message is referring to.
+Always use names that match names in strings in the vanilla code, unless that string is outdated or inaccurate. This avoids
+confusion, especially from new modders who may not understand what an class exception message is referring to.
 
-Even if a known Mojang name doesn't appear in any strings, it's a good idea to use it, since the official name is a good indicator of
-the the class's actual purpose and what changes Mojang may do to it in the future. For example, don't name a class that Mojang calls
-`BedrockBlock` `NoSpawningBlock`, even if its only purpose is to disable mob spawning, because Mojang may decide to override more
-methods in that class, breaking mods that were using it in an unexpected way. Additionally, using a known Mojang name it less likely
-that the name will have to be changed in the future.
+Even if a known Mojang name doesn't appear in any strings, it's a good idea to use it, since the official name is a good
+indicator of the the class's actual purpose and what changes Mojang may do to it in the future. For example, don't name a class
+that Mojang calls `BedrockBlock` `NoSpawningBlock`, even if its only purpose is to disable mob spawning, because Mojang may
+decide to override more methods in that class, breaking mods that were using it in an unexpected way. Additionally, using a
+known Mojang name it less likely that the name will have to be changed in the future.
 
 There are however three exceptions to this rule:
  - Use "world" for what Mojang calls "level" (see https://github.com/FabricMC/yarn/issues/89)
@@ -58,13 +60,13 @@ There are however three exceptions to this rule:
 
 ## Packages
 
-Package names should always be singular, to respect Java conventions. Try to respect the Mojang package structure to avoid visibility
-problems in the future.
+Package names should always be singular, to respect Java conventions. Try to respect the Mojang package structure to avoid
+visibility problems in the future.
 
 ## Common names
 
-This section lists common names that are used throughout Yarn. There's no particular reason these are the names are being used instead
-of others, but you should use them for consistency.
+This section lists common names that are used throughout Yarn. There's no particular reason these are the names are being used
+instead of others, but you should use them for consistency.
 
 ### Ticks and updates
 
@@ -72,29 +74,29 @@ Use the term "tick" for updates done once per tick. Use "update" for other kind 
 
 ### Value last tick
 
-When a field (or getter) is the value that something had last tick (for interpolation, for example), prefix the field with the `last`
-prefix, (`lastX`, `lastWidth`, etc.).
+When a field (or getter) is the value that something had last tick (for interpolation, for example), prefix the field with the
+`last` prefix, (`lastX`, `lastWidth`, etc.).
 
 ### Getters, setters, and creators
 
-Use the word "get" for getters and other methods that calculate some property with no side effects other than possibly caching the value
-in a private field only used by that method.
+Use the word "get" for getters and other methods that calculate some property with no side effects other than possibly caching
+the value in a private field only used by that method.
 
 Use the word "set" for methods that set some property.
 
-Use the word "create" for methods that create a new instance of some object. Use the term "get or create" for methods that create a new
-instance only if one does not already exist. Don't use "get or create" for lazy initialization, though. 
+Use the word "create" for methods that create a new instance of some object. Use the term "get or create" for methods that
+create a new instance only if one does not already exist. Don't use "get or create" for lazy initialization, though. 
 
 ### Serializing and deserializing
 
-Use "serializer" for naming classes whose purpose is serializing or deserializing some type of object (ex. `RecipeSerializer`). Use the
-words "serialize" and "deserialize" only when refering to serializing or deserializing some object other.
+Use "serializer" for naming classes whose purpose is serializing or deserializing some type of object (ex. `RecipeSerializer`).
+Use the words "serialize" and "deserialize" only when refering to serializing or deserializing some object other.
 
-Use "from" for static methods that create an object of the method owner's type (`fromJson`, `fromNbt`, `fromString`, etc.). Use "to" for
-methods that convert an object to another type (`toString`, `toLong`, `toNbt`, etc.).
+Use "from" for static methods that create an object of the method owner's type (`fromJson`, `fromNbt`, `fromString`, etc.). Use
+"to" for methods that convert an object to another type (`toString`, `toLong`, `toNbt`, etc.).
 
-Use "read" for non-static methods that load data into a class. Use "write" for methods that save data to an *existing* object passed as
-a parameter.
+Use "read" for non-static methods that load data into a class. Use "write" for methods that save data to an *existing* object
+passed as a parameter.
 
 ### Factories and builders
 
@@ -102,8 +104,8 @@ Use the word "factory" (rather than "provider", etc.) for factories. Use "builde
 
 ### Collections
 
-Use a plural name for collections and maps rather than the words "list", "set", "array", etc., unless it's a collection of collection or
-there are several collections of different types containing the same objects (`entities`, `entityLists`, etc.).
+Use a plural name for collections and maps rather than the words "list", "set", "array", etc., unless it's a collection of
+collection or there are several collections of different types containing the same objects (`entities`, `entityLists`, etc.).
 
 When it's enough, name maps based on the value type. Otherwise, name it in the "`valuesByKeys`" format.
 
@@ -111,6 +113,6 @@ When it's enough, name maps based on the value type. Otherwise, name it in the "
 
 Avoid naming methods based on implementation details.
 
-Avoid including Java-related information in names. For example, don't prefix class names with `I`, `Enum`, or `Abstract` and don't
-prefix methods with `private`. Instead, try to find meaningful names to describe differences between classes. In the case of abstract
-classes, this may involve renaming subclasses to more specific names.
+Avoid including Java-related information in names. For example, don't prefix class names with `I`, `Enum`, or `Abstract` and
+don't prefix methods with `private`. Instead, try to find meaningful names to describe differences between classes. In the
+case of abstract classes, this may involve renaming subclasses to more specific names.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -18,6 +18,9 @@ grouping classes together in an IDE's tree view, reading and writing code is don
 
 Use American English for consistency throughout Yarn and with known Mojang names.
 
+If there are two accepted spellings of the same word, first check if one is already being used in Yarn or by Mojang, and if
+not, use the most common spelling.
+
 ## Conciseness
 
 Omit words that are made redundant by parameter names or owner class names. For example, use `getChunk(BlockPos pos)` rather

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -8,9 +8,17 @@ Use `UpperCamelCase` for class names. Use `lowerCamelCase` for method, variable,
 
 To make code as easy to read as possible, keep names in the natural English language order. For example, a class representing a "chest block entity" should be named `ChestBlockEntity`, not `BlockEntityChest`. Though using prefix naming may be helpful for grouping classes together in the IDE's tree view, reading and writing code is done much more often than browsing files.
 
+Avoid redundant words, but don't omit important words: the purpose of names is to give as much information about what the class, field, or method does.
+
 ## Acronym and abbreviations
 
-Try to avoid acronyms and abbreviations unless it's a common one that everyone knows, and other yarn names involving the same word all use its abbreviated form. Full names are easier to read quickly and remember ("Which words were abbreviated?") and they often don't take more time to type due to IDE autocompletion.
+Try to avoid acronyms and abbreviations unless it's a common one that everyone knows, and other yarn names involving the same word all use its abbreviated form. Full names are easier to read quickly and remember ("Which words were abbreviated?") and they often don't take more time to type thanks to IDE autocompletion. The common abbreviations you *should* use are:
+
+ - "id" for "identifier"
+ - "pos" for "position"
+ - "NBT" for "named binary tag"
+ - "init" for "initialize"
+ - Any abbreviations used by Java or libraries ("json", "html", etc.)
 
 Treat acronyms as single words rather than capitalising every letter. This improves readability (compare `JsonObject` and `JSONObject`) and is consistent with Mojang naming (a known name is `NbtIo`).
 
@@ -24,6 +32,15 @@ However, there are three exceptions to this rule (all have open issues suggestin
  - Use "container" for what Mojang calls "menu"
  - Use "inventory" for what Mojang calls "container"
  - Use "world" for what Mojang calls "level"
+
+## Common names
+
+
+### Collections
+
+Use a plural name for collections and maps (ex. rather than the words "list", "set", "array", etc., unless it's a collection of collections (ex, `entityLists` for an array of entity lists) or there are several collections of different types containing the same objects.
+
+When it's enough, name maps based on the value type. Otherwise, name it `valuesByKeys`.
 
 ## Other conventions
 


### PR DESCRIPTION
[Click for rendered view](https://github.com/Runemoro/yarn/blob/conventions/CONVENTIONS.md)

Adds a `CONVENTIONS.md` file which lists some naming conventions that should be followed when naming things.

There is some overlap with section 4 of https://github.com/FabricMC/yarn/pull/477, but the two documents have very different purposes (this one lists conventions that should be used in yarn names, the other lists more general information about how to contribute).