### PR TITLE
LivingEntity mappings

### DIFF
--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -223,7 +223,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	METHOD method_3296 loadEntityOutlineShader ()V
 	METHOD method_8562 playSong (Lnet/minecraft/class_3414;Lnet/minecraft/class_2338;)V
 		ARG 1 song
-		ARG 2 pos
+		ARG 2 songPosition
 	METHOD method_8563 addParticle (Lnet/minecraft/class_2394;ZZDDDDDD)V
 		ARG 1 parameters
 		ARG 2 shouldAlwaysSpawn

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -256,7 +256,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_5670 baseTick ()V
 	METHOD method_5671 getCommandSource ()Lnet/minecraft/class_2168;
 	METHOD method_5672 getHighSpeedSplashSound ()Lnet/minecraft/class_3414;
-	METHOD method_5673 setEquippedStack (Lnet/minecraft/class_1304;Lnet/minecraft/class_1799;)V
+	METHOD method_5673 equipStack (Lnet/minecraft/class_1304;Lnet/minecraft/class_1799;)V
 		ARG 1 slot
 		ARG 2 stack
 	METHOD method_5674 onTrackedDataSet (Lnet/minecraft/class_2940;)V

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -301,7 +301,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		ARG 1 drag
 	METHOD method_5701 isSilent ()Z
 	METHOD method_5702 lookAt (Lnet/minecraft/class_2183$class_2184;Lnet/minecraft/class_243;)V
-		ARG 1 anchor
+		ARG 1 anchorPoint
 		ARG 2 target
 	METHOD method_5703 hasPassengerType (Ljava/lang/Class;)Z
 		ARG 1 clazz

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -170,8 +170,8 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_5623 fall (DZLnet/minecraft/class_2680;Lnet/minecraft/class_2338;)V
 		ARG 1 heightDifference
 		ARG 3 onGround
-		ARG 4 blockState
-		ARG 5 blockPos
+		ARG 4 landedState
+		ARG 5 landedPosition
 	METHOD method_5624 isSprinting ()Z
 	METHOD method_5625 getSplashSound ()Lnet/minecraft/class_3414;
 	METHOD method_5626 hasPassenger (Lnet/minecraft/class_1297;)Z

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -39,6 +39,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6250 forwardSpeed F
 	FIELD field_6251 handSwingProgress F
 	FIELD field_6252 isHandSwinging Z
+	FIELD field_6253 lastDamageTaken F
 	FIELD field_6254 maxHurtTime I
 	FIELD field_6255 lookDirection F
 	FIELD field_6256 damageTracker Lnet/minecraft/class_1283;

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -182,7 +182,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6048 getItemUseTime ()I
 	METHOD method_6049 isPotionEffective (Lnet/minecraft/class_1293;)Z
 		ARG 1 effect
-	METHOD method_6050 spawnPotionParticles ()V
+	METHOD method_6050 tickStatusEffects ()V
 	METHOD method_6051 getRand ()Ljava/util/Random;
 	METHOD method_6052 getAttacking ()Lnet/minecraft/class_1309;
 	METHOD method_6053 initAi ()V

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -173,6 +173,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6037 spawnItemParticles (Lnet/minecraft/class_1799;I)V
 		ARG 1 item
 		ARG 2 count
+	METHOD method_6038 onDismounted (Lnet/minecraft/class_1297;)V
 	METHOD method_6039 isBlocking ()Z
 	METHOD method_6040 consumeItem ()V
 	METHOD method_6041 getFallSound (I)Lnet/minecraft/class_3414;

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -85,7 +85,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_16079 getLootContextBuilder (ZLnet/minecraft/class_1282;)Lnet/minecraft/class_47$class_48;
 		ARG 1 killedByPlayer
 	METHOD method_16080 drop (Lnet/minecraft/class_1282;)V
-	METHOD method_16212 getBlockStateUnderFeet ()Lnet/minecraft/class_2680;
+	METHOD method_16212 getBlockState ()Lnet/minecraft/class_2680;
 	METHOD method_16826 setDespawnCounter (I)V
 		ARG 1 despawnCounter
 	METHOD method_17825 getScaleFactor ()F

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -220,7 +220,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6046 getGroup ()Lnet/minecraft/class_1310;
 	METHOD method_6047 getMainHandStack ()Lnet/minecraft/class_1799;
 	METHOD method_6048 getItemUseTime ()I
-	METHOD method_6049 isPotionEffective (Lnet/minecraft/class_1293;)Z
+	METHOD method_6049 canHaveStatusEffect (Lnet/minecraft/class_1293;)Z
 		ARG 1 effect
 	METHOD method_6050 tickStatusEffects ()V
 	METHOD method_6051 getRand ()Ljava/util/Random;

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -93,9 +93,10 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 despawnCounter
 	METHOD method_17825 getScaleFactor ()F
 	METHOD method_18390 getAttackDistanceScalingFactor (Lnet/minecraft/class_1297;)D
+		ARG 1 entity
 	METHOD method_18391 isTarget (Lnet/minecraft/class_1309;Lnet/minecraft/class_4051;)Z
-		ARG 1 target
-		ARG 2 targetPredicate
+		ARG 1 entity
+		ARG 2 predicate
 	METHOD method_18392 setPositionInBed (Lnet/minecraft/class_2338;)V
 		ARG 1 pos
 	METHOD method_18394 getActiveEyeHeight (Lnet/minecraft/class_4050;Lnet/minecraft/class_4048;)F
@@ -130,6 +131,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 world
 		ARG 2 stack
 	METHOD method_18867 deserializeBrain (Lcom/mojang/datafixers/Dynamic;)Lnet/minecraft/class_4095;
+		ARG 1 memory
 	METHOD method_18868 getBrain ()Lnet/minecraft/class_4095;
 	METHOD method_18869 getEatSound (Lnet/minecraft/class_1799;)Lnet/minecraft/class_3414;
 		ARG 1 stack
@@ -185,6 +187,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6022 getStuckArrows ()I
 	METHOD method_6023 tickNewAi ()V
 	METHOD method_6024 getLeaningPitch (F)F
+		ARG 1 tickDelta
 	METHOD method_6025 heal (F)V
 		ARG 1 amount
 	METHOD method_6026 getStatusEffects ()Ljava/util/Collection;
@@ -235,6 +238,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 entity
 	METHOD method_6058 getActiveHand ()Lnet/minecraft/class_1268;
 	METHOD method_6059 hasStatusEffect (Lnet/minecraft/class_1291;)Z
+		ARG 1 effect
 	METHOD method_6060 knockback (Lnet/minecraft/class_1309;)V
 		ARG 1 target
 	METHOD method_6061 tryUseShield (Lnet/minecraft/class_1282;)Z
@@ -321,8 +325,10 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6111 removeStatusEffect (Lnet/minecraft/class_1291;)Lnet/minecraft/class_1293;
 		ARG 1 effect
 	METHOD method_6112 getStatusEffect (Lnet/minecraft/class_1291;)Lnet/minecraft/class_1293;
+		ARG 1 effect
 	METHOD method_6113 isSleeping ()Z
 	METHOD method_6114 onAttacking (Lnet/minecraft/class_1297;)V
+		ARG 1 target
 	METHOD method_6115 isUsingItem ()Z
 	METHOD method_6116 onEquipStack (Lnet/minecraft/class_1799;)V
 		ARG 1 stack

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -202,6 +202,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6069 clearPotionSwirls ()V
 	METHOD method_6070 tickPushing ()V
 	METHOD method_6071 shouldAlwaysDropXp ()Z
+	METHOD method_6072 updateLeaningPitch ()V
 	METHOD method_6073 setAbsorptionAmount (F)V
 		ARG 1 amount
 	METHOD method_6074 applyDamage (Lnet/minecraft/class_1282;F)V

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -117,7 +117,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 fluid
 	METHOD method_6011 getHurtSound (Lnet/minecraft/class_1282;)Lnet/minecraft/class_3414;
 		ARG 1 source
-	METHOD method_6012 clearPotionEffects ()Z
+	METHOD method_6012 clearStatusEffects ()Z
 	METHOD method_6013 playHurtSound (Lnet/minecraft/class_1282;)V
 		ARG 1 damageSource
 	METHOD method_6014 getItemUseTimeLeft ()I

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -164,6 +164,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 item
 		ARG 2 count
 	METHOD method_6039 isBlocking ()Z
+	METHOD method_6040 consumeItem ()V
 	METHOD method_6041 getFallSound (I)Lnet/minecraft/class_3414;
 		ARG 1 fallDistance
 	METHOD method_6043 jump ()V

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -210,6 +210,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 2 damage
 	METHOD method_6075 stopUsingItem ()V
 	METHOD method_6076 tickActiveItemStack ()V
+	METHOD method_6077 canEnterTrapdoor (Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)Z
 	METHOD method_6078 onDeath (Lnet/minecraft/class_1282;)V
 		ARG 1 damageSource
 	METHOD method_6079 getOffHandStack ()Lnet/minecraft/class_1799;

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -7,6 +7,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6212 sidewaysSpeed F
 	FIELD field_6213 deathTime I
 	FIELD field_6214 POTION_SWIRLS_AMBIENT Lnet/minecraft/class_2940;
+	FIELD field_6217 prevStepBobbingAmount F
 	FIELD field_6218 stuckArrowTimer I
 	FIELD field_6219 STUCK_ARROWS Lnet/minecraft/class_2940;
 	FIELD field_6220 prevBodyYaw F
@@ -21,6 +22,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6230 lastAttackedTime I
 	FIELD field_6231 ATTR_SPRINTING_SPEED_BOOST Lnet/minecraft/class_1322;
 	FIELD field_6232 scoreAmount I
+	FIELD field_6233 stepBobbingAmount F
 	FIELD field_6234 equippedHand Lnet/minecraft/class_2371;
 	FIELD field_6235 hurtTime I
 	FIELD field_6236 attacking Lnet/minecraft/class_1309;

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -229,6 +229,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 movementInput
 	METHOD method_6092 addStatusEffect (Lnet/minecraft/class_1293;)Z
 		ARG 1 effect
+	METHOD method_6093 knockDownwards ()V
 	METHOD method_6094 canBreatheInWater ()Z
 	METHOD method_6096 getArmor ()I
 	METHOD method_6097 setStuckArrows (I)V

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -174,7 +174,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6014 getItemUseTimeLeft ()I
 	METHOD method_6015 setAttacker (Lnet/minecraft/class_1309;)V
 		ARG 1 attacker
-	METHOD method_6016 removeStatusEffect (Lnet/minecraft/class_1291;)Z
+	METHOD method_6016 tryRemoveStatusEffect (Lnet/minecraft/class_1291;)Z
 		ARG 1 effect
 	METHOD method_6017 getSoundPitch ()F
 	METHOD method_6019 setCurrentHand (Lnet/minecraft/class_1268;)V
@@ -318,7 +318,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6109 isBaby ()Z
 	METHOD method_6110 getCurrentExperience (Lnet/minecraft/class_1657;)I
 		ARG 1 player
-	METHOD method_6111 removePotionEffect (Lnet/minecraft/class_1291;)Lnet/minecraft/class_1293;
+	METHOD method_6111 removeStatusEffect (Lnet/minecraft/class_1291;)Lnet/minecraft/class_1293;
 		ARG 1 effect
 	METHOD method_6112 getStatusEffect (Lnet/minecraft/class_1291;)Lnet/minecraft/class_1293;
 	METHOD method_6113 isSleeping ()Z

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -39,6 +39,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6251 handSwingProgress F
 	FIELD field_6252 isHandSwinging Z
 	FIELD field_6254 maxHurtTime I
+	FIELD field_6255 lookDirection F
 	FIELD field_6256 damageTracker Lnet/minecraft/class_1283;
 	FIELD field_6257 LIVING_FLAGS Lnet/minecraft/class_2940;
 	FIELD field_6258 attackingPlayer Lnet/minecraft/class_1657;

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -293,6 +293,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 pos
 	METHOD method_6127 getAttributes ()Lnet/minecraft/class_1325;
 	METHOD method_6128 isFallFlying ()Z
+	METHOD method_6129 onStatusEffectRemoved (Lnet/minecraft/class_1293;)V
 	METHOD method_6130 getNextBreathInWater (I)I
 		ARG 1 breath
 	METHOD method_6131 getDespawnCounter ()I

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -46,6 +46,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6266 preferredHand Lnet/minecraft/class_1268;
 	FIELD field_6268 lastBlockPos Lnet/minecraft/class_2338;
 	FIELD field_6270 lastAttackTime I
+	FIELD field_6271 knockbackVelocity F
 	FIELD field_6272 dead Z
 	FIELD field_6273 lastAttackedTicks I
 	FIELD field_6274 attacker Lnet/minecraft/class_1309;

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -54,11 +54,13 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6266 preferredHand Lnet/minecraft/class_1268;
 	FIELD field_6267 diagonalSpeed F
 	FIELD field_6268 lastBlockPos Lnet/minecraft/class_2338;
+	FIELD field_6269 field_6269 I
 	FIELD field_6270 lastAttackTime I
 	FIELD field_6271 knockbackVelocity F
 	FIELD field_6272 dead Z
 	FIELD field_6273 lastAttackedTicks I
 	FIELD field_6274 attacker Lnet/minecraft/class_1309;
+	FIELD field_6275 prevLookDirection F
 	FIELD field_6276 lastDamageSource Lnet/minecraft/class_1282;
 	FIELD field_6277 activeItemStack Lnet/minecraft/class_1799;
 	FIELD field_6278 despawnCounter I

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -61,6 +61,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6281 flyingSpeed F
 	FIELD field_6282 jumping Z
 	FIELD field_6284 serverYaw D
+	FIELD field_6285 effectsChanged Z
 	FIELD field_6287 movementSpeed F
 	METHOD <init> (Lnet/minecraft/class_1299;Lnet/minecraft/class_1937;)V
 		ARG 1 type

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -54,6 +54,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6278 despawnCounter I
 	FIELD field_6279 handSwingTicks I
 	FIELD field_6280 activeStatusEffects Ljava/util/Map;
+	FIELD field_6281 flyingSpeed F
 	FIELD field_6282 jumping Z
 	FIELD field_6284 serverYaw D
 	FIELD field_6287 movementSpeed F
@@ -90,6 +91,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_18403 sleep (Lnet/minecraft/class_2338;)V
 		ARG 1 pos
 	METHOD method_18406 isSleepingInBed ()Z
+	METHOD method_18802 getMovementSpeed (F)F
 	METHOD method_18807 getDrinkSound (Lnet/minecraft/class_1799;)Lnet/minecraft/class_3414;
 		ARG 1 stack
 	METHOD method_18808 getArrowType (Lnet/minecraft/class_1799;)Lnet/minecraft/class_1799;

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -81,6 +81,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 2 dimensions
 	METHOD method_18395 canTarget (Lnet/minecraft/class_1309;)Z
 		ARG 1 target
+	METHOD method_18396 getArmorVisibility ()F
 	METHOD method_18397 canPickUp (Lnet/minecraft/class_1799;)Z
 		ARG 1 stack
 	METHOD method_18398 getSleepingPosition ()Ljava/util/Optional;

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -56,7 +56,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6264 lastLeaningPitch F
 	FIELD field_6265 headTrackingIncrements I
 	FIELD field_6266 preferredHand Lnet/minecraft/class_1268;
-	FIELD field_6267 diagonalSpeed F
+	FIELD field_6267 turningSpeed F
 	FIELD field_6268 lastBlockPos Lnet/minecraft/class_2338;
 	FIELD field_6269 defaultMaximumHealth I
 	FIELD field_6270 lastAttackTime I

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -23,6 +23,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6236 attacking Lnet/minecraft/class_1309;
 	FIELD field_6237 ATTR_SPRINTING_SPEED_BOOST_ID Ljava/util/UUID;
 	FIELD field_6238 playerHitTimer I
+	FIELD field_6239 roll I
 	FIELD field_6240 POTION_SWIRLS_COLOR Lnet/minecraft/class_2940;
 	FIELD field_6241 headYaw F
 	FIELD field_6242 serverHeadYaw D
@@ -119,6 +120,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_5999 isUndead ()Z
 	METHOD method_6001 initAttributes ()V
 	METHOD method_6002 getDeathSound ()Lnet/minecraft/class_3414;
+	METHOD method_6003 getRoll ()I
 	METHOD method_6005 takeKnockback (Lnet/minecraft/class_1297;FDD)V
 		ARG 1 source
 		ARG 2 scale

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -239,6 +239,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 effect
 	METHOD method_6093 knockDownwards ()V
 	METHOD method_6094 canBreatheInWater ()Z
+	METHOD method_6095 absorbDamage (Lnet/minecraft/class_1282;)Z
 	METHOD method_6096 getArmor ()I
 	METHOD method_6097 setStuckArrows (I)V
 	METHOD method_6098 spawnConsumptionEffects (Lnet/minecraft/class_1799;I)V

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -241,7 +241,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 effect
 	METHOD method_6060 knockback (Lnet/minecraft/class_1309;)V
 		ARG 1 target
-	METHOD method_6061 tryUseShield (Lnet/minecraft/class_1282;)Z
+	METHOD method_6061 blockedByShield (Lnet/minecraft/class_1282;)Z
 		ARG 1 source
 	METHOD method_6062 isImmobile ()Z
 	METHOD method_6063 getMaximumHealth ()F

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -49,6 +49,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6264 lastLeaningPitch F
 	FIELD field_6265 headTrackingIncrements I
 	FIELD field_6266 preferredHand Lnet/minecraft/class_1268;
+	FIELD field_6267 diagonalSpeed F
 	FIELD field_6268 lastBlockPos Lnet/minecraft/class_2338;
 	FIELD field_6270 lastAttackTime I
 	FIELD field_6271 knockbackVelocity F

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -211,7 +211,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 source
 	METHOD method_6091 travel (Lnet/minecraft/class_243;)V
 		ARG 1 movementInput
-	METHOD method_6092 addPotionEffect (Lnet/minecraft/class_1293;)Z
+	METHOD method_6092 addStatusEffect (Lnet/minecraft/class_1293;)Z
 		ARG 1 effect
 	METHOD method_6094 canBreatheInWater ()Z
 	METHOD method_6096 getArmor ()I

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -67,6 +67,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_16079 getLootContextBuilder (ZLnet/minecraft/class_1282;)Lnet/minecraft/class_47$class_48;
 		ARG 1 killedByPlayer
 	METHOD method_16080 drop (Lnet/minecraft/class_1282;)V
+	METHOD method_16212 getBlockStateUnderFeet ()Lnet/minecraft/class_2680;
 	METHOD method_16826 setDespawnCounter (I)V
 		ARG 1 despawnCounter
 	METHOD method_17825 getScaleFactor ()F

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -2,13 +2,16 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_18072 SLEEPING_DIMENSIONS Lnet/minecraft/class_4048;
 	FIELD field_18073 SLEEPING_POSITION Lnet/minecraft/class_2940;
 	FIELD field_18321 brain Lnet/minecraft/class_4095;
+	FIELD field_6210 bodyTrackingIncrements I
 	FIELD field_6211 lastLimbDistance F
 	FIELD field_6212 sidewaysSpeed F
 	FIELD field_6213 deathTime I
 	FIELD field_6214 POTION_SWIRLS_AMBIENT Lnet/minecraft/class_2940;
 	FIELD field_6218 stuckArrowTimer I
 	FIELD field_6219 STUCK_ARROWS Lnet/minecraft/class_2940;
+	FIELD field_6221 serverPitch D
 	FIELD field_6222 itemUseTimeLeft I
+	FIELD field_6224 serverX D
 	FIELD field_6225 limbDistance F
 	FIELD field_6226 lastDamageTime J
 	FIELD field_6227 upwardSpeed F
@@ -22,7 +25,9 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6238 playerHitTimer I
 	FIELD field_6240 POTION_SWIRLS_COLOR Lnet/minecraft/class_2940;
 	FIELD field_6241 headYaw F
+	FIELD field_6242 serverHeadYaw D
 	FIELD field_6243 leaningPitch F
+	FIELD field_6245 serverY D
 	FIELD field_6246 absorptionAmount F
 	FIELD field_6247 HEALTH Lnet/minecraft/class_2940;
 	FIELD field_6248 equippedArmor Lnet/minecraft/class_2371;
@@ -35,7 +40,9 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6258 attackingPlayer Lnet/minecraft/class_1657;
 	FIELD field_6259 prevHeadYaw F
 	FIELD field_6260 attributeContainer Lnet/minecraft/class_1325;
+	FIELD field_6263 serverZ D
 	FIELD field_6264 lastLeaningPitch F
+	FIELD field_6265 headTrackingIncrements I
 	FIELD field_6266 preferredHand Lnet/minecraft/class_1268;
 	FIELD field_6268 lastBlockPos Lnet/minecraft/class_2338;
 	FIELD field_6270 lastAttackTime I
@@ -48,6 +55,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6279 handSwingTicks I
 	FIELD field_6280 activeStatusEffects Ljava/util/Map;
 	FIELD field_6282 jumping Z
+	FIELD field_6284 serverYaw D
 	FIELD field_6287 movementSpeed F
 	METHOD <init> (Lnet/minecraft/class_1299;Lnet/minecraft/class_1937;)V
 		ARG 1 type

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -9,6 +9,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6214 POTION_SWIRLS_AMBIENT Lnet/minecraft/class_2940;
 	FIELD field_6218 stuckArrowTimer I
 	FIELD field_6219 STUCK_ARROWS Lnet/minecraft/class_2940;
+	FIELD field_6220 prevBodyYaw F
 	FIELD field_6221 serverPitch D
 	FIELD field_6222 itemUseTimeLeft I
 	FIELD field_6224 serverX D
@@ -60,6 +61,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6280 activeStatusEffects Ljava/util/Map;
 	FIELD field_6281 flyingSpeed F
 	FIELD field_6282 jumping Z
+	FIELD field_6283 bodyYaw F
 	FIELD field_6284 serverYaw D
 	FIELD field_6285 effectsChanged Z
 	FIELD field_6287 movementSpeed F
@@ -159,7 +161,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6028 getHandSwingDuration ()I
 	METHOD method_6029 getMovementSpeed ()F
 	METHOD method_6030 getActiveItem ()Lnet/minecraft/class_1799;
-	METHOD method_6031 (FF)F
+	METHOD method_6031 turnHead (FF)F
 		ARG 1 yaw
 	METHOD method_6032 getHealth ()F
 	METHOD method_6033 setHealth (F)V

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -255,6 +255,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6122 setStackInHand (Lnet/minecraft/class_1268;Lnet/minecraft/class_1799;)V
 		ARG 1 hand
 	METHOD method_6123 isUsingRiptide ()Z
+	METHOD method_6124 getPrimeAdversary ()Lnet/minecraft/class_1309;
 	METHOD method_6125 setMovementSpeed (F)V
 		ARG 1 movementSpeed
 	METHOD method_6126 applyFrostWalker (Lnet/minecraft/class_2338;)V

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -78,13 +78,16 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6287 movementSpeed F
 	METHOD <init> (Lnet/minecraft/class_1299;Lnet/minecraft/class_1937;)V
 		ARG 1 type
+		ARG 2 world
 	METHOD method_16077 dropLoot (Lnet/minecraft/class_1282;Z)V
 		ARG 1 source
-		ARG 2 killedByPlayer
+		ARG 2 causedByPlayer
 	METHOD method_16078 dropInventory ()V
 	METHOD method_16079 getLootContextBuilder (ZLnet/minecraft/class_1282;)Lnet/minecraft/class_47$class_48;
-		ARG 1 killedByPlayer
+		ARG 1 causedByPlayer
+		ARG 2 source
 	METHOD method_16080 drop (Lnet/minecraft/class_1282;)V
+		ARG 1 source
 	METHOD method_16212 getBlockState ()Lnet/minecraft/class_2680;
 	METHOD method_16826 setDespawnCounter (I)V
 		ARG 1 despawnCounter
@@ -108,16 +111,24 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_18400 wakeUp ()V
 	METHOD method_18401 getSleepingDirection ()Lnet/minecraft/class_2350;
 	METHOD method_18402 setSleepingPosition (Lnet/minecraft/class_2338;)V
+		ARG 1 pos
 	METHOD method_18403 sleep (Lnet/minecraft/class_2338;)V
 		ARG 1 pos
 	METHOD method_18406 isSleepingInBed ()Z
 	METHOD method_18801 applyClimbingSpeed (Lnet/minecraft/class_243;)Lnet/minecraft/class_243;
+		ARG 1 motion
 	METHOD method_18802 getMovementSpeed (F)F
+		ARG 1 slipperiness
 	METHOD method_18807 getDrinkSound (Lnet/minecraft/class_1799;)Lnet/minecraft/class_3414;
 		ARG 1 stack
 	METHOD method_18808 getArrowType (Lnet/minecraft/class_1799;)Lnet/minecraft/class_1799;
 	METHOD method_18865 applyFoodEffects (Lnet/minecraft/class_1799;Lnet/minecraft/class_1937;Lnet/minecraft/class_1309;)V
+		ARG 1 stack
+		ARG 2 world
+		ARG 3 targetEntity
 	METHOD method_18866 eatFood (Lnet/minecraft/class_1937;Lnet/minecraft/class_1799;)Lnet/minecraft/class_1799;
+		ARG 1 world
+		ARG 2 stack
 	METHOD method_18867 deserializeBrain (Lcom/mojang/datafixers/Dynamic;)Lnet/minecraft/class_4095;
 	METHOD method_18868 getBrain ()Lnet/minecraft/class_4095;
 	METHOD method_18869 getEatSound (Lnet/minecraft/class_1799;)Lnet/minecraft/class_3414;
@@ -125,42 +136,51 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_20235 sendEquipmentBreakStatus (Lnet/minecraft/class_1304;)V
 		ARG 1 slot
 	METHOD method_20236 sendToolBreakStatus (Lnet/minecraft/class_1268;)V
+		ARG 1 hand
 	METHOD method_20237 getEquipmentBreakStatus (Lnet/minecraft/class_1304;)B
+		ARG 0 slot
 	METHOD method_5973 canTarget (Lnet/minecraft/class_1299;)Z
 		ARG 1 type
 	METHOD method_5989 getLootTable ()Lnet/minecraft/class_2960;
 	METHOD method_5996 getAttributeInstance (Lnet/minecraft/class_1320;)Lnet/minecraft/class_1324;
+		ARG 1 attribute
 	METHOD method_5997 attackLivingEntity (Lnet/minecraft/class_1309;)V
 		ARG 1 target
 	METHOD method_5998 getStackInHand (Lnet/minecraft/class_1268;)Lnet/minecraft/class_1799;
+		ARG 1 hand
 	METHOD method_5999 isUndead ()Z
 	METHOD method_6001 initAttributes ()V
 	METHOD method_6002 getDeathSound ()Lnet/minecraft/class_3414;
 	METHOD method_6003 getRoll ()I
 	METHOD method_6005 takeKnockback (Lnet/minecraft/class_1297;FDD)V
-		ARG 1 source
-		ARG 2 scale
-		ARG 3 x
-		ARG 5 z
+		ARG 1 attacker
+		ARG 2 speed
+		ARG 3 xMovement
+		ARG 5 zMovement
 	METHOD method_6006 setNearbySongPlaying (Lnet/minecraft/class_2338;Z)V
-		ARG 1 songSource
+		ARG 1 songPosition
 		ARG 2 playing
 	METHOD method_6007 tickMovement ()V
 	METHOD method_6009 onStatusEffectUpgraded (Lnet/minecraft/class_1293;Z)V
+		ARG 1 effect
+		ARG 2 reapplyEffect
 	METHOD method_6010 swimUpward (Lnet/minecraft/class_3494;)V
 		ARG 1 fluid
 	METHOD method_6011 getHurtSound (Lnet/minecraft/class_1282;)Lnet/minecraft/class_3414;
 		ARG 1 source
 	METHOD method_6012 clearStatusEffects ()Z
 	METHOD method_6013 playHurtSound (Lnet/minecraft/class_1282;)V
-		ARG 1 damageSource
+		ARG 1 source
 	METHOD method_6014 getItemUseTimeLeft ()I
 	METHOD method_6015 setAttacker (Lnet/minecraft/class_1309;)V
 		ARG 1 attacker
 	METHOD method_6016 removeStatusEffect (Lnet/minecraft/class_1291;)Z
+		ARG 1 effect
 	METHOD method_6017 getSoundPitch ()F
 	METHOD method_6019 setCurrentHand (Lnet/minecraft/class_1268;)V
+		ARG 1 hand
 	METHOD method_6020 onStatusEffectApplied (Lnet/minecraft/class_1293;)V
+		ARG 1 effect
 	METHOD method_6021 clearActiveItem ()V
 	METHOD method_6022 getStuckArrows ()I
 	METHOD method_6023 tickNewAi ()V
@@ -173,25 +193,30 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6029 getMovementSpeed ()F
 	METHOD method_6030 getActiveItem ()Lnet/minecraft/class_1799;
 	METHOD method_6031 turnHead (FF)F
-		ARG 1 yaw
+		ARG 1 bodyRotation
+		ARG 2 headRotation
 	METHOD method_6032 getHealth ()F
 	METHOD method_6033 setHealth (F)V
+		ARG 1 health
 	METHOD method_6034 canMoveVoluntarily ()Z
 	METHOD method_6035 push (Lnet/minecraft/class_238;Lnet/minecraft/class_238;)V
+		ARG 1 a
+		ARG 2 b
 	METHOD method_6036 applyEnchantmentsToDamage (Lnet/minecraft/class_1282;F)F
 		ARG 1 source
 		ARG 2 amount
 	METHOD method_6037 spawnItemParticles (Lnet/minecraft/class_1799;I)V
-		ARG 1 item
-		ARG 2 count
+		ARG 1 stack
+		ARG 2 particleCount
 	METHOD method_6038 onDismounted (Lnet/minecraft/class_1297;)V
+		ARG 1 vehicle
 	METHOD method_6039 isBlocking ()Z
 	METHOD method_6040 consumeItem ()V
 	METHOD method_6041 getFallSound (I)Lnet/minecraft/class_3414;
-		ARG 1 fallDistance
+		ARG 1 distance
 	METHOD method_6043 jump ()V
 	METHOD method_6045 playEquipmentBreakEffects (Lnet/minecraft/class_1799;)V
-		ARG 1 item
+		ARG 1 stack
 	METHOD method_6046 getGroup ()Lnet/minecraft/class_1310;
 	METHOD method_6047 getMainHandStack ()Lnet/minecraft/class_1799;
 	METHOD method_6048 getItemUseTime ()I
@@ -213,6 +238,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6060 knockback (Lnet/minecraft/class_1309;)V
 		ARG 1 target
 	METHOD method_6061 tryUseShield (Lnet/minecraft/class_1282;)Z
+		ARG 1 source
 	METHOD method_6062 isImmobile ()Z
 	METHOD method_6063 getMaximumHealth ()F
 	METHOD method_6064 getNextBreathInAir (I)I
@@ -229,12 +255,14 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 amount
 	METHOD method_6074 applyDamage (Lnet/minecraft/class_1282;F)V
 		ARG 1 source
-		ARG 2 damage
+		ARG 2 amount
 	METHOD method_6075 stopUsingItem ()V
 	METHOD method_6076 tickActiveItemStack ()V
 	METHOD method_6077 canEnterTrapdoor (Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)Z
+		ARG 1 pos
+		ARG 2 state
 	METHOD method_6078 onDeath (Lnet/minecraft/class_1282;)V
-		ARG 1 damageSource
+		ARG 1 source
 	METHOD method_6079 getOffHandStack ()Lnet/minecraft/class_1799;
 	METHOD method_6081 getRecentDamageSource ()Lnet/minecraft/class_1282;
 	METHOD method_6082 teleport (DDDZ)Z
@@ -244,16 +272,18 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 7 particleEffects
 	METHOD method_6083 getLastAttackTime ()I
 	METHOD method_6084 hasStackEquipped (Lnet/minecraft/class_1304;)Z
+		ARG 1 slot
 	METHOD method_6085 setLivingFlag (IZ)V
 		ARG 1 mask
 		ARG 2 value
 	METHOD method_6086 isAffectedBySplashPotions ()Z
 	METHOD method_6087 pushAway (Lnet/minecraft/class_1297;)V
+		ARG 1 entity
 	METHOD method_6088 getActiveStatusEffects ()Ljava/util/Map;
 	METHOD method_6089 containsOnlyAmbientEffects (Ljava/util/Collection;)Z
 		ARG 0 effects
 	METHOD method_6090 takeShieldHit (Lnet/minecraft/class_1309;)V
-		ARG 1 source
+		ARG 1 attacker
 	METHOD method_6091 travel (Lnet/minecraft/class_243;)V
 		ARG 1 movementInput
 	METHOD method_6092 addStatusEffect (Lnet/minecraft/class_1293;)Z
@@ -261,15 +291,17 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6093 knockDownwards ()V
 	METHOD method_6094 canBreatheInWater ()Z
 	METHOD method_6095 tryUseTotem (Lnet/minecraft/class_1282;)Z
+		ARG 1 source
 	METHOD method_6096 getArmor ()I
 	METHOD method_6097 setStuckArrows (I)V
+		ARG 1 stuckArrows
 	METHOD method_6098 spawnConsumptionEffects (Lnet/minecraft/class_1799;I)V
-		ARG 1 item
+		ARG 1 stack
 		ARG 2 particleCount
 	METHOD method_6099 dropEquipment (Lnet/minecraft/class_1282;IZ)V
-		ARG 1 damageSource
-		ARG 2 addedDropChance
-		ARG 3 dropAllowed
+		ARG 1 source
+		ARG 2 lootingMultiplier
+		ARG 3 allowDrops
 	METHOD method_6100 setJumping (Z)V
 		ARG 1 jumping
 	METHOD method_6101 isClimbing ()Z
@@ -277,6 +309,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 item
 		ARG 2 count
 	METHOD method_6104 swingHand (Lnet/minecraft/class_1268;)V
+		ARG 1 hand
 	METHOD method_6105 damageArmor (F)V
 		ARG 1 amount
 	METHOD method_6106 getJumpVelocity ()F
@@ -286,6 +319,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6110 getCurrentExperience (Lnet/minecraft/class_1657;)I
 		ARG 1 player
 	METHOD method_6111 removePotionEffect (Lnet/minecraft/class_1291;)Lnet/minecraft/class_1293;
+		ARG 1 effect
 	METHOD method_6112 getStatusEffect (Lnet/minecraft/class_1291;)Lnet/minecraft/class_1293;
 	METHOD method_6113 isSleeping ()Z
 	METHOD method_6114 onAttacking (Lnet/minecraft/class_1297;)V
@@ -301,6 +335,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 target
 	METHOD method_6122 setStackInHand (Lnet/minecraft/class_1268;Lnet/minecraft/class_1799;)V
 		ARG 1 hand
+		ARG 2 stack
 	METHOD method_6123 isUsingRiptide ()Z
 	METHOD method_6124 getPrimeAdversary ()Lnet/minecraft/class_1309;
 	METHOD method_6125 setMovementSpeed (F)V
@@ -310,9 +345,10 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6127 getAttributes ()Lnet/minecraft/class_1325;
 	METHOD method_6128 isFallFlying ()Z
 	METHOD method_6129 onStatusEffectRemoved (Lnet/minecraft/class_1293;)V
+		ARG 1 effect
 	METHOD method_6130 getNextBreathInWater (I)I
 		ARG 1 breath
 	METHOD method_6131 getDespawnCounter ()I
 	METHOD method_6132 applyArmorToDamage (Lnet/minecraft/class_1282;F)F
 		ARG 1 source
-		ARG 2 damage
+		ARG 2 amount

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -172,7 +172,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6060 knockback (Lnet/minecraft/class_1309;)V
 		ARG 1 target
 	METHOD method_6062 cannotMove ()Z
-	METHOD method_6063 getHealthMaximum ()F
+	METHOD method_6063 getMaximumHealth ()F
 	METHOD method_6064 getNextBreathInAir (I)I
 		ARG 1 breath
 	METHOD method_6065 getAttacker ()Lnet/minecraft/class_1309;

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -20,6 +20,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6229 lastHandSwingProgress F
 	FIELD field_6230 lastAttackedTime I
 	FIELD field_6231 ATTR_SPRINTING_SPEED_BOOST Lnet/minecraft/class_1322;
+	FIELD field_6232 scoreAmount I
 	FIELD field_6234 equippedHand Lnet/minecraft/class_2371;
 	FIELD field_6235 hurtTime I
 	FIELD field_6236 attacking Lnet/minecraft/class_1309;

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -163,6 +163,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6037 spawnItemParticles (Lnet/minecraft/class_1799;I)V
 		ARG 1 item
 		ARG 2 count
+	METHOD method_6039 isBlocking ()Z
 	METHOD method_6041 getFallSound (I)Lnet/minecraft/class_3414;
 		ARG 1 fallDistance
 	METHOD method_6043 jump ()V
@@ -188,6 +189,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6059 hasStatusEffect (Lnet/minecraft/class_1291;)Z
 	METHOD method_6060 knockback (Lnet/minecraft/class_1309;)V
 		ARG 1 target
+	METHOD method_6061 canPierceDefense (Lnet/minecraft/class_1282;)Z
 	METHOD method_6062 isImmobile ()Z
 	METHOD method_6063 getMaximumHealth ()F
 	METHOD method_6064 getNextBreathInAir (I)I

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -39,7 +39,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6257 LIVING_FLAGS Lnet/minecraft/class_2940;
 	FIELD field_6258 attackingPlayer Lnet/minecraft/class_1657;
 	FIELD field_6259 prevHeadYaw F
-	FIELD field_6260 attributeContainer Lnet/minecraft/class_1325;
+	FIELD field_6260 attributes Lnet/minecraft/class_1325;
 	FIELD field_6263 serverZ D
 	FIELD field_6264 lastLeaningPitch F
 	FIELD field_6265 headTrackingIncrements I
@@ -278,7 +278,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 movementSpeed
 	METHOD method_6126 applyFrostWalker (Lnet/minecraft/class_2338;)V
 		ARG 1 pos
-	METHOD method_6127 getAttributeContainer ()Lnet/minecraft/class_1325;
+	METHOD method_6127 getAttributes ()Lnet/minecraft/class_1325;
 	METHOD method_6128 isFallFlying ()Z
 	METHOD method_6130 getNextBreathInWater (I)I
 		ARG 1 breath

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -187,7 +187,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6059 hasStatusEffect (Lnet/minecraft/class_1291;)Z
 	METHOD method_6060 knockback (Lnet/minecraft/class_1309;)V
 		ARG 1 target
-	METHOD method_6062 cannotMove ()Z
+	METHOD method_6062 isImmobile ()Z
 	METHOD method_6063 getMaximumHealth ()F
 	METHOD method_6064 getNextBreathInAir (I)I
 		ARG 1 breath

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -208,6 +208,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 source
 		ARG 2 damage
 	METHOD method_6075 stopUsingItem ()V
+	METHOD method_6076 tickActiveItemStack ()V
 	METHOD method_6078 onDeath (Lnet/minecraft/class_1282;)V
 		ARG 1 damageSource
 	METHOD method_6079 getOffHandStack ()Lnet/minecraft/class_1799;

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -10,6 +10,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6219 STUCK_ARROWS Lnet/minecraft/class_2940;
 	FIELD field_6222 itemUseTimeLeft I
 	FIELD field_6225 limbDistance F
+	FIELD field_6226 lastDamageTime J
 	FIELD field_6227 upwardSpeed F
 	FIELD field_6229 lastHandSwingProgress F
 	FIELD field_6230 lastAttackedTime I
@@ -39,6 +40,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6272 dead Z
 	FIELD field_6273 lastAttackedTicks I
 	FIELD field_6274 attacker Lnet/minecraft/class_1309;
+	FIELD field_6276 lastDamageSource Lnet/minecraft/class_1282;
 	FIELD field_6277 activeItemStack Lnet/minecraft/class_1799;
 	FIELD field_6278 despawnCounter I
 	FIELD field_6279 handSwingTicks I

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -45,6 +45,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6258 attackingPlayer Lnet/minecraft/class_1657;
 	FIELD field_6259 prevHeadYaw F
 	FIELD field_6260 attributes Lnet/minecraft/class_1325;
+	FIELD field_6261 pushCooldown I
 	FIELD field_6263 serverZ D
 	FIELD field_6264 lastLeaningPitch F
 	FIELD field_6265 headTrackingIncrements I
@@ -168,6 +169,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6032 getHealth ()F
 	METHOD method_6033 setHealth (F)V
 	METHOD method_6034 canMoveVoluntarily ()Z
+	METHOD method_6035 push (Lnet/minecraft/class_238;Lnet/minecraft/class_238;)V
 	METHOD method_6036 applyEnchantmentsToDamage (Lnet/minecraft/class_1282;F)F
 		ARG 1 source
 		ARG 2 amount
@@ -212,7 +214,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6067 getAbsorptionAmount ()F
 	METHOD method_6068 getMainArm ()Lnet/minecraft/class_1306;
 	METHOD method_6069 clearPotionSwirls ()V
-	METHOD method_6070 tickPushing ()V
+	METHOD method_6070 tickCramming ()V
 	METHOD method_6071 shouldAlwaysDropXp ()Z
 	METHOD method_6072 updateLeaningPitch ()V
 	METHOD method_6073 setAbsorptionAmount (F)V

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -22,6 +22,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6238 playerHitTimer I
 	FIELD field_6240 POTION_SWIRLS_COLOR Lnet/minecraft/class_2940;
 	FIELD field_6241 headYaw F
+	FIELD field_6243 leaningPitch F
 	FIELD field_6246 absorptionAmount F
 	FIELD field_6247 HEALTH Lnet/minecraft/class_2940;
 	FIELD field_6248 equippedArmor Lnet/minecraft/class_2371;
@@ -34,6 +35,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6258 attackingPlayer Lnet/minecraft/class_1657;
 	FIELD field_6259 prevHeadYaw F
 	FIELD field_6260 attributeContainer Lnet/minecraft/class_1325;
+	FIELD field_6264 lastLeaningPitch F
 	FIELD field_6266 preferredHand Lnet/minecraft/class_1268;
 	FIELD field_6268 lastBlockPos Lnet/minecraft/class_2338;
 	FIELD field_6270 lastAttackTime I
@@ -130,6 +132,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6021 clearActiveItem ()V
 	METHOD method_6022 getStuckArrows ()I
 	METHOD method_6023 tickNewAi ()V
+	METHOD method_6024 getLeaningPitch (F)F
 	METHOD method_6025 heal (F)V
 		ARG 1 amount
 	METHOD method_6026 getStatusEffects ()Ljava/util/Collection;

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -91,6 +91,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_18403 sleep (Lnet/minecraft/class_2338;)V
 		ARG 1 pos
 	METHOD method_18406 isSleepingInBed ()Z
+	METHOD method_18801 applyClimbingSpeed (Lnet/minecraft/class_243;)Lnet/minecraft/class_243;
 	METHOD method_18802 getMovementSpeed (F)F
 	METHOD method_18807 getDrinkSound (Lnet/minecraft/class_1799;)Lnet/minecraft/class_3414;
 		ARG 1 stack

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -37,6 +37,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6250 forwardSpeed F
 	FIELD field_6251 handSwingProgress F
 	FIELD field_6252 isHandSwinging Z
+	FIELD field_6254 maxHurtTime I
 	FIELD field_6256 damageTracker Lnet/minecraft/class_1283;
 	FIELD field_6257 LIVING_FLAGS Lnet/minecraft/class_2940;
 	FIELD field_6258 attackingPlayer Lnet/minecraft/class_1657;

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -212,7 +212,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6059 hasStatusEffect (Lnet/minecraft/class_1291;)Z
 	METHOD method_6060 knockback (Lnet/minecraft/class_1309;)V
 		ARG 1 target
-	METHOD method_6061 canPierceDefense (Lnet/minecraft/class_1282;)Z
+	METHOD method_6061 tryUseShield (Lnet/minecraft/class_1282;)Z
 	METHOD method_6062 isImmobile ()Z
 	METHOD method_6063 getMaximumHealth ()F
 	METHOD method_6064 getNextBreathInAir (I)I

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -33,6 +33,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6241 headYaw F
 	FIELD field_6242 serverHeadYaw D
 	FIELD field_6243 leaningPitch F
+	FIELD field_6244 randomLargeSeed F
 	FIELD field_6245 serverY D
 	FIELD field_6246 absorptionAmount F
 	FIELD field_6247 HEALTH Lnet/minecraft/class_2940;
@@ -50,6 +51,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6259 prevHeadYaw F
 	FIELD field_6260 attributes Lnet/minecraft/class_1325;
 	FIELD field_6261 pushCooldown I
+	FIELD field_6262 randomSmallSeed F
 	FIELD field_6263 serverZ D
 	FIELD field_6264 lastLeaningPitch F
 	FIELD field_6265 headTrackingIncrements I

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -112,6 +112,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 songSource
 		ARG 2 playing
 	METHOD method_6007 tickMovement ()V
+	METHOD method_6009 onStatusEffectUpgraded (Lnet/minecraft/class_1293;Z)V
 	METHOD method_6010 swimUpward (Lnet/minecraft/class_3494;)V
 		ARG 1 fluid
 	METHOD method_6011 getHurtSound (Lnet/minecraft/class_1282;)Lnet/minecraft/class_3414;
@@ -125,6 +126,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6016 removeStatusEffect (Lnet/minecraft/class_1291;)Z
 	METHOD method_6017 getSoundPitch ()F
 	METHOD method_6019 setCurrentHand (Lnet/minecraft/class_1268;)V
+	METHOD method_6020 onStatusEffectApplied (Lnet/minecraft/class_1293;)V
 	METHOD method_6021 clearActiveItem ()V
 	METHOD method_6022 getStuckArrows ()I
 	METHOD method_6023 tickNewAi ()V

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -15,6 +15,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6225 limbDistance F
 	FIELD field_6226 lastDamageTime J
 	FIELD field_6227 upwardSpeed F
+	FIELD field_6228 jumpingCooldown I
 	FIELD field_6229 lastHandSwingProgress F
 	FIELD field_6230 lastAttackedTime I
 	FIELD field_6231 ATTR_SPRINTING_SPEED_BOOST Lnet/minecraft/class_1322;

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -54,7 +54,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6266 preferredHand Lnet/minecraft/class_1268;
 	FIELD field_6267 diagonalSpeed F
 	FIELD field_6268 lastBlockPos Lnet/minecraft/class_2338;
-	FIELD field_6269 field_6269 I
+	FIELD field_6269 defaultMaximumHealth I
 	FIELD field_6270 lastAttackTime I
 	FIELD field_6271 knockbackVelocity F
 	FIELD field_6272 dead Z

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -215,7 +215,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 5 z
 		ARG 7 particleEffects
 	METHOD method_6083 getLastAttackTime ()I
-	METHOD method_6084 isEquippedStackValid (Lnet/minecraft/class_1304;)Z
+	METHOD method_6084 hasStackEquipped (Lnet/minecraft/class_1304;)Z
 	METHOD method_6085 setLivingFlag (IZ)V
 		ARG 1 mask
 		ARG 2 value

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -260,7 +260,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 effect
 	METHOD method_6093 knockDownwards ()V
 	METHOD method_6094 canBreatheInWater ()Z
-	METHOD method_6095 absorbDamage (Lnet/minecraft/class_1282;)Z
+	METHOD method_6095 tryUseTotem (Lnet/minecraft/class_1282;)Z
 	METHOD method_6096 getArmor ()I
 	METHOD method_6097 setStuckArrows (I)V
 	METHOD method_6098 spawnConsumptionEffects (Lnet/minecraft/class_1799;I)V

--- a/mappings/net/minecraft/entity/effect/StatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/StatusEffect.mapping
@@ -10,6 +10,7 @@ CLASS net/minecraft/class_1291 net/minecraft/entity/effect/StatusEffect
 		ARG 0 type
 	METHOD method_5556 getColor ()I
 	METHOD method_5561 isInstant ()Z
+	METHOD method_5562 onRemoved (Lnet/minecraft/class_1309;Lnet/minecraft/class_1325;I)V
 	METHOD method_5564 applyInstantEffect (Lnet/minecraft/class_1297;Lnet/minecraft/class_1297;Lnet/minecraft/class_1309;ID)V
 		ARG 1 source
 		ARG 2 attacker

--- a/mappings/net/minecraft/entity/effect/StatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/StatusEffect.mapping
@@ -8,6 +8,7 @@ CLASS net/minecraft/class_1291 net/minecraft/entity/effect/StatusEffect
 		ARG 1 duration
 	METHOD method_5554 getRawId (Lnet/minecraft/class_1291;)I
 		ARG 0 type
+	METHOD method_5555 onApplied (Lnet/minecraft/class_1309;Lnet/minecraft/class_1325;I)V
 	METHOD method_5556 getColor ()I
 	METHOD method_5561 isInstant ()Z
 	METHOD method_5562 onRemoved (Lnet/minecraft/class_1309;Lnet/minecraft/class_1325;I)V

--- a/mappings/net/minecraft/resource/ResourceReloadListener.mapping
+++ b/mappings/net/minecraft/resource/ResourceReloadListener.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_3302 net/minecraft/resource/ResourceReloadListener
 	CLASS class_4045 Synchronizer
 		METHOD method_18352 whenPrepared (Ljava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
 			ARG 1 preparedObject
-	METHOD reload reload (Lnet/minecraft/class_3302$class_4045;Lnet/minecraft/class_3300;Lnet/minecraft/class_3695;Lnet/minecraft/class_3695;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;)Ljava/util/concurrent/CompletableFuture;
+	METHOD reload (Lnet/minecraft/class_3302$class_4045;Lnet/minecraft/class_3300;Lnet/minecraft/class_3695;Lnet/minecraft/class_3695;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 synchronizer
 		ARG 2 manager
 		ARG 3 prepareProfiler


### PR DESCRIPTION
Using Stitch (and the extracted sources from the gradle task) I finally managed to open LivingEntity so I could map the fields.

Notable changes:
`getHealthMaximum` -> `getMaximumHealth`
Pretty obvious.

Instances of PotionEffect become StatusEffect (we call them Status Effects almost everywhere else)
    `addPotionEffect` -> `addStatusEffect` ()
    `clearPotionEffects` -> `clearStatusEffects`
    `spawnPotionParticles` -> `tickStatusEffects` (this does a lot more than spawn particles. It will also remove expired ones

`method_18396` -> `getArmorVisibility`
Called only when the entity is invisible. The value is just the factor (0-1) of what percentage the body is covered by armour. A higher value makes you more visible to enemies.

`method_16212` -> `getBlockStateUnderFeet` (suggestions welcome)
This gets the blockstate the entity is standing in. 

`field_6239` -> `roll`
Used in the renderer when swimming or flying with an elytra.

`field_6267` -> `diagonalSpeed`
Used by the Ender Dragon.

`field_6255` -> `lookDirection` (result of turnHead) 
`turnHead` takes an angle as the second parameter, and will either return the same angle or `angle * -1`.

`field_6228` -> `jumpingCooldown`
A cooldown timer used to keep you from ~~breaking your legs~~ bunnyhopping too quickly.

`method_6024` -> `getLeaningPitch`
`field_6243` -> `leaningPitch`
`field_6264` -> `lastLeaningPitch`
This is the angles used to make the player lean forwards as it transitions between standing and crawlling/swiming.
