### PR TITLE
StatusEffect mapping and Cuboid Method rename

### DIFF
--- a/mappings/net/minecraft/client/model/ModelPart.mapping
+++ b/mappings/net/minecraft/client/model/ModelPart.mapping
@@ -77,7 +77,7 @@ CLASS net/minecraft/class_630 net/minecraft/client/model/ModelPart
 		ARG 1 model
 		ARG 2 textureOffsetU
 		ARG 3 textureOffsetV
-	METHOD method_17138 copyRotationAndPoint (Lnet/minecraft/class_630;)V
+	METHOD method_17138 copyPositionAndRotation (Lnet/minecraft/class_630;)V
 	METHOD method_22698 render (Lnet/minecraft/class_4587;Lnet/minecraft/class_4588;FIILnet/minecraft/class_1058;)V
 		ARG 1 matrix
 		ARG 2 vertexConsumer

--- a/mappings/net/minecraft/client/model/ModelPart.mapping
+++ b/mappings/net/minecraft/client/model/ModelPart.mapping
@@ -77,7 +77,7 @@ CLASS net/minecraft/class_630 net/minecraft/client/model/ModelPart
 		ARG 1 model
 		ARG 2 textureOffsetU
 		ARG 3 textureOffsetV
-	METHOD method_17138 copyRotation (Lnet/minecraft/class_630;)V
+	METHOD method_17138 copyRotationAndPoint (Lnet/minecraft/class_630;)V
 	METHOD method_22698 render (Lnet/minecraft/class_4587;Lnet/minecraft/class_4588;FIILnet/minecraft/class_1058;)V
 		ARG 1 matrix
 		ARG 2 vertexConsumer

--- a/mappings/net/minecraft/entity/effect/StatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/StatusEffect.mapping
@@ -10,7 +10,7 @@ CLASS net/minecraft/class_1291 net/minecraft/entity/effect/StatusEffect
 		ARG 0 type
 	METHOD method_5555 onApplied (Lnet/minecraft/class_1309;Lnet/minecraft/class_1325;I)V
 	METHOD method_5556 getColor ()I
-	METHOD method_5559 getOrCreateTranslationKey ()Ljava/lang/String;
+	METHOD method_5559 getTranslationKey ()Ljava/lang/String;
 	METHOD method_5560 getName ()Lnet/minecraft/class_2561;
 	METHOD method_5561 isInstant ()Z
 	METHOD method_5562 onRemoved (Lnet/minecraft/class_1309;Lnet/minecraft/class_1325;I)V

--- a/mappings/net/minecraft/entity/effect/StatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/StatusEffect.mapping
@@ -10,7 +10,7 @@ CLASS net/minecraft/class_1291 net/minecraft/entity/effect/StatusEffect
 		ARG 0 type
 	METHOD method_5555 onApplied (Lnet/minecraft/class_1309;Lnet/minecraft/class_1325;I)V
 	METHOD method_5556 getColor ()I
-	METHOD method_5559 getTranslationKey ()Ljava/lang/String;
+	METHOD method_5559 loadTranslationKey ()Ljava/lang/String;
 	METHOD method_5560 getName ()Lnet/minecraft/class_2561;
 	METHOD method_5561 isInstant ()Z
 	METHOD method_5562 onRemoved (Lnet/minecraft/class_1309;Lnet/minecraft/class_1325;I)V

--- a/mappings/net/minecraft/entity/effect/StatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/StatusEffect.mapping
@@ -10,6 +10,8 @@ CLASS net/minecraft/class_1291 net/minecraft/entity/effect/StatusEffect
 		ARG 0 type
 	METHOD method_5555 onApplied (Lnet/minecraft/class_1309;Lnet/minecraft/class_1325;I)V
 	METHOD method_5556 getColor ()I
+	METHOD method_5559 getOrCreateTranslationKey ()Ljava/lang/String;
+	METHOD method_5560 getName ()Lnet/minecraft/class_2561;
 	METHOD method_5561 isInstant ()Z
 	METHOD method_5562 onRemoved (Lnet/minecraft/class_1309;Lnet/minecraft/class_1325;I)V
 	METHOD method_5564 applyInstantEffect (Lnet/minecraft/class_1297;Lnet/minecraft/class_1297;Lnet/minecraft/class_1309;ID)V


### PR DESCRIPTION
Mappings for statusEffects
Changed Cuboid.copyRotation -> Cuboid.copyRotationAndPoint
copyRotation doesn't just set yaw, pitch, and roll; it also copies over the rotation origin point