### PR TITLE
CraftResponseS2CPacket -> CraftFailedResponseS2CPacket

### DIFF
--- a/mappings/net/minecraft/client/network/packet/CraftFailedResponseS2CPacket.mapping
+++ b/mappings/net/minecraft/client/network/packet/CraftFailedResponseS2CPacket.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2695 net/minecraft/client/network/packet/CraftResponseS2CPacket
+CLASS net/minecraft/class_2695 net/minecraft/client/network/packet/CraftFailedResponseS2CPacket
 	FIELD field_12332 recipeId Lnet/minecraft/class_2960;
 	FIELD field_12333 syncId I
 	METHOD <init> (ILnet/minecraft/class_1860;)V

--- a/mappings/net/minecraft/network/listener/ClientPlayPacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ClientPlayPacketListener.mapping
@@ -25,7 +25,7 @@ CLASS net/minecraft/class_2602 net/minecraft/network/listener/ClientPlayPacketLi
 		ARG 1 packet
 	METHOD method_11089 onGuiOpen (Lnet/minecraft/class_2648;)V
 		ARG 1 packet
-	METHOD method_11090 onCraftResponse (Lnet/minecraft/class_2695;)V
+	METHOD method_11090 onCraftFailedResponse (Lnet/minecraft/class_2695;)V
 		ARG 1 packet
 	METHOD method_11091 onExperienceOrbSpawn (Lnet/minecraft/class_2606;)V
 		ARG 1 packet


### PR DESCRIPTION
This packet is called when the recipe book doesn't have enough resources to craft even one item.