### PR TITLE
FixItemName/ChoiceTypes -> ItemName/ChoiceTypesFix

### DIFF
--- a/mappings/net/minecraft/datafixers/fixes/ChoiceTypesFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ChoiceTypesFix.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_3553 net/minecraft/datafixers/fixes/ChoiceTypesFix
 	FIELD field_15779 name Ljava/lang/String;
 	FIELD field_15780 types Lcom/mojang/datafixers/DSL$TypeReference;
 	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;Lcom/mojang/datafixers/DSL$TypeReference;)V
-		ARG 1 ouputSchema
+		ARG 1 outputSchema
 		ARG 2 name
 		ARG 3 types
 	METHOD method_15476 (Ljava/lang/String;Lcom/mojang/datafixers/types/templates/TaggedChoice$TaggedChoiceType;Lcom/mojang/datafixers/types/templates/TaggedChoice$TaggedChoiceType;)Lcom/mojang/datafixers/TypeRewriteRule;

--- a/mappings/net/minecraft/datafixers/fixes/ChoiceTypesFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ChoiceTypesFix.mapping
@@ -1,0 +1,9 @@
+CLASS net/minecraft/class_3553 net/minecraft/datafixers/fixes/ChoiceTypesFix
+	FIELD field_15779 name Ljava/lang/String;
+	FIELD field_15780 types Lcom/mojang/datafixers/DSL$TypeReference;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;Lcom/mojang/datafixers/DSL$TypeReference;)V
+		ARG 1 ouputSchema
+		ARG 2 name
+		ARG 3 types
+	METHOD method_15476 (Ljava/lang/String;Lcom/mojang/datafixers/types/templates/TaggedChoice$TaggedChoiceType;Lcom/mojang/datafixers/types/templates/TaggedChoice$TaggedChoiceType;)Lcom/mojang/datafixers/TypeRewriteRule;
+		ARG 1 name

--- a/mappings/net/minecraft/datafixers/fixes/FixChoiceTypes.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/FixChoiceTypes.mapping
@@ -1,7 +1,0 @@
-CLASS net/minecraft/class_3553 net/minecraft/datafixers/fixes/FixChoiceTypes
-	FIELD field_15779 name Ljava/lang/String;
-	FIELD field_15780 types Lcom/mojang/datafixers/DSL$TypeReference;
-	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;Lcom/mojang/datafixers/DSL$TypeReference;)V
-		ARG 1 ouputSchema
-		ARG 2 name
-		ARG 3 types

--- a/mappings/net/minecraft/datafixers/fixes/ItemNameFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/ItemNameFix.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_1182 net/minecraft/datafixers/fixes/FixItemName
+CLASS net/minecraft/class_1182 net/minecraft/datafixers/fixes/ItemNameFix
 	FIELD field_5676 name Ljava/lang/String;
 	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Ljava/lang/String;)V
 		ARG 1 outputSchema


### PR DESCRIPTION
Closes #795.

All other datafixes are suffix-named and Mojang seems to use suffixes for fixes (most other datafixes are named by the name strings in the classes).