### PR TITLE
Shape mappings

### DIFF
--- a/mappings/net/minecraft/block/BlockState.mapping
+++ b/mappings/net/minecraft/block/BlockState.mapping
@@ -5,9 +5,11 @@ CLASS net/minecraft/class_2680 net/minecraft/block/BlockState
 		FIELD field_16557 fullOpaque Z
 		FIELD field_16558 opaque Z
 		FIELD field_16559 DIRECTIONS [Lnet/minecraft/class_2350;
-		FIELD field_16560 shapes [Lnet/minecraft/class_265;
+		FIELD field_16560 extrudedFaces [Lnet/minecraft/class_265;
+		FIELD field_17651 exceedsCube Z
 		FIELD field_19360 collisionShape Lnet/minecraft/class_265;
 		FIELD field_19429 solidFullSquare [Z
+		FIELD field_20337 isFullCube Z
 		METHOD <init> (Lnet/minecraft/class_2680;)V
 			ARG 1 state
 	FIELD field_12290 shapeCache Lnet/minecraft/class_2680$class_3752;
@@ -60,6 +62,7 @@ CLASS net/minecraft/class_2680 net/minecraft/block/BlockState
 		ARG 3 pos
 	METHOD method_11590 initShapeCache ()V
 	METHOD method_11591 canPlaceAt (Lnet/minecraft/class_4538;Lnet/minecraft/class_2338;)Z
+		ARG 1 view
 		ARG 2 pos
 	METHOD method_11592 isSideInvisible (Lnet/minecraft/class_2680;Lnet/minecraft/class_2350;)Z
 		ARG 1 neighbor
@@ -96,6 +99,7 @@ CLASS net/minecraft/class_2680 net/minecraft/block/BlockState
 	METHOD method_11606 getOutlineShape (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_3726;)Lnet/minecraft/class_265;
 		ARG 1 view
 		ARG 2 pos
+		ARG 3 context
 	METHOD method_11607 getRayTraceShape (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Lnet/minecraft/class_265;
 		ARG 1 view
 		ARG 2 pos
@@ -178,7 +182,7 @@ CLASS net/minecraft/class_2680 net/minecraft/block/BlockState
 		ARG 1 view
 		ARG 2 pos
 		ARG 3 ePos
-	METHOD method_16384 getCullingShape (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Lnet/minecraft/class_265;
+	METHOD method_16384 getCullingFace (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Lnet/minecraft/class_265;
 		ARG 1 view
 		ARG 2 pos
 		ARG 3 facing
@@ -192,14 +196,18 @@ CLASS net/minecraft/class_2680 net/minecraft/block/BlockState
 	METHOD method_17770 getOutlineShape (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Lnet/minecraft/class_265;
 		ARG 1 view
 		ARG 2 pos
+	METHOD method_17900 exceedsCube ()Z
 	METHOD method_19287 onProjectileHit (Lnet/minecraft/class_1937;Lnet/minecraft/class_2680;Lnet/minecraft/class_3965;Lnet/minecraft/class_1297;)V
 		ARG 1 world
 		ARG 2 state
 		ARG 3 hitResult
 		ARG 4 projectile
 	METHOD method_20827 isSideSolidFullSquare (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Z
+		ARG 1 view
+		ARG 2 pos
+		ARG 3 direction
 	METHOD method_21743 isFullCube (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z
-		ARG 1 world
+		ARG 1 view
 		ARG 2 pos
 	METHOD method_22360 canBucketPlace (Lnet/minecraft/class_3611;)Z
 		ARG 1 fluid

--- a/mappings/net/minecraft/block/FenceBlock.mapping
+++ b/mappings/net/minecraft/block/FenceBlock.mapping
@@ -4,4 +4,5 @@ CLASS net/minecraft/class_2354 net/minecraft/block/FenceBlock
 		ARG 1 settings
 	METHOD method_10184 canConnect (Lnet/minecraft/class_2680;ZLnet/minecraft/class_2350;)Z
 		ARG 1 state
+		ARG 2 neighborIsFullSquare
 		ARG 3 dir

--- a/mappings/net/minecraft/block/FenceGateBlock.mapping
+++ b/mappings/net/minecraft/block/FenceGateBlock.mapping
@@ -1,12 +1,16 @@
 CLASS net/minecraft/class_2349 net/minecraft/block/FenceGateBlock
 	FIELD field_11016 IN_WALL_X_AXIS_SHAPE Lnet/minecraft/class_265;
 	FIELD field_11017 X_AXIS_SHAPE Lnet/minecraft/class_265;
+	FIELD field_11018 Z_AXIS_CULL_SHAPE Lnet/minecraft/class_265;
 	FIELD field_11019 X_AXIS_COLLISION_SHAPE Lnet/minecraft/class_265;
+	FIELD field_11020 IN_WALL_Z_AXIS_CULL_SHAPE Lnet/minecraft/class_265;
 	FIELD field_11021 POWERED Lnet/minecraft/class_2746;
 	FIELD field_11022 Z_AXIS_SHAPE Lnet/minecraft/class_265;
+	FIELD field_11023 X_AXIS_CULL_SHAPE Lnet/minecraft/class_265;
 	FIELD field_11024 IN_WALL Lnet/minecraft/class_2746;
 	FIELD field_11025 IN_WALL_Z_AXIS_SHAPE Lnet/minecraft/class_265;
 	FIELD field_11026 OPEN Lnet/minecraft/class_2746;
+	FIELD field_11027 IN_WALL_X_AXIS_CULL_SHAPE Lnet/minecraft/class_265;
 	FIELD field_11028 Z_AXIS_COLLISION_SHAPE Lnet/minecraft/class_265;
 	METHOD <init> (Lnet/minecraft/class_2248$class_2251;)V
 		ARG 1 settings

--- a/mappings/net/minecraft/client/render/block/FluidRenderer.mapping
+++ b/mappings/net/minecraft/client/render/block/FluidRenderer.mapping
@@ -17,10 +17,10 @@ CLASS net/minecraft/class_775 net/minecraft/client/render/block/FluidRenderer
 		ARG 1 world
 		ARG 2 pos
 	METHOD method_3344 isSideCovered (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;F)Z
-		ARG 0 world
+		ARG 0 view
 		ARG 1 pos
-		ARG 2 side
-		ARG 3 height
+		ARG 2 direction
+		ARG 3 maxDeviation
 	METHOD method_3345 onResourceReload ()V
 	METHOD method_3346 getNorthWestCornerFluidHeight (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_3611;)F
 		ARG 1 world

--- a/mappings/net/minecraft/fluid/FluidState.mapping
+++ b/mappings/net/minecraft/fluid/FluidState.mapping
@@ -1,5 +1,11 @@
 CLASS net/minecraft/class_3610 net/minecraft/fluid/FluidState
+	METHOD method_15756 (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z
+		ARG 1 view
+		ARG 2 pos
 	METHOD method_15757 onRandomTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Ljava/util/Random;)V
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 random
 	METHOD method_15758 getVelocity (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Lnet/minecraft/class_243;
 		ARG 1 world
 		ARG 2 pos
@@ -12,8 +18,13 @@ CLASS net/minecraft/class_3610 net/minecraft/fluid/FluidState
 	METHOD method_15766 getParticle ()Lnet/minecraft/class_2394;
 	METHOD method_15767 matches (Lnet/minecraft/class_3494;)Z
 	METHOD method_15768 randomDisplayTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Ljava/util/Random;)V
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 random
 	METHOD method_15769 isEmpty ()Z
 	METHOD method_15770 onScheduledTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)V
+		ARG 1 world
+		ARG 2 pos
 	METHOD method_15771 isStill ()Z
 	METHOD method_15772 getFluid ()Lnet/minecraft/class_3611;
 	METHOD method_15773 hasRandomTicks ()Z

--- a/mappings/net/minecraft/util/math/Direction.mapping
+++ b/mappings/net/minecraft/util/math/Direction.mapping
@@ -16,6 +16,9 @@ CLASS net/minecraft/class_2350 net/minecraft/util/math/Direction
 			ARG 3 y
 			ARG 5 z
 		METHOD method_10173 choose (III)I
+			ARG 1 x
+			ARG 2 y
+			ARG 3 z
 		METHOD method_10174 getName ()Ljava/lang/String;
 		METHOD method_10177 fromName (Ljava/lang/String;)Lnet/minecraft/class_2350$class_2351;
 			ARG 0 name
@@ -27,11 +30,19 @@ CLASS net/minecraft/class_2350 net/minecraft/util/math/Direction
 	CLASS class_2352 AxisDirection
 		FIELD field_11057 desc Ljava/lang/String;
 		FIELD field_11059 offset I
+		METHOD <init> (Ljava/lang/String;IILjava/lang/String;)V
+			ARG 3 offset
+			ARG 4 description
 		METHOD method_10181 offset ()I
 	CLASS class_2353 Type
 		FIELD field_11061 facingArray [Lnet/minecraft/class_2350;
 		FIELD field_11065 axisArray [Lnet/minecraft/class_2350$class_2351;
+		METHOD <init> (Ljava/lang/String;I[Lnet/minecraft/class_2350;[Lnet/minecraft/class_2350$class_2351;)V
+			ARG 3 directions
 		METHOD method_10183 random (Ljava/util/Random;)Lnet/minecraft/class_2350;
+			ARG 1 random
+		METHOD test (Ljava/lang/Object;)Z
+			ARG 1 direction
 	FIELD field_11030 idHorizontal I
 	FIELD field_11031 idOpposite I
 	FIELD field_11032 id I

--- a/mappings/net/minecraft/util/shape/DisjointPairList.mapping
+++ b/mappings/net/minecraft/util/shape/DisjointPairList.mapping
@@ -1,8 +1,11 @@
-CLASS net/minecraft/class_257 net/minecraft/util/shape/DisjointDoubleListPair
+CLASS net/minecraft/class_257 net/minecraft/util/shape/DisjointPairList
 	FIELD field_1379 second Lit/unimi/dsi/fastutil/doubles/DoubleList;
+	FIELD field_1380 inverted Z
 	FIELD field_1381 first Lit/unimi/dsi/fastutil/doubles/DoubleList;
 	METHOD <init> (Lit/unimi/dsi/fastutil/doubles/DoubleList;Lit/unimi/dsi/fastutil/doubles/DoubleList;Z)V
 		ARG 1 first
 		ARG 2 second
+		ARG 3 inverted
 	METHOD getDouble (I)D
 		ARG 1 position
+	METHOD method_1067 iterateSections (Lnet/minecraft/class_255$class_256;)Z

--- a/mappings/net/minecraft/util/shape/DoubleListPair.mapping
+++ b/mappings/net/minecraft/util/shape/DoubleListPair.mapping
@@ -1,5 +1,0 @@
-CLASS net/minecraft/class_255 net/minecraft/util/shape/DoubleListPair
-	CLASS class_256 SectionPairPredicate
-	METHOD method_1065 forAllOverlappingSections (Lnet/minecraft/class_255$class_256;)Z
-		ARG 1 predicate
-	METHOD method_1066 getMergedList ()Lit/unimi/dsi/fastutil/doubles/DoubleList;

--- a/mappings/net/minecraft/util/shape/FractionalPairList.mapping
+++ b/mappings/net/minecraft/util/shape/FractionalPairList.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_248 net/minecraft/util/shape/FractionalDoubleListPair
+CLASS net/minecraft/class_248 net/minecraft/util/shape/FractionalPairList
 	FIELD field_1367 mergedList Lnet/minecraft/class_246;
 	FIELD field_1368 gcd I
 	FIELD field_1369 secondSectionCount I

--- a/mappings/net/minecraft/util/shape/IdentityListMerger.mapping
+++ b/mappings/net/minecraft/util/shape/IdentityListMerger.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/class_250 net/minecraft/util/shape/IdentityListMerger
-	FIELD field_1371 merged Lit/unimi/dsi/fastutil/doubles/DoubleList;

--- a/mappings/net/minecraft/util/shape/IdentityPairList.mapping
+++ b/mappings/net/minecraft/util/shape/IdentityPairList.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_250 net/minecraft/util/shape/IdentityPairList
+	FIELD field_1371 merged Lit/unimi/dsi/fastutil/doubles/DoubleList;
+	METHOD <init> (Lit/unimi/dsi/fastutil/doubles/DoubleList;)V
+		ARG 1 values

--- a/mappings/net/minecraft/util/shape/PairList.mapping
+++ b/mappings/net/minecraft/util/shape/PairList.mapping
@@ -1,0 +1,9 @@
+CLASS net/minecraft/class_255 net/minecraft/util/shape/PairList
+	CLASS class_256 Consumer
+		METHOD merge (III)Z
+			ARG 1 x
+			ARG 2 y
+			ARG 3 index
+	METHOD method_1065 forEachPair (Lnet/minecraft/class_255$class_256;)Z
+		ARG 1 predicate
+	METHOD method_1066 getPairs ()Lit/unimi/dsi/fastutil/doubles/DoubleList;

--- a/mappings/net/minecraft/util/shape/SimpleDoubleListPair.mapping
+++ b/mappings/net/minecraft/util/shape/SimpleDoubleListPair.mapping
@@ -1,7 +1,0 @@
-CLASS net/minecraft/class_254 net/minecraft/util/shape/SimpleDoubleListPair
-	FIELD field_1377 mergedList Lit/unimi/dsi/fastutil/doubles/DoubleArrayList;
-	METHOD <init> (Lit/unimi/dsi/fastutil/doubles/DoubleList;Lit/unimi/dsi/fastutil/doubles/DoubleList;ZZ)V
-		ARG 1 first
-		ARG 2 second
-		ARG 3 includeFirstOnly
-		ARG 4 includeSecondOnly

--- a/mappings/net/minecraft/util/shape/SimplePairList.mapping
+++ b/mappings/net/minecraft/util/shape/SimplePairList.mapping
@@ -1,0 +1,9 @@
+CLASS net/minecraft/class_254 net/minecraft/util/shape/SimplePairList
+	FIELD field_1376 minValues Lit/unimi/dsi/fastutil/ints/IntArrayList;
+	FIELD field_1377 valueIndices Lit/unimi/dsi/fastutil/doubles/DoubleArrayList;
+	FIELD field_1378 maxValues Lit/unimi/dsi/fastutil/ints/IntArrayList;
+	METHOD <init> (Lit/unimi/dsi/fastutil/doubles/DoubleList;Lit/unimi/dsi/fastutil/doubles/DoubleList;ZZ)V
+		ARG 1 first
+		ARG 2 second
+		ARG 3 includeFirstOnly
+		ARG 4 includeSecondOnly

--- a/mappings/net/minecraft/util/shape/SlicedVoxelShape.mapping
+++ b/mappings/net/minecraft/util/shape/SlicedVoxelShape.mapping
@@ -1,11 +1,11 @@
-CLASS net/minecraft/class_263 net/minecraft/util/shape/SliceVoxelShape
+CLASS net/minecraft/class_263 net/minecraft/util/shape/SlicedVoxelShape
 	FIELD field_1395 POINTS Lit/unimi/dsi/fastutil/doubles/DoubleList;
 	FIELD field_1396 axis Lnet/minecraft/class_2350$class_2351;
 	FIELD field_1397 shape Lnet/minecraft/class_265;
 	METHOD <init> (Lnet/minecraft/class_265;Lnet/minecraft/class_2350$class_2351;I)V
 		ARG 1 shape
 		ARG 2 axis
-		ARG 3 voxelIndex
+		ARG 3 sliceWidth
 	METHOD method_1088 createVoxelSet (Lnet/minecraft/class_251;Lnet/minecraft/class_2350$class_2351;I)Lnet/minecraft/class_251;
-		ARG 0 voxels
-		ARG 1 axis
+		ARG 0 voxelSet
+		ARG 2 sliceWidth

--- a/mappings/net/minecraft/util/shape/VoxelSet.mapping
+++ b/mappings/net/minecraft/util/shape/VoxelSet.mapping
@@ -1,6 +1,18 @@
 CLASS net/minecraft/class_251 net/minecraft/util/shape/VoxelSet
-	CLASS class_252 DirectionalPointConsumer
-	CLASS class_253 VolumeConsumer
+	CLASS class_252 PositionConsumer
+		METHOD consume (Lnet/minecraft/class_2350;III)V
+			ARG 1 direction
+			ARG 2 x
+			ARG 3 y
+			ARG 4 z
+	CLASS class_253 PositionBiConsumer
+		METHOD consume (IIIIII)V
+			ARG 1 x1
+			ARG 2 y1
+			ARG 3 z1
+			ARG 4 x2
+			ARG 5 y2
+			ARG 6 z2
 	FIELD field_1372 zSize I
 	FIELD field_1373 ySize I
 	FIELD field_1374 xSize I
@@ -9,12 +21,16 @@ CLASS net/minecraft/class_251 net/minecraft/util/shape/VoxelSet
 		ARG 1 xSize
 		ARG 2 ySize
 		ARG 3 zSize
+	METHOD method_1043 getBeginningAxisCoord (Lnet/minecraft/class_2350$class_2351;II)I
+		ARG 2 begin
+		ARG 3 end
 	METHOD method_1044 inBoundsAndContains (III)Z
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
 	METHOD method_1045 getMax (Lnet/minecraft/class_2350$class_2351;)I
 		ARG 1 axis
+	METHOD method_1046 forEachDirection (Lnet/minecraft/class_251$class_252;)V
 	METHOD method_1047 getYSize ()I
 	METHOD method_1048 getZSize ()I
 	METHOD method_1049 set (IIIZZ)V
@@ -27,6 +43,7 @@ CLASS net/minecraft/class_251 net/minecraft/util/shape/VoxelSet
 	METHOD method_1051 getSize (Lnet/minecraft/class_2350$class_2351;)I
 		ARG 1 axis
 	METHOD method_1052 forEachEdge (Lnet/minecraft/class_251$class_253;Lnet/minecraft/class_2335;Z)V
+		ARG 2 direction
 	METHOD method_1053 forEachBox (Lnet/minecraft/class_251$class_253;Z)V
 		ARG 1 consumer
 		ARG 2 largest
@@ -41,6 +58,12 @@ CLASS net/minecraft/class_251 net/minecraft/util/shape/VoxelSet
 	METHOD method_1056 isEmpty ()Z
 	METHOD method_1057 contains (Lnet/minecraft/class_2335;III)Z
 		ARG 1 cycle
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD method_1058 getEndingAxisCoord (Lnet/minecraft/class_2350$class_2351;II)I
+		ARG 2 from
+		ARG 3 to
 	METHOD method_1059 isColumnFull (IIII)Z
 		ARG 1 minZ
 		ARG 2 maxZ
@@ -52,6 +75,8 @@ CLASS net/minecraft/class_251 net/minecraft/util/shape/VoxelSet
 		ARG 3 x
 		ARG 4 y
 		ARG 5 included
+	METHOD method_1061 forEachDirection (Lnet/minecraft/class_251$class_252;Lnet/minecraft/class_2335;)V
+		ARG 2 direction
 	METHOD method_1062 inBoundsAndContains (Lnet/minecraft/class_2335;III)Z
 		ARG 1 cycle
 		ARG 2 x

--- a/mappings/net/minecraft/util/shape/VoxelShape.mapping
+++ b/mappings/net/minecraft/util/shape/VoxelShape.mapping
@@ -11,6 +11,9 @@ CLASS net/minecraft/class_265 net/minecraft/util/shape/VoxelShape
 		ARG 1 start
 		ARG 2 end
 		ARG 3 pos
+	METHOD method_1093 getBeginningCoord (Lnet/minecraft/class_2350$class_2351;DD)D
+		ARG 2 from
+		ARG 4 to
 	METHOD method_1095 contains (DDD)Z
 		ARG 1 x
 		ARG 3 y
@@ -27,7 +30,10 @@ CLASS net/minecraft/class_265 net/minecraft/util/shape/VoxelShape
 		ARG 2 index
 	METHOD method_1100 getCoordIndex (Lnet/minecraft/class_2350$class_2351;D)I
 		ARG 2 coord
-	METHOD method_1103 (Lnet/minecraft/class_2335;Lnet/minecraft/class_238;D)D
+	METHOD method_1102 getEndingCoord (Lnet/minecraft/class_2350$class_2351;DD)D
+		ARG 2 from
+		ARG 4 to
+	METHOD method_1103 calculateMaxDistance (Lnet/minecraft/class_2335;Lnet/minecraft/class_238;D)D
 		ARG 1 axisCycle
 		ARG 2 box
 		ARG 3 maxDist
@@ -35,9 +41,10 @@ CLASS net/minecraft/class_265 net/minecraft/util/shape/VoxelShape
 	METHOD method_1105 getMaximum (Lnet/minecraft/class_2350$class_2351;)D
 		ARG 1 axis
 	METHOD method_1107 getBoundingBox ()Lnet/minecraft/class_238;
-	METHOD method_1108 (Lnet/minecraft/class_2350$class_2351;Lnet/minecraft/class_238;D)D
+	METHOD method_1108 calculateMaxDistance (Lnet/minecraft/class_2350$class_2351;Lnet/minecraft/class_238;D)D
 		ARG 1 axis
 		ARG 2 box
+		ARG 3 maxDist
 	METHOD method_1109 getPointPositions (Lnet/minecraft/class_2350$class_2351;)Lit/unimi/dsi/fastutil/doubles/DoubleList;
 		ARG 1 axis
 	METHOD method_1110 isEmpty ()Z

--- a/mappings/net/minecraft/util/shape/VoxelShapes.mapping
+++ b/mappings/net/minecraft/util/shape/VoxelShapes.mapping
@@ -2,6 +2,11 @@ CLASS net/minecraft/class_259 net/minecraft/util/shape/VoxelShapes
 	CLASS class_260 BoxConsumer
 		METHOD consume (DDDDDD)V
 			ARG 1 minX
+			ARG 3 minY
+			ARG 5 minZ
+			ARG 7 maxX
+			ARG 9 maxY
+			ARG 11 maxZ
 	FIELD field_1384 EMPTY Lnet/minecraft/class_265;
 	FIELD field_1385 FULL_CUBE Lnet/minecraft/class_265;
 	FIELD field_17669 UNBOUNDED Lnet/minecraft/class_265;
@@ -11,6 +16,10 @@ CLASS net/minecraft/class_259 net/minecraft/util/shape/VoxelShapes
 		ARG 2 second
 		ARG 3 includeFirst
 		ARG 4 includeSecond
+	METHOD method_1070 (Lnet/minecraft/class_247;Lnet/minecraft/class_251;IILnet/minecraft/class_251;IIIII)Z
+		ARG 7 z1
+		ARG 8 z2
+		ARG 9 index3
 	METHOD method_1071 matchesAnywhere (Lnet/minecraft/class_255;Lnet/minecraft/class_255;Lnet/minecraft/class_255;Lnet/minecraft/class_251;Lnet/minecraft/class_251;Lnet/minecraft/class_247;)Z
 		ARG 0 mergedX
 		ARG 1 mergedY
@@ -27,13 +36,23 @@ CLASS net/minecraft/class_259 net/minecraft/util/shape/VoxelShapes
 		ARG 0 shape1
 		ARG 1 shape2
 		ARG 2 predicate
+	METHOD method_1075 (Lnet/minecraft/class_255;Lnet/minecraft/class_255;Lnet/minecraft/class_247;Lnet/minecraft/class_251;Lnet/minecraft/class_251;III)Z
+		ARG 5 x1
+		ARG 6 x2
+		ARG 7 index1
+	METHOD method_1076 (Lnet/minecraft/class_255;Lnet/minecraft/class_247;Lnet/minecraft/class_251;ILnet/minecraft/class_251;IIII)Z
+		ARG 6 y1
+		ARG 7 y2
+		ARG 8 index2
 	METHOD method_1077 fullCube ()Lnet/minecraft/class_265;
 	METHOD method_1078 cuboid (Lnet/minecraft/class_238;)Lnet/minecraft/class_265;
 		ARG 0 box
 	METHOD method_1079 lcm (II)J
+		ARG 0 a
+		ARG 1 b
 	METHOD method_1080 adjacentSidesCoverSquare (Lnet/minecraft/class_265;Lnet/minecraft/class_265;Lnet/minecraft/class_2350;)Z
-		ARG 0 shape1
-		ARG 1 shape2
+		ARG 0 one
+		ARG 1 two
 		ARG 2 direction
 	METHOD method_1081 cuboid (DDDDDD)Lnet/minecraft/class_265;
 		ARG 0 xMin
@@ -43,13 +62,13 @@ CLASS net/minecraft/class_259 net/minecraft/util/shape/VoxelShapes
 		ARG 8 yMax
 		ARG 10 zMax
 	METHOD method_1082 combine (Lnet/minecraft/class_265;Lnet/minecraft/class_265;Lnet/minecraft/class_247;)Lnet/minecraft/class_265;
-		ARG 0 shape1
-		ARG 1 shape2
+		ARG 0 one
+		ARG 1 two
 		ARG 2 function
 	METHOD method_1083 isSideCovered (Lnet/minecraft/class_265;Lnet/minecraft/class_265;Lnet/minecraft/class_2350;)Z
 		ARG 0 shape
 		ARG 1 neighbor
-		ARG 2 side
+		ARG 2 direction
 	METHOD method_1084 union (Lnet/minecraft/class_265;Lnet/minecraft/class_265;)Lnet/minecraft/class_265;
 		ARG 0 first
 		ARG 1 second
@@ -57,15 +76,33 @@ CLASS net/minecraft/class_259 net/minecraft/util/shape/VoxelShapes
 		ARG 0 axis
 		ARG 1 box
 		ARG 2 shapes
+		ARG 3 maxDist
 	METHOD method_1086 findRequiredBitResolution (DD)I
 		ARG 0 min
 		ARG 2 max
-	METHOD method_16344 slice (Lnet/minecraft/class_265;Lnet/minecraft/class_2350;)Lnet/minecraft/class_265;
+	METHOD method_16344 extrudeFace (Lnet/minecraft/class_265;Lnet/minecraft/class_2350;)Lnet/minecraft/class_265;
 		ARG 0 shape
 		ARG 1 direction
 	METHOD method_17786 union (Lnet/minecraft/class_265;[Lnet/minecraft/class_265;)Lnet/minecraft/class_265;
 		ARG 0 first
 		ARG 1 others
+	METHOD method_17943 clamp (DDD)I
+		ARG 0 value
+		ARG 2 min
+		ARG 4 max
+	METHOD method_17944 calculatePushVelocity (Lnet/minecraft/class_238;Lnet/minecraft/class_4538;DLnet/minecraft/class_3726;Lnet/minecraft/class_2335;Ljava/util/stream/Stream;)D
+		ARG 0 box
+		ARG 1 world
+		ARG 2 initial
+		ARG 4 context
+		ARG 5 direction
+		ARG 6 shapes
+	METHOD method_17945 calculatePushVelocity (Lnet/minecraft/class_2350$class_2351;Lnet/minecraft/class_238;Lnet/minecraft/class_4538;DLnet/minecraft/class_3726;Ljava/util/stream/Stream;)D
+		ARG 1 box
+		ARG 2 world
+		ARG 3 initial
+		ARG 5 context
+		ARG 6 shapes
 	METHOD method_20713 unionCoversFullCube (Lnet/minecraft/class_265;Lnet/minecraft/class_265;)Z
-		ARG 0 shape1
-		ARG 1 shape2
+		ARG 0 one
+		ARG 1 two


### PR DESCRIPTION
This maps all the remaining methods in `net/minecraft/util/shape`.

Also renamed `DoubleListPair` -> `PairList`. It's a list of pairs (of doubles) not a double pair of lists.

You can see this when looking at `DoubleListPair.SectionPairPredicate` (`PairList.Consumer`) which accepts a value from the first element of the pair (`x`), the second element of the pair (`y`), and the position in the list (`index`).

```
    public interface PairList.Consumer {
        boolean merge(int x, int y, int index);
    }
```

From SimplePairList:
```
    @Override
    public boolean forEachPair(PairList.Consumer consumer) {
        for (int index = 0; index< this.valueIndices.size() - 1; index++) {
            if (!consumer.merge(minValues.getInt(index), maxValues.getInt(index), index)) {
                return false;
            }
        }
        return true;
    }
```