### PR TITLE
isOpaque backing field/block settings

### DIFF
--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -22,11 +22,13 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 		FIELD field_10668 material Lnet/minecraft/class_3614;
 		FIELD field_10669 hardness F
 		FIELD field_10670 dynamicBounds Z
+		FIELD field_20721 opaque Z
 		METHOD <init> (Lnet/minecraft/class_3614;Lnet/minecraft/class_3620;)V
 			ARG 2 materialColor
 		METHOD method_16228 dropsLike (Lnet/minecraft/class_2248;)Lnet/minecraft/class_2248$class_2251;
 			ARG 1 source
 		METHOD method_16229 dropsNothing ()Lnet/minecraft/class_2248$class_2251;
+		METHOD method_22488 nonOpaque ()Lnet/minecraft/class_2248$class_2251;
 		METHOD method_9617 of (Lnet/minecraft/class_3614;Lnet/minecraft/class_1767;)Lnet/minecraft/class_2248$class_2251;
 			ARG 0 material
 			ARG 1 color
@@ -74,6 +76,7 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 	FIELD field_18966 SOLID_MEDIUM_SQUARE_SHAPE Lnet/minecraft/class_265;
 	FIELD field_19061 SOLID_SMALL_SQUARE_SHAPE Lnet/minecraft/class_265;
 	FIELD field_19312 FULL_CUBE_SHAPE_CACHE Lcom/google/common/cache/LoadingCache;
+	FIELD field_20720 opaque Z
 	METHOD <init> (Lnet/minecraft/class_2248$class_2251;)V
 		ARG 1 settings
 	METHOD method_16361 topCoversMediumSquare (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z


### PR DESCRIPTION
isOpaque just returns field_20720 so it seems rather obvious. BlockState method is called "nonOpaque" instead of "transparent" because stuff like beds use it.