### PR TITLE
Some entity mappings

### DIFF
--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -30,7 +30,7 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 		ARG 1 client
 	METHOD method_18654 updateNausea ()V
 	METHOD method_20303 isHoldingSneakKey ()Z
-	METHOD method_22419 getShowsDeathScreen ()Z
+	METHOD method_22419 showsDeathScreen ()Z
 	METHOD method_22420 setShowsDeathScreen (Z)V
 		ARG 1 shouldShow
 	METHOD method_3130 getRecipeBook ()Lnet/minecraft/class_299;

--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -30,8 +30,8 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 		ARG 1 client
 	METHOD method_18654 updateNausea ()V
 	METHOD method_20303 isHoldingSneakKey ()Z
-	METHOD method_22419 setShowsDeathScreen ()Z
-	METHOD method_22420 getShowsDeathScreen (Z)V
+	METHOD method_22419 getShowsDeathScreen ()Z
+	METHOD method_22420 setShowsDeathScreen (Z)V
 		ARG 1 shouldShow
 	METHOD method_3130 getRecipeBook ()Lnet/minecraft/class_299;
 	METHOD method_3131 hasJumpingMount ()Z

--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -1,8 +1,10 @@
 CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
+	FIELD field_20663 showsDeathScreen Z
 	FIELD field_3911 lastNauseaStrength F
 	FIELD field_3912 clientPermissionLevel I
 	FIELD field_3913 input Lnet/minecraft/class_744;
 	FIELD field_3914 lastRenderPitch F
+	FIELD field_3915 usingItem Z
 	FIELD field_3916 renderPitch F
 	FIELD field_3919 lastSprinting Z
 	FIELD field_3920 lastOnGround Z
@@ -28,6 +30,9 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 		ARG 1 client
 	METHOD method_18654 updateNausea ()V
 	METHOD method_20303 isHoldingSneakKey ()Z
+	METHOD method_22419 setShowsDeathScreen ()Z
+	METHOD method_22420 getShowsDeathScreen (Z)V
+		ARG 1 shouldShow
 	METHOD method_3130 getRecipeBook ()Lnet/minecraft/class_299;
 	METHOD method_3131 hasJumpingMount ()Z
 	METHOD method_3132 openRidingInventory ()V
@@ -41,6 +46,10 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 	METHOD method_3142 sendChatMessage (Ljava/lang/String;)V
 	METHOD method_3143 getStats ()Lnet/minecraft/class_3469;
 	METHOD method_3144 isRiding ()Z
+	METHOD method_3145 setExperience (FII)V
+		ARG 1 progress
+		ARG 2 total
+		ARG 3 level
 	METHOD method_3146 setServerBrand (Ljava/lang/String;)V
 		ARG 1 serverBrand
 	METHOD method_3147 setClientPermissionLevel (I)V

--- a/mappings/net/minecraft/client/network/packet/GameJoinS2CPacket.mapping
+++ b/mappings/net/minecraft/client/network/packet/GameJoinS2CPacket.mapping
@@ -28,4 +28,4 @@ CLASS net/minecraft/class_2678 net/minecraft/client/network/packet/GameJoinS2CPa
 	METHOD method_11568 isHardcore ()Z
 	METHOD method_20204 getChunkLoadDistance ()I
 	METHOD method_22423 getSeed ()J
-	METHOD method_22424 getShowsDeathScreen ()Z
+	METHOD method_22424 showsDeathScreen ()Z

--- a/mappings/net/minecraft/client/network/packet/GameJoinS2CPacket.mapping
+++ b/mappings/net/minecraft/client/network/packet/GameJoinS2CPacket.mapping
@@ -7,8 +7,19 @@ CLASS net/minecraft/class_2678 net/minecraft/client/network/packet/GameJoinS2CPa
 	FIELD field_12282 gameMode Lnet/minecraft/class_1934;
 	FIELD field_12284 dimension Lnet/minecraft/class_2874;
 	FIELD field_19145 chunkLoadDistance I
+	FIELD field_20665 seed J
+	FIELD field_20666 showsDeathScreen Z
 	METHOD <init> (ILnet/minecraft/class_1934;JZLnet/minecraft/class_2874;ILnet/minecraft/class_1942;IZZ)V
 		ARG 1 playerEntityId
+		ARG 2 gameMode
+		ARG 3 seed
+		ARG 5 hardcore
+		ARG 6 dimensionType
+		ARG 7 maxPlayers
+		ARG 8 levelGeneratorType
+		ARG 9 chunkLoadDistance
+		ARG 10 reducedDebugInfo
+		ARG 11 showsDeathScreen
 	METHOD method_11561 getGameMode ()Lnet/minecraft/class_1934;
 	METHOD method_11562 hasReducedDebugInfo ()Z
 	METHOD method_11563 getGeneratorType ()Lnet/minecraft/class_1942;
@@ -16,3 +27,5 @@ CLASS net/minecraft/class_2678 net/minecraft/client/network/packet/GameJoinS2CPa
 	METHOD method_11565 getDimension ()Lnet/minecraft/class_2874;
 	METHOD method_11568 isHardcore ()Z
 	METHOD method_20204 getChunkLoadDistance ()I
+	METHOD method_22423 getSeed ()J
+	METHOD method_22424 getShowsDeathScreen ()Z

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -167,6 +167,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 songPosition
 		ARG 2 playing
 	METHOD method_6007 tickMovement ()V
+	METHOD method_6008 markEffectsDirty ()V
 	METHOD method_6009 onStatusEffectUpgraded (Lnet/minecraft/class_1293;Z)V
 		ARG 1 effect
 		ARG 2 reapplyEffect

--- a/mappings/net/minecraft/entity/passive/BeeEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/BeeEntity.mapping
@@ -31,8 +31,11 @@ CLASS net/minecraft/class_4466 net/minecraft/entity/passive/BeeEntity
 	CLASS class_4478 PollinateGoal
 		FIELD field_20378 pollinationTicks I
 		FIELD field_20379 lastPollinationTick I
+		FIELD field_20617 flowerPredicate Ljava/util/function/Predicate;
 		METHOD method_21820 completedPollination ()Z
 		METHOD method_21821 getFlower ()Ljava/util/Optional;
+		METHOD method_22326 findFlower (Ljava/util/function/Predicate;D)Ljava/util/Optional;
+			ARG 2 searchDistance
 	CLASS class_4479 BeeWanderAroundGoal
 		METHOD method_21822 getRandomLocation ()Lnet/minecraft/class_243;
 	FIELD field_20353 multipleByteTracker Lnet/minecraft/class_2940;

--- a/mappings/net/minecraft/entity/vehicle/AbstractMinecartEntity.mapping
+++ b/mappings/net/minecraft/entity/vehicle/AbstractMinecartEntity.mapping
@@ -6,13 +6,13 @@ CLASS net/minecraft/class_1688 net/minecraft/entity/vehicle/AbstractMinecartEnti
 	FIELD field_7658 clientXVelocity D
 	FIELD field_7659 clientYaw D
 	FIELD field_7661 CUSTOM_BLOCK_OFFSET Lnet/minecraft/class_2940;
-	FIELD field_7662 clientZPos D
+	FIELD field_7662 clientZ D
 	FIELD field_7663 DAMAGE_WOBBLE_TICKS Lnet/minecraft/class_2940;
-	FIELD field_7665 clientXPos D
-	FIELD field_7666 clientYPos D
+	FIELD field_7665 clientX D
+	FIELD field_7666 clientY D
 	FIELD field_7667 DAMAGE_WOBBLE_STRENGTH Lnet/minecraft/class_2940;
 	FIELD field_7668 DAMAGE_WOBBLE_SIDE Lnet/minecraft/class_2940;
-	FIELD field_7669 cliientInterpolationSteps I
+	FIELD field_7669 clientInterpolationSteps I
 	FIELD field_7670 CUSTOM_BLOCK_PRESENT Lnet/minecraft/class_2940;
 	FIELD field_7671 CUSTOM_BLOCK_ID Lnet/minecraft/class_2940;
 	METHOD <init> (Lnet/minecraft/class_1299;Lnet/minecraft/class_1937;)V

--- a/mappings/net/minecraft/entity/vehicle/AbstractMinecartEntity.mapping
+++ b/mappings/net/minecraft/entity/vehicle/AbstractMinecartEntity.mapping
@@ -1,18 +1,18 @@
 CLASS net/minecraft/class_1688 net/minecraft/entity/vehicle/AbstractMinecartEntity
 	CLASS class_1689 Type
-	FIELD field_7655 yVelocityClient D
-	FIELD field_7656 zVelocityClient D
-	FIELD field_7657 pitchClient D
-	FIELD field_7658 xVelocityClient D
-	FIELD field_7659 yawClient D
+	FIELD field_7655 clientYVelocity D
+	FIELD field_7656 clientZVelocity D
+	FIELD field_7657 clientPitch D
+	FIELD field_7658 clientXVelocity D
+	FIELD field_7659 clientYaw D
 	FIELD field_7661 CUSTOM_BLOCK_OFFSET Lnet/minecraft/class_2940;
-	FIELD field_7662 zPosClient D
+	FIELD field_7662 clientZPos D
 	FIELD field_7663 DAMAGE_WOBBLE_TICKS Lnet/minecraft/class_2940;
-	FIELD field_7665 xPosClient D
-	FIELD field_7666 yPosClient D
+	FIELD field_7665 clientXPos D
+	FIELD field_7666 clientYPos D
 	FIELD field_7667 DAMAGE_WOBBLE_STRENGTH Lnet/minecraft/class_2940;
 	FIELD field_7668 DAMAGE_WOBBLE_SIDE Lnet/minecraft/class_2940;
-	FIELD field_7669 interpolationStepsClient I
+	FIELD field_7669 cliientInterpolationSteps I
 	FIELD field_7670 CUSTOM_BLOCK_PRESENT Lnet/minecraft/class_2940;
 	FIELD field_7671 CUSTOM_BLOCK_ID Lnet/minecraft/class_2940;
 	METHOD <init> (Lnet/minecraft/class_1299;Lnet/minecraft/class_1937;)V
@@ -25,7 +25,7 @@ CLASS net/minecraft/class_1688 net/minecraft/entity/vehicle/AbstractMinecartEnti
 		ARG 7 z
 	METHOD method_18803 willHitBlockAt (Lnet/minecraft/class_2338;)Z
 		ARG 1 pos
-	METHOD method_7504 getMaxSpeedOffRail ()D
+	METHOD method_7504 getMaxOffRailSpeed ()D
 	METHOD method_7506 onActivatorRail (IIIZ)V
 		ARG 1 x
 		ARG 2 y

--- a/mappings/net/minecraft/entity/vehicle/AbstractMinecartEntity.mapping
+++ b/mappings/net/minecraft/entity/vehicle/AbstractMinecartEntity.mapping
@@ -1,9 +1,18 @@
 CLASS net/minecraft/class_1688 net/minecraft/entity/vehicle/AbstractMinecartEntity
 	CLASS class_1689 Type
+	FIELD field_7655 yVelocityClient D
+	FIELD field_7656 zVelocityClient D
+	FIELD field_7657 pitchClient D
+	FIELD field_7658 xVelocityClient D
+	FIELD field_7659 yawClient D
 	FIELD field_7661 CUSTOM_BLOCK_OFFSET Lnet/minecraft/class_2940;
+	FIELD field_7662 zPosClient D
 	FIELD field_7663 DAMAGE_WOBBLE_TICKS Lnet/minecraft/class_2940;
+	FIELD field_7665 xPosClient D
+	FIELD field_7666 yPosClient D
 	FIELD field_7667 DAMAGE_WOBBLE_STRENGTH Lnet/minecraft/class_2940;
 	FIELD field_7668 DAMAGE_WOBBLE_SIDE Lnet/minecraft/class_2940;
+	FIELD field_7669 interpolationStepsClient I
 	FIELD field_7670 CUSTOM_BLOCK_PRESENT Lnet/minecraft/class_2940;
 	FIELD field_7671 CUSTOM_BLOCK_ID Lnet/minecraft/class_2940;
 	METHOD <init> (Lnet/minecraft/class_1299;Lnet/minecraft/class_1937;)V
@@ -14,15 +23,23 @@ CLASS net/minecraft/class_1688 net/minecraft/entity/vehicle/AbstractMinecartEnti
 		ARG 3 x
 		ARG 5 y
 		ARG 7 z
+	METHOD method_18803 willHitBlockAt (Lnet/minecraft/class_2338;)Z
+		ARG 1 pos
+	METHOD method_7504 getMaxSpeedOffRail ()D
 	METHOD method_7506 onActivatorRail (IIIZ)V
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
+		ARG 4 powered
 	METHOD method_7507 getDamageWobbleTicks ()I
 	METHOD method_7509 setDamageWobbleTicks (I)V
 		ARG 1 wobbleTicks
 	METHOD method_7510 hasCustomBlock ()Z
 	METHOD method_7511 setCustomBlockPresent (Z)V
+	METHOD method_7512 moveOffRail ()V
+	METHOD method_7513 moveOnRail (Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)V
+		ARG 1 pos
+		ARG 2 state
 	METHOD method_7514 getBlockOffset ()I
 	METHOD method_7515 setCustomBlockOffset (I)V
 	METHOD method_7516 dropItems (Lnet/minecraft/class_1282;)V
@@ -41,5 +58,6 @@ CLASS net/minecraft/class_1688 net/minecraft/entity/vehicle/AbstractMinecartEnti
 		ARG 7 type
 	METHOD method_7524 setDamageWobbleSide (I)V
 		ARG 1 wobbleSide
+	METHOD method_7525 applySlowdown ()V
 	METHOD method_7526 getDefaultBlockOffset ()I
 	METHOD method_7527 setCustomBlock (Lnet/minecraft/class_2680;)V

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -53,7 +53,11 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	METHOD method_14224 setCameraEntity (Lnet/minecraft/class_1297;)V
 		ARG 1 entity
 	METHOD method_14226 playerTick ()V
+	METHOD method_14227 updateScoreboardScore (Ljava/lang/String;Ljava/lang/String;[Lnet/minecraft/class_274;)V
+		ARG 1 playerName
+		ARG 2 team
 	METHOD method_14228 setExperiencePoints (I)V
+	METHOD method_14230 isPvpEnabled ()Z
 	METHOD method_14232 getCameraPosition ()Lnet/minecraft/class_4076;
 	METHOD method_14234 updateLastActionTime ()V
 	METHOD method_14236 getAdvancementManager ()Lnet/minecraft/class_2985;
@@ -77,6 +81,9 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 		ARG 1 level
 	METHOD method_14253 getRecipeBook ()Lnet/minecraft/class_3441;
 	METHOD method_14254 sendChatMessage (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556;)V
+	METHOD method_14255 sendResourcePackUrl (Ljava/lang/String;Ljava/lang/String;)V
+		ARG 1 url
+		ARG 2 hash
 	METHOD method_17668 setCameraPosition (Lnet/minecraft/class_4076;)V
 		ARG 1 cameraPosition
 	METHOD method_18783 dimensionChanged (Lnet/minecraft/class_3218;)V

--- a/mappings/net/minecraft/server/network/packet/ClientSettingsC2SPacket.mapping
+++ b/mappings/net/minecraft/server/network/packet/ClientSettingsC2SPacket.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_2803 net/minecraft/server/network/packet/ClientSettingsC2SPacket
 	FIELD field_12777 language Ljava/lang/String;
 	FIELD field_12778 playerModelBitMask I
+	FIELD field_12779 chatColors Z
 	FIELD field_12780 viewDistance I
 	FIELD field_12781 chatVisibility Lnet/minecraft/class_1659;
 	FIELD field_12782 mainArm Lnet/minecraft/class_1306;
@@ -8,9 +9,11 @@ CLASS net/minecraft/class_2803 net/minecraft/server/network/packet/ClientSetting
 		ARG 1 language
 		ARG 2 viewDistance
 		ARG 3 chatVisibility
+		ARG 4 chatColors
 		ARG 5 modelBitMask
 		ARG 6 mainArm
 	METHOD method_12131 getLanguage ()Ljava/lang/String;
 	METHOD method_12132 getMainArm ()Lnet/minecraft/class_1306;
 	METHOD method_12134 getChatVisibility ()Lnet/minecraft/class_1659;
+	METHOD method_12135 getChatColors ()Z
 	METHOD method_12136 getPlayerModelBitMask ()I

--- a/mappings/net/minecraft/server/network/packet/ClientSettingsC2SPacket.mapping
+++ b/mappings/net/minecraft/server/network/packet/ClientSettingsC2SPacket.mapping
@@ -15,5 +15,5 @@ CLASS net/minecraft/class_2803 net/minecraft/server/network/packet/ClientSetting
 	METHOD method_12131 getLanguage ()Ljava/lang/String;
 	METHOD method_12132 getMainArm ()Lnet/minecraft/class_1306;
 	METHOD method_12134 getChatVisibility ()Lnet/minecraft/class_1659;
-	METHOD method_12135 getChatColors ()Z
+	METHOD method_12135 hasChatColors ()Z
 	METHOD method_12136 getPlayerModelBitMask ()I


### PR DESCRIPTION
Was unsure what to name the death screen functions; was torn between showDeathScreen and notInstantRespawn but the latter sounds kind of weird and this is only used on the client for is the death screen should be shown.

Doesn't clash with #882.