### PR TITLE
Remap Biome#getTemperature

### DIFF
--- a/mappings/net/minecraft/world/biome/Biome.mapping
+++ b/mappings/net/minecraft/world/biome/Biome.mapping
@@ -53,6 +53,7 @@ CLASS net/minecraft/class_1959 net/minecraft/world/biome/Biome
 			ARG 2 weight
 			ARG 3 minGroupSize
 			ARG 4 maxGroupSize
+	FIELD field_20335 temperatureCache Ljava/lang/ThreadLocal;
 	FIELD field_9323 BIOMES Ljava/util/Set;
 	FIELD field_9324 FOLIAGE_NOISE Lnet/minecraft/class_3543;
 	FIELD field_9325 spawns Ljava/util/Map;
@@ -76,6 +77,8 @@ CLASS net/minecraft/class_1959 net/minecraft/world/biome/Biome
 	FIELD field_9343 depth F
 	METHOD <init> (Lnet/minecraft/class_1959$class_1960;)V
 		ARG 1 settings
+	METHOD method_21740 getTemperature (Lnet/minecraft/class_2338;)F
+		ARG 1 blockPos
 	METHOD method_8684 hasStructureFeature (Lnet/minecraft/class_3195;)Z
 	METHOD method_8685 canSetSnow (Lnet/minecraft/class_1941;Lnet/minecraft/class_2338;Z)Z
 		ARG 1 world
@@ -121,7 +124,7 @@ CLASS net/minecraft/class_1959 net/minecraft/world/biome/Biome
 		ARG 1 world
 		ARG 2 blockPos
 	METHOD method_8706 getStructureFeatureConfig (Lnet/minecraft/class_3195;)Lnet/minecraft/class_3037;
-	METHOD method_8707 getTemperature (Lnet/minecraft/class_2338;)F
+	METHOD method_8707 computeTemperature (Lnet/minecraft/class_2338;)F
 		ARG 1 blockPos
 	METHOD method_8708 addSpawn (Lnet/minecraft/class_1311;Lnet/minecraft/class_1959$class_1964;)V
 		ARG 1 type


### PR DESCRIPTION
Map `method_21740` -> `getTemperature`
Remap `getTemperature` -> `computeTemperature`
Map `field_20335` -> `temperatureCache`

The `Biome#getTemperature` method was made `protected` in 1.14.4, with a new `public` method added in its place. 