### PR TITLE
BlockHitResult.field_17591 -> isEnteringBlock

### DIFF
--- a/mappings/net/minecraft/item/ItemUsageContext.mapping
+++ b/mappings/net/minecraft/item/ItemUsageContext.mapping
@@ -15,6 +15,7 @@ CLASS net/minecraft/class_1838 net/minecraft/item/ItemUsageContext
 		ARG 4 stack
 		ARG 5 hit
 	METHOD method_17698 getHitPos ()Lnet/minecraft/class_243;
+	METHOD method_17699 isHitInteringBlock ()Z
 	METHOD method_20287 getHand ()Lnet/minecraft/class_1268;
 	METHOD method_8036 getPlayer ()Lnet/minecraft/class_1657;
 	METHOD method_8037 getBlockPos ()Lnet/minecraft/class_2338;

--- a/mappings/net/minecraft/item/ItemUsageContext.mapping
+++ b/mappings/net/minecraft/item/ItemUsageContext.mapping
@@ -15,7 +15,7 @@ CLASS net/minecraft/class_1838 net/minecraft/item/ItemUsageContext
 		ARG 4 stack
 		ARG 5 hit
 	METHOD method_17698 getHitPos ()Lnet/minecraft/class_243;
-	METHOD method_17699 isHitInteringBlock ()Z
+	METHOD method_17699 isHitEnteringBlock ()Z
 	METHOD method_20287 getHand ()Lnet/minecraft/class_1268;
 	METHOD method_8036 getPlayer ()Lnet/minecraft/class_1657;
 	METHOD method_8037 getBlockPos ()Lnet/minecraft/class_2338;

--- a/mappings/net/minecraft/util/hit/BlockHitResult.mapping
+++ b/mappings/net/minecraft/util/hit/BlockHitResult.mapping
@@ -2,15 +2,18 @@ CLASS net/minecraft/class_3965 net/minecraft/util/hit/BlockHitResult
 	FIELD field_17588 side Lnet/minecraft/class_2350;
 	FIELD field_17589 blockPos Lnet/minecraft/class_2338;
 	FIELD field_17590 missed Z
+	FIELD field_17591 entering Z
 	METHOD <init> (Lnet/minecraft/class_243;Lnet/minecraft/class_2350;Lnet/minecraft/class_2338;Z)V
 		ARG 1 pos
 		ARG 2 side
 		ARG 3 blockPos
+		ARG 4 isEntering
 	METHOD <init> (ZLnet/minecraft/class_243;Lnet/minecraft/class_2350;Lnet/minecraft/class_2338;Z)V
 		ARG 1 missed
 		ARG 2 pos
 		ARG 3 side
 		ARG 4 blockPos
+		ARG 5 isEntering
 	METHOD method_17777 getBlockPos ()Lnet/minecraft/class_2338;
 	METHOD method_17778 createMissed (Lnet/minecraft/class_243;Lnet/minecraft/class_2350;Lnet/minecraft/class_2338;)Lnet/minecraft/class_3965;
 		ARG 0 pos
@@ -19,3 +22,4 @@ CLASS net/minecraft/class_3965 net/minecraft/util/hit/BlockHitResult
 	METHOD method_17779 withSide (Lnet/minecraft/class_2350;)Lnet/minecraft/class_3965;
 		ARG 1 side
 	METHOD method_17780 getSide ()Lnet/minecraft/class_2350;
+	METHOD method_17781 isEnteringBlock ()Z


### PR DESCRIPTION
This field is set to true in only one place (`VoxelShape.rayTrace`) where it does the below check and returns a hit with an opposite facing:

```
@Nullable
public BlockHitResult rayTrace(Vec3d start, Vec3d end, BlockPos pos) {
		if (this.isEmpty()) {
				return null;
		}

		Vec3d ray = end.subtract(start);
		if (ray.lengthSquared() < 1.0E-7) {
				return null;
		}

		Vec3d projection = start.add(ray.multiply(0.001));
		if (this.contains(projection.x - pos.getX(), projection.y - pos.getY(), projection.z - pos.getZ())) {
				return new BlockHitResult(projection, Direction.getFacing(ray.x, ray.y, ray.z).getOpposite(), pos, true);
		}
		return Box.rayTrace(this.getBoundingBoxes(), start, end, pos);
}
```

The method starts by calculating the `ray` which is the approach vector between the start and end point, then scaling that down to project the start a small amount forward.

It then checks if that new position is inside the current `VoxelShape`. and if it is will return a hit at the projected position (`pos + projection`), and inverts the direction to be facing away from the block (towards the origin of the ray).

The value is then only used in `ScaffoldingItem` where it reverses the direction again so players can still place scaffolds at the block they're standing inside of (since Scaffolding will just stack higher when you do so).

```
 if (context.isEnteringBlock()) {
                Direction direction7 = context.isHitInsideBlock() ? context.getSide().getOpposite() : context.getSide();
            }
```

tl;dr
`isEnteringBlock() == false` implies `getSide()` is a direction leading in the same direction as the ray that caused the hit. (Ray is _leaving_ the block)
`isEnteringBlock() == true` implies `getSide()` is a direction _opposite_ to the ray that caused the hit. (Ray is _entering_ the block)