### PR TITLE
Randoms and datafixers

### DIFF
--- a/mappings/net/minecraft/block/BambooBlock.mapping
+++ b/mappings/net/minecraft/block/BambooBlock.mapping
@@ -11,7 +11,7 @@ CLASS net/minecraft/class_2211 net/minecraft/block/BambooBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-		ARG 4 rand
+		ARG 4 random
 		ARG 5 height
 	METHOD method_9386 countBambooBelow (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)I
 		ARG 1 world

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -104,7 +104,7 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 		ARG 3 side
 	METHOD method_22358 (Lnet/minecraft/class_2680;Lnet/minecraft/class_3611;)Z
 		ARG 1 state
-	METHOD method_9496 onRandomDisplayTick (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Ljava/util/Random;)V
+	METHOD method_9496 randomDisplayTick (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Ljava/util/Random;)V
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -104,11 +104,11 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 		ARG 3 side
 	METHOD method_22358 (Lnet/minecraft/class_2680;Lnet/minecraft/class_3611;)Z
 		ARG 1 state
-	METHOD method_9496 randomDisplayTick (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Ljava/util/Random;)V
+	METHOD method_9496 onRandomDisplayTick (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Ljava/util/Random;)V
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-		ARG 4 rnd
+		ARG 4 random
 	METHOD method_9497 dropStacks (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)V
 		ARG 0 state
 		ARG 1 world
@@ -150,6 +150,7 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 		ARG 5 stack
 	METHOD method_9514 onRandomTick (Lnet/minecraft/class_2680;Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;Ljava/util/Random;)V
 		ARG 1 state
+		ARG 2 world
 		ARG 3 pos
 		ARG 4 random
 	METHOD method_9515 appendProperties (Lnet/minecraft/class_2689$class_2690;)V
@@ -378,6 +379,7 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 		ARG 3 explosion
 	METHOD method_9588 onScheduledTick (Lnet/minecraft/class_2680;Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;Ljava/util/Random;)V
 		ARG 1 state
+		ARG 2 world
 		ARG 3 pos
 		ARG 4 random
 	METHOD method_9589 hasBlockEntityBreakingRender (Lnet/minecraft/class_2680;)Z

--- a/mappings/net/minecraft/block/BlockState.mapping
+++ b/mappings/net/minecraft/block/BlockState.mapping
@@ -46,7 +46,7 @@ CLASS net/minecraft/class_2680 net/minecraft/block/BlockState
 		ARG 3 type
 		ARG 4 data
 	METHOD method_11584 hasComparatorOutput ()Z
-	METHOD method_11585 onScheduledTick (Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;Ljava/util/Random;)V
+	METHOD method_11585 scheduledTick (Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;Ljava/util/Random;)V
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 random

--- a/mappings/net/minecraft/block/BlockState.mapping
+++ b/mappings/net/minecraft/block/BlockState.mapping
@@ -46,9 +46,10 @@ CLASS net/minecraft/class_2680 net/minecraft/block/BlockState
 		ARG 3 type
 		ARG 4 data
 	METHOD method_11584 hasComparatorOutput ()Z
-	METHOD method_11585 scheduledTick (Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;Ljava/util/Random;)V
+	METHOD method_11585 onScheduledTick (Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;Ljava/util/Random;)V
+		ARG 1 world
 		ARG 2 pos
-		ARG 3 rnd
+		ARG 3 random
 	METHOD method_11586 getPistonBehavior ()Lnet/minecraft/class_3619;
 	METHOD method_11587 canReplace (Lnet/minecraft/class_1750;)Z
 		ARG 1 ctx
@@ -136,8 +137,9 @@ CLASS net/minecraft/class_2680 net/minecraft/block/BlockState
 		ARG 1 view
 		ARG 2 pos
 	METHOD method_11624 onRandomTick (Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;Ljava/util/Random;)V
+		ARG 1 world
 		ARG 2 pos
-		ARG 3 rnd
+		ARG 3 random
 	METHOD method_11625 getTopMaterialColor (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Lnet/minecraft/class_3620;
 		ARG 1 view
 		ARG 2 pos

--- a/mappings/net/minecraft/block/Fertilizable.mapping
+++ b/mappings/net/minecraft/block/Fertilizable.mapping
@@ -10,6 +10,7 @@ CLASS net/minecraft/class_2256 net/minecraft/block/Fertilizable
 		ARG 3 state
 		ARG 4 isClient
 	METHOD method_9652 grow (Lnet/minecraft/class_3218;Ljava/util/Random;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)V
+		ARG 1 world
 		ARG 2 random
 		ARG 3 pos
 		ARG 4 state

--- a/mappings/net/minecraft/block/RedstoneTorchBlock.mapping
+++ b/mappings/net/minecraft/block/RedstoneTorchBlock.mapping
@@ -21,5 +21,5 @@ CLASS net/minecraft/class_2459 net/minecraft/block/RedstoneTorchBlock
 		ARG 0 state
 		ARG 1 world
 		ARG 2 pos
-		ARG 3 rand
+		ARG 3 random
 		ARG 4 unpower

--- a/mappings/net/minecraft/datafixer/fixes/LeavesFix.mapping
+++ b/mappings/net/minecraft/datafixer/fixes/LeavesFix.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_4541 net/minecraft/datafixer/fixes/LeavesFix

--- a/mappings/net/minecraft/datafixer/fixes/PoiRebuildFix.mapping
+++ b/mappings/net/minecraft/datafixer/fixes/PoiRebuildFix.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_4542 net/minecraft/datafixer/fixes/PoiRebuildFix

--- a/mappings/net/minecraft/datafixers/fixes/BiomeFormatFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/BiomeFormatFix.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_4541 net/minecraft/datafixers/fixes/BiomeFormatFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 schema
+		ARG 2 changesType

--- a/mappings/net/minecraft/datafixers/fixes/PoiRebuildFix.mapping
+++ b/mappings/net/minecraft/datafixers/fixes/PoiRebuildFix.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_4542 net/minecraft/datafixers/fixes/PoiRebuildFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
+		ARG 1 schema
+		ARG 2 changesType

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -230,7 +230,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6049 canHaveStatusEffect (Lnet/minecraft/class_1293;)Z
 		ARG 1 effect
 	METHOD method_6050 tickStatusEffects ()V
-	METHOD method_6051 getRand ()Ljava/util/Random;
+	METHOD method_6051 getRandom ()Ljava/util/Random;
 	METHOD method_6052 getAttacking ()Lnet/minecraft/class_1309;
 	METHOD method_6053 initAi ()V
 	METHOD method_6054 canDropLootAndXp ()Z

--- a/mappings/net/minecraft/util/registry/Registry.mapping
+++ b/mappings/net/minecraft/util/registry/Registry.mapping
@@ -63,7 +63,7 @@ CLASS net/minecraft/class_2378 net/minecraft/util/registry/Registry
 		ARG 3 entry
 	METHOD method_10235 getIds ()Ljava/util/Set;
 	METHOD method_10240 getRandom (Ljava/util/Random;)Ljava/lang/Object;
-		ARG 1 rand
+		ARG 1 random
 	METHOD method_10247 create (Ljava/lang/String;Ljava/util/function/Supplier;)Lnet/minecraft/class_2378;
 		ARG 0 id
 	METHOD method_10249 getRawId (Ljava/lang/Object;)I


### PR DESCRIPTION
- Moved the new datafixers that were mapped in #866 to the correct package. (`n.m.datafixer` -> `n.m.datafixers`)
  - There was already a `LeavesFix` in the correct package, so I renamed the new `LeavesFix` to `BiomeFormatFix`. I think the `"Leaves fix"` in the class is just a mistake from the actual `LeavesFix`. Mojang seems to have used it as a template (the `makeRule` methods have a similar structure).
- Added `on` to `Block.onRandomDisplayTick` and `BlockState.onScheduledTick`.
- Renamed `rnd` and `rand` in various places to `random` for consistency.