### PR TITLE
BlockPos mappings

### DIFF
--- a/mappings/net/minecraft/util/math/BlockPos.mapping
+++ b/mappings/net/minecraft/util/math/BlockPos.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_2338 net/minecraft/util/math/BlockPos
 	CLASS 1
 		FIELD field_17676 connector Lnet/minecraft/class_3980;
+		FIELD field_18231 position Lnet/minecraft/class_2338$class_2339;
 		METHOD tryAdvance (Ljava/util/function/Consumer;)Z
 			ARG 1 consumer
 	CLASS 2
@@ -19,28 +20,60 @@ CLASS net/minecraft/class_2338 net/minecraft/util/math/BlockPos
 		METHOD <init> (III)V
 			ARG 1 y
 			ARG 2 z
+		METHOD <init> (Lnet/minecraft/class_2338;)V
+			ARG 1 pos
 		METHOD method_10098 setOffset (Lnet/minecraft/class_2350;)Lnet/minecraft/class_2338$class_2339;
+			ARG 1 direction
 		METHOD method_10099 setY (I)V
+			ARG 1 y
 		METHOD method_10100 setOffset (III)Lnet/minecraft/class_2338$class_2339;
+			ARG 1 x
+			ARG 2 y
+			ARG 3 z
 		METHOD method_10101 set (Lnet/minecraft/class_2382;)Lnet/minecraft/class_2338$class_2339;
+			ARG 1 pos
 		METHOD method_10102 set (DDD)Lnet/minecraft/class_2338$class_2339;
+			ARG 1 x
+			ARG 3 y
+			ARG 5 z
 		METHOD method_10103 set (III)Lnet/minecraft/class_2338$class_2339;
 			ARG 1 x
 			ARG 2 y
 			ARG 3 z
 		METHOD method_10104 setOffset (Lnet/minecraft/class_2350;I)Lnet/minecraft/class_2338$class_2339;
+			ARG 1 direction
+			ARG 2 distance
 		METHOD method_10105 set (Lnet/minecraft/class_1297;)Lnet/minecraft/class_2338$class_2339;
-		METHOD method_16363 setFromLong (J)Lnet/minecraft/class_2338$class_2339;
+			ARG 1 entity
+		METHOD method_16363 set (J)Lnet/minecraft/class_2338$class_2339;
+			ARG 1 pos
+		METHOD method_17965 set (Lnet/minecraft/class_2335;III)Lnet/minecraft/class_2338$class_2339;
+			ARG 1 axis
+			ARG 2 x
+			ARG 3 y
+			ARG 4 z
+		METHOD method_20787 setX (I)V
+			ARG 1 x
+		METHOD method_20788 setZ (I)V
+			ARG 1 z
 	CLASS class_2340 PooledMutable
 		FIELD field_11004 free Z
 		FIELD field_11005 POOL Ljava/util/List;
 		METHOD <init> (III)V
-			ARG 1 y
-			ARG 2 z
+			ARG 1 x
+			ARG 2 y
+			ARG 3 z
 		METHOD method_10109 get ()Lnet/minecraft/class_2338$class_2340;
 		METHOD method_10111 get (III)Lnet/minecraft/class_2338$class_2340;
+			ARG 0 x
+			ARG 1 y
+			ARG 2 z
 		METHOD method_10115 get (DDD)Lnet/minecraft/class_2338$class_2340;
+			ARG 0 x
+			ARG 2 y
+			ARG 4 z
 		METHOD method_10117 getEntityPos (Lnet/minecraft/class_1297;)Lnet/minecraft/class_2338$class_2340;
+			ARG 0 entity
 	FIELD field_10973 BITS_Z J
 	FIELD field_10974 BITS_Y J
 	FIELD field_10975 SIZE_BITS_Y I
@@ -56,10 +89,21 @@ CLASS net/minecraft/class_2338 net/minecraft/util/math/BlockPos
 	METHOD <init> (III)V
 		ARG 1 x
 		ARG 2 y
+	METHOD <init> (Lnet/minecraft/class_1297;)V
+		ARG 1 entity
+	METHOD <init> (Lnet/minecraft/class_2374;)V
+		ARG 1 pos
+	METHOD <init> (Lnet/minecraft/class_2382;)V
+		ARG 1 pos
+	METHOD <init> (Lnet/minecraft/class_243;)V
+		ARG 1 pos
 	METHOD method_10059 subtract (Lnet/minecraft/class_2382;)Lnet/minecraft/class_2338;
+		ARG 1 pos
 	METHOD method_10060 offset (JLnet/minecraft/class_2350;)J
 		ARG 0 value
+		ARG 2 direction
 	METHOD method_10061 unpackLongX (J)I
+		ARG 0 x
 	METHOD method_10062 toImmutable ()Lnet/minecraft/class_2338;
 	METHOD method_10063 asLong ()J
 	METHOD method_10064 asLong (III)J
@@ -72,27 +116,44 @@ CLASS net/minecraft/class_2338 net/minecraft/util/math/BlockPos
 		ARG 2 y
 		ARG 3 z
 	METHOD method_10070 rotate (Lnet/minecraft/class_2470;)Lnet/minecraft/class_2338;
+		ARG 1 rotation
 	METHOD method_10071 unpackLongY (J)I
+		ARG 0 y
 	METHOD method_10072 south ()Lnet/minecraft/class_2338;
 	METHOD method_10074 down ()Lnet/minecraft/class_2338;
+	METHOD method_10075 crossProductPos (Lnet/minecraft/class_2382;)Lnet/minecraft/class_2338;
+		ARG 1 pos
 	METHOD method_10076 north (I)Lnet/minecraft/class_2338;
+		ARG 1 distance
 	METHOD method_10077 south (I)Lnet/minecraft/class_2338;
+		ARG 1 distance
 	METHOD method_10078 east ()Lnet/minecraft/class_2338;
 	METHOD method_10079 offset (Lnet/minecraft/class_2350;I)Lnet/minecraft/class_2338;
-		ARG 1 distance
+		ARG 1 direction
+		ARG 2 distance
 	METHOD method_10080 add (DDD)Lnet/minecraft/class_2338;
-		ARG 1 y
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
 	METHOD method_10081 add (Lnet/minecraft/class_2382;)Lnet/minecraft/class_2338;
+		ARG 1 pos
 	METHOD method_10083 unpackLongZ (J)I
+		ARG 0 z
 	METHOD method_10084 up ()Lnet/minecraft/class_2338;
 	METHOD method_10086 up (I)Lnet/minecraft/class_2338;
+		ARG 1 distance
 	METHOD method_10087 down (I)Lnet/minecraft/class_2338;
+		ARG 1 distance
 	METHOD method_10088 west (I)Lnet/minecraft/class_2338;
+		ARG 1 distance
 	METHOD method_10089 east (I)Lnet/minecraft/class_2338;
+		ARG 1 distance
 	METHOD method_10091 removeChunkSectionLocalY (J)J
+		ARG 0 y
 	METHOD method_10092 fromLong (J)Lnet/minecraft/class_2338;
 		ARG 0 value
 	METHOD method_10093 offset (Lnet/minecraft/class_2350;)Lnet/minecraft/class_2338;
+		ARG 1 direction
 	METHOD method_10094 iterate (IIIIII)Ljava/lang/Iterable;
 		ARG 0 minX
 		ARG 1 maxX
@@ -105,6 +166,7 @@ CLASS net/minecraft/class_2338 net/minecraft/util/math/BlockPos
 		ARG 0 value
 		ARG 2 x
 		ARG 3 y
+		ARG 4 z
 	METHOD method_10097 iterate (Lnet/minecraft/class_2338;Lnet/minecraft/class_2338;)Ljava/lang/Iterable;
 		ARG 0 pos1
 		ARG 1 pos2

--- a/mappings/net/minecraft/util/math/BlockPos.mapping
+++ b/mappings/net/minecraft/util/math/BlockPos.mapping
@@ -121,7 +121,7 @@ CLASS net/minecraft/class_2338 net/minecraft/util/math/BlockPos
 		ARG 0 y
 	METHOD method_10072 south ()Lnet/minecraft/class_2338;
 	METHOD method_10074 down ()Lnet/minecraft/class_2338;
-	METHOD method_10075 crossProductPos (Lnet/minecraft/class_2382;)Lnet/minecraft/class_2338;
+	METHOD method_10075 crossProduct (Lnet/minecraft/class_2382;)Lnet/minecraft/class_2338;
 		ARG 1 pos
 	METHOD method_10076 north (I)Lnet/minecraft/class_2338;
 		ARG 1 distance

--- a/mappings/net/minecraft/util/math/ChunkPos.mapping
+++ b/mappings/net/minecraft/util/math/ChunkPos.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_1923 net/minecraft/util/math/ChunkPos
 	CLASS 1
+		FIELD field_18684 position Lnet/minecraft/class_1923;
 		METHOD tryAdvance (Ljava/util/function/Consumer;)Z
 			ARG 1 consumer
 	FIELD field_17348 INVALID J

--- a/mappings/net/minecraft/util/math/Vec3i.mapping
+++ b/mappings/net/minecraft/util/math/Vec3i.mapping
@@ -3,6 +3,14 @@ CLASS net/minecraft/class_2382 net/minecraft/util/math/Vec3i
 	FIELD field_11174 y I
 	FIELD field_11175 x I
 	FIELD field_11176 ZERO Lnet/minecraft/class_2382;
+	METHOD <init> (DDD)V
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
+	METHOD <init> (III)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
 	METHOD method_10259 crossProduct (Lnet/minecraft/class_2382;)Lnet/minecraft/class_2382;
 		ARG 1 vec
 	METHOD method_10260 getZ ()I


### PR DESCRIPTION
I swear this is the last one! I noticed BlockPos was missing almost all of its parameter name mappings, and what we had were half wrong.

`method_10075` -> `crossProductPos`
This is just a `crossProduct`, however I couldn't name it that because Vec3i already defines a method with that name (same thing, but returning a Vec3i)