### PR TITLE
StructurePoolBasedGenerator mappings (#919)

### DIFF
--- a/mappings/net/minecraft/structure/pool/StructurePoolBasedGenerator.mapping
+++ b/mappings/net/minecraft/structure/pool/StructurePoolBasedGenerator.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_3778 net/minecraft/structure/pool/StructurePoolBasedGenerator
 	CLASS class_3779 PieceFactory
-		METHOD create create (Lnet/minecraft/class_3485;Lnet/minecraft/class_3784;Lnet/minecraft/class_2338;ILnet/minecraft/class_2470;Lnet/minecraft/class_3341;)Lnet/minecraft/class_3790;
+		METHOD create (Lnet/minecraft/class_3485;Lnet/minecraft/class_3784;Lnet/minecraft/class_2338;ILnet/minecraft/class_2470;Lnet/minecraft/class_3341;)Lnet/minecraft/class_3790;
 			ARG 1 structureManager
 			ARG 2 poolElement
 			ARG 3 pos

--- a/mappings/net/minecraft/structure/pool/StructurePoolBasedGenerator.mapping
+++ b/mappings/net/minecraft/structure/pool/StructurePoolBasedGenerator.mapping
@@ -1,5 +1,41 @@
 CLASS net/minecraft/class_3778 net/minecraft/structure/pool/StructurePoolBasedGenerator
 	CLASS class_3779 PieceFactory
+		METHOD create create (Lnet/minecraft/class_3485;Lnet/minecraft/class_3784;Lnet/minecraft/class_2338;ILnet/minecraft/class_2470;Lnet/minecraft/class_3341;)Lnet/minecraft/class_3790;
+			ARG 1 structureManager
+			ARG 2 poolElement
+			ARG 3 pos
+			ARG 5 rotation
+			ARG 6 elementBounds
+	CLASS class_4181 ShapedPoolStructurePiece
+		FIELD field_18696 piece Lnet/minecraft/class_3790;
+		FIELD field_18697 pieceShape Ljava/util/concurrent/atomic/AtomicReference;
+		FIELD field_18698 minY I
+		FIELD field_18699 currentSize I
+		METHOD <init> (Lnet/minecraft/class_3790;Ljava/util/concurrent/atomic/AtomicReference;II)V
+			ARG 1 piece
+			ARG 2 pieceShape
+			ARG 3 minY
+			ARG 4 currentSize
+	CLASS class_4182 StructurePoolGenerator
+		FIELD field_18700 maxSize I
+		FIELD field_18701 pieceFactory Lnet/minecraft/class_3778$class_3779;
+		FIELD field_18702 chunkGenerator Lnet/minecraft/class_2794;
+		FIELD field_18703 structureManager Lnet/minecraft/class_3485;
+		FIELD field_18704 children Ljava/util/List;
+		FIELD field_18705 random Ljava/util/Random;
+		FIELD field_18706 structurePieces Ljava/util/Deque;
+		METHOD <init> (Lnet/minecraft/class_2960;ILnet/minecraft/class_3778$class_3779;Lnet/minecraft/class_2794;Lnet/minecraft/class_3485;Lnet/minecraft/class_2338;Ljava/util/List;Ljava/util/Random;)V
+			ARG 1 startingPool
+			ARG 2 maxSize
+			ARG 4 chunkGenerator
+			ARG 5 structureManager
+			ARG 7 children
+			ARG 8 random
+		METHOD method_19306 generatePiece (Lnet/minecraft/class_3790;Ljava/util/concurrent/atomic/AtomicReference;II)V
+			ARG 1 piece
+			ARG 2 pieceShape
+			ARG 3 minY
+			ARG 4 currentSize
 	FIELD field_16665 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_16666 REGISTRY Lnet/minecraft/class_3787;
 	METHOD method_16605 addPieces (Lnet/minecraft/class_2960;ILnet/minecraft/class_3778$class_3779;Lnet/minecraft/class_2794;Lnet/minecraft/class_3485;Lnet/minecraft/class_2338;Ljava/util/List;Ljava/util/Random;)V


### PR DESCRIPTION
Here is a start on mappings for `StructurePoolBasedGenerator`, which I detailed in #919.

For a quick rundown, here's how it works:
  - an initial target pool is passed in alongside a max structure size
  - a random element is selected from the target pool
  - the random element is generated, and each jigsaw inside each piece re-calls the generation process