### PR TITLE
Small book and text tweaks

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/ingame/BookEditScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/BookEditScreen.mapping
@@ -11,19 +11,19 @@ CLASS net/minecraft/class_473 net/minecraft/client/gui/screen/ingame/BookEditScr
 	FIELD field_2828 signing Z
 	FIELD field_2829 highlightTo I
 	FIELD field_2830 lastClickTime J
-	FIELD field_2831 buttonSign Lnet/minecraft/class_4185;
+	FIELD field_2831 signButton Lnet/minecraft/class_4185;
 	FIELD field_2832 hand Lnet/minecraft/class_1268;
 	FIELD field_2833 cursorIndex I
 	FIELD field_2835 itemStack Lnet/minecraft/class_1799;
 	FIELD field_2837 dirty Z
-	FIELD field_2839 buttonNextPage Lnet/minecraft/class_474;
+	FIELD field_2839 previousPageButton Lnet/minecraft/class_474;
 	FIELD field_2840 currentPage I
-	FIELD field_2841 buttonFinalize Lnet/minecraft/class_4185;
-	FIELD field_2843 buttonPreviousPage Lnet/minecraft/class_474;
+	FIELD field_2841 finalizeButton Lnet/minecraft/class_4185;
+	FIELD field_2843 nextPageButton Lnet/minecraft/class_474;
 	FIELD field_2844 tickCounter I
 	FIELD field_2847 title Ljava/lang/String;
-	FIELD field_2848 buttonDone Lnet/minecraft/class_4185;
-	FIELD field_2849 buttonCancel Lnet/minecraft/class_4185;
+	FIELD field_2848 doneButton Lnet/minecraft/class_4185;
+	FIELD field_2849 cancelButton Lnet/minecraft/class_4185;
 	METHOD <init> (Lnet/minecraft/class_1657;Lnet/minecraft/class_1799;Lnet/minecraft/class_1268;)V
 		ARG 1 playerEntity
 		ARG 2 itemStack

--- a/mappings/net/minecraft/client/gui/screen/ingame/BookScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/BookScreen.mapping
@@ -24,7 +24,7 @@ CLASS net/minecraft/class_3872 net/minecraft/client/gui/screen/ingame/BookScreen
 	FIELD field_17120 cachedPage Ljava/util/List;
 	FIELD field_17121 cachedPageIndex I
 	FIELD field_17122 nextPageButton Lnet/minecraft/class_474;
-	FIELD field_17123 lastPageButton Lnet/minecraft/class_474;
+	FIELD field_17123 previousPageButton Lnet/minecraft/class_474;
 	FIELD field_17417 EMPTY_PROVIDER Lnet/minecraft/class_3872$class_3931;
 	FIELD field_17418 contents Lnet/minecraft/class_3872$class_3931;
 	FIELD field_18976 pageTurnSound Z

--- a/mappings/net/minecraft/client/gui/screen/ingame/BookScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/BookScreen.mapping
@@ -37,7 +37,7 @@ CLASS net/minecraft/class_3872 net/minecraft/client/gui/screen/ingame/BookScreen
 		ARG 1 keyCode
 		ARG 2 scanCode
 		ARG 3 modifiers
-	METHOD method_17048 getLineAt (DD)Lnet/minecraft/class_2561;
+	METHOD method_17048 getTextAt (DD)Lnet/minecraft/class_2561;
 		ARG 1 x
 		ARG 3 y
 	METHOD method_17053 getStringWidth (Ljava/lang/String;)I

--- a/mappings/net/minecraft/client/gui/screen/ingame/BookScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/BookScreen.mapping
@@ -23,8 +23,8 @@ CLASS net/minecraft/class_3872 net/minecraft/client/gui/screen/ingame/BookScreen
 	FIELD field_17119 pageIndex I
 	FIELD field_17120 cachedPage Ljava/util/List;
 	FIELD field_17121 cachedPageIndex I
-	FIELD field_17122 lastPageButton Lnet/minecraft/class_474;
-	FIELD field_17123 nextPageButton Lnet/minecraft/class_474;
+	FIELD field_17122 nextPageButton Lnet/minecraft/class_474;
+	FIELD field_17123 lastPageButton Lnet/minecraft/class_474;
 	FIELD field_17417 EMPTY_PROVIDER Lnet/minecraft/class_3872$class_3931;
 	FIELD field_17418 contents Lnet/minecraft/class_3872$class_3931;
 	FIELD field_18976 pageTurnSound Z

--- a/mappings/net/minecraft/client/util/Texts.mapping
+++ b/mappings/net/minecraft/client/util/Texts.mapping
@@ -1,8 +1,9 @@
-CLASS net/minecraft/class_341 net/minecraft/client/util/TextComponentUtil
+CLASS net/minecraft/class_341 net/minecraft/client/util/Texts
 	METHOD method_1849 getRenderChatMessage (Ljava/lang/String;Z)Ljava/lang/String;
 		ARG 0 string
 		ARG 1 forceColor
 	METHOD method_1850 wrapLines (Lnet/minecraft/class_2561;ILnet/minecraft/class_327;ZZ)Ljava/util/List;
 		ARG 0 text
 		ARG 1 width
-		ARG 2 fontRenderer
+		ARG 2 textRenderer
+		ARG 4 forceColor


### PR DESCRIPTION
- `BookScreen.previousPageButton` and `BookScreen.nextPageButton` were reversed
- Improved `BookEditScreen` button field names (previous and next were also reversed here)
- `getLineAt` actually can get a smaller part of a line, so `getTextAt`
- Renamed `TextComponentUtil` to `Texts`