### PR TITLE
Smol potion stuff

### DIFF
--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -200,7 +200,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6085 setLivingFlag (IZ)V
 		ARG 1 mask
 		ARG 2 value
-	METHOD method_6086 canApplyPotion ()Z
+	METHOD method_6086 acceptsThrownPotions ()Z
 	METHOD method_6087 pushAway (Lnet/minecraft/class_1297;)V
 	METHOD method_6088 getActiveStatusEffects ()Ljava/util/Map;
 	METHOD method_6089 containsOnlyAmbientEffects (Ljava/util/Collection;)Z

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -200,6 +200,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6085 setLivingFlag (IZ)V
 		ARG 1 mask
 		ARG 2 value
+	METHOD method_6086 canApplyPotion ()Z
 	METHOD method_6087 pushAway (Lnet/minecraft/class_1297;)V
 	METHOD method_6088 getActiveStatusEffects ()Ljava/util/Map;
 	METHOD method_6089 containsOnlyAmbientEffects (Ljava/util/Collection;)Z

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -200,7 +200,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6085 setLivingFlag (IZ)V
 		ARG 1 mask
 		ARG 2 value
-	METHOD method_6086 acceptsThrownPotions ()Z
+	METHOD method_6086 isAffectedBySplashPotions ()Z
 	METHOD method_6087 pushAway (Lnet/minecraft/class_1297;)V
 	METHOD method_6088 getActiveStatusEffects ()Ljava/util/Map;
 	METHOD method_6089 containsOnlyAmbientEffects (Ljava/util/Collection;)Z

--- a/mappings/net/minecraft/entity/thrown/ThrownPotionEntity.mapping
+++ b/mappings/net/minecraft/entity/thrown/ThrownPotionEntity.mapping
@@ -11,6 +11,8 @@ CLASS net/minecraft/class_1686 net/minecraft/entity/thrown/ThrownPotionEntity
 	METHOD method_7494 setItemStack (Lnet/minecraft/class_1799;)V
 	METHOD method_7496 doesWaterHurt (Lnet/minecraft/class_1309;)Z
 		ARG 0 entityHit
+	METHOD method_7497 applyLingeringPotion (Lnet/minecraft/class_1799;Lnet/minecraft/class_1842;)V
+	METHOD method_7498 applySplashPotion (Ljava/util/List;Lnet/minecraft/class_1297;)V
 	METHOD method_7499 extinguishFire (Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)V
 	METHOD method_7500 damageEntitiesHurtByWater ()V
 	METHOD method_7501 isLingering ()Z


### PR DESCRIPTION
at the request of blayyke:

* `ThrownPotionEntity#method_7498` -> `applySplashPotion`
  * called when a splash potion lands
  * applies the splash potion effect
* `ThrownPotionEntity#method_7497` -> `applyLingeringPotion`
  * called when a lingering potion lands
  * creates an area effect cloud entity

one more:

* `LivingEntity#method_6086` -> `acceptsThrownPotions`
  * called in `applySplashPotion` and `AreaEffectCloudEntity#tick`
  * if it returns `false`, the potion effect is not applied. in vanilla armor stands have this `false`