### PR TITLE
getCustomName -> getName

### DIFF
--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -176,7 +176,7 @@ CLASS bcc net/minecraft/item/ItemStack
 	METHOD o getTag ()Lib;
 	METHOD p getOrCreateTag ()Lib;
 	METHOD q getEnchantments ()Lii;
-	METHOD r getCustomName ()Ljm;
+	METHOD r getName ()Ljm;
 	METHOD s removeCustomName ()V
 	METHOD t hasCustomName ()Z
 	METHOD u hasEnchantmentGlint ()Z


### PR DESCRIPTION
This method actually returns the fixed name of the Item (computed with `Item#getTranslationKey(ItemStack)`) if no custom name is present, it is not specific to custom names.
