### PR TITLE
Some NBT mappings

### DIFF
--- a/mappings/net/minecraft/nbt/CompoundTag.mapping
+++ b/mappings/net/minecraft/nbt/CompoundTag.mapping
@@ -67,7 +67,7 @@ CLASS net/minecraft/class_2487 net/minecraft/nbt/CompoundTag
 	METHOD method_10574 getDouble (Ljava/lang/String;)D
 	METHOD method_10575 putShort (Ljava/lang/String;S)V
 		ARG 1 key
-	METHOD method_10576 hasUuid (Ljava/lang/String;)Z
+	METHOD method_10576 containsUuid (Ljava/lang/String;)Z
 	METHOD method_10577 getBoolean (Ljava/lang/String;)Z
 	METHOD method_10578 escapeTagKey (Ljava/lang/String;)Ljava/lang/String;
 		ARG 0 key
@@ -82,3 +82,4 @@ CLASS net/minecraft/class_2487 net/minecraft/nbt/CompoundTag
 		ARG 1 key
 	METHOD method_10583 getFloat (Ljava/lang/String;)F
 	METHOD method_10584 getUuid (Ljava/lang/String;)Ljava/util/UUID;
+	METHOD method_22421 removeUuid (Ljava/lang/String;)V


### PR DESCRIPTION
Renamed `hasUuid`→`containsUuid` to keep it consistent with `containsKey`.