### PR TITLE
Add Vec3i constructor params

### DIFF
--- a/mappings/net/minecraft/util/math/Vec3i.mapping
+++ b/mappings/net/minecraft/util/math/Vec3i.mapping
@@ -3,6 +3,14 @@ CLASS net/minecraft/class_2382 net/minecraft/util/math/Vec3i
 	FIELD field_11174 y I
 	FIELD field_11175 x I
 	FIELD field_11176 ZERO Lnet/minecraft/class_2382;
+	METHOD <init> (DDD)V
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z
+	METHOD <init> (III)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
 	METHOD method_10259 crossProduct (Lnet/minecraft/class_2382;)Lnet/minecraft/class_2382;
 		ARG 1 vec
 	METHOD method_10260 getZ ()I


### PR DESCRIPTION
Does what it says on the tin. I can group a lot of these simple x/y/z changes into one PR if preferred, but I figured I'd keep them seperate for finer-grained acceptance.

Additionally, `method_10265` is probably `compareTo`, but it only gets resolved to that automatically some (?) of the time.