### PR TITLE
AbsoluteHand -> Arm

### DIFF
--- a/mappings/net/minecraft/client/options/GameOptions.mapping
+++ b/mappings/net/minecraft/client/options/GameOptions.mapping
@@ -85,7 +85,7 @@ CLASS cvr net/minecraft/client/options/GameOptions
 	FIELD n hideServerAddress Z
 	FIELD o advancedItemTooltips Z
 	FIELD p pauseOnLostFocus Z
-	FIELD q mainHand Lait;
+	FIELD q mainArm Lait;
 	FIELD r overrideWidth I
 	FIELD s overrideHeight I
 	FIELD t heldItemTooltips Z

--- a/mappings/net/minecraft/client/render/entity/model/BipedEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BipedEntityModel.mapping
@@ -14,7 +14,9 @@ CLASS dfa net/minecraft/client/render/entity/model/BipedEntityModel
 		ARG 1 scale
 		ARG 3 textureWidth
 	METHOD a getArm (Lait;)Ldhg;
-	METHOD a getPreferedHand (Laiu;)Lait;
+		ARG 1 arm
+	METHOD a getPreferredArm (Laiu;)Lait;
+		ARG 1 entity
 	METHOD a setAttributes (Ldfa;)V
 	METHOD b_ setVisible (Z)V
 		ARG 1 visible

--- a/mappings/net/minecraft/client/render/entity/model/ModelWithArms.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/ModelWithArms.mapping
@@ -1,2 +1,3 @@
 CLASS doo net/minecraft/client/render/entity/model/ModelWithArms
 	METHOD a setArmAngle (FLait;)V
+		ARG 2 arm

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -207,7 +207,7 @@ CLASS aiu net/minecraft/entity/LivingEntity
 	METHOD dd isUsingRiptide ()Z
 	METHOD de canMoveVoluntarily ()Z
 	METHOD df getAbsorptionAmount ()F
-	METHOD dh getMainHand ()Lait;
+	METHOD dh getMainArm ()Lait;
 	METHOD di isUsingItem ()Z
 	METHOD dj getActiveHand ()Lahf;
 	METHOD dl getActiveItem ()Lbce;

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -22,7 +22,7 @@ CLASS awb net/minecraft/entity/player/PlayerEntity
 	FIELD bY itemCooldownManager Lbca;
 	FIELD bs STANDING_SIZE Laim;
 	FIELD bt PLAYER_MODEL_BIT_MASK Lqi;
-	FIELD bu MAIN_HAND Lqi;
+	FIELD bu MAIN_ARM Lqi;
 	FIELD bv LEFT_SHOULDER_ENTITY Lqi;
 	FIELD bw RIGHT_SHOULDER_ENTITY Lqi;
 	FIELD bx inventory Lawa;
@@ -49,8 +49,8 @@ CLASS awb net/minecraft/entity/player/PlayerEntity
 	METHOD a interact (Lail;Lahf;)Lahg;
 		ARG 1 entity
 		ARG 2 hand
-	METHOD a setMainHand (Lait;)V
-		ARG 1 absoluteHand
+	METHOD a setMainArm (Lait;)V
+		ARG 1 arm
 	METHOD a openHorseInventory (Larw;Lagz;)V
 	METHOD a shouldDamagePlayer (Lawb;)Z
 		ARG 1 player

--- a/mappings/net/minecraft/server/network/packet/ClientSettingsC2SPacket.mapping
+++ b/mappings/net/minecraft/server/network/packet/ClientSettingsC2SPacket.mapping
@@ -3,14 +3,14 @@ CLASS ny net/minecraft/server/network/packet/ClientSettingsC2SPacket
 	FIELD b viewDistance I
 	FIELD c chatVisibility Lavz;
 	FIELD e playerModelBitMask I
-	FIELD f mainHand Lait;
+	FIELD f mainArm Lait;
 	METHOD <init> (Ljava/lang/String;ILavz;ZILait;)V
 		ARG 1 language
 		ARG 2 viewDistance
 		ARG 3 chatVisibility
 		ARG 5 modelBitMask
-		ARG 6 mainHand
+		ARG 6 mainArm
 	METHOD b getLanguage ()Ljava/lang/String;
 	METHOD d getChatVisibility ()Lavz;
 	METHOD f getPlayerModelBitMask ()I
-	METHOD g getMainHand ()Lait;
+	METHOD g getMainArm ()Lait;

--- a/mappings/net/minecraft/util/AbsoluteHand.mapping
+++ b/mappings/net/minecraft/util/AbsoluteHand.mapping
@@ -1,3 +1,0 @@
-CLASS ait net/minecraft/util/AbsoluteHand
-	FIELD c name Ljn;
-	METHOD a getOpposite ()Lait;

--- a/mappings/net/minecraft/util/Arm.mapping
+++ b/mappings/net/minecraft/util/Arm.mapping
@@ -1,0 +1,5 @@
+CLASS ait net/minecraft/util/Arm
+	FIELD c optionName Ljn;
+	METHOD <init> (Ljava/lang/String;ILjn;)V
+		ARG 3 optionName
+	METHOD a getOpposite ()Lait;


### PR DESCRIPTION
It represents an arm, used for changing the arm angles of models, and for determining the arm that the main hand is bound to. Some example uses of this enum can be seen below:
```java
// ModelWithArms

void setArmAngle(float <unmapped>, Arm arm);
```
```java
// BipedEntityModel

protected Arm getPreferredArm(T entity) {
    Arm arm = entity.getMainArm();
    return (entity.preferredHand == Hand.MAIN_HAND) ? arm : arm.getOpposite();
}
```
```java
// HeldItemFeatureRenderer

boolean mainHand = hand == Hand.MAIN_HAND;
Arm arm = mainHand ? player.getMainArm() : player.getMainArm().getOpposite();
```
```java
// GameOptions

if ("mainHand".equals(key)) {
    this.mainArm = "left".equals(value) ? Arm.LEFT : Arm.RIGHT;
}
```