### PR TITLE
Mapped the remaining fields in Camera

### DIFF
--- a/mappings/net/minecraft/client/render/Camera.mapping
+++ b/mappings/net/minecraft/client/render/Camera.mapping
@@ -4,11 +4,18 @@ CLASS cva net/minecraft/client/render/Camera
 	FIELD c focusedEntity Laij;
 	FIELD d pos Lcry;
 	FIELD e blockPos Lev$a;
+	FIELD f horizontalPlane Lcry;
+	FIELD g verticalPlane Lcry;
+	FIELD h diagonalPlane Lcry;
 	FIELD i pitch F
 	FIELD j yaw F
 	FIELD k thirdPerson Z
 	FIELD l inverseView Z
+	FIELD m cameraY F
+	FIELD n lastCameraY F
 	METHOD a updateEyeHeight ()V
+	METHOD a clipToSpace (D)D
+		ARG 1 desiredCameraDistance
 	METHOD a moveBy (DDD)V
 		ARG 1 x
 		ARG 3 y
@@ -37,4 +44,6 @@ CLASS cva net/minecraft/client/render/Camera
 	METHOD h isReady ()Z
 	METHOD i isThirdPerson ()Z
 	METHOD k getSubmergedFluidState ()Lclc;
+	METHOD l getHorizontalPlane ()Lcry;
+	METHOD m getVerticalPlane ()Lcry;
 	METHOD o reset ()V


### PR DESCRIPTION
I hope these are correct, I've had to make some careful guesses around the X/Y/V planes.

`f` -> `horizontalPlane`
`g` -> `verticalPlane`
`h` -> `diagonalPlane`

`moveBy(DDD)V` appears to be calculating planes from the yaw and pitch, with a dot-product to create a diagonal between them.

`a(D)D` -> `clipToSpace(D)D`

This method is taking a `desiredCameraDistance` of 4; it's checking the surroundings for any objects that intersect, and returns a new distance reduced fit in the available space to prevent views from clipping into walls.

`m` -> cameraY
`n` -> lastCameraY

`updateEyeHeight()V` is just a lerp function. It moves `cameraY` to `lastCameraY` and calculates a new one from the standing eye height of the currently focused entity.
