### PR TITLE
Improve game rule mappings

### DIFF
--- a/mappings/net/minecraft/world/GameRules.mapping
+++ b/mappings/net/minecraft/world/GameRules.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_1928 net/minecraft/world/GameRules
 		FIELD field_19411 value Z
 		METHOD <init> (Lnet/minecraft/class_1928$class_4314;Z)V
 			ARG 1 type
-			ARG 2 value
+			ARG 2 initialValue
 		METHOD method_20753 get ()Z
 		METHOD method_20754 (Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/class_1928$class_4310;)V
 			ARG 0 server
@@ -13,12 +13,12 @@ CLASS net/minecraft/class_1928 net/minecraft/world/GameRules
 		METHOD method_20758 set (ZLnet/minecraft/server/MinecraftServer;)V
 			ARG 1 value
 			ARG 2 server
-		METHOD method_20759 of (Z)Lnet/minecraft/class_1928$class_4314;
-			ARG 0 value
-		METHOD method_20760 of (ZLjava/util/function/BiConsumer;)Lnet/minecraft/class_1928$class_4314;
-			ARG 0 value
-			ARG 1 notifier
-	CLASS class_4311 RuleConsumer
+		METHOD method_20759 create (Z)Lnet/minecraft/class_1928$class_4314;
+			ARG 0 initialValue
+		METHOD method_20760 create (ZLjava/util/function/BiConsumer;)Lnet/minecraft/class_1928$class_4314;
+			ARG 0 initialValue
+			ARG 1 changeCallback
+	CLASS class_4311 RuleTypeConsumer
 		METHOD method_20762 accept (Lnet/minecraft/class_1928$class_4313;Lnet/minecraft/class_1928$class_4314;)V
 			ARG 1 key
 			ARG 2 type
@@ -26,18 +26,18 @@ CLASS net/minecraft/class_1928 net/minecraft/world/GameRules
 		FIELD field_19412 value I
 		METHOD <init> (Lnet/minecraft/class_1928$class_4314;I)V
 			ARG 1 rule
-			ARG 2 value
+			ARG 2 initialValue
 		METHOD method_20763 get ()I
 		METHOD method_20765 (ILnet/minecraft/class_1928$class_4314;)Lnet/minecraft/class_1928$class_4312;
 			ARG 1 type
-		METHOD method_20766 of (ILjava/util/function/BiConsumer;)Lnet/minecraft/class_1928$class_4314;
-			ARG 0 value
-			ARG 1 notifier
+		METHOD method_20766 create (ILjava/util/function/BiConsumer;)Lnet/minecraft/class_1928$class_4314;
+			ARG 0 initialValue
+			ARG 1 changeCallback
 		METHOD method_20767 (Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/class_1928$class_4312;)V
 			ARG 0 server
 			ARG 1 rule
-		METHOD method_20768 of (I)Lnet/minecraft/class_1928$class_4314;
-			ARG 0 value
+		METHOD method_20768 create (I)Lnet/minecraft/class_1928$class_4314;
+			ARG 0 initialValue
 		METHOD method_20769 parseInt (Ljava/lang/String;)I
 			ARG 0 string
 	CLASS class_4313 RuleKey
@@ -49,13 +49,13 @@ CLASS net/minecraft/class_1928 net/minecraft/world/GameRules
 		METHOD method_20771 getName ()Ljava/lang/String;
 	CLASS class_4314 RuleType
 		FIELD field_19414 argumentType Ljava/util/function/Supplier;
-		FIELD field_19415 factory Ljava/util/function/Function;
-		FIELD field_19416 notifier Ljava/util/function/BiConsumer;
+		FIELD field_19415 ruleFactory Ljava/util/function/Function;
+		FIELD field_19416 changeCallback Ljava/util/function/BiConsumer;
 		METHOD <init> (Ljava/util/function/Supplier;Ljava/util/function/Function;Ljava/util/function/BiConsumer;)V
 			ARG 1 argumentType
-			ARG 2 factory
-			ARG 3 notifier
-		METHOD method_20773 newRule ()Lnet/minecraft/class_1928$class_4315;
+			ARG 2 ruleFactory
+			ARG 3 changeCallback
+		METHOD method_20773 createRule ()Lnet/minecraft/class_1928$class_4315;
 		METHOD method_20775 argument (Ljava/lang/String;)Lcom/mojang/brigadier/builder/RequiredArgumentBuilder;
 			ARG 1 name
 	CLASS class_4315 Rule
@@ -65,27 +65,30 @@ CLASS net/minecraft/class_1928 net/minecraft/world/GameRules
 		METHOD method_20776 setFromArgument (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)V
 			ARG 1 context
 			ARG 2 name
-		METHOD method_20777 setFromString (Ljava/lang/String;)V
+		METHOD method_20777 deserialize (Ljava/lang/String;)V
 			ARG 1 value
-		METHOD method_20778 notify (Lnet/minecraft/server/MinecraftServer;)V
+		METHOD method_20778 changed (Lnet/minecraft/server/MinecraftServer;)V
 			ARG 1 server
-		METHOD method_20779 valueToString ()Ljava/lang/String;
+		METHOD method_20779 serialize ()Ljava/lang/String;
 		METHOD method_20780 set (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)V
 			ARG 1 context
 			ARG 2 name
-		METHOD method_20781 toCommandResult ()I
+		METHOD method_20781 getCommandResult ()I
 		METHOD method_20782 getThis ()Lnet/minecraft/class_1928$class_4315;
 	FIELD field_19410 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_9196 rules Ljava/util/Map;
-	FIELD field_9197 RULES Ljava/util/Map;
-	METHOD method_20744 forEach (Lnet/minecraft/class_1928$class_4311;)V
-		ARG 0 consumer
-	METHOD method_20745 consumeTyped (Lnet/minecraft/class_1928$class_4311;Lnet/minecraft/class_1928$class_4313;Lnet/minecraft/class_1928$class_4314;)V
+	FIELD field_9197 RULE_TYPES Ljava/util/Map;
+	METHOD method_20744 forEachType (Lnet/minecraft/class_1928$class_4311;)V
+		ARG 0 action
+	METHOD method_20745 accept (Lnet/minecraft/class_1928$class_4311;Lnet/minecraft/class_1928$class_4313;Lnet/minecraft/class_1928$class_4314;)V
 		ARG 0 consumer
 		ARG 1 key
 		ARG 2 type
 	METHOD method_20746 get (Lnet/minecraft/class_1928$class_4313;)Lnet/minecraft/class_1928$class_4315;
 		ARG 1 key
+	METHOD method_20747 (Lnet/minecraft/class_2487;Lnet/minecraft/class_1928$class_4313;Lnet/minecraft/class_1928$class_4315;)V
+		ARG 1 key
+		ARG 2 rule
 	METHOD method_20748 (Ljava/util/Map$Entry;)Lnet/minecraft/class_1928$class_4315;
 		ARG 0 e
 	METHOD method_20750 (Lnet/minecraft/class_1928$class_4311;Lnet/minecraft/class_1928$class_4313;Lnet/minecraft/class_1928$class_4314;)V
@@ -96,11 +99,14 @@ CLASS net/minecraft/class_1928 net/minecraft/world/GameRules
 		ARG 2 rule
 	METHOD method_20752 (Lnet/minecraft/class_1928$class_4313;)Ljava/lang/String;
 		ARG 0 key
+	METHOD method_22386 (Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/class_1928$class_4310;)V
+		ARG 0 server
+		ARG 1 rule
 	METHOD method_8355 getBoolean (Lnet/minecraft/class_1928$class_4313;)Z
 		ARG 1 rule
 	METHOD method_8356 getInt (Lnet/minecraft/class_1928$class_4313;)I
 		ARG 1 rule
-	METHOD method_8357 fromNbt (Lnet/minecraft/class_2487;)V
+	METHOD method_8357 load (Lnet/minecraft/class_2487;)V
 		ARG 1 nbt
 	METHOD method_8358 toNbt ()Lnet/minecraft/class_2487;
 	METHOD method_8359 register (Ljava/lang/String;Lnet/minecraft/class_1928$class_4314;)Lnet/minecraft/class_1928$class_4313;


### PR DESCRIPTION
- `of` -> `create`: The former implied it was constructing an instance of the class, which is not the case. It constructs a type representation of the rule.
- `value` -> `initialValue`: Better implies the semantics of the given value during construction.
- `notifier` -> `changeCallback`: It is a callback executed when the rule is changed, this name is more appropriate.
- `fromNbt` -> `load`: The method is non-static, so `fromX` naming is a unconventional. It loads the game rules from the given NBT.
- `RULES`, `forEach`, `RuleConsumer` -> `RULE_TYPES`, `forEachType`, `RuleTypeConsumer`: Better clarification between the concept of rules and rule types.
- `setFromString`, `valueToString` -> `deserialize`, `serialize`: These String-based methods are used exclusively for (de)serializing the rules to and from NBT.