### PR TITLE
Change mappings in selector

### DIFF
--- a/mappings/net/minecraft/command/EntitySelector.mapping
+++ b/mappings/net/minecraft/command/EntitySelector.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_2300 net/minecraft/command/EntitySelector
 	FIELD field_10820 basePredicate Ljava/util/function/Predicate;
 	FIELD field_10821 uuid Ljava/util/UUID;
-	FIELD field_10822 count I
+	FIELD field_10822 limit I
 	FIELD field_10823 positionOffset Ljava/util/function/Function;
 	FIELD field_10824 box Lnet/minecraft/class_238;
 	FIELD field_10825 distance Lnet/minecraft/class_2096$class_2099;
@@ -30,7 +30,7 @@ CLASS net/minecraft/class_2300 net/minecraft/command/EntitySelector
 	METHOD method_9811 getPlayer (Lnet/minecraft/class_2168;)Lnet/minecraft/class_3222;
 	METHOD method_9813 getPlayers (Lnet/minecraft/class_2168;)Ljava/util/List;
 	METHOD method_9814 getEntities (Lnet/minecraft/class_243;Ljava/util/List;)Ljava/util/List;
-	METHOD method_9815 getCount ()I
+	METHOD method_9815 getLimit ()I
 	METHOD method_9816 getEntities (Lnet/minecraft/class_2168;)Ljava/util/List;
 	METHOD method_9817 getPositionPredicate (Lnet/minecraft/class_243;)Ljava/util/function/Predicate;
 	METHOD method_9818 check (Lnet/minecraft/class_2168;)V

--- a/mappings/net/minecraft/command/EntitySelectorReader.mapping
+++ b/mappings/net/minecraft/command/EntitySelectorReader.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_2303 net/minecraft/command/EntitySelectorReader
 	FIELD field_10838 distance Lnet/minecraft/class_2096$class_2099;
 	FIELD field_10839 offsetZ Ljava/lang/Double;
 	FIELD field_10840 checkPermissions Z
-	FIELD field_10842 experienceRange Lnet/minecraft/class_2096$class_2100;
+	FIELD field_10842 levelRange Lnet/minecraft/class_2096$class_2100;
 	FIELD field_10843 includingNonPlayer Z
 	FIELD field_10844 MISSING_EXCEPTION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
 	FIELD field_10847 sorter Ljava/util/function/BiConsumer;
@@ -42,7 +42,7 @@ CLASS net/minecraft/class_2303 net/minecraft/command/EntitySelectorReader
 		ARG 1 entityType
 	METHOD method_9845 setSorter (Ljava/util/function/BiConsumer;)V
 		ARG 1 sorter
-	METHOD method_9846 setExperienceRange (Lnet/minecraft/class_2096$class_2100;)V
+	METHOD method_9846 setLevelRange (Lnet/minecraft/class_2096$class_2100;)V
 		ARG 1 experienceRange
 	METHOD method_9847 suggestEndNext (Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;Ljava/util/function/Consumer;)Ljava/util/concurrent/CompletableFuture;
 	METHOD method_9849 readRegular ()V
@@ -81,7 +81,7 @@ CLASS net/minecraft/class_2303 net/minecraft/command/EntitySelectorReader
 		ARG 1 x
 		ARG 3 y
 		ARG 5 z
-	METHOD method_9895 getExperienceRange ()Lnet/minecraft/class_2096$class_2100;
+	METHOD method_9895 getLevelRange ()Lnet/minecraft/class_2096$class_2100;
 	METHOD method_9896 suggestSelector (Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)V
 	METHOD method_9898 setPitchRange (Lnet/minecraft/class_2152;)V
 	METHOD method_9900 setLimit (I)V

--- a/mappings/net/minecraft/command/EntitySelectorReader.mapping
+++ b/mappings/net/minecraft/command/EntitySelectorReader.mapping
@@ -12,9 +12,9 @@ CLASS net/minecraft/class_2303 net/minecraft/command/EntitySelectorReader
 	FIELD field_10852 boxY Ljava/lang/Double;
 	FIELD field_10853 UNKNOWN_SELECTOR_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD field_10855 VALUELESS_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
-	FIELD field_10856 UNSORTED Ljava/util/function/BiConsumer;
+	FIELD field_10856 ARBITRARY Ljava/util/function/BiConsumer;
 	FIELD field_10857 offsetX Ljava/lang/Double;
-	FIELD field_10858 count I
+	FIELD field_10858 limit I
 	FIELD field_10859 yawRange Lnet/minecraft/class_2152;
 	FIELD field_10860 reader Lcom/mojang/brigadier/StringReader;
 	FIELD field_10861 startCursor I
@@ -22,7 +22,7 @@ CLASS net/minecraft/class_2303 net/minecraft/command/EntitySelectorReader
 	FIELD field_10863 entityType Lnet/minecraft/class_1299;
 	FIELD field_10866 localWorldOnly Z
 	FIELD field_10867 DEFAULT_SUGGESTION_PROVIDER Ljava/util/function/BiFunction;
-	FIELD field_10869 NEAREST_FIRST Ljava/util/function/BiConsumer;
+	FIELD field_10869 NEAREST Ljava/util/function/BiConsumer;
 	FIELD field_10870 predicate Ljava/util/function/Predicate;
 	FIELD field_10872 offsetY Ljava/lang/Double;
 	FIELD field_10875 INVALID_ENTITY_EXCEPTION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
@@ -32,7 +32,7 @@ CLASS net/minecraft/class_2303 net/minecraft/command/EntitySelectorReader
 	FIELD field_10879 senderOnly Z
 	FIELD field_10880 NOT_ALLOWED_EXCEPTION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
 	FIELD field_10881 boxZ Ljava/lang/Double;
-	FIELD field_10882 FURTHEST_FIRST Ljava/util/function/BiConsumer;
+	FIELD field_10882 FURTHEST Ljava/util/function/BiConsumer;
 	METHOD method_9834 suggestSelectorRest (Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;Ljava/util/function/Consumer;)Ljava/util/concurrent/CompletableFuture;
 	METHOD method_9835 getReader ()Lcom/mojang/brigadier/StringReader;
 	METHOD method_9840 getBoxY ()Ljava/lang/Double;
@@ -84,8 +84,8 @@ CLASS net/minecraft/class_2303 net/minecraft/command/EntitySelectorReader
 	METHOD method_9895 getExperienceRange ()Lnet/minecraft/class_2096$class_2100;
 	METHOD method_9896 suggestSelector (Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)V
 	METHOD method_9898 setPitchRange (Lnet/minecraft/class_2152;)V
-	METHOD method_9900 setCount (I)V
-		ARG 1 count
+	METHOD method_9900 setLimit (I)V
+		ARG 1 limit
 	METHOD method_9902 getOffsetX ()Ljava/lang/Double;
 	METHOD method_9905 setBoxY (D)V
 		ARG 1 boxY

--- a/mappings/net/minecraft/command/EntitySelectorReader.mapping
+++ b/mappings/net/minecraft/command/EntitySelectorReader.mapping
@@ -61,7 +61,7 @@ CLASS net/minecraft/class_2303 net/minecraft/command/EntitySelectorReader
 		ARG 1 distance
 	METHOD method_9871 build ()Lnet/minecraft/class_2300;
 	METHOD method_9873 getDistance ()Lnet/minecraft/class_2096$class_2099;
-	METHOD method_9874 readOption ()V
+	METHOD method_9874 readArguments ()V
 	METHOD method_9875 setSuggestionProvider (Ljava/util/function/BiFunction;)V
 	METHOD method_9878 buildPredicate ()V
 	METHOD method_9879 setOffsetZ (D)V
@@ -95,6 +95,6 @@ CLASS net/minecraft/class_2303 net/minecraft/command/EntitySelectorReader
 	METHOD method_9911 suggestOptionOrEnd (Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;Ljava/util/function/Consumer;)Ljava/util/concurrent/CompletableFuture;
 	METHOD method_9915 readTagCharacter ()Z
 	METHOD method_9916 setPredicate (Ljava/util/function/Predicate;)V
-	METHOD method_9917 readAtSelector ()V
+	METHOD method_9917 readAtVariable ()V
 	METHOD method_9918 setBoxZ (D)V
 		ARG 1 boxZ


### PR DESCRIPTION
# Changes of Selector Arguments
| before | after |
| - | - |
| `EntitySelector#count` | `EntitySelector#limit` |
| `EntitySelectorReader#count` | `EntitySelectorReader#limit` |
| `EntitySelectorReader#UNSORT` | `EntitySelectorReader#ARBITRARY` |
| `EntitySelectorReader#NEAREST_FIRST` | `EntitySelectorReader#NEAREST` |
| `EntitySelectorReader#FURTHEST_FIRST` | `EntitySelectorReader#FURTHEST` |
| `EntitySelectorReader#experienceRange` | `EntitySelectorReader#levelRange` |

I'm not sure whether these changes are necessary, but they are named so in [selector arguments](https://minecraft.gamepedia.com/Commands#Target_selector_arguments) so I opened this PR. 

However, I don't change `offsetX`, `boxX`, `pitchRange` and `yawRange` according to the selector arguments, because I personally think they make more sense than `x`, `dx`, `xRotationRange` and `yRotationRange`.

# Other Changes
| before | after | note |
| - | - | - |
| `EntitySelectorReader#readAtSelector` | `EntitySelectorReader#readAtVariable` | IMO `variable` is more accurate and common because [wiki](https://minecraft.gamepedia.com/Commands#Target_selector_variables) called so. |
| `EntitySelectorReader#readOption` | `EntitySelectorReader#readArguments` | - |