### PR TITLE
Identifier.ofNullable -> Identifier.tryParse

### DIFF
--- a/mappings/net/minecraft/util/Identifier.mapping
+++ b/mappings/net/minecraft/util/Identifier.mapping
@@ -12,7 +12,7 @@ CLASS qt net/minecraft/util/Identifier
 		ARG 0 c
 	METHOD a fromCommandInput (Lcom/mojang/brigadier/StringReader;)Lqt;
 		ARG 0 reader
-	METHOD a orNull (Ljava/lang/String;)Lqt;
+	METHOD a tryParse (Ljava/lang/String;)Lqt;
 		ARG 0 id
 	METHOD a splitOn (Ljava/lang/String;C)Lqt;
 		ARG 0 id

--- a/mappings/net/minecraft/util/Identifier.mapping
+++ b/mappings/net/minecraft/util/Identifier.mapping
@@ -12,7 +12,7 @@ CLASS qt net/minecraft/util/Identifier
 		ARG 0 c
 	METHOD a fromCommandInput (Lcom/mojang/brigadier/StringReader;)Lqt;
 		ARG 0 reader
-	METHOD a ofNullable (Ljava/lang/String;)Lqt;
+	METHOD a orNull (Ljava/lang/String;)Lqt;
 		ARG 0 id
 	METHOD a splitOn (Ljava/lang/String;C)Lqt;
 		ARG 0 id


### PR DESCRIPTION
It is not the argument that is nullable, it parses the given `String` into an `Identifier`, and returns null if it is invalid. 

Example use:
```java
@Nullable Identifier id = Identifier.tryParse(this.getPossibilyInvalidPath());
```
