### PR TITLE
Fix dust particle effect scale misnamed as alpha

### DIFF
--- a/mappings/net/minecraft/particle/DustParticleEffect.mapping
+++ b/mappings/net/minecraft/particle/DustParticleEffect.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_2390 net/minecraft/particle/DustParticleEffect
-	FIELD field_11184 alpha F
+	FIELD field_11184 scale F
 	FIELD field_11185 blue F
 	FIELD field_11186 green F
 	FIELD field_11187 red F
@@ -9,8 +9,8 @@ CLASS net/minecraft/class_2390 net/minecraft/particle/DustParticleEffect
 		ARG 1 red
 		ARG 2 green
 		ARG 3 blue
-		ARG 4 alpha
-	METHOD method_10283 getAlpha ()F
+		ARG 4 scale
+	METHOD method_10283 getScale ()F
 	METHOD method_10284 getBlue ()F
 	METHOD method_10285 getRed ()F
 	METHOD method_10286 getGreen ()F


### PR DESCRIPTION
As @ChloeDawn so helpfully pointed out, this field does not contain the alpha, but rather the scale.