### PR TITLE
Fix #751

### DIFF
--- a/mappings/net/minecraft/command/arguments/BlockArgumentParser.mapping
+++ b/mappings/net/minecraft/command/arguments/BlockArgumentParser.mapping
@@ -18,6 +18,9 @@ CLASS dh net/minecraft/command/arguments/BlockArgumentParser
 	FIELD q tagId Lqt;
 	FIELD r cursorPos I
 	FIELD s suggestions Ljava/util/function/Function;
+	METHOD <init> (Lcom/mojang/brigadier/StringReader;Z)V
+		ARG 1 reader
+		ARG 2 allowTag
 	METHOD a getBlockProperties ()Ljava/util/Map;
 	METHOD a stringifyBlockState (Lbvn;)Ljava/lang/String;
 	METHOD a parsePropertyValue (Lbwq;Ljava/lang/String;I)V
@@ -26,6 +29,7 @@ CLASS dh net/minecraft/command/arguments/BlockArgumentParser
 	METHOD a suggestTagPropertyValues (Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
 	METHOD a stringifyProperty (Ljava/lang/StringBuilder;Lbwq;Ljava/lang/Comparable;)V
 	METHOD a parse (Z)Ldh;
+		ARG 1 allowNbt
 	METHOD b getBlockState ()Lbvn;
 	METHOD b suggestBlockPropertiesOrEnd (Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 	METHOD c getNbtData ()Lic;

--- a/mappings/net/minecraft/command/arguments/BlockPosArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/BlockPosArgumentType.mapping
@@ -2,11 +2,13 @@ CLASS dj net/minecraft/command/arguments/BlockPosArgumentType
 	FIELD a UNLOADED_EXCEPTION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
 	FIELD b OUT_OF_WORLD_EXCEPTION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
 	FIELD c EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Ldj;
+	METHOD a blockPos ()Ldj;
 	METHOD a getLoadedBlockPos (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lev;
 		ARG 0 context
 		ARG 1 name
 	METHOD b getBlockPos (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lev;
+		ARG 0 context
+		ARG 1 name
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 context
 		ARG 2 builder

--- a/mappings/net/minecraft/command/arguments/BlockPredicateArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/BlockPredicateArgumentType.mapping
@@ -18,7 +18,7 @@ CLASS df net/minecraft/command/arguments/BlockPredicateArgumentType
 			ARG 3 nbt
 	FIELD a EXAMPLES Ljava/util/Collection;
 	FIELD b UNKNOWN_TAG_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
-	METHOD a create ()Ldf;
+	METHOD a blockPredicate ()Ldf;
 	METHOD a getBlockPredicate (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Ljava/util/function/Predicate;
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/command/arguments/BlockStateArgument.mapping
+++ b/mappings/net/minecraft/command/arguments/BlockStateArgument.mapping
@@ -2,6 +2,10 @@ CLASS de net/minecraft/command/arguments/BlockStateArgument
 	FIELD a state Lbvn;
 	FIELD b properties Ljava/util/Set;
 	FIELD c data Lic;
+	METHOD <init> (Lbvn;Ljava/util/Set;Lic;)V
+		ARG 1 state
+		ARG 2 properties
+		ARG 3 data
 	METHOD a getBlockState ()Lbvn;
 	METHOD a setBlockState (Lvi;Lev;I)Z
 	METHOD test (Ljava/lang/Object;)Z

--- a/mappings/net/minecraft/command/arguments/BlockStateArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/BlockStateArgumentType.mapping
@@ -1,9 +1,11 @@
 CLASS dg net/minecraft/command/arguments/BlockStateArgumentType
 	FIELD a EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Ldg;
+	METHOD a blockState ()Ldg;
 	METHOD a (Lcom/mojang/brigadier/StringReader;)Lde;
 		ARG 1 reader
 	METHOD a getBlockState (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lde;
+		ARG 0 context
+		ARG 1 name
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 context
 		ARG 2 builder

--- a/mappings/net/minecraft/command/arguments/ColorArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ColorArgumentType.mapping
@@ -1,8 +1,10 @@
 CLASS cg net/minecraft/command/arguments/ColorArgumentType
 	FIELD a INVALID_COLOR_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD b EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Lcg;
+	METHOD a color ()Lcg;
 	METHOD a getColor (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lc;
+		ARG 0 context
+		ARG 1 name
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 context
 		ARG 2 builder

--- a/mappings/net/minecraft/command/arguments/ColumnPosArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ColumnPosArgumentType.mapping
@@ -1,7 +1,7 @@
 CLASS dk net/minecraft/command/arguments/ColumnPosArgumentType
 	FIELD a INCOMPLETE_EXCEPTION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
 	FIELD b EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Ldk;
+	METHOD a columnPos ()Ldk;
 	METHOD a getColumnPos (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Luy;
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/command/arguments/DimensionArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/DimensionArgumentType.mapping
@@ -1,8 +1,10 @@
 CLASS cj net/minecraft/command/arguments/DimensionArgumentType
 	FIELD a INVALID_DIMENSION_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD b EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Lcj;
+	METHOD a dimension ()Lcj;
 	METHOD a getDimensionArgument (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lbyh;
+		ARG 0 context
+		ARG 1 name
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 context
 		ARG 2 builder

--- a/mappings/net/minecraft/command/arguments/EntityAnchorArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/EntityAnchorArgumentType.mapping
@@ -3,12 +3,16 @@ CLASS ck net/minecraft/command/arguments/EntityAnchorArgumentType
 		FIELD c anchors Ljava/util/Map;
 		FIELD d id Ljava/lang/String;
 		FIELD e offset Ljava/util/function/BiFunction;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;Ljava/util/function/BiFunction;)V
+			ARG 3 id
+			ARG 4 offset
 		METHOD a positionAt (Lail;)Lcsa;
 		METHOD a positionAt (Lcd;)Lcsa;
 		METHOD a fromId (Ljava/lang/String;)Lck$a;
+			ARG 0 id
 	FIELD a EXAMPLES Ljava/util/Collection;
 	FIELD b INVALID_ANCHOR_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
-	METHOD a create ()Lck;
+	METHOD a entityAnchor ()Lck;
 	METHOD a getEntityAnchor (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lck$a;
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 context

--- a/mappings/net/minecraft/command/arguments/EntityArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/EntityArgumentType.mapping
@@ -9,6 +9,9 @@ CLASS cl net/minecraft/command/arguments/EntityArgumentType
 	FIELD g EXAMPLES Ljava/util/Collection;
 	FIELD h singleTarget Z
 	FIELD i playersOnly Z
+	METHOD <init> (ZZ)V
+		ARG 1 singleTarget
+		ARG 2 playersOnly
 	METHOD a entity ()Lcl;
 	METHOD a getEntity (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lail;
 		ARG 0 context

--- a/mappings/net/minecraft/command/arguments/EntitySummonArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/EntitySummonArgumentType.mapping
@@ -1,6 +1,8 @@
 CLASS cm net/minecraft/command/arguments/EntitySummonArgumentType
 	FIELD a NOT_FOUND_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD b EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Lcm;
+	METHOD a entitySummon ()Lcm;
 	METHOD a getEntitySummon (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lqt;
+		ARG 0 context
+		ARG 1 name
 	METHOD a validate (Lqt;)Lqt;

--- a/mappings/net/minecraft/command/arguments/FunctionArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/FunctionArgumentType.mapping
@@ -5,7 +5,7 @@ CLASS dv net/minecraft/command/arguments/FunctionArgumentType
 	FIELD a EXAMPLES Ljava/util/Collection;
 	FIELD b UNKNOWN_FUNCTION_TAG_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD c UNKNOWN_FUNCTION_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
-	METHOD a create ()Ldv;
+	METHOD a function ()Ldv;
 	METHOD a getFunctions (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Ljava/util/Collection;
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/command/arguments/GameProfileArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/GameProfileArgumentType.mapping
@@ -2,7 +2,7 @@ CLASS cn net/minecraft/command/arguments/GameProfileArgumentType
 	CLASS cn$a GameProfileArgument
 	FIELD a UNKNOWN_PLAYER_EXCEPTION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
 	FIELD b EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Lcn;
+	METHOD a gameProfile ()Lcn;
 	METHOD a getProfileArgument (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Ljava/util/Collection;
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 context

--- a/mappings/net/minecraft/command/arguments/IdentifierArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/IdentifierArgumentType.mapping
@@ -3,7 +3,7 @@ CLASS cy net/minecraft/command/arguments/IdentifierArgumentType
 	FIELD b UNKNOWN_ADVANCEMENT_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD c UNKNOWN_RECIPE_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD d EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Lcy;
+	METHOD a identifier ()Lcy;
 	METHOD a getAdvancementArgument (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lq;
 	METHOD b getRecipeArgument (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lbem;
 	METHOD c getIdentifier (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lqt;

--- a/mappings/net/minecraft/command/arguments/ItemEnchantmentArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ItemEnchantmentArgumentType.mapping
@@ -1,8 +1,10 @@
 CLASS co net/minecraft/command/arguments/ItemEnchantmentArgumentType
 	FIELD a UNKNOWN_ENCHANTMENT_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD b EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Lco;
+	METHOD a itemEnchantment ()Lco;
 	METHOD a getEnchantment (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lbfm;
+		ARG 0 context
+		ARG 1 name
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 context
 		ARG 2 builder

--- a/mappings/net/minecraft/command/arguments/ItemPredicateArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ItemPredicateArgumentType.mapping
@@ -10,7 +10,7 @@ CLASS dz net/minecraft/command/arguments/ItemPredicateArgumentType
 			ARG 1 context
 	FIELD a EXAMPLES Ljava/util/Collection;
 	FIELD b UNKNOWN_TAG_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
-	METHOD a create ()Ldz;
+	METHOD a itemPredicate ()Ldz;
 	METHOD a getItemPredicate (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Ljava/util/function/Predicate;
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/command/arguments/ItemSlotArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ItemSlotArgumentType.mapping
@@ -2,7 +2,7 @@ CLASS db net/minecraft/command/arguments/ItemSlotArgumentType
 	FIELD a EXAMPLES Ljava/util/Collection;
 	FIELD b UNKNOWN_SLOT_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD c slotNamesToSlotCommandId Ljava/util/Map;
-	METHOD a create ()Ldb;
+	METHOD a itemSlot ()Ldb;
 	METHOD a (Lcom/mojang/brigadier/StringReader;)Ljava/lang/Integer;
 		ARG 1 reader
 	METHOD a getItemSlot (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)I

--- a/mappings/net/minecraft/command/arguments/ItemStackArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ItemStackArgumentType.mapping
@@ -1,6 +1,6 @@
 CLASS dw net/minecraft/command/arguments/ItemStackArgumentType
 	FIELD a EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Ldw;
+	METHOD a itemStack ()Ldw;
 	METHOD a getItemStackArgument (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Ldx;
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/command/arguments/MessageArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/MessageArgumentType.mapping
@@ -12,7 +12,7 @@ CLASS cp net/minecraft/command/arguments/MessageArgumentType
 		METHOD a format (Lcd;)Ljn;
 		METHOD b getEnd ()I
 	FIELD a EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Lcp;
+	METHOD a message ()Lcp;
 	METHOD a getMessage (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Ljn;
 		ARG 0 command
 		ARG 1 name

--- a/mappings/net/minecraft/command/arguments/MobEffectArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/MobEffectArgumentType.mapping
@@ -1,7 +1,7 @@
 CLASS cq net/minecraft/command/arguments/MobEffectArgumentType
 	FIELD a INVALID_EFFECT_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD b EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Lcq;
+	METHOD a mobEffect ()Lcq;
 	METHOD a getMobEffect (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Laid;
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 context

--- a/mappings/net/minecraft/command/arguments/NbtCompoundTagArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/NbtCompoundTagArgumentType.mapping
@@ -1,6 +1,6 @@
 CLASS ci net/minecraft/command/arguments/NbtCompoundTagArgumentType
 	FIELD a EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Lci;
+	METHOD a nbtCompound ()Lci;
 	METHOD a getCompoundTag (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lic;
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/command/arguments/NbtPathArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/NbtPathArgumentType.mapping
@@ -73,7 +73,7 @@ CLASS cr net/minecraft/command/arguments/NbtPathArgumentType
 	FIELD a INVALID_PATH_NODE_EXCEPTION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
 	FIELD b NOTHING_FOUND_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD c EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Lcr;
+	METHOD a nbtPath ()Lcr;
 	METHOD a isNameCharacter (C)Z
 		ARG 0 c
 	METHOD a readCompoundChildNode (Lcom/mojang/brigadier/StringReader;Ljava/lang/String;)Lcr$i;

--- a/mappings/net/minecraft/command/arguments/NbtTagArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/NbtTagArgumentType.mapping
@@ -1,6 +1,6 @@
 CLASS cs net/minecraft/command/arguments/NbtTagArgumentType
 	FIELD a EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Lcs;
+	METHOD a nbtTag ()Lcs;
 	METHOD a getTag (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lit;
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/command/arguments/NumberRangeArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/NumberRangeArgumentType.mapping
@@ -7,4 +7,4 @@ CLASS cx net/minecraft/command/arguments/NumberRangeArgumentType
 		FIELD a EXAMPLES Ljava/util/Collection;
 		METHOD a getRangeArgument (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lbi$d;
 	CLASS cx$c NumberSerializer
-	METHOD a create ()Lcx$b;
+	METHOD a numberRange ()Lcx$b;

--- a/mappings/net/minecraft/command/arguments/ObjectiveArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ObjectiveArgumentType.mapping
@@ -3,7 +3,7 @@ CLASS ct net/minecraft/command/arguments/ObjectiveArgumentType
 	FIELD b EXAMPLES Ljava/util/Collection;
 	FIELD c UNKNOWN_OBJECTIVE_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD d READONLY_OBJECTIVE_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
-	METHOD a create ()Lct;
+	METHOD a objective ()Lct;
 	METHOD a getObjective (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lcsx;
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/command/arguments/ObjectiveCriteriaArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ObjectiveCriteriaArgumentType.mapping
@@ -1,7 +1,7 @@
 CLASS cu net/minecraft/command/arguments/ObjectiveCriteriaArgumentType
 	FIELD a INVALID_CRITERIA_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD b EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Lcu;
+	METHOD a objectiveCriteria ()Lcu;
 	METHOD a getCriteria (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lctd;
 	METHOD a getStatName (Lyv;Ljava/lang/Object;)Ljava/lang/String;
 		ARG 1 stat

--- a/mappings/net/minecraft/command/arguments/OperationArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/OperationArgumentType.mapping
@@ -4,7 +4,7 @@ CLASS cv net/minecraft/command/arguments/OperationArgumentType
 	FIELD a EXAMPLES Ljava/util/Collection;
 	FIELD b INVALID_OPERATION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
 	FIELD c DIVISION_ZERO_EXCEPTION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
-	METHOD a create ()Lcv;
+	METHOD a operation ()Lcv;
 	METHOD a getOperation (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lcv$a;
 	METHOD a getOperator (Ljava/lang/String;)Lcv$a;
 	METHOD b getIntOperator (Ljava/lang/String;)Lcv$b;

--- a/mappings/net/minecraft/command/arguments/ParticleArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ParticleArgumentType.mapping
@@ -1,7 +1,7 @@
 CLASS cw net/minecraft/command/arguments/ParticleArgumentType
 	FIELD a UNKNOWN_PARTICLE_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD b EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Lcw;
+	METHOD a particle ()Lcw;
 	METHOD a (Lcom/mojang/brigadier/StringReader;)Lge;
 		ARG 1 reader
 	METHOD a readParameters (Lcom/mojang/brigadier/StringReader;Lgf;)Lge;

--- a/mappings/net/minecraft/command/arguments/RotationArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/RotationArgumentType.mapping
@@ -1,7 +1,7 @@
 CLASS dn net/minecraft/command/arguments/RotationArgumentType
 	FIELD a INCOMPLETE_ROTATION_EXCEPTION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
 	FIELD b EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Ldn;
+	METHOD a rotation ()Ldn;
 	METHOD a getRotation (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Ldl;
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/command/arguments/ScoreboardSlotArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ScoreboardSlotArgumentType.mapping
@@ -1,7 +1,7 @@
 CLASS da net/minecraft/command/arguments/ScoreboardSlotArgumentType
 	FIELD a INVALID_SLOT_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD b EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Lda;
+	METHOD a scoreboardSlot ()Lda;
 	METHOD a getScorebordSlot (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)I
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/command/arguments/SwizzleArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/SwizzleArgumentType.mapping
@@ -1,5 +1,5 @@
 CLASS dp net/minecraft/command/arguments/SwizzleArgumentType
 	FIELD a EXAMPLES Ljava/util/Collection;
 	FIELD b INVALID_SWIZZLE_EXCEPTION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
-	METHOD a create ()Ldp;
+	METHOD a swizzle ()Ldp;
 	METHOD a getSwizzle (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Ljava/util/EnumSet;

--- a/mappings/net/minecraft/command/arguments/TeamArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/TeamArgumentType.mapping
@@ -1,7 +1,7 @@
 CLASS dc net/minecraft/command/arguments/TeamArgumentType
 	FIELD a EXAMPLES Ljava/util/Collection;
 	FIELD b UNKNOWN_TEAM_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
-	METHOD a create ()Ldc;
+	METHOD a team ()Ldc;
 	METHOD a getTeam (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lcsy;
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/command/arguments/TextArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/TextArgumentType.mapping
@@ -1,7 +1,7 @@
 CLASS ch net/minecraft/command/arguments/TextArgumentType
 	FIELD a INVALID_COMPONENT_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD b EXAMPLES Ljava/util/Collection;
-	METHOD a create ()Lch;
+	METHOD a text ()Lch;
 	METHOD a getTextArgument (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Ljn;
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/command/arguments/TimeArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/TimeArgumentType.mapping
@@ -3,7 +3,7 @@ CLASS dd net/minecraft/command/arguments/TimeArgumentType
 	FIELD b INVALID_UNIT_EXCEPTION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
 	FIELD c INVALID_COUNT_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD d units Lit/unimi/dsi/fastutil/objects/Object2IntMap;
-	METHOD a create ()Ldd;
+	METHOD a time ()Ldd;
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 context
 		ARG 2 builder

--- a/mappings/net/minecraft/command/arguments/Vec2ArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/Vec2ArgumentType.mapping
@@ -4,7 +4,7 @@ CLASS dq net/minecraft/command/arguments/Vec2ArgumentType
 	FIELD c centerIntegers Z
 	METHOD <init> (Z)V
 		ARG 1 centerIntegers
-	METHOD a create ()Ldq;
+	METHOD a vec2 ()Ldq;
 	METHOD a getVec2 (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lcrz;
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/command/arguments/Vec3ArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/Vec3ArgumentType.mapping
@@ -5,11 +5,11 @@ CLASS dr net/minecraft/command/arguments/Vec3ArgumentType
 	FIELD d centerIntegers Z
 	METHOD <init> (Z)V
 		ARG 1 centerIntegers
-	METHOD a create ()Ldr;
+	METHOD a vec3 ()Ldr;
 	METHOD a getVec3 (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lcsa;
 		ARG 0 context
 		ARG 1 name
-	METHOD a create (Z)Ldr;
+	METHOD a vec3 (Z)Ldr;
 		ARG 0 centerIntegers
 	METHOD b getPosArgument (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Ldl;
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;


### PR DESCRIPTION
Additionally maps some ArgumentType parameters.
#751 Has 6 upvotes and no downvotes. I think the pattern to use static imports is quite nice and should be enabled in mods.
Plus it makes things consistent with e.g. `EntityArgumentType`, where multiple parameterless create methods are already named in the same fashion.