### PR TITLE
1.14.4: Fix clash of CommandBlockBlockEntity#getType with BlockEntity#getType

### DIFF
--- a/mappings/net/minecraft/block/entity/CommandBlockBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/CommandBlockBlockEntity.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_2593 net/minecraft/block/entity/CommandBlockBlockEntit
 	METHOD method_11037 setNeedsUpdatePacket (Z)V
 		ARG 1 needsUpdatePacket
 	METHOD method_11038 setPowered (Z)V
-	METHOD method_11039 getType ()Lnet/minecraft/class_2593$class_2594;
+	METHOD method_11039 getCommandBlockType ()Lnet/minecraft/class_2593$class_2594;
 	METHOD method_11040 getCommandExecutor ()Lnet/minecraft/class_1918;
 	METHOD method_11041 setAuto (Z)V
 	METHOD method_11042 isAuto ()Z


### PR DESCRIPTION
Same as #874, but 1.14.4 as target branch.