### PR TITLE
Mapped Quarternion

### DIFF
--- a/mappings/net/minecraft/client/util/math/Quaternion.mapping
+++ b/mappings/net/minecraft/client/util/math/Quaternion.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_1158 net/minecraft/client/util/math/Quaternion
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
-		ARG 4 magnitude
+		ARG 4 w
 	METHOD <init> (FFFZ)V
 		ARG 1 x
 		ARG 2 y
@@ -22,10 +22,10 @@ CLASS net/minecraft/class_1158 net/minecraft/client/util/math/Quaternion
 		ARG 0 value
 	METHOD method_16003 fCos (F)F
 		ARG 0 value
-	METHOD method_4921 i ()F
-	METHOD method_4922 j ()F
-	METHOD method_4923 k ()F
-	METHOD method_4924 magnitude ()F
+	METHOD method_4921 x ()F
+	METHOD method_4922 y ()F
+	METHOD method_4923 z ()F
+	METHOD method_4924 w ()F
 	METHOD method_4925 copyFrom (Lnet/minecraft/class_1158;)V
 		ARG 1 other
 	METHOD method_4926 reverse ()V

--- a/mappings/net/minecraft/client/util/math/Quaternion.mapping
+++ b/mappings/net/minecraft/client/util/math/Quaternion.mapping
@@ -1,4 +1,31 @@
 CLASS net/minecraft/class_1158 net/minecraft/client/util/math/Quaternion
 	FIELD field_5656 components [F
+	METHOD <init> (FFFF)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+		ARG 4 magnitude
+	METHOD <init> (FFFZ)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+		ARG 4 w
+	METHOD <init> (Lnet/minecraft/class_1158;)V
+		ARG 1 other
+	METHOD <init> (Lnet/minecraft/class_1160;FZ)V
+		ARG 1 direction
+		ARG 2 magnitude
+		ARG 3 normalize
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o
+	METHOD method_16002 fSin (F)F
+		ARG 0 value
+	METHOD method_16003 fCos (F)F
+		ARG 0 value
+	METHOD method_4921 i ()F
+	METHOD method_4922 j ()F
+	METHOD method_4923 k ()F
+	METHOD method_4924 length ()F
+	METHOD method_4925 copyFrom (Lnet/minecraft/class_1158;)V
+		ARG 1 other
+	METHOD method_4926 reverse ()V

--- a/mappings/net/minecraft/client/util/math/Quaternion.mapping
+++ b/mappings/net/minecraft/client/util/math/Quaternion.mapping
@@ -25,7 +25,7 @@ CLASS net/minecraft/class_1158 net/minecraft/client/util/math/Quaternion
 	METHOD method_4921 i ()F
 	METHOD method_4922 j ()F
 	METHOD method_4923 k ()F
-	METHOD method_4924 length ()F
+	METHOD method_4924 magnitude ()F
 	METHOD method_4925 copyFrom (Lnet/minecraft/class_1158;)V
 		ARG 1 other
 	METHOD method_4926 reverse ()V

--- a/mappings/net/minecraft/util/math/Quaternion.mapping
+++ b/mappings/net/minecraft/util/math/Quaternion.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/class_1158 net/minecraft/util/math/Quaternion
 	METHOD <init> (Lnet/minecraft/class_1158;)V
 		ARG 1 other
 	METHOD <init> (Lnet/minecraft/class_1160;FZ)V
-		ARG 1 direction
+		ARG 1 axis
 		ARG 2 angle
 		ARG 3 isDegrees
 	METHOD equals (Ljava/lang/Object;)Z

--- a/mappings/net/minecraft/util/math/Quaternion.mapping
+++ b/mappings/net/minecraft/util/math/Quaternion.mapping
@@ -22,10 +22,10 @@ CLASS net/minecraft/class_1158 net/minecraft/util/math/Quaternion
 		ARG 0 value
 	METHOD method_16003 cos (F)F
 		ARG 0 value
-	METHOD method_4921 x ()F
-	METHOD method_4922 y ()F
-	METHOD method_4923 z ()F
-	METHOD method_4924 w ()F
+	METHOD method_4921 getX ()F
+	METHOD method_4922 getY ()F
+	METHOD method_4923 getZ ()F
+	METHOD method_4924 getW ()F
 	METHOD method_4925 copyFrom (Lnet/minecraft/class_1158;)V
 		ARG 1 other
 	METHOD method_4926 reverse ()V

--- a/mappings/net/minecraft/util/math/Quaternion.mapping
+++ b/mappings/net/minecraft/util/math/Quaternion.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_1158 net/minecraft/client/util/math/Quaternion
+CLASS net/minecraft/class_1158 net/minecraft/util/math/Quaternion
 	FIELD field_5656 components [F
 	METHOD <init> (FFFF)V
 		ARG 1 x

--- a/mappings/net/minecraft/util/math/Quaternion.mapping
+++ b/mappings/net/minecraft/util/math/Quaternion.mapping
@@ -18,9 +18,9 @@ CLASS net/minecraft/class_1158 net/minecraft/util/math/Quaternion
 		ARG 3 normalize
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o
-	METHOD method_16002 fSin (F)F
+	METHOD method_16002 sin (F)F
 		ARG 0 value
-	METHOD method_16003 fCos (F)F
+	METHOD method_16003 cos (F)F
 		ARG 0 value
 	METHOD method_4921 x ()F
 	METHOD method_4922 y ()F

--- a/mappings/net/minecraft/util/math/Quaternion.mapping
+++ b/mappings/net/minecraft/util/math/Quaternion.mapping
@@ -15,7 +15,7 @@ CLASS net/minecraft/class_1158 net/minecraft/util/math/Quaternion
 	METHOD <init> (Lnet/minecraft/class_1160;FZ)V
 		ARG 1 axis
 		ARG 2 angle
-		ARG 3 isDegrees
+		ARG 3 degrees
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o
 	METHOD method_16002 sin (F)F

--- a/mappings/net/minecraft/util/math/Quaternion.mapping
+++ b/mappings/net/minecraft/util/math/Quaternion.mapping
@@ -14,8 +14,8 @@ CLASS net/minecraft/class_1158 net/minecraft/util/math/Quaternion
 		ARG 1 other
 	METHOD <init> (Lnet/minecraft/class_1160;FZ)V
 		ARG 1 direction
-		ARG 2 magnitude
-		ARG 3 normalize
+		ARG 2 angle
+		ARG 3 isDegrees
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o
 	METHOD method_16002 sin (F)F


### PR DESCRIPTION
A bit torn between using mojang names or not here. The constructors are used together with Vec4f (x,y,z) but the toString in this class clearly indicates that they're (i, j, k)

    @Override
    public String toString() {
        return new StringBuilder()
             .append("Quaternion[" + this.magnitude()).append(" + ")
             .append(this.i()).append("i + ")
             .append(this.j()).append("j + ")
             .append(this.k()).append("k]")
             .toString();
    }