### PR TITLE
Fix pages being called lines in BookScreen

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/ingame/BookEditScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/BookEditScreen.mapping
@@ -2,6 +2,9 @@ CLASS net/minecraft/class_473 net/minecraft/client/gui/screen/ingame/BookEditScr
 	CLASS class_475 Position
 		FIELD field_2853 y I
 		FIELD field_2854 x I
+		METHOD <init> (Lnet/minecraft/class_473;II)V
+			ARG 2 x
+			ARG 3 y
 	FIELD field_17116 pages Ljava/util/List;
 	FIELD field_2826 player Lnet/minecraft/class_1657;
 	FIELD field_2827 lastClickIndex I

--- a/mappings/net/minecraft/client/gui/screen/ingame/BookScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/BookScreen.mapping
@@ -1,11 +1,11 @@
 CLASS net/minecraft/class_3872 net/minecraft/client/gui/screen/ingame/BookScreen
 	CLASS class_3931 Contents
 		METHOD method_17560 getPageCount ()I
-		METHOD method_17561 getPage (I)Lnet/minecraft/class_2561;
+		METHOD method_17561 getPageUnchecked (I)Lnet/minecraft/class_2561;
 			ARG 1 index
 		METHOD method_17562 create (Lnet/minecraft/class_1799;)Lnet/minecraft/class_3872$class_3931;
 			ARG 0 stack
-		METHOD method_17563 getPageOrDefault (I)Lnet/minecraft/class_2561;
+		METHOD method_17563 getPage (I)Lnet/minecraft/class_2561;
 			ARG 1 index
 	CLASS class_3932 WritableBookContents
 		FIELD field_17419 pages Ljava/util/List;
@@ -48,7 +48,7 @@ CLASS net/minecraft/class_3872 net/minecraft/client/gui/screen/ingame/BookScreen
 	METHOD method_17059 updatePageButtons ()V
 	METHOD method_17554 setPageProvider (Lnet/minecraft/class_3872$class_3931;)V
 		ARG 1 pageProvider
-	METHOD method_17555 getPages (Lnet/minecraft/class_2487;)Ljava/util/List;
+	METHOD method_17555 readPages (Lnet/minecraft/class_2487;)Ljava/util/List;
 		ARG 0 tag
 	METHOD method_17556 setPage (I)Z
 		ARG 1 index

--- a/mappings/net/minecraft/client/gui/screen/ingame/BookScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/BookScreen.mapping
@@ -1,18 +1,24 @@
 CLASS net/minecraft/class_3872 net/minecraft/client/gui/screen/ingame/BookScreen
 	CLASS class_3931 Contents
-		METHOD method_17560 getLineCount ()I
-		METHOD method_17561 getLine (I)Lnet/minecraft/class_2561;
-			ARG 1 line
+		METHOD method_17560 getPageCount ()I
+		METHOD method_17561 getPage (I)Lnet/minecraft/class_2561;
+			ARG 1 index
 		METHOD method_17562 create (Lnet/minecraft/class_1799;)Lnet/minecraft/class_3872$class_3931;
 			ARG 0 stack
-		METHOD method_17563 getLineOrDefault (I)Lnet/minecraft/class_2561;
-			ARG 1 line
+		METHOD method_17563 getPageOrDefault (I)Lnet/minecraft/class_2561;
+			ARG 1 index
 	CLASS class_3932 WritableBookContents
-		FIELD field_17419 lines Ljava/util/List;
-		METHOD method_17564 getLines (Lnet/minecraft/class_1799;)Ljava/util/List;
+		FIELD field_17419 pages Ljava/util/List;
+		METHOD <init> (Lnet/minecraft/class_1799;)V
+			ARG 1 stack
+		METHOD method_17564 getPages (Lnet/minecraft/class_1799;)Ljava/util/List;
+			ARG 0 stack
 	CLASS class_3933 WrittenBookContents
-		FIELD field_17420 lines Ljava/util/List;
-		METHOD method_17565 getLines (Lnet/minecraft/class_1799;)Ljava/util/List;
+		FIELD field_17420 pages Ljava/util/List;
+		METHOD <init> (Lnet/minecraft/class_1799;)V
+			ARG 1 stack
+		METHOD method_17565 getPages (Lnet/minecraft/class_1799;)Ljava/util/List;
+			ARG 0 stack
 	FIELD field_17117 BOOK_TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_17119 pageIndex I
 	FIELD field_17120 cachedPage Ljava/util/List;
@@ -42,7 +48,8 @@ CLASS net/minecraft/class_3872 net/minecraft/client/gui/screen/ingame/BookScreen
 	METHOD method_17059 updatePageButtons ()V
 	METHOD method_17554 setPageProvider (Lnet/minecraft/class_3872$class_3931;)V
 		ARG 1 pageProvider
-	METHOD method_17555 getLines (Lnet/minecraft/class_2487;)Ljava/util/List;
+	METHOD method_17555 getPages (Lnet/minecraft/class_2487;)Ljava/util/List;
+		ARG 0 tag
 	METHOD method_17556 setPage (I)Z
 		ARG 1 index
 	METHOD method_17557 addCloseButton ()V


### PR DESCRIPTION
`BookScreen.getLines(CompoundTag)` actually gets the book tag's list of pages.