### PR TITLE
Mapped PlayerSkinTexture

### DIFF
--- a/mappings/net/minecraft/client/texture/AbstractTexture.mapping
+++ b/mappings/net/minecraft/client/texture/AbstractTexture.mapping
@@ -10,3 +10,4 @@ CLASS net/minecraft/class_1044 net/minecraft/client/texture/AbstractTexture
 	METHOD method_4528 clearGlId ()V
 	METHOD method_4624 getGlId ()I
 	METHOD method_4625 load (Lnet/minecraft/class_3300;)V
+		ARG 1 resManager

--- a/mappings/net/minecraft/client/texture/AbstractTexture.mapping
+++ b/mappings/net/minecraft/client/texture/AbstractTexture.mapping
@@ -10,4 +10,4 @@ CLASS net/minecraft/class_1044 net/minecraft/client/texture/AbstractTexture
 	METHOD method_4528 clearGlId ()V
 	METHOD method_4624 getGlId ()I
 	METHOD method_4625 load (Lnet/minecraft/class_3300;)V
-		ARG 1 resManager
+		ARG 1 manager

--- a/mappings/net/minecraft/client/texture/PlayerSkinProvider.mapping
+++ b/mappings/net/minecraft/client/texture/PlayerSkinProvider.mapping
@@ -1,9 +1,18 @@
 CLASS net/minecraft/class_1071 net/minecraft/client/texture/PlayerSkinProvider
+	CLASS 1
+		METHOD load (Ljava/lang/Object;)Ljava/lang/Object;
+			ARG 1 profile
 	CLASS class_1072 SkinTextureAvailableCallback
+		METHOD onSkinTextureAvailable (Lcom/mojang/authlib/minecraft/MinecraftProfileTexture$Type;Lnet/minecraft/class_2960;Lcom/mojang/authlib/minecraft/MinecraftProfileTexture;)V
+			ARG 3 texture
 	FIELD field_5304 textureManager Lnet/minecraft/class_1060;
 	FIELD field_5305 skinCacheDir Ljava/io/File;
 	FIELD field_5306 skinCache Lcom/google/common/cache/LoadingCache;
 	FIELD field_5308 sessionService Lcom/mojang/authlib/minecraft/MinecraftSessionService;
+	METHOD <init> (Lnet/minecraft/class_1060;Ljava/io/File;Lcom/mojang/authlib/minecraft/MinecraftSessionService;)V
+		ARG 1 textureManager
+		ARG 2 skinCacheDir
+		ARG 3 sessionService
 	METHOD method_4651 loadSkin (Lcom/mojang/authlib/minecraft/MinecraftProfileTexture;Lcom/mojang/authlib/minecraft/MinecraftProfileTexture$Type;Lnet/minecraft/class_1071$class_1072;)Lnet/minecraft/class_2960;
 		ARG 1 profileTexture
 		ARG 2 type
@@ -13,7 +22,7 @@ CLASS net/minecraft/class_1071 net/minecraft/client/texture/PlayerSkinProvider
 		ARG 2 callback
 		ARG 3 requireSecure
 	METHOD method_4654 getTextures (Lcom/mojang/authlib/GameProfile;)Ljava/util/Map;
-		ARG 1 gameProfile
+		ARG 1 profile
 	METHOD method_4656 loadSkin (Lcom/mojang/authlib/minecraft/MinecraftProfileTexture;Lcom/mojang/authlib/minecraft/MinecraftProfileTexture$Type;)Lnet/minecraft/class_2960;
 		ARG 1 profileTexture
 		ARG 2 type

--- a/mappings/net/minecraft/client/texture/PlayerSkinTexture.mapping
+++ b/mappings/net/minecraft/client/texture/PlayerSkinTexture.mapping
@@ -1,8 +1,34 @@
 CLASS net/minecraft/class_1046 net/minecraft/client/texture/PlayerSkinTexture
+	FIELD field_20842 convertLegacy Z
+	FIELD field_20843 loadedCallback Ljava/lang/Runnable;
+	FIELD field_20844 loader Ljava/util/concurrent/CompletableFuture;
 	FIELD field_5210 cacheFile Ljava/io/File;
 	FIELD field_5212 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_5214 url Ljava/lang/String;
+	FIELD field_5215 isLoaded Z
 	METHOD <init> (Ljava/io/File;Ljava/lang/String;Lnet/minecraft/class_2960;ZLjava/lang/Runnable;)V
 		ARG 1 cacheFile
 		ARG 2 url
 		ARG 3 fallbackSkin
+		ARG 4 convertLegacy
+		ARG 5 callback
+	METHOD method_22794 stripColor (Lnet/minecraft/class_1011;IIII)V
+		ARG 0 image
+		ARG 1 x
+		ARG 2 y
+		ARG 3 width
+		ARG 4 height
+	METHOD method_22795 loadTexture (Ljava/io/InputStream;)Lnet/minecraft/class_1011;
+		ARG 1 stream
+	METHOD method_22796 stripAlpha (Lnet/minecraft/class_1011;IIII)V
+		ARG 0 image
+		ARG 1 x
+		ARG 2 y
+		ARG 3 width
+		ARG 4 height
+	METHOD method_22798 remapTexture (Lnet/minecraft/class_1011;)Lnet/minecraft/class_1011;
+		ARG 0 image
+	METHOD method_4531 uploadTexture (Lnet/minecraft/class_1011;)V
+		ARG 1 image
+	METHOD method_4534 onTextureLoaded (Lnet/minecraft/class_1011;)V
+		ARG 1 image

--- a/mappings/net/minecraft/client/texture/PlayerSkinTexture.mapping
+++ b/mappings/net/minecraft/client/texture/PlayerSkinTexture.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/class_1046 net/minecraft/client/texture/PlayerSkinTexture
 	FIELD field_5210 cacheFile Ljava/io/File;
 	FIELD field_5212 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_5214 url Ljava/lang/String;
-	FIELD field_5215 isLoaded Z
+	FIELD field_5215 loaded Z
 	METHOD <init> (Ljava/io/File;Ljava/lang/String;Lnet/minecraft/class_2960;ZLjava/lang/Runnable;)V
 		ARG 1 cacheFile
 		ARG 2 url


### PR DESCRIPTION
A lot of this is code that was moved from `SkinRemappingImageFilter`. 

`ImageFilter`, the interface, seems to have been deleted and its old `filter` method was converted into a static method in `PlayerSkinTexture`.