### PR TITLE
Entity properties

### DIFF
--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -78,7 +78,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	FIELD field_6029 scoreboardTags Ljava/util/Set;
 	FIELD field_6030 EMPTY_STACK_LIST Ljava/util/List;
 	FIELD field_6031 yaw F
-	FIELD field_6032 BREATH Lnet/minecraft/class_2940;
+	FIELD field_6032 AIR Lnet/minecraft/class_2940;
 	FIELD field_6033 inanimate Z
 	FIELD field_6034 vehicle Lnet/minecraft/class_1297;
 	FIELD field_6035 z D
@@ -260,7 +260,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_5666 attemptSprintingParticles ()V
 	METHOD method_5667 getUuid ()Ljava/util/UUID;
 	METHOD method_5668 getRootVehicle ()Lnet/minecraft/class_1297;
-	METHOD method_5669 getBreath ()I
+	METHOD method_5669 getAir ()I
 	METHOD method_5670 baseTick ()V
 	METHOD method_5671 getCommandSource ()Lnet/minecraft/class_2168;
 	METHOD method_5672 getHighSpeedSplashSound ()Lnet/minecraft/class_3414;
@@ -399,7 +399,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_5747 handleFallDamage (FF)V
 		ARG 1 fallDistance
 		ARG 2 damageMultiplier
-	METHOD method_5748 getMaxBreath ()I
+	METHOD method_5748 getMaxAir ()I
 	METHOD method_5749 readCustomDataFromTag (Lnet/minecraft/class_2487;)V
 		ARG 1 tag
 	METHOD method_5750 setVelocityClient (DDD)V
@@ -567,8 +567,8 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		ARG 4 state
 		ARG 5 explosionPower
 	METHOD method_5854 getVehicle ()Lnet/minecraft/class_1297;
-	METHOD method_5855 setBreath (I)V
-		ARG 1 breath
+	METHOD method_5855 setAir (I)V
+		ARG 1 air
 	METHOD method_5856 removeClickEvents (Lnet/minecraft/class_2561;)V
 		ARG 0 textComponent
 	METHOD method_5857 setBoundingBox (Lnet/minecraft/class_238;)V

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -250,7 +250,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 source
 	METHOD method_6062 isImmobile ()Z
 	METHOD method_6063 getMaximumHealth ()F
-	METHOD method_6064 updateAirOnLand (I)I
+	METHOD method_6064 getNextAirOnLand (I)I
 		ARG 1 air
 	METHOD method_6065 getAttacker ()Lnet/minecraft/class_1309;
 	METHOD method_6066 getDamageTracker ()Lnet/minecraft/class_1283;
@@ -357,7 +357,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6128 isFallFlying ()Z
 	METHOD method_6129 onStatusEffectRemoved (Lnet/minecraft/class_1293;)V
 		ARG 1 effect
-	METHOD method_6130 updateAirUnderwater (I)I
+	METHOD method_6130 getNextAirUnderwater (I)I
 		ARG 1 air
 	METHOD method_6131 getDespawnCounter ()I
 	METHOD method_6132 applyArmorToDamage (Lnet/minecraft/class_1282;F)F

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -248,8 +248,8 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 source
 	METHOD method_6062 isImmobile ()Z
 	METHOD method_6063 getMaximumHealth ()F
-	METHOD method_6064 getNextBreathInAir (I)I
-		ARG 1 breath
+	METHOD method_6064 updateAirOnLand (I)I
+		ARG 1 air
 	METHOD method_6065 getAttacker ()Lnet/minecraft/class_1309;
 	METHOD method_6066 getDamageTracker ()Lnet/minecraft/class_1283;
 	METHOD method_6067 getAbsorptionAmount ()F
@@ -355,8 +355,8 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6128 isFallFlying ()Z
 	METHOD method_6129 onStatusEffectRemoved (Lnet/minecraft/class_1293;)V
 		ARG 1 effect
-	METHOD method_6130 getNextBreathInWater (I)I
-		ARG 1 breath
+	METHOD method_6130 updateAirUnderwater (I)I
+		ARG 1 air
 	METHOD method_6131 getDespawnCounter ()I
 	METHOD method_6132 applyArmorToDamage (Lnet/minecraft/class_1282;F)F
 		ARG 1 source

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -154,6 +154,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_5998 getStackInHand (Lnet/minecraft/class_1268;)Lnet/minecraft/class_1799;
 		ARG 1 hand
 	METHOD method_5999 isUndead ()Z
+	METHOD method_6000 enterCombat ()V
 	METHOD method_6001 initAttributes ()V
 	METHOD method_6002 getDeathSound ()Lnet/minecraft/class_3414;
 	METHOD method_6003 getRoll ()I
@@ -221,6 +222,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6041 getFallSound (I)Lnet/minecraft/class_3414;
 		ARG 1 distance
 	METHOD method_6043 jump ()V
+	METHOD method_6044 endCombat ()V
 	METHOD method_6045 playEquipmentBreakEffects (Lnet/minecraft/class_1799;)V
 		ARG 1 stack
 	METHOD method_6046 getGroup ()Lnet/minecraft/class_1310;

--- a/mappings/net/minecraft/entity/WaterCreatureEntity.mapping
+++ b/mappings/net/minecraft/entity/WaterCreatureEntity.mapping
@@ -1,5 +1,0 @@
-CLASS net/minecraft/class_1480 net/minecraft/entity/WaterCreatureEntity
-	METHOD <init> (Lnet/minecraft/class_1299;Lnet/minecraft/class_1937;)V
-		ARG 1 type
-	METHOD method_6673 tickAir (I)V
-		ARG 1 air

--- a/mappings/net/minecraft/entity/WaterCreatureEntity.mapping
+++ b/mappings/net/minecraft/entity/WaterCreatureEntity.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_1480 net/minecraft/entity/WaterCreatureEntity
 	METHOD <init> (Lnet/minecraft/class_1299;Lnet/minecraft/class_1937;)V
 		ARG 1 type
-	METHOD method_6673 tickBreath (I)V
-		ARG 1 breath
+	METHOD method_6673 tickAir (I)V
+		ARG 1 air

--- a/mappings/net/minecraft/entity/mob/WaterCreatureEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/WaterCreatureEntity.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_1480 net/minecraft/entity/mob/WaterCreatureEntity
+	METHOD <init> (Lnet/minecraft/class_1299;Lnet/minecraft/class_1937;)V
+		ARG 1 type
+	METHOD method_6673 tickWaterBreathingAir (I)V
+		ARG 1 air

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -1,12 +1,21 @@
 CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
+	FIELD field_13963 healthScore F
+	FIELD field_13965 levelScore I
 	FIELD field_13966 statHandler Lnet/minecraft/class_3442;
 	FIELD field_13967 pingMilliseconds I
+	FIELD field_13968 airScore I
 	FIELD field_13969 seenCredits Z
 	FIELD field_13970 advancementManager Lnet/minecraft/class_2985;
+	FIELD field_13972 syncedSaturationIsZero Z
 	FIELD field_13974 interactionManager Lnet/minecraft/class_3225;
 	FIELD field_13975 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_13976 lastActionTime J
+	FIELD field_13978 syncedExperience I
+	FIELD field_13979 syncedFoodLevel I
+	FIELD field_13980 experienceScore I
 	FIELD field_13981 clientLanguage Ljava/lang/String;
+	FIELD field_13982 armorScore I
+	FIELD field_13983 foodScore I
 	FIELD field_13984 cameraEntity Lnet/minecraft/class_1297;
 	FIELD field_13985 inTeleportationState Z
 	FIELD field_13986 containerSyncId I
@@ -18,6 +27,7 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	FIELD field_13994 enteredNetherPos Lnet/minecraft/class_243;
 	FIELD field_13995 server Lnet/minecraft/server/MinecraftServer;
 	FIELD field_13996 recipeBook Lnet/minecraft/class_3441;
+	FIELD field_13997 syncedHealth F
 	METHOD method_14203 copyFrom (Lnet/minecraft/class_3222;Z)V
 		ARG 1 oldPlayer
 		ARG 2 alive
@@ -27,12 +37,17 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	METHOD method_14208 isInTeleportationState ()Z
 	METHOD method_14209 getServerBrand ()Ljava/lang/String;
 	METHOD method_14211 onStartedTracking (Lnet/minecraft/class_1297;)V
+	METHOD method_14212 updateScores (Lnet/minecraft/class_274;I)V
+		ARG 1 criterion
+		ARG 2 score
 	METHOD method_14213 setClientSettings (Lnet/minecraft/class_2803;)V
 	METHOD method_14216 sendBlockEntityUpdate (Lnet/minecraft/class_2586;)V
+	METHOD method_14217 markHealthDirty ()V
 	METHOD method_14219 getLastActionTime ()J
 	METHOD method_14220 getServerWorld ()Lnet/minecraft/class_3218;
 	METHOD method_14224 setCameraEntity (Lnet/minecraft/class_1297;)V
 		ARG 1 entity
+	METHOD method_14226 playerTick ()V
 	METHOD method_14228 setExperiencePoints (I)V
 	METHOD method_14232 getCameraPosition ()Lnet/minecraft/class_4076;
 	METHOD method_14234 updateLastActionTime ()V
@@ -45,9 +60,17 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	METHOD method_14248 getStatHandler ()Lnet/minecraft/class_3442;
 	METHOD method_14249 onStoppedTracking (Lnet/minecraft/class_1297;)V
 	METHOD method_14251 teleport (Lnet/minecraft/class_3218;DDDFF)V
+		ARG 1 world
+		ARG 2 x
+		ARG 4 y
+		ARG 6 z
+		ARG 8 yaw
+		ARG 9 pitch
 	METHOD method_14252 setExperienceLevel (I)V
 		ARG 1 level
 	METHOD method_14253 getRecipeBook ()Lnet/minecraft/class_3441;
 	METHOD method_14254 sendChatMessage (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556;)V
 	METHOD method_17668 setCameraPosition (Lnet/minecraft/class_4076;)V
 		ARG 1 cameraPosition
+	METHOD method_18783 dimensionChanged (Lnet/minecraft/class_3218;)V
+		ARG 1 targetWorld

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -28,6 +28,11 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	FIELD field_13995 server Lnet/minecraft/server/MinecraftServer;
 	FIELD field_13996 recipeBook Lnet/minecraft/class_3441;
 	FIELD field_13997 syncedHealth F
+	METHOD <init> (Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/class_3218;Lcom/mojang/authlib/GameProfile;Lnet/minecraft/class_3225;)V
+		ARG 1 server
+		ARG 2 world
+		ARG 3 profile
+		ARG 4 interactionManager
 	METHOD method_14203 copyFrom (Lnet/minecraft/class_3222;Z)V
 		ARG 1 oldPlayer
 		ARG 2 alive
@@ -56,6 +61,8 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	METHOD method_14238 getClientChatVisibility ()Lnet/minecraft/class_1659;
 	METHOD method_14240 onTeleportationDone ()V
 	METHOD method_14242 getCameraEntity ()Lnet/minecraft/class_1297;
+	METHOD method_14245 moveToSpawnPos (Lnet/minecraft/class_3218;)V
+		ARG 1 world
 	METHOD method_14246 sendUnloadChunkPacket (Lnet/minecraft/class_1923;)V
 	METHOD method_14248 getStatHandler ()Lnet/minecraft/class_3442;
 	METHOD method_14249 onStoppedTracking (Lnet/minecraft/class_1297;)V

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -1,9 +1,9 @@
 CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
-	FIELD field_13963 healthScore F
-	FIELD field_13965 levelScore I
+	FIELD field_13963 lastHealthScore F
+	FIELD field_13965 lastLevelScore I
 	FIELD field_13966 statHandler Lnet/minecraft/class_3442;
 	FIELD field_13967 pingMilliseconds I
-	FIELD field_13968 airScore I
+	FIELD field_13968 lastAirScore I
 	FIELD field_13969 seenCredits Z
 	FIELD field_13970 advancementManager Lnet/minecraft/class_2985;
 	FIELD field_13972 syncedSaturationIsZero Z
@@ -12,10 +12,10 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	FIELD field_13976 lastActionTime J
 	FIELD field_13978 syncedExperience I
 	FIELD field_13979 syncedFoodLevel I
-	FIELD field_13980 experienceScore I
+	FIELD field_13980 lastExperienceScore I
 	FIELD field_13981 clientLanguage Ljava/lang/String;
-	FIELD field_13982 armorScore I
-	FIELD field_13983 foodScore I
+	FIELD field_13982 lastArmorScore I
+	FIELD field_13983 lastFoodScore I
 	FIELD field_13984 cameraEntity Lnet/minecraft/class_1297;
 	FIELD field_13985 inTeleportationState Z
 	FIELD field_13986 containerSyncId I

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -60,7 +60,7 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	METHOD method_14248 getStatHandler ()Lnet/minecraft/class_3442;
 	METHOD method_14249 onStoppedTracking (Lnet/minecraft/class_1297;)V
 	METHOD method_14251 teleport (Lnet/minecraft/class_3218;DDDFF)V
-		ARG 1 world
+		ARG 1 targetWorld
 		ARG 2 x
 		ARG 4 y
 		ARG 6 z

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -61,7 +61,7 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	METHOD method_14238 getClientChatVisibility ()Lnet/minecraft/class_1659;
 	METHOD method_14240 onTeleportationDone ()V
 	METHOD method_14242 getCameraEntity ()Lnet/minecraft/class_1297;
-	METHOD method_14245 moveToSpawnPos (Lnet/minecraft/class_3218;)V
+	METHOD method_14245 moveToSpawn (Lnet/minecraft/class_3218;)V
 		ARG 1 world
 	METHOD method_14246 sendUnloadChunkPacket (Lnet/minecraft/class_1923;)V
 	METHOD method_14248 getStatHandler ()Lnet/minecraft/class_3442;

--- a/mappings/net/minecraft/world/border/WorldBorder.mapping
+++ b/mappings/net/minecraft/world/border/WorldBorder.mapping
@@ -12,18 +12,24 @@ CLASS net/minecraft/class_2784 net/minecraft/world/border/WorldBorder
 		METHOD method_11993 getTargetRemainingTime ()J
 		METHOD method_11994 getBoundWest ()D
 		METHOD method_11995 getStage ()Lnet/minecraft/class_2789;
+		METHOD method_17906 asVoxelShape ()Lnet/minecraft/class_265;
 	CLASS class_2786 MovingArea
 		FIELD field_12739 newSize D
 		FIELD field_12740 oldSize D
 		FIELD field_12741 timeStart J
 		FIELD field_12742 timeEnd J
 		FIELD field_12744 timeDuration D
+		METHOD <init> (Lnet/minecraft/class_2784;DDJ)V
+			ARG 2 oldSize
+			ARG 4 newSize
+			ARG 6 duration
 	CLASS class_2787 StaticArea
 		FIELD field_12745 boundNorth D
 		FIELD field_12746 boundWest D
 		FIELD field_12747 size D
 		FIELD field_12749 boundSouth D
 		FIELD field_12750 boundEast D
+		FIELD field_17653 shape Lnet/minecraft/class_265;
 		METHOD <init> (Lnet/minecraft/class_2784;D)V
 			ARG 1 size
 		METHOD method_11996 recalculateBounds ()V
@@ -37,7 +43,9 @@ CLASS net/minecraft/class_2784 net/minecraft/world/border/WorldBorder
 	FIELD field_12737 centerZ D
 	FIELD field_12738 centerX D
 	METHOD method_11951 contains (Lnet/minecraft/class_1923;)Z
+		ARG 1 pos
 	METHOD method_11952 contains (Lnet/minecraft/class_2338;)Z
+		ARG 1 pos
 	METHOD method_11953 getDamagePerBlock ()D
 	METHOD method_11954 getTargetSize ()D
 	METHOD method_11955 setDamagePerBlock (D)V
@@ -49,12 +57,15 @@ CLASS net/minecraft/class_2784 net/minecraft/world/border/WorldBorder
 		ARG 5 time
 	METHOD method_11958 getBoundNorth ()D
 	METHOD method_11959 getMaxWorldBorderRadius ()I
-	METHOD method_11961 contains (DD)D
+	METHOD method_11961 getDistanceInsideBorder (DD)D
+		ARG 1 x
+		ARG 3 z
 	METHOD method_11962 getTargetRemainingTime ()J
 	METHOD method_11963 getBoundEast ()D
 	METHOD method_11964 getCenterX ()D
 	METHOD method_11965 getSize ()D
 	METHOD method_11966 contains (Lnet/minecraft/class_238;)Z
+		ARG 1 box
 	METHOD method_11967 setWarningBlocks (I)V
 		ARG 1 warningBlocks
 	METHOD method_11968 getStage ()Lnet/minecraft/class_2789;
@@ -72,7 +83,8 @@ CLASS net/minecraft/class_2784 net/minecraft/world/border/WorldBorder
 	METHOD method_11978 setCenter (DD)V
 		ARG 1 x
 		ARG 3 z
-	METHOD method_11979 contains (Lnet/minecraft/class_1297;)D
+	METHOD method_11979 getDistanceInsideBorder (Lnet/minecraft/class_1297;)D
+		ARG 1 entity
 	METHOD method_11980 getCenterZ ()D
 	METHOD method_11981 setBuffer (D)V
 		ARG 1 buffer


### PR DESCRIPTION
- Changed `Entity.BREATH` and related mappings to `AIR`
  - `air` is used by Mojang in entity NBT and scoreboards
- Mapped some `ServerPlayerEntity` fields and tick/update methods
  - `playerTick()` comes from the crash handler in the method (`Ticking player`)
- Some world border mappings
- Moved `WaterCreatureEntity` to the mob package (it extends `MobEntityWithAi`)