### PR TITLE
New vector and direction methods used in ModelPart

### DIFF
--- a/mappings/net/minecraft/client/model/ModelPart.mapping
+++ b/mappings/net/minecraft/client/model/ModelPart.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_630 net/minecraft/client/model/ModelPart
 	CLASS class_593 Quad
+		FIELD field_21618 direction Lnet/minecraft/class_1160;
 		FIELD field_3502 vertices [Lnet/minecraft/class_630$class_618;
 		METHOD <init> ([Lnet/minecraft/class_630$class_618;FFFFFFZLnet/minecraft/class_2350;)V
 			ARG 1 vertices
@@ -9,6 +10,7 @@ CLASS net/minecraft/class_630 net/minecraft/client/model/ModelPart
 			ARG 5 v2
 			ARG 6 squishU
 			ARG 7 squishV
+			ARG 8 flip
 	CLASS class_618 Vertex
 		FIELD field_3603 v F
 		FIELD field_3604 u F

--- a/mappings/net/minecraft/client/util/math/Vector3f.mapping
+++ b/mappings/net/minecraft/client/util/math/Vector3f.mapping
@@ -16,8 +16,25 @@ CLASS net/minecraft/class_1160 net/minecraft/client/util/math/Vector3f
 		ARG 1 other
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o
-	METHOD method_23214 getRotationQuaternion (F)Lnet/minecraft/class_1158;
+	METHOD method_23214 getDegreesQuaternion (F)Lnet/minecraft/class_1158;
+		ARG 1 angle
 	METHOD method_23215 multiply (Lnet/minecraft/class_4581;)V
+		ARG 1 matrix
+	METHOD method_23626 getRadialQuaternion (F)Lnet/minecraft/class_1158;
+		ARG 1 angle
+	METHOD method_23691 crossMultiplyRow (ILnet/minecraft/class_4581;FFF)F
+		ARG 0 row
+		ARG 1 matrix
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD method_23846 add (Lnet/minecraft/class_1160;)V
+		ARG 1 vector
+	METHOD method_23849 piecewiseMultiply (FFF)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+	METHOD method_23850 copy ()Lnet/minecraft/class_1160;
 	METHOD method_4942 scale (F)V
 		ARG 1 scale
 	METHOD method_4943 getX ()F

--- a/mappings/net/minecraft/util/math/Direction.mapping
+++ b/mappings/net/minecraft/util/math/Direction.mapping
@@ -106,3 +106,4 @@ CLASS net/minecraft/class_2350 net/minecraft/util/math/Direction
 		ARG 2 z
 	METHOD method_23224 getRotationQuaternion ()Lnet/minecraft/class_1158;
 	METHOD method_23225 transform (Lnet/minecraft/class_1159;Lnet/minecraft/class_2350;)Lnet/minecraft/class_2350;
+	METHOD method_23955 getUnitVector ()Lnet/minecraft/class_1160;


### PR DESCRIPTION
# Vector3f
`getRotationQuaternion` -> `getDegreesQuaternion`
`method_23626` -> `getRadialQuaternion`
These create a quarternions for degree an radian angles respectively.
    
`method_23691` -> `crossMultiplyRow`
does the single component multiplication seen when multiplying a vector by a matrix

`method_23850` -> `copy`
Returns a new copy of `this` vector. I could have called it `clone` but I didn't want to potentially conflict with `Object.clone`.

# Direction

`method_23955` -> `getUnitVector`
It returns the unit vector for the direction.

Edit: Now with fewer typos.