### PR TITLE
Mapped (almost) all the missing methods and fields in Entity

### DIFF
--- a/mappings/net/minecraft/client/network/packet/EntityS2CPacket.mapping
+++ b/mappings/net/minecraft/client/network/packet/EntityS2CPacket.mapping
@@ -10,7 +10,17 @@ CLASS lt net/minecraft/client/network/packet/EntityS2CPacket
 	FIELD f pitch B
 	FIELD g onGround Z
 	FIELD h rotate Z
+	METHOD <init> (I)V
+		ARG 1 entityId
+	METHOD a encodePacketCoordinate (D)J
+		ARG 0 coord
+	METHOD a decodePacketCoordinates (JJJ)Lcsa;
+		ARG 0 x
+		ARG 2 y
+		ARG 4 z
 	METHOD a getEntity (Lbhl;)Lail;
+	METHOD a (Lke;)V
+		ARG 1 listener
 	METHOD b getDeltaXShort ()S
 	METHOD c getDeltaYShort ()S
 	METHOD d getDeltaZShort ()S

--- a/mappings/net/minecraft/client/particle/Particle.mapping
+++ b/mappings/net/minecraft/client/particle/Particle.mapping
@@ -48,8 +48,10 @@ CLASS diy net/minecraft/client/particle/Particle
 		ARG 3 dy
 		ARG 5 dz
 	METHOD a getColorMultiplier (F)I
+		ARG 1 tint
 	METHOD a setBoundingBoxSpacing (FF)V
 		ARG 1 spacingXZ
+		ARG 2 spacingY
 	METHOD a setColor (FFF)V
 		ARG 1 red
 		ARG 2 green

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -606,7 +606,7 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD u copyPositionAndRotation (Lail;)V
 		ARG 1 entity
 	METHOD u_ initDataTracker ()V
-	METHOD v initNewDimension (Lail;)V
+	METHOD v copyFrom (Lail;)V
 		ARG 1 original
 	METHOD w hasPassenger (Lail;)Z
 		ARG 1 passenger

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -237,7 +237,7 @@ CLASS ail net/minecraft/entity/Entity
 		ARG 1 observerBounds
 		ARG 2 world
 		ARG 3 subject
-	METHOD a calculateTangentalMotionVector (Lcsa;Lcrv;Lbho;Lcsf;Lzx;)Lcsa;
+	METHOD a calculateTangentialMotionVector (Lcsa;Lcrv;Lbho;Lcsf;Lzx;)Lcsa;
 		ARG 0 collisionVector
 		ARG 1 observerBounds
 		ARG 2 world

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -18,7 +18,7 @@ CLASS ail net/minecraft/entity/Entity
 	FIELD Q waterHeight D
 	FIELD R inWater Z
 	FIELD S inLava Z
-	FIELD T regenTimer I
+	FIELD T timeUntilRegen I
 	FIELD U firstUpdate Z
 	FIELD V dataTracker Lql;
 	FIELD W FLAGS Lqi;

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -301,7 +301,7 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD aO getMountedHeightOffset ()D
 	METHOD aP isLiving ()Z
 	METHOD aQ removeAllPassengers ()V
-	METHOD aR getTargetingDistance ()F
+	METHOD aR getTargetingMargin ()F
 	METHOD aS getRotationVector ()Lcsa;
 	METHOD aT getRotationClient ()Lcrz;
 	METHOD aU getRotationVecClient ()Lcsa;

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -301,7 +301,7 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD aO getMountedHeightOffset ()D
 	METHOD aP isLiving ()Z
 	METHOD aQ removeAllPassengers ()V
-	METHOD aR getTargettingDistance ()F
+	METHOD aR getTargetingDistance ()F
 	METHOD aS getRotationVector ()Lcsa;
 	METHOD aT getRotationClient ()Lcrz;
 	METHOD aU getRotationVecClient ()Lcsa;

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -324,7 +324,6 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD ai getSplashSound ()Lym;
 	METHOD aj getHighSpeedSplashSound ()Lym;
 	METHOD ak checkBlockCollision ()V
-	METHOD al playsFlyingSounds ()Z
 	METHOD am isSilent ()Z
 	METHOD an hasNoGravity ()Z
 	METHOD ao canClimb ()Z

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -606,7 +606,7 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD u copyPositionAndRotation (Lail;)V
 		ARG 1 entity
 	METHOD u_ initDataTracker ()V
-	METHOD v initNewDimention (Lail;)V
+	METHOD v initNewDimension (Lail;)V
 		ARG 1 original
 	METHOD w hasPassenger (Lail;)Z
 		ARG 1 passenger

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -407,7 +407,7 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD bU getPrimaryPassenger ()Lail;
 	METHOD bV getPassengerList ()Ljava/util/List;
 	METHOD bW getPassengersDeep ()Ljava/util/Collection;
-	METHOD bX hasPlayerMount ()Z
+	METHOD bX hasRider ()Z
 	METHOD bY getRootVehicle ()Lail;
 	METHOD bZ isLogicalSideForUpdatingMovement ()Z
 	METHOD ba getItemsEquipped ()Ljava/lang/Iterable;

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -37,9 +37,9 @@ CLASS ail net/minecraft/entity/Entity
 	FIELD aJ standingEyeHeight F
 	FIELD aa chunkY I
 	FIELD ab chunkZ I
-	FIELD ac trackedXPosition J
-	FIELD ad trackedYPosition J
-	FIELD ae trackedZPosition J
+	FIELD ac trackedX J
+	FIELD ad trackedY J
+	FIELD ae trackedZ J
 	FIELD af ignoreCameraFrustum Z
 	FIELD ag velocityDirty Z
 	FIELD ah portalCooldown I

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -406,7 +406,7 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD bU getPrimaryPassenger ()Lail;
 	METHOD bV getPassengerList ()Ljava/util/List;
 	METHOD bW getPassengersDeep ()Ljava/util/Collection;
-	METHOD bX hasRider ()Z
+	METHOD bX hasPlayerRider ()Z
 	METHOD bY getRootVehicle ()Lail;
 	METHOD bZ isLogicalSideForUpdatingMovement ()Z
 	METHOD ba getItemsEquipped ()Ljava/lang/Iterable;

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -407,7 +407,7 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD bU getPrimaryPassenger ()Lail;
 	METHOD bV getPassengerList ()Ljava/util/List;
 	METHOD bW getPassengersDeep ()Ljava/util/Collection;
-	METHOD bX hasPlayerJockey ()Z
+	METHOD bX hasPlayerMount ()Z
 	METHOD bY getPrimaryVehicle ()Lail;
 	METHOD bZ isLogicalSideForUpdatingMovement ()Z
 	METHOD ba getItemsEquipped ()Ljava/lang/Iterable;

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -2,7 +2,7 @@ CLASS ail net/minecraft/entity/Entity
 	FIELD A velocityModified Z
 	FIELD B movementMultiplier Lcsa;
 	FIELD C removed Z
-	FIELD D previousHorizontalSpeed F
+	FIELD D prevHorizontalSpeed F
 	FIELD E horizontalSpeed F
 	FIELD F distanceWalked F
 	FIELD G fallDistance F

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -16,7 +16,7 @@ CLASS ail net/minecraft/entity/Entity
 	FIELD O age I
 	FIELD P insideWater Z
 	FIELD Q waterHeight D
-	FIELD R wet Z
+	FIELD R inWater Z
 	FIELD S inLava Z
 	FIELD T regenTimer I
 	FIELD U firstUpdate Z

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -139,7 +139,7 @@ CLASS ail net/minecraft/entity/Entity
 		ARG 2 pitch
 	METHOD a updateTrackedHeadRotation (FI)V
 		ARG 1 yaw
-		ARG 2 pitch
+		ARG 2 interpolationSteps
 	METHOD a updateVelocity (FLcsa;)V
 		ARG 1 speed
 		ARG 2 movementInput

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -147,18 +147,18 @@ CLASS ail net/minecraft/entity/Entity
 		ARG 1 source
 		ARG 2 amount
 	METHOD a (Laij;)Ljava/util/stream/Stream;
-		ARG 1 collissionVector
+		ARG 1 collisionVector
 	METHOD a updateKilledAdvancementCriterion (Lail;ILahu;)V
 		ARG 1 killer
 		ARG 2 score
 		ARG 3 damageSource
 	METHOD a calculateMotionVector (Lail;Lcsa;Lcrv;Lbhl;Lcsf;Lzx;)Lcsa;
 		ARG 0 subject
-		ARG 1 collissionVector
+		ARG 1 collisionVector
 		ARG 2 observerBounds
 		ARG 3 world
 		ARG 4 context
-		ARG 5 collissions
+		ARG 5 collisions
 	METHOD a startRiding (Lail;Z)Z
 		ARG 1 entity
 		ARG 2 force
@@ -238,11 +238,11 @@ CLASS ail net/minecraft/entity/Entity
 		ARG 2 world
 		ARG 3 subject
 	METHOD a calculateTangentalMotionVector (Lcsa;Lcrv;Lbho;Lcsf;Lzx;)Lcsa;
-		ARG 0 collissionVector
+		ARG 0 collisionVector
 		ARG 1 observerBounds
 		ARG 2 world
 		ARG 3 context
-		ARG 4 collissions
+		ARG 4 collisions
 	METHOD a isTeamPlayer (Lctc;)Z
 		ARG 1 team
 	METHOD a populateCrashReport (Le;)V

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -117,7 +117,7 @@ CLASS ail net/minecraft/entity/Entity
 		ARG 5 z
 		ARG 7 yaw
 		ARG 8 pitch
-	METHOD a updateClientPositionAndAngles (DDDFFIZ)V
+	METHOD a updateTrackedPositionAndAngles (DDDFFIZ)V
 		ARG 1 x
 		ARG 3 y
 		ARG 5 z
@@ -137,7 +137,7 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD a setRotation (FF)V
 		ARG 1 yaw
 		ARG 2 pitch
-	METHOD a updateClientHeadRotation (FI)V
+	METHOD a updateTrackedHeadRotation (FI)V
 		ARG 1 yaw
 		ARG 2 pitch
 	METHOD a updateVelocity (FLcsa;)V

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -408,7 +408,7 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD bV getPassengerList ()Ljava/util/List;
 	METHOD bW getPassengersDeep ()Ljava/util/Collection;
 	METHOD bX hasPlayerMount ()Z
-	METHOD bY getPrimaryVehicle ()Lail;
+	METHOD bY getRootVehicle ()Lail;
 	METHOD bZ isLogicalSideForUpdatingMovement ()Z
 	METHOD ba getItemsEquipped ()Ljava/lang/Iterable;
 	METHOD bb isOnFire ()Z

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -2,6 +2,9 @@ CLASS ail net/minecraft/entity/Entity
 	FIELD A velocityModified Z
 	FIELD B movementMultiplier Lcsa;
 	FIELD C removed Z
+	FIELD D previousHorizontalSpeed F
+	FIELD E horizontalSpeed F
+	FIELD F distanceWalked F
 	FIELD G fallDistance F
 	FIELD H prevRenderX D
 	FIELD I prevRenderY D
@@ -13,22 +16,30 @@ CLASS ail net/minecraft/entity/Entity
 	FIELD O age I
 	FIELD P insideWater Z
 	FIELD Q waterHeight D
+	FIELD R wet Z
 	FIELD S inLava Z
+	FIELD T regenTimer I
+	FIELD U firstUpdate Z
 	FIELD V dataTracker Lql;
 	FIELD W FLAGS Lqi;
 	FIELD X POSE Lqi;
+	FIELD Y updateNeeded Z
 	FIELD Z chunkX I
 	FIELD aA NAME_VISIBLE Lqi;
 	FIELD aB SILENT Lqi;
 	FIELD aC NO_GRAVITY Lqi;
 	FIELD aD invulnerable Z
 	FIELD aE scoreboardTags Ljava/util/Set;
+	FIELD aF teleportRequested Z
 	FIELD aG pistonMovementDelta [D
 	FIELD aH pistonMovementTick J
 	FIELD aI size Laim;
 	FIELD aJ standingEyeHeight F
 	FIELD aa chunkY I
 	FIELD ab chunkZ I
+	FIELD ac trackedXPosition J
+	FIELD ad trackedYPosition J
+	FIELD ae trackedZPosition J
 	FIELD af ignoreCameraFrustum Z
 	FIELD ag velocityDirty Z
 	FIELD ah portalCooldown I
@@ -36,13 +47,17 @@ CLASS ail net/minecraft/entity/Entity
 	FIELD aj portalTime I
 	FIELD ak dimension Lbyh;
 	FIELD al lastPortalPosition Lev;
+	FIELD am lastPortalDirectionVector Lcsa;
+	FIELD an lastPortalDirection Lfa;
 	FIELD ao uuid Ljava/util/UUID;
 	FIELD ap uuidString Ljava/lang/String;
 	FIELD aq glowing Z
 	FIELD ar passengerList Ljava/util/List;
 	FIELD as vehicle Lail;
 	FIELD at velocity Lcsa;
-	FIELD au boundingBox Lcrv;
+	FIELD au entityBounds Lcrv;
+	FIELD av nextStepDistance F
+	FIELD aw nextAerialStepDistance F
 	FIELD ax fireTime I
 	FIELD ay BREATH Lqi;
 	FIELD az CUSTOM_NAME Lqi;
@@ -53,6 +68,7 @@ CLASS ail net/minecraft/entity/Entity
 	FIELD f type Laip;
 	FIELD g entityId I
 	FIELD h LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD i inanimate Z
 	FIELD j ridingCooldown I
 	FIELD k teleporting Z
 	FIELD l world Lbhl;
@@ -92,21 +108,23 @@ CLASS ail net/minecraft/entity/Entity
 		ARG 1 cursorDeltaX
 		ARG 3 cursorDeltaY
 	METHOD a requestTeleport (DDD)V
-		ARG 1 x
-		ARG 3 y
-		ARG 5 z
+		ARG 1 destX
+		ARG 3 destY
+		ARG 5 destZ
 	METHOD a setPositionAnglesAndUpdate (DDDFF)V
 		ARG 1 x
 		ARG 3 y
 		ARG 5 z
 		ARG 7 yaw
 		ARG 8 pitch
-	METHOD a setPositionAndRotations (DDDFFIZ)V
+	METHOD a updateClientPositionAndAngles (DDDFFIZ)V
 		ARG 1 x
 		ARG 3 y
 		ARG 5 z
 		ARG 7 yaw
 		ARG 8 pitch
+		ARG 9 interpolationSteps
+		ARG 10 interpolate
 	METHOD a rayTrace (DFZ)Lcry;
 		ARG 1 maxDistance
 		ARG 3 tickDelta
@@ -119,18 +137,31 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD a setRotation (FF)V
 		ARG 1 yaw
 		ARG 2 pitch
+	METHOD a updateClientHeadRotation (FI)V
+		ARG 1 yaw
+		ARG 2 pitch
 	METHOD a updateVelocity (FLcsa;)V
 		ARG 1 speed
 		ARG 2 movementInput
 	METHOD a damage (Lahu;F)Z
 		ARG 1 source
 		ARG 2 amount
+	METHOD a (Laij;)Ljava/util/stream/Stream;
+		ARG 1 collissionVector
 	METHOD a updateKilledAdvancementCriterion (Lail;ILahu;)V
 		ARG 1 killer
 		ARG 2 score
 		ARG 3 damageSource
+	METHOD a calculateMotionVector (Lail;Lcsa;Lcrv;Lbhl;Lcsf;Lzx;)Lcsa;
+		ARG 0 subject
+		ARG 1 collissionVector
+		ARG 2 observerBounds
+		ARG 3 world
+		ARG 4 context
+		ARG 5 collissions
 	METHOD a startRiding (Lail;Z)Z
 		ARG 1 entity
+		ARG 2 force
 	METHOD a setEquippedStack (Laiq;Lbce;)V
 		ARG 1 slot
 		ARG 2 stack
@@ -192,6 +223,8 @@ CLASS ail net/minecraft/entity/Entity
 		ARG 2 target
 	METHOD a setBoundingBox (Lcrv;)V
 		ARG 1 boundingBox
+	METHOD a applyPistonMovement (Lcsa;)Lcsa;
+		ARG 1 offset
 	METHOD a movementInputToVelocity (Lcsa;FF)Lcsa;
 		ARG 0 movementInput
 		ARG 1 speed
@@ -199,6 +232,17 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD a clipSneakingMovement (Lcsa;Laiz;)Lcsa;
 		ARG 1 offset
 		ARG 2 type
+	METHOD a calculatePerpendicularMotionVector (Lcsa;Lcrv;Lbho;Lail;)Lcsa;
+		ARG 0 collisionVector
+		ARG 1 observerBounds
+		ARG 2 world
+		ARG 3 subject
+	METHOD a calculateTangentalMotionVector (Lcsa;Lcrv;Lbho;Lcsf;Lzx;)Lcsa;
+		ARG 0 collissionVector
+		ARG 1 observerBounds
+		ARG 2 world
+		ARG 3 context
+		ARG 4 collissions
 	METHOD a isTeamPlayer (Lctc;)Z
 		ARG 1 team
 	METHOD a populateCrashReport (Le;)V
@@ -210,6 +254,8 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD a playStepSound (Lev;Lbvn;)V
 		ARG 1 pos
 		ARG 2 state
+	METHOD a calculatePistonMovementFactor (Lfa$a;D)D
+		ARG 2 offsetFactor
 	METHOD a readCustomDataFromTag (Lic;)V
 		ARG 1 tag
 	METHOD a hasPassengerType (Ljava/lang/Class;)Z
@@ -231,6 +277,9 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD a isInFluid (Lze;Z)Z
 		ARG 1 fluidTag
 		ARG 2 requireLoadedChunk
+	METHOD a collectPassengers (ZLjava/util/Set;)V
+		ARG 1 playersOnly
+		ARG 2 output
 	METHOD a toListTag ([D)Lij;
 		ARG 1 values
 	METHOD a toListTag ([F)Lij;
@@ -252,7 +301,7 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD aO getMountedHeightOffset ()D
 	METHOD aP isLiving ()Z
 	METHOD aQ removeAllPassengers ()V
-	METHOD aR getBoundingBoxMarginForTargeting ()F
+	METHOD aR getTargettingDistance ()F
 	METHOD aS getRotationVector ()Lcsa;
 	METHOD aT getRotationClient ()Lcrz;
 	METHOD aU getRotationVecClient ()Lcsa;
@@ -269,11 +318,13 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD ac setOnFireFromLava ()V
 	METHOD ad extinguish ()V
 	METHOD ae destroy ()V
+	METHOD af calculateNextStepDistance ()F
 	METHOD ag moveToBoundingBoxCenter ()V
 	METHOD ah getSwimSound ()Lym;
 	METHOD ai getSplashSound ()Lym;
 	METHOD aj getHighSpeedSplashSound ()Lym;
 	METHOD ak checkBlockCollision ()V
+	METHOD al isJesus ()Z
 	METHOD am isSilent ()Z
 	METHOD an hasNoGravity ()Z
 	METHOD ao canClimb ()Z
@@ -285,10 +336,15 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD au isInsideWaterOrBubbleColumn ()Z
 	METHOD av isInWater ()Z
 	METHOD aw updateSwimming ()V
+	METHOD ax checkWaterState ()Z
 	METHOD ay onSwimmingStart ()V
 	METHOD az attemptSprintingParticles ()V
 	METHOD b setRenderDistanceMultiplier (D)V
 		ARG 0 value
+	METHOD b updateTrackedPosition (DDD)V
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
 	METHOD b setPositionAndAngles (DDDFF)V
 		ARG 1 x
 		ARG 3 y
@@ -303,6 +359,8 @@ CLASS ail net/minecraft/entity/Entity
 		ARG 2 value
 	METHOD b isInvulnerableTo (Lahu;)Z
 		ARG 1 damageSource
+	METHOD b (Laij;)Z
+		ARG 1 e
 	METHOD b onKilledOther (Laiu;)V
 		ARG 1 other
 	METHOD b setPose (Laje;)V
@@ -345,10 +403,12 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD bQ getServer ()Lnet/minecraft/server/MinecraftServer;
 	METHOD bR isImmuneToExplosion ()Z
 	METHOD bS entityDataRequiresOperator ()Z
+	METHOD bT teleportRequested ()Z
 	METHOD bU getPrimaryPassenger ()Lail;
 	METHOD bV getPassengerList ()Ljava/util/List;
 	METHOD bW getPassengersDeep ()Ljava/util/Collection;
-	METHOD bY getTopmostVehicle ()Lail;
+	METHOD bX hasPlayerJockey ()Z
+	METHOD bY getPrimaryVehicle ()Lail;
 	METHOD bZ isLogicalSideForUpdatingMovement ()Z
 	METHOD ba getItemsEquipped ()Ljava/lang/Iterable;
 	METHOD bb isOnFire ()Z
@@ -367,10 +427,12 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD bo getMaxBreath ()I
 	METHOD bp getBreath ()I
 	METHOD bq getHeadYaw ()F
-	METHOD br canPlayerAttack ()Z
+	METHOD br isAttackable ()Z
 	METHOD bs isInvulnerable ()Z
 	METHOD bt canUsePortals ()Z
 	METHOD bu getSafeFallDistance ()I
+	METHOD bw getLastPortalDirectionVector ()Lcsa;
+	METHOD bx getLastPortalDirection ()Lfa;
 	METHOD by canAvoidTraps ()Z
 	METHOD bz doesRenderOnFire ()Z
 	METHOD c setPosition (DDD)V
@@ -398,6 +460,7 @@ CLASS ail net/minecraft/entity/Entity
 		ARG 1 silent
 	METHOD ca getVehicle ()Lail;
 	METHOD cb getSoundCategory ()Lyo;
+	METHOD cc getBurningDuration ()I
 	METHOD cd getCommandSource ()Lcd;
 	METHOD ce getWaterHeight ()D
 	METHOD cf getWidth ()F
@@ -413,6 +476,8 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD d getOppositeRotationVector (FF)Lcsa;
 		ARG 1 pitch
 		ARG 2 yaw
+	METHOD d calculatePoseBounds (Laje;)Lcrv;
+		ARG 1 pos
 	METHOD d setVelocity (Lcsa;)V
 		ARG 1 velocity
 	METHOD d saveToTag (Lic;)Z
@@ -423,10 +488,14 @@ CLASS ail net/minecraft/entity/Entity
 		ARG 1 x
 		ARG 3 y
 		ARG 5 z
+	METHOD e calculateNextAerialStepDistance (F)F
+		ARG 1 distance
 	METHOD e setEntityId (I)V
 		ARG 1 id
 	METHOD e getEyeHeight (Laje;)F
 		ARG 1 pose
+	METHOD e handleCollissions (Lcsa;)Lcsa;
+		ARG 1 motionOffset
 	METHOD e toTag (Lic;)Lic;
 		ARG 1 tag
 	METHOD e setSneaking (Z)V
@@ -483,9 +552,16 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD i setInvisible (Z)V
 		ARG 1 invisible
 	METHOD j stopRiding ()V
+	METHOD j teleport (DDD)V
+		ARG 1 destX
+		ARG 3 destY
+		ARG 5 destZ
 	METHOD j getCameraPosVec (F)Lcsa;
 		ARG 1 tickDelta
 	METHOD j allowsPermissionLevel (I)Z
+		ARG 1 permissionLevel
+	METHOD j getHardCollissionBox (Lail;)Lcrv;
+		ARG 1 colliddingEntity
 	METHOD j onBubbleColumnSurfaceCollision (Z)V
 		ARG 1 drag
 	METHOD k isBeingRainedOn ()Z
@@ -506,10 +582,12 @@ CLASS ail net/minecraft/entity/Entity
 		ARG 1 passenger
 	METHOD l setInvulnerable (Z)V
 		ARG 1 invulnerable
+	METHOD m updateInWater ()V
 	METHOD m startRiding (Lail;)Z
 		ARG 1 entity
 	METHOD m setCustomNameVisible (Z)V
 		ARG 1 visible
+	METHOD n updateWetState ()V
 	METHOD n canStartRiding (Lail;)Z
 		ARG 1 entity
 	METHOD o addPassenger (Lail;)V
@@ -523,10 +601,13 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD s isPartOf (Lail;)Z
 		ARG 1 entity
 	METHOD t isSpectator ()Z
-	METHOD t handlePlayerAttack (Lail;)Z
+	METHOD t onAttack (Lail;)Z
+		ARG 1 attacker
 	METHOD u copyPositionAndRotation (Lail;)V
 		ARG 1 entity
 	METHOD u_ initDataTracker ()V
+	METHOD v initNewDimention (Lail;)V
+		ARG 1 original
 	METHOD w hasPassenger (Lail;)Z
 		ARG 1 passenger
 	METHOD x isConnectedThroughVehicle (Lail;)Z

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -476,7 +476,7 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD d getOppositeRotationVector (FF)Lcsa;
 		ARG 1 pitch
 		ARG 2 yaw
-	METHOD d calculatePoseBounds (Laje;)Lcrv;
+	METHOD d calculateBoundsForPose (Laje;)Lcrv;
 		ARG 1 pos
 	METHOD d setVelocity (Lcsa;)V
 		ARG 1 velocity

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -494,7 +494,7 @@ CLASS ail net/minecraft/entity/Entity
 		ARG 1 id
 	METHOD e getEyeHeight (Laje;)F
 		ARG 1 pose
-	METHOD e handleCollissions (Lcsa;)Lcsa;
+	METHOD e handleCollisions (Lcsa;)Lcsa;
 		ARG 1 motionOffset
 	METHOD e toTag (Lic;)Lic;
 		ARG 1 tag

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -274,7 +274,7 @@ CLASS ail net/minecraft/entity/Entity
 		ARG 3 pitch
 	METHOD a isInFluid (Lze;)Z
 		ARG 1 fluidTag
-	METHOD a isInFluid (Lze;Z)Z
+	METHOD a isSubmergedIn (Lze;Z)Z
 		ARG 1 fluidTag
 		ARG 2 requireLoadedChunk
 	METHOD a collectPassengers (ZLjava/util/Set;)V

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -560,7 +560,7 @@ CLASS ail net/minecraft/entity/Entity
 		ARG 1 tickDelta
 	METHOD j allowsPermissionLevel (I)Z
 		ARG 1 permissionLevel
-	METHOD j getHardCollissionBox (Lail;)Lcrv;
+	METHOD j getHardCollisionBox (Lail;)Lcrv;
 		ARG 1 colliddingEntity
 	METHOD j onBubbleColumnSurfaceCollision (Z)V
 		ARG 1 drag

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -601,7 +601,7 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD s isPartOf (Lail;)Z
 		ARG 1 entity
 	METHOD t isSpectator ()Z
-	METHOD t onAttack (Lail;)Z
+	METHOD t handleAttack (Lail;)Z
 		ARG 1 attacker
 	METHOD u copyPositionAndRotation (Lail;)V
 		ARG 1 entity

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -561,7 +561,7 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD j allowsPermissionLevel (I)Z
 		ARG 1 permissionLevel
 	METHOD j getHardCollisionBox (Lail;)Lcrv;
-		ARG 1 colliddingEntity
+		ARG 1 collidingEntity
 	METHOD j onBubbleColumnSurfaceCollision (Z)V
 		ARG 1 drag
 	METHOD k isBeingRainedOn ()Z

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -57,7 +57,7 @@ CLASS ail net/minecraft/entity/Entity
 	FIELD at velocity Lcsa;
 	FIELD au entityBounds Lcrv;
 	FIELD av nextStepDistance F
-	FIELD aw nextAerialStepDistance F
+	FIELD aw aerialStepDelta F
 	FIELD ax fireTime I
 	FIELD ay BREATH Lqi;
 	FIELD az CUSTOM_NAME Lqi;
@@ -318,13 +318,13 @@ CLASS ail net/minecraft/entity/Entity
 	METHOD ac setOnFireFromLava ()V
 	METHOD ad extinguish ()V
 	METHOD ae destroy ()V
-	METHOD af calculateNextStepDistance ()F
+	METHOD af calculateStepDelta ()F
 	METHOD ag moveToBoundingBoxCenter ()V
 	METHOD ah getSwimSound ()Lym;
 	METHOD ai getSplashSound ()Lym;
 	METHOD aj getHighSpeedSplashSound ()Lym;
 	METHOD ak checkBlockCollision ()V
-	METHOD al isJesus ()Z
+	METHOD al playsFlyingSounds ()Z
 	METHOD am isSilent ()Z
 	METHOD an hasNoGravity ()Z
 	METHOD ao canClimb ()Z
@@ -488,7 +488,7 @@ CLASS ail net/minecraft/entity/Entity
 		ARG 1 x
 		ARG 3 y
 		ARG 5 z
-	METHOD e calculateNextAerialStepDistance (F)F
+	METHOD e calculateAerialStepDelta (F)F
 		ARG 1 distance
 	METHOD e setEntityId (I)V
 		ARG 1 id

--- a/mappings/net/minecraft/util/shape/VoxelShapes.mapping
+++ b/mappings/net/minecraft/util/shape/VoxelShapes.mapping
@@ -42,6 +42,7 @@ CLASS csr net/minecraft/util/shape/VoxelShapes
 	METHOD a union (Lcsu;[Lcsu;)Lcsu;
 		ARG 0 first
 		ARG 1 others
+	METHOD a calculateSoftOffset (Lfa$a;Lcrv;Lbho;DLcsf;Ljava/util/stream/Stream;)D
 	METHOD a calculateMaxOffset (Lfa$a;Lcrv;Ljava/util/stream/Stream;D)D
 		ARG 0 axis
 		ARG 1 box

--- a/mappings/net/minecraft/world/EntityView.mapping
+++ b/mappings/net/minecraft/world/EntityView.mapping
@@ -24,6 +24,10 @@ CLASS bhd net/minecraft/world/EntityView
 	METHOD a getClosestPlayer (Lail;D)Lawb;
 		ARG 1 entity
 		ARG 2 maxDistance
+	METHOD a (Lail;Lail;)Ljava/util/stream/Stream;
+		ARG 1 e
+	METHOD a (Lail;Lail;)Z
+		ARG 1 e
 	METHOD a getEntities (Lail;Lcrv;)Ljava/util/List;
 		ARG 1 except
 		ARG 2 box
@@ -44,6 +48,8 @@ CLASS bhd net/minecraft/world/EntityView
 		ARG 5 y
 		ARG 7 z
 	METHOD a getPlayersInBox (Laqd;Laiu;Lcrv;)Ljava/util/List;
+	METHOD a (Lcss;Lail;)Z
+		ARG 1 e
 	METHOD a getClosestEntity (Ljava/lang/Class;Laqd;Laiu;DDDLcrv;)Laiu;
 		ARG 1 entityClass
 		ARG 4 x
@@ -66,5 +72,13 @@ CLASS bhd net/minecraft/world/EntityView
 		ARG 4 x
 		ARG 6 y
 		ARG 8 z
+	METHOD a (Ljava/util/Set;Lail;)Z
+		ARG 1 e
+	METHOD a (Ljava/util/Set;Lail;Lail;)Z
+		ARG 2 e
+	METHOD b (Lail;Lail;)Z
+		ARG 1 e
 	METHOD b getPlayerByUuid (Ljava/util/UUID;)Lawb;
 		ARG 1 uuid
+	METHOD c (Lail;Lail;)Z
+		ARG 1 e

--- a/mappings/net/minecraft/world/chunk/WorldChunk.mapping
+++ b/mappings/net/minecraft/world/chunk/WorldChunk.mapping
@@ -61,7 +61,7 @@ CLASS bxn net/minecraft/world/chunk/WorldChunk
 	METHOD b remove (Lail;)V
 	METHOD c setLoadedToWorld (Z)V
 	METHOD d setUnsaved (Z)V
-		ARG 1 saved
+		ARG 1 unsaved
 	METHOD k createBlockEntity (Lev;)Lbtq;
 	METHOD s markDirty ()V
 	METHOD t isEmpty ()Z

--- a/mappings/net/minecraft/world/chunk/WorldChunk.mapping
+++ b/mappings/net/minecraft/world/chunk/WorldChunk.mapping
@@ -16,6 +16,7 @@ CLASS bxn net/minecraft/world/chunk/WorldChunk
 	FIELD n postProcessingLists [Lit/unimi/dsi/fastutil/shorts/ShortList;
 	FIELD o blockTickScheduler Lbia;
 	FIELD p fluidTickScheduler Lbia;
+	FIELD q unsaved Z
 	FIELD r lastSaveTime J
 	FIELD s shouldSave Z
 	FIELD t inhabitedTime J
@@ -59,6 +60,8 @@ CLASS bxn net/minecraft/world/chunk/WorldChunk
 		ARG 4 clearOld
 	METHOD b remove (Lail;)V
 	METHOD c setLoadedToWorld (Z)V
+	METHOD d setUnsaved (Z)V
+		ARG 1 saved
 	METHOD k createBlockEntity (Lev;)Lbtq;
 	METHOD s markDirty ()V
 	METHOD t isEmpty ()Z


### PR DESCRIPTION
`EntityS2CPacket.a(D)J` -> `encodePacketCoordinate`
`EntityS2CPacket.a(JJJ)` -> `decodePacketCoordinate`

These are both being used when translating between actual world coordinates and the coordinate format used by the packets and by extension the entity tracker too.

`ac` -> `trackedXPosition`
`ad` -> `trackedYPosition`
`ae` -> `trackedZPosition`
All values used by the entity tracker. Their values are set (added to) in `ClientPlayNetworkHandler` and come from `packet.getDeltaXShort`, `packet.getDeltaYShort`, and `packet.getDeltaZShort` respectively.

`U` -> `firstUpdate`
Initialized to true and set to false at the bottom of `Entity.baseUpdate`. It's pretty straight forward.

`D` -> `previousHorizontalSpeed`
`E` -> `horizontalSpeed`
`F` -> `distanceWalked`
`av` -> `nextStepDistance`
`aw` -> `nextAerialStepDistance`
These seem to be used to track stepping sounds when walking on the ground. `horizontalSpeed` is moved to `previousHorizontalSpeed` on every tick, and recalculated using the already-known horizontal speed method. They are also used with `distanceWalked` when determining when to play the footstep sounds.

`i` -> `inanimate`
Stays false most of the time and is set to true by boats, end crystals, armour stands, falling block entities, tnt, and minecarts. Used in one of the predicates for `EntityView.intersectsEntities`

`R` -> `wet`
`m()V` -> `updateInWater()V`
`n()V` -> `updateWetState ()V`
`wet` is set to true by `updateWetState` if an entity is in a water/fluid (state) block, and checked against by `Entity.isInWater`

`updateWetState` is the first method called by `updateInWater` 

`Y` -> `updateNeeded`
Set to true when an entity is added to the world and used all over the place by chunks when they're ticked. Also shortcuts some checks in the riding update functions, too.

`aF` -> `teleportRequested`
The teleport functions set this to true, and it gets reset atomically by the server when checking if an entity has requested a teleport.

`T` -> `regenTimer`
Used in `ClientPlayerEntity.updateHealth`.
This is set to 10 or 20 after health is set, and is decremented every tick in `LivingEntity.baseTick`

`setPositionAndRotations ` -> `updateClientPositionAndAngles`
`a` -> `updateClientHeadRotation`
This is a client-only method, and called in response to position/rotation change packets.
Ditto for `updateClientHeadRotation` which takes the yaw and pitch and just sets head Yaw.

`getBoundingBoxMarginForTargeting` -> `getTargettingDistance`


I think that is the most notable changes I can think of right now from reading the diff.

Note to self: really need to mark these as I do them, rather than after.