### PR TITLE
Drop 'on' prefixes from block tick methods, Block.activate -> onUse

### DIFF
--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -207,7 +207,7 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 		ARG 0 stateId
 	METHOD method_9533 shouldDropItemsOnExplosion (Lnet/minecraft/class_1927;)Z
 		ARG 1 explosion
-	METHOD method_9534 use (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_1657;Lnet/minecraft/class_1268;Lnet/minecraft/class_3965;)Z
+	METHOD method_9534 onUse (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_1657;Lnet/minecraft/class_1268;Lnet/minecraft/class_3965;)Z
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -126,7 +126,7 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 		ARG 2 entity
 	METHOD method_9503 getBlockFromItem (Lnet/minecraft/class_1792;)Lnet/minecraft/class_2248;
 		ARG 0 item
-	METHOD method_9504 onRainTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)V
+	METHOD method_9504 rainTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)V
 		ARG 1 world
 		ARG 2 pos
 	METHOD method_9505 getOpacity (Lnet/minecraft/class_2680;Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)I
@@ -148,7 +148,7 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 		ARG 3 blockEntity
 		ARG 4 entity
 		ARG 5 stack
-	METHOD method_9514 onRandomTick (Lnet/minecraft/class_2680;Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;Ljava/util/Random;)V
+	METHOD method_9514 randomTick (Lnet/minecraft/class_2680;Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;Ljava/util/Random;)V
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
@@ -207,7 +207,7 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 		ARG 0 stateId
 	METHOD method_9533 shouldDropItemsOnExplosion (Lnet/minecraft/class_1927;)Z
 		ARG 1 explosion
-	METHOD method_9534 activate (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_1657;Lnet/minecraft/class_1268;Lnet/minecraft/class_3965;)Z
+	METHOD method_9534 use (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_1657;Lnet/minecraft/class_1268;Lnet/minecraft/class_3965;)Z
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
@@ -377,7 +377,7 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 explosion
-	METHOD method_9588 onScheduledTick (Lnet/minecraft/class_2680;Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;Ljava/util/Random;)V
+	METHOD method_9588 scheduledTick (Lnet/minecraft/class_2680;Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;Ljava/util/Random;)V
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos

--- a/mappings/net/minecraft/block/BlockState.mapping
+++ b/mappings/net/minecraft/block/BlockState.mapping
@@ -148,7 +148,7 @@ CLASS net/minecraft/class_2680 net/minecraft/block/BlockState
 		ARG 1 world
 		ARG 2 pos
 	METHOD method_11628 getCollisionShape (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Lnet/minecraft/class_265;
-	METHOD method_11629 use (Lnet/minecraft/class_1937;Lnet/minecraft/class_1657;Lnet/minecraft/class_1268;Lnet/minecraft/class_3965;)Z
+	METHOD method_11629 onUse (Lnet/minecraft/class_1937;Lnet/minecraft/class_1657;Lnet/minecraft/class_1268;Lnet/minecraft/class_3965;)Z
 		ARG 1 world
 		ARG 2 player
 		ARG 3 hand

--- a/mappings/net/minecraft/block/BlockState.mapping
+++ b/mappings/net/minecraft/block/BlockState.mapping
@@ -135,7 +135,7 @@ CLASS net/minecraft/class_2680 net/minecraft/block/BlockState
 	METHOD method_11623 isTranslucent (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z
 		ARG 1 view
 		ARG 2 pos
-	METHOD method_11624 onRandomTick (Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;Ljava/util/Random;)V
+	METHOD method_11624 randomTick (Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;Ljava/util/Random;)V
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 random
@@ -148,7 +148,7 @@ CLASS net/minecraft/class_2680 net/minecraft/block/BlockState
 		ARG 1 world
 		ARG 2 pos
 	METHOD method_11628 getCollisionShape (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Lnet/minecraft/class_265;
-	METHOD method_11629 activate (Lnet/minecraft/class_1937;Lnet/minecraft/class_1657;Lnet/minecraft/class_1268;Lnet/minecraft/class_3965;)Z
+	METHOD method_11629 use (Lnet/minecraft/class_1937;Lnet/minecraft/class_1657;Lnet/minecraft/class_1268;Lnet/minecraft/class_3965;)Z
 		ARG 1 world
 		ARG 2 player
 		ARG 3 hand


### PR DESCRIPTION
Closes #872.

- Dropped `on` prefixes from block tick methods, see #872.
- Renamed `activate` to `use` to be consistent with the item method and the keybind name.