### PR TITLE
Item entity mappings

### DIFF
--- a/mappings/net/minecraft/entity/ItemEntity.mapping
+++ b/mappings/net/minecraft/entity/ItemEntity.mapping
@@ -22,6 +22,7 @@ CLASS net/minecraft/class_1542 net/minecraft/entity/ItemEntity
 		ARG 1 targetStack
 		ARG 2 sourceEntity
 		ARG 3 sourceStack
+	METHOD method_20397 canMerge ()Z
 	METHOD method_6972 tryMerge (Lnet/minecraft/class_1542;)V
 		ARG 1 other
 	METHOD method_6973 tryMerge ()V

--- a/mappings/net/minecraft/entity/ItemEntity.mapping
+++ b/mappings/net/minecraft/entity/ItemEntity.mapping
@@ -28,6 +28,7 @@ CLASS net/minecraft/class_1542 net/minecraft/entity/ItemEntity
 	METHOD method_6973 tryMerge ()V
 	METHOD method_6974 applyBuoyancy ()V
 	METHOD method_6975 resetPickupDelay ()V
+	METHOD method_6976 setCovetedItem ()V
 	METHOD method_6977 cannotPickup ()Z
 	METHOD method_6978 getThrower ()Ljava/util/UUID;
 	METHOD method_6979 setStack (Lnet/minecraft/class_1799;)V

--- a/mappings/net/minecraft/entity/ItemEntity.mapping
+++ b/mappings/net/minecraft/entity/ItemEntity.mapping
@@ -43,5 +43,6 @@ CLASS net/minecraft/class_1542 net/minecraft/entity/ItemEntity
 		ARG 1 uuid
 	METHOD method_6985 getAge ()I
 	METHOD method_6986 getOwner ()Ljava/util/UUID;
+	METHOD method_6987 setDespawnImmediately ()V
 	METHOD method_6988 setToDefaultPickupDelay ()V
 	METHOD method_6989 setPickupDelayInfinite ()V

--- a/mappings/net/minecraft/entity/ItemEntity.mapping
+++ b/mappings/net/minecraft/entity/ItemEntity.mapping
@@ -30,6 +30,7 @@ CLASS net/minecraft/class_1542 net/minecraft/entity/ItemEntity
 	METHOD method_6978 getThrower ()Ljava/util/UUID;
 	METHOD method_6979 setStack (Lnet/minecraft/class_1799;)V
 		ARG 1 stack
+	METHOD method_6980 setCreativeDespawnTime ()V
 	METHOD method_6981 setThrower (Ljava/util/UUID;)V
 		ARG 1 uuid
 	METHOD method_6982 setPickupDelay (I)V

--- a/mappings/net/minecraft/entity/ItemEntity.mapping
+++ b/mappings/net/minecraft/entity/ItemEntity.mapping
@@ -26,6 +26,7 @@ CLASS net/minecraft/class_1542 net/minecraft/entity/ItemEntity
 	METHOD method_6972 tryMerge (Lnet/minecraft/class_1542;)V
 		ARG 1 other
 	METHOD method_6973 tryMerge ()V
+	METHOD method_6974 applyBuoyancy ()V
 	METHOD method_6975 resetPickupDelay ()V
 	METHOD method_6977 cannotPickup ()Z
 	METHOD method_6978 getThrower ()Ljava/util/UUID;


### PR DESCRIPTION
`method_6980 -> setCreativeDespawnTime`
Called from `ServerPlayNetworkHandler.onCreativeInventoryAction` in response to an item drop. It sets the age to 4800 (as opposed to the default: 0, and exactly 4/5ths of the maximum age to despawn: 6000)

Items dropped from the creative screen end up despawning ~5 times faster than regular item. (if my math is correct)

`method_20397 -> canMerge`
Called by `tryMerge` to determine whether an item can be merged any further. It will continue to attempt to merge other items into this one until `canMerge` returns false.

`canMerge` is true if the item is:
1. Alive
2. Does not have an infinite pickup delay (pickupDelay = 32767)
3. Does not have an infinite age (age = -32768)
4. Is not about to despawn on the next tick (age = 6000)
5. It's stack size is smaller than the maximum

`method_6974 -> applyBuoyancy`
Called by `tick` when the item is in the water. It will change the vertical velocity to make items float, and reduce their horizontal motion to account for a higher viscosity.

        if (this.isInFluid(FluidTags.WATER)) {
            this.applyBuoyancy();
        }

`method_6976 -> setCovetedItem `
Only used for when the Wither drops a Nether Star, though it's use can be a little more varied than one item so I decided to give it a more generalised name.

Calling `setCovetedItem` will set the age to -6000 effectively doubling the amount of time the item takes to despawn. An age of -6000 will also make pickups immediate:

        //ItemEntity.onPlayerCollision(player)
        if (this.pickupDelay == 0 && (
                          this.owner == null
                         || 6000 - this.age <= 200  // 6000 - (-6000) == 0
                         || this.owner.equals(player.getUuid())
          ) && player.inventory.insertStack(itemStack3)) {
            player.sendPickup(this, integer5);

`
method_6987 -> setDespawnImmediately`
Used by the give command when a player's inventory "overflows". It makes it impossible to pick up the item (infinite pickup delay) and will also set the age to 5999 (one tick before despawning).

These items cannot be picked up, will despawn in one tick, and cannot be merged with other stacks (see above).