### PR TITLE
Fix various issues

### DIFF
--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -67,7 +67,7 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 	FIELD field_10644 FACINGS [Lnet/minecraft/class_2350;
 	FIELD field_10645 dynamicBounds Z
 	FIELD field_10646 defaultState Lnet/minecraft/class_2680;
-	FIELD field_10647 stateFactory Lnet/minecraft/class_2689;
+	FIELD field_10647 stateManager Lnet/minecraft/class_2689;
 	FIELD field_10648 resistance F
 	FIELD field_10649 FACE_CULL_MAP Ljava/lang/ThreadLocal;
 	FIELD field_10650 hardness F
@@ -404,7 +404,7 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 		ARG 2 player
 		ARG 3 world
 		ARG 4 pos
-	METHOD method_9595 getStateFactory ()Lnet/minecraft/class_2689;
+	METHOD method_9595 getStateManager ()Lnet/minecraft/class_2689;
 	METHOD method_9597 getMaterial (Lnet/minecraft/class_2680;)Lnet/minecraft/class_3614;
 		ARG 1 state
 	METHOD method_9598 rotate (Lnet/minecraft/class_2680;Lnet/minecraft/class_2470;)Lnet/minecraft/class_2680;

--- a/mappings/net/minecraft/client/font/TextRenderer.mapping
+++ b/mappings/net/minecraft/client/font/TextRenderer.mapping
@@ -106,8 +106,8 @@ CLASS net/minecraft/class_327 net/minecraft/client/font/TextRenderer
 		ARG 1 string
 		ARG 2 x
 		ARG 3 y
-		ARG 4 z
-		ARG 5 color
+		ARG 4 color
+		ARG 5 withShadow
 		ARG 6 matrix
 		ARG 7 vertexConsumerProvider
 		ARG 8 seeThrough

--- a/mappings/net/minecraft/client/font/TextRenderer.mapping
+++ b/mappings/net/minecraft/client/font/TextRenderer.mapping
@@ -107,7 +107,7 @@ CLASS net/minecraft/class_327 net/minecraft/client/font/TextRenderer
 		ARG 2 x
 		ARG 3 y
 		ARG 4 color
-		ARG 5 withShadow
+		ARG 5 shadow
 		ARG 6 matrix
 		ARG 7 vertexConsumerProvider
 		ARG 8 seeThrough

--- a/mappings/net/minecraft/entity/passive/RabbitEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/RabbitEntity.mapping
@@ -40,6 +40,7 @@ CLASS net/minecraft/class_1463 net/minecraft/entity/passive/RabbitEntity
 	FIELD field_6850 lastOnGround Z
 	FIELD field_6851 jumpTicks I
 	FIELD field_6852 RABBIT_TYPE Lnet/minecraft/class_2940;
+	METHOD method_20669 canSpawn (Lnet/minecraft/class_1299;Lnet/minecraft/class_1936;Lnet/minecraft/class_3730;Lnet/minecraft/class_2338;Ljava/util/Random;)Z
 	METHOD method_6606 setSpeed (D)V
 		ARG 1 speed
 	METHOD method_6607 wantsCarrots ()Z

--- a/mappings/net/minecraft/fluid/Fluid.mapping
+++ b/mappings/net/minecraft/fluid/Fluid.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_3611 net/minecraft/fluid/Fluid
 	FIELD field_15903 defaultState Lnet/minecraft/class_3610;
 	FIELD field_15904 STATE_IDS Lnet/minecraft/class_2361;
-	FIELD field_15905 stateFactory Lnet/minecraft/class_2689;
+	FIELD field_15905 stateManager Lnet/minecraft/class_2689;
 	METHOD method_15774 getBucketItem ()Lnet/minecraft/class_1792;
 	METHOD method_15775 appendProperties (Lnet/minecraft/class_2689$class_2690;)V
 	METHOD method_15776 randomDisplayTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_3610;Ljava/util/Random;)V
@@ -16,7 +16,7 @@ CLASS net/minecraft/class_3611 net/minecraft/fluid/Fluid
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
-	METHOD method_15783 getStateFactory ()Lnet/minecraft/class_2689;
+	METHOD method_15783 getStateManager ()Lnet/minecraft/class_2689;
 	METHOD method_15784 getBlastResistance ()F
 	METHOD method_15785 getDefaultState ()Lnet/minecraft/class_3610;
 	METHOD method_15787 getParticle ()Lnet/minecraft/class_2394;

--- a/mappings/net/minecraft/predicate/StatePredicate.mapping
+++ b/mappings/net/minecraft/predicate/StatePredicate.mapping
@@ -56,7 +56,7 @@ CLASS net/minecraft/class_4559 net/minecraft/predicate/StatePredicate
 		ARG 1 factory
 		ARG 2 reporter
 	METHOD method_22518 test (Lnet/minecraft/class_3610;)Z
-		ARG 1 sate
+		ARG 1 state
 	METHOD method_22519 fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/class_4559;
 		ARG 0 json
 	METHOD method_22521 createPredicate (Ljava/lang/String;Lcom/google/gson/JsonElement;)Lnet/minecraft/class_4559$class_4562;

--- a/mappings/net/minecraft/server/MinecraftServer.mapping
+++ b/mappings/net/minecraft/server/MinecraftServer.mapping
@@ -34,7 +34,7 @@ CLASS net/minecraft/server/MinecraftServer
 	FIELD field_4564 motd Ljava/lang/String;
 	FIELD field_4565 levelName Ljava/lang/String;
 	FIELD field_4566 recipeManager Lnet/minecraft/class_1863;
-	FIELD field_4567 advancementManager Lnet/minecraft/class_2989;
+	FIELD field_4567 advancementLoader Lnet/minecraft/class_2989;
 	FIELD field_4568 serverGuiTickables Ljava/util/List;
 	FIELD field_4569 bonusChest Z
 	FIELD field_4570 whitelistEnabled Z
@@ -259,7 +259,7 @@ CLASS net/minecraft/server/MinecraftServer
 		ARG 1 serverName
 	METHOD method_3850 setWorldHeight (I)V
 		ARG 1 worldHeight
-	METHOD method_3851 getAdvancementManager ()Lnet/minecraft/class_2989;
+	METHOD method_3851 getAdvancementLoader ()Lnet/minecraft/class_2989;
 	METHOD method_3852 isPvpEnabled ()Z
 	METHOD method_3853 setKeyPair (Ljava/security/KeyPair;)V
 	METHOD method_3855 getDataFixer ()Lcom/mojang/datafixers/DataFixer;

--- a/mappings/net/minecraft/server/PlayerManager.mapping
+++ b/mappings/net/minecraft/server/PlayerManager.mapping
@@ -52,7 +52,7 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		ARG 1 player
 	METHOD method_14577 savePlayerData (Lnet/minecraft/class_3222;)V
 		ARG 1 player
-	METHOD method_14578 getAdvancementManager (Lnet/minecraft/class_3222;)Lnet/minecraft/class_2985;
+	METHOD method_14578 getAdvancementTracker (Lnet/minecraft/class_3222;)Lnet/minecraft/class_2985;
 		ARG 1 player
 	METHOD method_14579 areCheatsAllowed ()Z
 	METHOD method_14580 getPlayerNames ()[Ljava/lang/String;

--- a/mappings/net/minecraft/server/PlayerManager.mapping
+++ b/mappings/net/minecraft/server/PlayerManager.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 	FIELD field_14343 WHITELIST_FILE Ljava/io/File;
 	FIELD field_14344 bannedProfiles Lnet/minecraft/class_3335;
 	FIELD field_14345 bannedIps Lnet/minecraft/class_3317;
-	FIELD field_14346 advancementManagerMap Ljava/util/Map;
+	FIELD field_14346 advancementTrackers Ljava/util/Map;
 	FIELD field_14347 maxPlayers I
 	FIELD field_14348 OPERATORS_FILE Ljava/io/File;
 	FIELD field_14349 LOGGER Lorg/apache/logging/log4j/Logger;

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	FIELD field_13967 pingMilliseconds I
 	FIELD field_13968 lastAirScore I
 	FIELD field_13969 seenCredits Z
-	FIELD field_13970 advancementManager Lnet/minecraft/class_2985;
+	FIELD field_13970 advancementTracker Lnet/minecraft/class_2985;
 	FIELD field_13972 syncedSaturationIsZero Z
 	FIELD field_13973 levitationStartTick I
 	FIELD field_13974 interactionManager Lnet/minecraft/class_3225;
@@ -62,7 +62,7 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	METHOD method_14230 isPvpEnabled ()Z
 	METHOD method_14232 getCameraPosition ()Lnet/minecraft/class_4076;
 	METHOD method_14234 updateLastActionTime ()V
-	METHOD method_14236 getAdvancementManager ()Lnet/minecraft/class_2985;
+	METHOD method_14236 getAdvancementTracker ()Lnet/minecraft/class_2985;
 	METHOD method_14237 incrementContainerSyncId ()V
 	METHOD method_14238 getClientChatVisibility ()Lnet/minecraft/class_1659;
 	METHOD method_14240 onTeleportationDone ()V


### PR DESCRIPTION
- Fixed `TextRenderer.draw` parameter names. Closes #965.
- `RabbitEntity.method_20669` -> `canSpawn`. Closes #956.
- `Block`/`Fluid.stateFactory` + getters -> `stateManager`. Closes #957.
- Renamed fields and methods with "advancement managers" loader/tracker to match the classes (most of #960, but not all):
  - `MinecraftServer.advancementManager` + getter -> `advancementLoader`
  - `ServerPlayerEntity.advancementManager` + getter -> `advancementTracker`
  - `PlayerManager.getAdvancementManager` -> `getAdvancementTracker`
  - `PlayerManager.advancementManagerMap` -> `advancementTrackers`
- Fixed typo in `StatePredicate.test` param name (`sate` -> `state`).