### PR TITLE
Fix noop mapping in ResourceReloadListener

### DIFF
--- a/mappings/net/minecraft/resource/ResourceReloadListener.mapping
+++ b/mappings/net/minecraft/resource/ResourceReloadListener.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_3302 net/minecraft/resource/ResourceReloadListener
 	CLASS class_4045 Synchronizer
 		METHOD method_18352 whenPrepared (Ljava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
 			ARG 1 preparedObject
-	METHOD reload reload (Lnet/minecraft/class_3302$class_4045;Lnet/minecraft/class_3300;Lnet/minecraft/class_3695;Lnet/minecraft/class_3695;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;)Ljava/util/concurrent/CompletableFuture;
+	METHOD reload (Lnet/minecraft/class_3302$class_4045;Lnet/minecraft/class_3300;Lnet/minecraft/class_3695;Lnet/minecraft/class_3695;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 synchronizer
 		ARG 2 manager
 		ARG 3 prepareProfiler


### PR DESCRIPTION
Came up as a mapping without an associated Intermediary name

Apparently backports this fix from #802 which was pulled to 19w34a