### PR TITLE
Map bindTexture() to public method

### DIFF
--- a/mappings/net/minecraft/client/texture/TextureManager.mapping
+++ b/mappings/net/minecraft/client/texture/TextureManager.mapping
@@ -11,7 +11,8 @@ CLASS net/minecraft/class_1060 net/minecraft/client/texture/TextureManager
 		ARG 1 id
 	METHOD method_4617 registerDynamicTexture (Ljava/lang/String;Lnet/minecraft/class_1043;)Lnet/minecraft/class_2960;
 		ARG 1 prefix
-	METHOD method_4618 bindTexture (Lnet/minecraft/class_2960;)V
+	METHOD method_4618 bindTextureInner (Lnet/minecraft/class_2960;)V
 	METHOD method_4619 getTexture (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1062;
 	METHOD method_4620 registerTextureUpdateable (Lnet/minecraft/class_2960;Lnet/minecraft/class_1063;)Z
 		ARG 1 id
+	METHOD method_22813 bindTexture (Lnet/minecraft/class_2960;)V


### PR DESCRIPTION
In the latest snapshot the old bindTexture method was made private and is now wrapped by a public method that ensures thread safety.  Mods calling `bindTexture()` will fail due to an access violate.  This PR maps `bindTexture` to the new publicMethod and renames the private method.