### PR TITLE
Add some player interaction mappings

### DIFF
--- a/mappings/net/minecraft/client/network/ClientPlayerInteractionManager.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerInteractionManager.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_636 net/minecraft/client/network/ClientPlayerInteractionManager
 	FIELD field_20316 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_20317 unacknowledgedPlayerActions Lit/unimi/dsi/fastutil/objects/Object2ObjectLinkedOpenHashMap;
 	FIELD field_3712 client Lnet/minecraft/class_310;
 	FIELD field_3713 blockBreakingSoundCooldown F
 	FIELD field_3714 currentBreakingPos Lnet/minecraft/class_2338;
@@ -10,6 +11,11 @@ CLASS net/minecraft/class_636 net/minecraft/client/network/ClientPlayerInteracti
 	FIELD field_3719 gameMode Lnet/minecraft/class_1934;
 	FIELD field_3720 networkHandler Lnet/minecraft/class_634;
 	FIELD field_3721 lastSelectedSlot I
+	METHOD method_21705 processPlayerActionResponse (Lnet/minecraft/class_638;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2846$class_2847;Z)V
+		ARG 1 world
+		ARG 2 pos
+		ARG 5 approved
+	METHOD method_21706 sendPlayerAction (Lnet/minecraft/class_2846$class_2847;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)V
 	METHOD method_2895 hasRidingInventory ()Z
 	METHOD method_2896 interactBlock (Lnet/minecraft/class_746;Lnet/minecraft/class_638;Lnet/minecraft/class_1268;Lnet/minecraft/class_3965;)Lnet/minecraft/class_1269;
 		ARG 1 player
@@ -17,6 +23,7 @@ CLASS net/minecraft/class_636 net/minecraft/client/network/ClientPlayerInteracti
 		ARG 3 hand
 		ARG 4 hitResult
 	METHOD method_2897 stopUsingItem (Lnet/minecraft/class_1657;)V
+		ARG 1 player
 	METHOD method_2899 breakBlock (Lnet/minecraft/class_2338;)Z
 	METHOD method_2900 clickButton (II)V
 		ARG 1 syncId
@@ -32,22 +39,33 @@ CLASS net/minecraft/class_636 net/minecraft/client/network/ClientPlayerInteracti
 		ARG 1 player
 		ARG 2 entity
 		ARG 3 hand
+	METHOD method_2906 clickSlot (IIILnet/minecraft/class_1713;Lnet/minecraft/class_1657;)Lnet/minecraft/class_1799;
+		ARG 1 syncId
+		ARG 2 slotId
+		ARG 3 mouseButton
+		ARG 4 actionType
+		ARG 5 player
 	METHOD method_2907 setGameMode (Lnet/minecraft/class_1934;)V
 	METHOD method_2908 hasStatusBars ()Z
 	METHOD method_2909 clickCreativeStack (Lnet/minecraft/class_1799;I)V
 		ARG 1 stack
+		ARG 2 slotId
 	METHOD method_2910 attackBlock (Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Z
 		ARG 1 pos
 	METHOD method_2911 syncSelectedSlot ()V
 	METHOD method_2912 clickRecipe (ILnet/minecraft/class_1860;Z)V
 		ARG 1 syncId
 		ARG 2 recipe
+		ARG 3 craftAll
 	METHOD method_2913 hasExperienceBar ()Z
 	METHOD method_2914 hasCreativeInventory ()Z
 	METHOD method_2915 dropCreativeStack (Lnet/minecraft/class_1799;)V
+		ARG 1 stack
 	METHOD method_2916 pickFromInventory (I)V
 		ARG 1 slot
 	METHOD method_2917 interactEntityAtLocation (Lnet/minecraft/class_1657;Lnet/minecraft/class_1297;Lnet/minecraft/class_3966;Lnet/minecraft/class_1268;)Lnet/minecraft/class_1269;
+		ARG 1 player
+		ARG 3 hitResult
 	METHOD method_2918 attackEntity (Lnet/minecraft/class_1657;Lnet/minecraft/class_1297;)V
 		ARG 1 player
 		ARG 2 target
@@ -56,6 +74,7 @@ CLASS net/minecraft/class_636 net/minecraft/client/network/ClientPlayerInteracti
 		ARG 2 world
 		ARG 3 hand
 	METHOD method_2920 getCurrentGameMode ()Lnet/minecraft/class_1934;
+	METHOD method_2921 breakBlockOrFire (Lnet/minecraft/class_310;Lnet/minecraft/class_636;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)V
 	METHOD method_2922 isCurrentlyBreaking (Lnet/minecraft/class_2338;)Z
 		ARG 1 pos
 	METHOD method_2923 isBreakingBlock ()Z

--- a/mappings/net/minecraft/client/network/packet/BlockPlayerActionS2CPacket.mapping
+++ b/mappings/net/minecraft/client/network/packet/BlockPlayerActionS2CPacket.mapping
@@ -3,9 +3,13 @@ CLASS net/minecraft/class_4463 net/minecraft/client/network/packet/BlockPlayerAc
 	FIELD field_20320 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_20321 pos Lnet/minecraft/class_2338;
 	FIELD field_20322 state Lnet/minecraft/class_2680;
+	FIELD field_20323 approved Z
 	METHOD <init> (Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2846$class_2847;ZLjava/lang/String;)V
 		ARG 1 pos
 		ARG 2 state
+		ARG 4 approved
+		ARG 5 reason
 	METHOD method_21709 getBlockState ()Lnet/minecraft/class_2680;
 	METHOD method_21710 getBlockPos ()Lnet/minecraft/class_2338;
+	METHOD method_21711 isApproved ()Z
 	METHOD method_21712 getAction ()Lnet/minecraft/class_2846$class_2847;

--- a/mappings/net/minecraft/client/network/packet/PlayerActionResponseS2CPacket.mapping
+++ b/mappings/net/minecraft/client/network/packet/PlayerActionResponseS2CPacket.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4463 net/minecraft/client/network/packet/BlockPlayerActionS2CPacket
+CLASS net/minecraft/class_4463 net/minecraft/client/network/packet/PlayerActionResponseS2CPacket
 	FIELD field_20319 action Lnet/minecraft/class_2846$class_2847;
 	FIELD field_20320 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_20321 pos Lnet/minecraft/class_2338;

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -55,6 +55,9 @@ CLASS net/minecraft/class_1657 net/minecraft/entity/player/PlayerEntity
 	METHOD method_19205 isBedObstructed (Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Z
 		ARG 1 pos
 		ARG 2 direction
+	METHOD method_21701 canMine (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_1934;)Z
+	METHOD method_21823 shouldCancelInteraction ()Z
+	METHOD method_21824 shouldDismount ()Z
 	METHOD method_7254 unlockRecipes (Ljava/util/Collection;)I
 		ARG 1 recipes
 	METHOD method_7255 addExperience (I)V

--- a/mappings/net/minecraft/item/ItemUsageContext.mapping
+++ b/mappings/net/minecraft/item/ItemUsageContext.mapping
@@ -23,4 +23,4 @@ CLASS net/minecraft/class_1838 net/minecraft/item/ItemUsageContext
 	METHOD method_8042 getPlayerFacing ()Lnet/minecraft/class_2350;
 	METHOD method_8044 getPlayerYaw ()F
 	METHOD method_8045 getWorld ()Lnet/minecraft/class_1937;
-	METHOD method_8046 isPlayerSneaking ()Z
+	METHOD method_8046 shouldCancelInteraction ()Z

--- a/mappings/net/minecraft/network/listener/ClientPlayPacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ClientPlayPacketListener.mapping
@@ -177,3 +177,5 @@ CLASS net/minecraft/class_2602 net/minecraft/network/listener/ClientPlayPacketLi
 		ARG 1 packet
 	METHOD method_20320 handleChunkRenderDistanceCenter (Lnet/minecraft/class_4282;)V
 		ARG 1 packet
+	METHOD method_21707 handlePlayerActionResponse (Lnet/minecraft/class_4463;)V
+		ARG 1 packet

--- a/mappings/net/minecraft/server/network/ServerPlayerInteractionManager.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerInteractionManager.mapping
@@ -1,10 +1,22 @@
 CLASS net/minecraft/class_3225 net/minecraft/server/network/ServerPlayerInteractionManager
+	FIELD field_14000 tickCounter I
+	FIELD field_14003 mining Z
 	FIELD field_14005 gameMode Lnet/minecraft/class_1934;
 	FIELD field_14007 world Lnet/minecraft/class_3218;
 	FIELD field_14008 player Lnet/minecraft/class_3222;
+	FIELD field_20325 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_20326 startMiningTime I
+	FIELD field_20327 miningPos Lnet/minecraft/class_2338;
+	FIELD field_20328 failedToMine Z
+	FIELD field_20329 failedMiningPos Lnet/minecraft/class_2338;
+	FIELD field_20330 failedStartMiningTime I
+	FIELD field_20331 blockBreakingProgress I
+	METHOD <init> (Lnet/minecraft/class_3218;)V
+		ARG 1 world
 	METHOD method_14256 interactItem (Lnet/minecraft/class_1657;Lnet/minecraft/class_1937;Lnet/minecraft/class_1799;Lnet/minecraft/class_1268;)Lnet/minecraft/class_1269;
 	METHOD method_14257 getGameMode ()Lnet/minecraft/class_1934;
 	METHOD method_14259 setWorld (Lnet/minecraft/class_3218;)V
+		ARG 1 world
 	METHOD method_14260 setGameModeIfNotPresent (Lnet/minecraft/class_1934;)V
 	METHOD method_14261 setGameMode (Lnet/minecraft/class_1934;)V
 	METHOD method_14262 interactBlock (Lnet/minecraft/class_1657;Lnet/minecraft/class_1937;Lnet/minecraft/class_1799;Lnet/minecraft/class_1268;Lnet/minecraft/class_3965;)Lnet/minecraft/class_1269;
@@ -12,7 +24,14 @@ CLASS net/minecraft/class_3225 net/minecraft/server/network/ServerPlayerInteract
 		ARG 2 world
 		ARG 3 stack
 		ARG 4 hand
+		ARG 5 hitResult
+	METHOD method_14263 processBlockBreakingAction (Lnet/minecraft/class_2338;Lnet/minecraft/class_2846$class_2847;Lnet/minecraft/class_2350;I)V
+		ARG 1 pos
+		ARG 4 worldHeight
 	METHOD method_14264 update ()V
 	METHOD method_14266 tryBreakBlock (Lnet/minecraft/class_2338;)Z
 	METHOD method_14267 isSurvivalLike ()Z
 	METHOD method_14268 isCreative ()Z
+	METHOD method_21716 continueMining (Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;)F
+	METHOD method_21717 finishMining (Lnet/minecraft/class_2338;Lnet/minecraft/class_2846$class_2847;Ljava/lang/String;)V
+		ARG 3 reason

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -174,6 +174,7 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 	METHOD method_8505 canPlayerModifyAt (Lnet/minecraft/class_1657;Lnet/minecraft/class_2338;)Z
 		ARG 1 player
 		ARG 2 pos
+	METHOD method_8506 extinguishFire (Lnet/minecraft/class_1657;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Z
 	METHOD method_8508 updateNeighborsExcept (Lnet/minecraft/class_2338;Lnet/minecraft/class_2248;Lnet/minecraft/class_2350;)V
 		ARG 1 pos
 		ARG 2 sourceBlock


### PR DESCRIPTION
This PR makes significant improvements to the mappings of `ClientPlayerInteractionManager` and `ServerPlayerInteractionManager`, as well as small related improvements to other classes.

Another thing to consider, but I refrained from, is renaming the `BlockPlayerActionS2CPacket` class to something like `PlayerActionResponseS2CPacket`, as it is currently misleading in that it might suggest that the player action was blocked, whereas it is actually sent whether the action was approved or not.