### PR TITLE
MutableIntBoundingBox -> BlockBox

### DIFF
--- a/mappings/net/minecraft/util/math/BlockBox.mapping
+++ b/mappings/net/minecraft/util/math/BlockBox.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3341 net/minecraft/util/math/MutableBox
+CLASS net/minecraft/class_3341 net/minecraft/util/math/BlockBox
 	FIELD field_14376 maxZ I
 	FIELD field_14377 maxY I
 	FIELD field_14378 maxX I

--- a/mappings/net/minecraft/util/math/BlockBox.mapping
+++ b/mappings/net/minecraft/util/math/BlockBox.mapping
@@ -39,12 +39,12 @@ CLASS net/minecraft/class_3341 net/minecraft/util/math/BlockBox
 	METHOD method_14664 getBlockCountZ ()I
 	METHOD method_14665 empty ()Lnet/minecraft/class_3341;
 	METHOD method_14666 create (IIIIII)Lnet/minecraft/class_3341;
-		ARG 0 minX
-		ARG 1 minY
-		ARG 2 minZ
-		ARG 3 maxX
-		ARG 4 maxY
-		ARG 5 maxZ
+		ARG 0 x1
+		ARG 1 y1
+		ARG 2 z1
+		ARG 3 x2
+		ARG 4 y2
+		ARG 5 z2
 	METHOD method_14667 rotated (IIIIIIIIILnet/minecraft/class_2350;)Lnet/minecraft/class_3341;
 		ARG 0 x
 		ARG 1 y

--- a/mappings/net/minecraft/util/math/BlockBox.mapping
+++ b/mappings/net/minecraft/util/math/BlockBox.mapping
@@ -56,8 +56,8 @@ CLASS net/minecraft/class_3341 net/minecraft/util/math/BlockBox
 		ARG 7 sizeY
 		ARG 8 sizeZ
 		ARG 9 facing
-	METHOD method_14668 setFrom (Lnet/minecraft/class_3341;)V
-		ARG 1 source
+	METHOD method_14668 encompass (Lnet/minecraft/class_3341;)V
+		ARG 1 region
 	METHOD method_14669 intersectsXZ (IIII)Z
 		ARG 1 minX
 		ARG 2 minZ

--- a/mappings/net/minecraft/util/math/BlockBox.mapping
+++ b/mappings/net/minecraft/util/math/BlockBox.mapping
@@ -28,15 +28,15 @@ CLASS net/minecraft/class_3341 net/minecraft/util/math/BlockBox
 		ARG 1 other
 	METHOD method_14658 toNbt ()Lnet/minecraft/class_2495;
 	METHOD method_14659 getDimensions ()Lnet/minecraft/class_2382;
-	METHOD method_14660 getXLength ()I
+	METHOD method_14660 getBlockCountX ()I
 	METHOD method_14661 offset (III)V
 		ARG 1 dx
 		ARG 2 dy
 		ARG 3 dz
 	METHOD method_14662 contains (Lnet/minecraft/class_2382;)Z
 		ARG 1 vec
-	METHOD method_14663 getYLength ()I
-	METHOD method_14664 getZLength ()I
+	METHOD method_14663 getBlockCountY ()I
+	METHOD method_14664 getBlockCountZ ()I
 	METHOD method_14665 empty ()Lnet/minecraft/class_3341;
 	METHOD method_14666 create (IIIIII)Lnet/minecraft/class_3341;
 		ARG 0 minX

--- a/mappings/net/minecraft/util/math/Box.mapping
+++ b/mappings/net/minecraft/util/math/Box.mapping
@@ -6,11 +6,17 @@ CLASS net/minecraft/class_238 net/minecraft/util/math/Box
 	FIELD field_1324 maxZ D
 	FIELD field_1325 maxY D
 	METHOD <init> (DDDDDD)V
-		ARG 1 x1
-		ARG 3 y1
-		ARG 5 z1
+		ARG 1 minX
+		ARG 3 minY
+		ARG 5 minZ
+		ARG 7 maxX
+		ARG 9 maxY
+		ARG 11 maxZ
+	METHOD <init> (Lnet/minecraft/class_2338;)V
+		ARG 1 pos
 	METHOD <init> (Lnet/minecraft/class_2338;Lnet/minecraft/class_2338;)V
 		ARG 1 min
+		ARG 2 max
 	METHOD <init> (Lnet/minecraft/class_243;Lnet/minecraft/class_243;)V
 		ARG 1 min
 		ARG 2 max
@@ -32,6 +38,14 @@ CLASS net/minecraft/class_238 net/minecraft/util/math/Box
 	METHOD method_1005 getCenter ()Lnet/minecraft/class_243;
 	METHOD method_1006 contains (Lnet/minecraft/class_243;)Z
 		ARG 1 vec
+	METHOD method_1007 traceCollissionSide (Lnet/minecraft/class_238;Lnet/minecraft/class_243;[DLnet/minecraft/class_2350;DDD)Lnet/minecraft/class_2350;
+		ARG 0 box
+		ARG 1 approachVector
+		ARG 2 traceDistanceResult
+		ARG 3 approachDirection
+		ARG 4 xDelta
+		ARG 6 yDelta
+		ARG 8 zDelta
 	METHOD method_1008 contains (DDD)Z
 		ARG 1 x
 		ARG 3 y
@@ -58,7 +72,9 @@ CLASS net/minecraft/class_238 net/minecraft/util/math/Box
 	METHOD method_17940 getYSize ()D
 	METHOD method_17941 getZSize ()D
 	METHOD method_18804 stretch (Lnet/minecraft/class_243;)Lnet/minecraft/class_238;
+		ARG 1 scale
 	METHOD method_19316 from (Lnet/minecraft/class_3341;)Lnet/minecraft/class_238;
+		ARG 0 mutable
 	METHOD method_989 offset (DDD)Lnet/minecraft/class_238;
 		ARG 1 x
 		ARG 3 y
@@ -66,8 +82,13 @@ CLASS net/minecraft/class_238 net/minecraft/util/math/Box
 	METHOD method_990 getMax (Lnet/minecraft/class_2350$class_2351;)D
 		ARG 1 axis
 	METHOD method_991 union (Lnet/minecraft/class_238;)Lnet/minecraft/class_238;
+		ARG 1 box
 	METHOD method_992 rayTrace (Lnet/minecraft/class_243;Lnet/minecraft/class_243;)Ljava/util/Optional;
+		ARG 1 min
+		ARG 2 max
 	METHOD method_993 intersects (Lnet/minecraft/class_243;Lnet/minecraft/class_243;)Z
+		ARG 1 from
+		ARG 2 to
 	METHOD method_994 intersects (Lnet/minecraft/class_238;)Z
 		ARG 1 box
 	METHOD method_995 averageDimension ()D
@@ -75,6 +96,20 @@ CLASS net/minecraft/class_238 net/minecraft/util/math/Box
 		ARG 1 blockPos
 	METHOD method_997 offset (Lnet/minecraft/class_243;)Lnet/minecraft/class_238;
 		ARG 1 vec3d
-	METHOD method_998 ([DLnet/minecraft/class_2350;DDDDDDDDLnet/minecraft/class_2350;DDD)Lnet/minecraft/class_2350;
-		ARG 18 maxZ
+	METHOD method_998 traceCollissionSide ([DLnet/minecraft/class_2350;DDDDDDDDLnet/minecraft/class_2350;DDD)Lnet/minecraft/class_2350;
+		ARG 0 traceDistanceResult
+		ARG 1 approachDirection
+		ARG 2 xDelta
+		ARG 4 yDelta
+		ARG 6 zDelta
+		ARG 8 begin
+		ARG 10 minX
+		ARG 12 maxX
+		ARG 14 minZ
+		ARG 16 maxZ
+		ARG 18 resultDirection
+		ARG 19 startX
+		ARG 21 startY
+		ARG 23 startZ
 	METHOD method_999 intersection (Lnet/minecraft/class_238;)Lnet/minecraft/class_238;
+		ARG 1 box

--- a/mappings/net/minecraft/util/math/Box.mapping
+++ b/mappings/net/minecraft/util/math/Box.mapping
@@ -6,20 +6,20 @@ CLASS net/minecraft/class_238 net/minecraft/util/math/Box
 	FIELD field_1324 maxZ D
 	FIELD field_1325 maxY D
 	METHOD <init> (DDDDDD)V
-		ARG 1 minX
-		ARG 3 minY
-		ARG 5 minZ
-		ARG 7 maxX
-		ARG 9 maxY
-		ARG 11 maxZ
+		ARG 1 x1
+		ARG 3 y1
+		ARG 5 z1
+		ARG 7 x2
+		ARG 9 y2
+		ARG 11 z2
 	METHOD <init> (Lnet/minecraft/class_2338;)V
 		ARG 1 pos
 	METHOD <init> (Lnet/minecraft/class_2338;Lnet/minecraft/class_2338;)V
-		ARG 1 min
-		ARG 2 max
+		ARG 1 pos1
+		ARG 2 pos2
 	METHOD <init> (Lnet/minecraft/class_243;Lnet/minecraft/class_243;)V
-		ARG 1 min
-		ARG 2 max
+		ARG 1 pos1
+		ARG 2 pos2
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o
 	METHOD method_1001 getMin (Lnet/minecraft/class_2350$class_2351;)D

--- a/mappings/net/minecraft/util/math/Box.mapping
+++ b/mappings/net/minecraft/util/math/Box.mapping
@@ -38,7 +38,7 @@ CLASS net/minecraft/class_238 net/minecraft/util/math/Box
 	METHOD method_1005 getCenter ()Lnet/minecraft/class_243;
 	METHOD method_1006 contains (Lnet/minecraft/class_243;)Z
 		ARG 1 vec
-	METHOD method_1007 traceCollissionSide (Lnet/minecraft/class_238;Lnet/minecraft/class_243;[DLnet/minecraft/class_2350;DDD)Lnet/minecraft/class_2350;
+	METHOD method_1007 traceCollisionSide (Lnet/minecraft/class_238;Lnet/minecraft/class_243;[DLnet/minecraft/class_2350;DDD)Lnet/minecraft/class_2350;
 		ARG 0 box
 		ARG 1 approachVector
 		ARG 2 traceDistanceResult
@@ -96,7 +96,7 @@ CLASS net/minecraft/class_238 net/minecraft/util/math/Box
 		ARG 1 blockPos
 	METHOD method_997 offset (Lnet/minecraft/class_243;)Lnet/minecraft/class_238;
 		ARG 1 vec3d
-	METHOD method_998 traceCollissionSide ([DLnet/minecraft/class_2350;DDDDDDDDLnet/minecraft/class_2350;DDD)Lnet/minecraft/class_2350;
+	METHOD method_998 traceCollisionSide ([DLnet/minecraft/class_2350;DDDDDDDDLnet/minecraft/class_2350;DDD)Lnet/minecraft/class_2350;
 		ARG 0 traceDistanceResult
 		ARG 1 approachDirection
 		ARG 2 xDelta

--- a/mappings/net/minecraft/util/math/Box.mapping
+++ b/mappings/net/minecraft/util/math/Box.mapping
@@ -40,7 +40,7 @@ CLASS net/minecraft/class_238 net/minecraft/util/math/Box
 		ARG 1 vec
 	METHOD method_1007 traceCollisionSide (Lnet/minecraft/class_238;Lnet/minecraft/class_243;[DLnet/minecraft/class_2350;DDD)Lnet/minecraft/class_2350;
 		ARG 0 box
-		ARG 1 approachVector
+		ARG 1 intersectingVector
 		ARG 2 traceDistanceResult
 		ARG 3 approachDirection
 		ARG 4 xDelta

--- a/mappings/net/minecraft/util/math/Box.mapping
+++ b/mappings/net/minecraft/util/math/Box.mapping
@@ -68,9 +68,9 @@ CLASS net/minecraft/class_238 net/minecraft/util/math/Box
 	METHOD method_1013 isValid ()Z
 	METHOD method_1014 expand (D)Lnet/minecraft/class_238;
 		ARG 1 value
-	METHOD method_17939 getXSize ()D
-	METHOD method_17940 getYSize ()D
-	METHOD method_17941 getZSize ()D
+	METHOD method_17939 getXLength ()D
+	METHOD method_17940 getYLength ()D
+	METHOD method_17941 getZLength ()D
 	METHOD method_18804 stretch (Lnet/minecraft/class_243;)Lnet/minecraft/class_238;
 		ARG 1 scale
 	METHOD method_19316 from (Lnet/minecraft/class_3341;)Lnet/minecraft/class_238;
@@ -91,7 +91,7 @@ CLASS net/minecraft/class_238 net/minecraft/util/math/Box
 		ARG 2 to
 	METHOD method_994 intersects (Lnet/minecraft/class_238;)Z
 		ARG 1 box
-	METHOD method_995 averageDimension ()D
+	METHOD method_995 getAverageSideLength ()D
 	METHOD method_996 offset (Lnet/minecraft/class_2338;)Lnet/minecraft/class_238;
 		ARG 1 blockPos
 	METHOD method_997 offset (Lnet/minecraft/class_243;)Lnet/minecraft/class_238;

--- a/mappings/net/minecraft/util/math/MutableBox.mapping
+++ b/mappings/net/minecraft/util/math/MutableBox.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3341 net/minecraft/util/math/MutableIntBoundingBox
+CLASS net/minecraft/class_3341 net/minecraft/util/math/MutableBox
 	FIELD field_14376 maxZ I
 	FIELD field_14377 maxY I
 	FIELD field_14378 maxX I
@@ -28,23 +28,23 @@ CLASS net/minecraft/class_3341 net/minecraft/util/math/MutableIntBoundingBox
 		ARG 1 other
 	METHOD method_14658 toNbt ()Lnet/minecraft/class_2495;
 	METHOD method_14659 getSize ()Lnet/minecraft/class_2382;
-	METHOD method_14660 getBlockCountX ()I
-	METHOD method_14661 translate (III)V
+	METHOD method_14660 getXSize ()I
+	METHOD method_14661 offset (III)V
 		ARG 1 dx
 		ARG 2 dy
 		ARG 3 dz
 	METHOD method_14662 contains (Lnet/minecraft/class_2382;)Z
 		ARG 1 vec
-	METHOD method_14663 getBlockCountY ()I
-	METHOD method_14664 getBlockCountZ ()I
+	METHOD method_14663 getYSize ()I
+	METHOD method_14664 getZSize ()I
 	METHOD method_14665 empty ()Lnet/minecraft/class_3341;
 	METHOD method_14666 create (IIIIII)Lnet/minecraft/class_3341;
-		ARG 0 x1
-		ARG 1 y1
-		ARG 2 z1
-		ARG 3 x2
-		ARG 4 y2
-		ARG 5 z2
+		ARG 0 minX
+		ARG 1 minY
+		ARG 2 minZ
+		ARG 3 maxX
+		ARG 4 maxY
+		ARG 5 maxZ
 	METHOD method_14667 createRotated (IIIIIIIIILnet/minecraft/class_2350;)Lnet/minecraft/class_3341;
 		ARG 0 x
 		ARG 1 y
@@ -57,3 +57,8 @@ CLASS net/minecraft/class_3341 net/minecraft/util/math/MutableIntBoundingBox
 		ARG 2 minZ
 		ARG 3 maxX
 		ARG 4 maxZ
+	METHOD method_19311 translated (III)Lnet/minecraft/class_3341;
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+	METHOD method_19635 getCenter ()Lnet/minecraft/class_2382;

--- a/mappings/net/minecraft/util/math/MutableBox.mapping
+++ b/mappings/net/minecraft/util/math/MutableBox.mapping
@@ -28,15 +28,15 @@ CLASS net/minecraft/class_3341 net/minecraft/util/math/MutableBox
 		ARG 1 other
 	METHOD method_14658 toNbt ()Lnet/minecraft/class_2495;
 	METHOD method_14659 getDimensions ()Lnet/minecraft/class_2382;
-	METHOD method_14660 getXSize ()I
+	METHOD method_14660 getXLength ()I
 	METHOD method_14661 offset (III)V
 		ARG 1 dx
 		ARG 2 dy
 		ARG 3 dz
 	METHOD method_14662 contains (Lnet/minecraft/class_2382;)Z
 		ARG 1 vec
-	METHOD method_14663 getYSize ()I
-	METHOD method_14664 getZSize ()I
+	METHOD method_14663 getYLength ()I
+	METHOD method_14664 getZLength ()I
 	METHOD method_14665 empty ()Lnet/minecraft/class_3341;
 	METHOD method_14666 create (IIIIII)Lnet/minecraft/class_3341;
 		ARG 0 minX

--- a/mappings/net/minecraft/util/math/MutableBox.mapping
+++ b/mappings/net/minecraft/util/math/MutableBox.mapping
@@ -27,7 +27,7 @@ CLASS net/minecraft/class_3341 net/minecraft/util/math/MutableBox
 	METHOD method_14657 intersects (Lnet/minecraft/class_3341;)Z
 		ARG 1 other
 	METHOD method_14658 toNbt ()Lnet/minecraft/class_2495;
-	METHOD method_14659 getSize ()Lnet/minecraft/class_2382;
+	METHOD method_14659 getDimensions ()Lnet/minecraft/class_2382;
 	METHOD method_14660 getXSize ()I
 	METHOD method_14661 offset (III)V
 		ARG 1 dx

--- a/mappings/net/minecraft/util/math/MutableBox.mapping
+++ b/mappings/net/minecraft/util/math/MutableBox.mapping
@@ -45,10 +45,16 @@ CLASS net/minecraft/class_3341 net/minecraft/util/math/MutableBox
 		ARG 3 maxX
 		ARG 4 maxY
 		ARG 5 maxZ
-	METHOD method_14667 createRotated (IIIIIIIIILnet/minecraft/class_2350;)Lnet/minecraft/class_3341;
+	METHOD method_14667 rotated (IIIIIIIIILnet/minecraft/class_2350;)Lnet/minecraft/class_3341;
 		ARG 0 x
 		ARG 1 y
 		ARG 2 z
+		ARG 3 offsetX
+		ARG 4 offsetY
+		ARG 5 offsetZ
+		ARG 6 sizeX
+		ARG 7 sizeY
+		ARG 8 sizeZ
 		ARG 9 facing
 	METHOD method_14668 setFrom (Lnet/minecraft/class_3341;)V
 		ARG 1 source


### PR DESCRIPTION
Last PR for today!

I renamed `MutableIntBoundingBox` to `MutableBox` as per #785. I also standardised the naming between the two clases.

`x0, y0, z0, x1, y1, z1` -> `minX, minY, minZ, maxX, maxY, maxZ`

I also kept the names `getXSize`, `getYSize`, and `getZSize` for now, though I want to know what people would think of me changing them to `getWidth`, `getHeight`, and `getDepth` instead.
