### PR TITLE
Add missing mappings in tick scheduler

### DIFF
--- a/mappings/net/minecraft/server/world/ServerTickScheduler.mapping
+++ b/mappings/net/minecraft/server/world/ServerTickScheduler.mapping
@@ -1,9 +1,12 @@
 CLASS bhy net/minecraft/server/world/ServerTickScheduler
 	FIELD a invalidObjPredicate Ljava/util/function/Predicate;
 	FIELD b idToName Ljava/util/function/Function;
+	FIELD c nameToId Ljava/util/function/Function;
 	FIELD d ticksScheduled Ljava/util/Set;
+	FIELD e ticksScheduledInOrder Ljava/util/TreeSet;
 	FIELD f world Lvi;
 	FIELD g ticksCurrent Ljava/util/Queue;
+	FIELD h ticksConsumed Ljava/util/List;
 	FIELD i tickConsumer Ljava/util/function/Consumer;
 	METHOD <init> (Lvi;Ljava/util/function/Predicate;Ljava/util/function/Function;Ljava/util/function/Function;Ljava/util/function/Consumer;)V
 		ARG 1 world
@@ -14,10 +17,21 @@ CLASS bhy net/minecraft/server/world/ServerTickScheduler
 	METHOD a tick ()V
 	METHOD a toTag (Lbgx;)Lij;
 	METHOD a getScheduledTicksInChunk (Lbgx;ZZ)Ljava/util/List;
+		ARG 2 updateState
+		ARG 3 getStaleTicks
+	METHOD a addScheduledTick (Lbib;)V
 	METHOD a copyScheduledTicks (Lchw;Lev;)V
 		ARG 1 box
 		ARG 2 offset
 	METHOD a getScheduledTicks (Lchw;ZZ)Ljava/util/List;
+		ARG 1 bounds
+		ARG 2 updateState
+		ARG 3 getStaleTicks
+	METHOD a transferTicksInBounds (Ljava/util/List;Ljava/util/Collection;Lchw;Z)Ljava/util/List;
+		ARG 1 dst
+		ARG 2 src
+		ARG 3 bounds
+		ARG 4 move
 	METHOD a serializeScheduledTicks (Ljava/util/function/Function;Ljava/lang/Iterable;J)Lij;
 		ARG 0 identifierProvider
 		ARG 1 scheduledTicks

--- a/mappings/net/minecraft/server/world/ServerTickScheduler.mapping
+++ b/mappings/net/minecraft/server/world/ServerTickScheduler.mapping
@@ -2,11 +2,11 @@ CLASS bhy net/minecraft/server/world/ServerTickScheduler
 	FIELD a invalidObjPredicate Ljava/util/function/Predicate;
 	FIELD b idToName Ljava/util/function/Function;
 	FIELD c nameToId Ljava/util/function/Function;
-	FIELD d ticksScheduled Ljava/util/Set;
-	FIELD e ticksScheduledInOrder Ljava/util/TreeSet;
+	FIELD d scheduledTickActions Ljava/util/Set;
+	FIELD e scheduledTickActionsInOrder Ljava/util/TreeSet;
 	FIELD f world Lvi;
-	FIELD g ticksCurrent Ljava/util/Queue;
-	FIELD h ticksConsumed Ljava/util/List;
+	FIELD g currentTickActions Ljava/util/Queue;
+	FIELD h consumedTickActions Ljava/util/List;
 	FIELD i tickConsumer Ljava/util/function/Consumer;
 	METHOD <init> (Lvi;Ljava/util/function/Predicate;Ljava/util/function/Function;Ljava/util/function/Function;Ljava/util/function/Consumer;)V
 		ARG 1 world

--- a/mappings/net/minecraft/server/world/SimpleTickScheduler.mapping
+++ b/mappings/net/minecraft/server/world/SimpleTickScheduler.mapping
@@ -4,3 +4,5 @@ CLASS bgy net/minecraft/server/world/SimpleTickScheduler
 	METHOD a stream ()Ljava/util/stream/Stream;
 	METHOD a toTag (J)Lij;
 		ARG 1 time
+	METHOD a fromNbt (Lij;Ljava/util/function/Function;Ljava/util/function/Function;)Lbgy;
+		ARG 0 ticks

--- a/mappings/net/minecraft/server/world/SimpleTickScheduler.mapping
+++ b/mappings/net/minecraft/server/world/SimpleTickScheduler.mapping
@@ -2,7 +2,7 @@ CLASS bgy net/minecraft/server/world/SimpleTickScheduler
 	FIELD a scheduledTicks Ljava/util/Set;
 	FIELD b identifierProvider Ljava/util/function/Function;
 	METHOD a stream ()Ljava/util/stream/Stream;
-	METHOD a toTag (J)Lij;
+	METHOD a toNbt (J)Lij;
 		ARG 1 time
 	METHOD a fromNbt (Lij;Ljava/util/function/Function;Ljava/util/function/Function;)Lbgy;
 		ARG 0 ticks

--- a/mappings/net/minecraft/world/ScheduledTick.mapping
+++ b/mappings/net/minecraft/world/ScheduledTick.mapping
@@ -13,6 +13,7 @@ CLASS bib net/minecraft/world/ScheduledTick
 		ARG 2 t
 		ARG 3 time
 		ARG 5 priority
+	METHOD a getComparator ()Ljava/util/Comparator;
 	METHOD b getObject ()Ljava/lang/Object;
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o

--- a/mappings/net/minecraft/world/TickScheduler.mapping
+++ b/mappings/net/minecraft/world/TickScheduler.mapping
@@ -11,6 +11,7 @@ CLASS bia net/minecraft/world/TickScheduler
 		ARG 2 object
 		ARG 3 delay
 		ARG 4 priority
+	METHOD a scheduleAll (Ljava/util/stream/Stream;)V
 	METHOD b isTicking (Lev;Ljava/lang/Object;)Z
 		ARG 1 pos
 		ARG 2 object


### PR DESCRIPTION
Mainly `TickScheduler#scheduleAll`, which in every implementation either forwards to `schedule` or copies its implementation. Also named some private methods in `ServerTickScheduler`.