### PR TITLE
SortedArraySet mappings

### DIFF
--- a/mappings/net/minecraft/util/SortedArraySet.mapping
+++ b/mappings/net/minecraft/util/SortedArraySet.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4706 net/minecraft/util/SortedSet
+CLASS net/minecraft/class_4706 net/minecraft/util/SortedArraySet
 	CLASS class_4707 SetIterator
 		FIELD field_21566 nextIndex I
 		FIELD field_21567 lastIndex I

--- a/mappings/net/minecraft/util/SortedSet.mapping
+++ b/mappings/net/minecraft/util/SortedSet.mapping
@@ -17,7 +17,7 @@ CLASS net/minecraft/class_4706 net/minecraft/util/SortedSet
 		ARG 2 index
 	METHOD method_23864 cast ([Ljava/lang/Object;)[Ljava/lang/Object;
 		ARG 0 array
-	METHOD method_23865 getFirst ()Ljava/lang/Object;
+	METHOD method_23865 first ()Ljava/lang/Object;
 	METHOD method_23866 insertionPoint (I)I
 		ARG 0 binarySearchResult
 	METHOD method_23868 ensureCapacity (I)V

--- a/mappings/net/minecraft/util/SortedSet.mapping
+++ b/mappings/net/minecraft/util/SortedSet.mapping
@@ -1,0 +1,30 @@
+CLASS net/minecraft/class_4706 net/minecraft/util/SortedSet
+	CLASS class_4707 SetIterator
+		FIELD field_21566 nextIndex I
+		FIELD field_21567 lastIndex I
+	FIELD field_21562 comparator Ljava/util/Comparator;
+	FIELD field_21563 elements [Ljava/lang/Object;
+	FIELD field_21564 size I
+	METHOD <init> (ILjava/util/Comparator;)V
+		ARG 1 initialCapacity
+		ARG 2 comparator
+	METHOD method_23859 create (I)Lnet/minecraft/class_4706;
+		ARG 0 initialCapacity
+	METHOD method_23862 addAndGet (Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 1 object
+	METHOD method_23863 add (Ljava/lang/Object;I)V
+		ARG 1 object
+		ARG 2 index
+	METHOD method_23864 cast ([Ljava/lang/Object;)[Ljava/lang/Object;
+		ARG 0 array
+	METHOD method_23865 getFirst ()Ljava/lang/Object;
+	METHOD method_23866 insertionPoint (I)I
+		ARG 0 binarySearchResult
+	METHOD method_23868 ensureCapacity (I)V
+		ARG 1 minCapacity
+	METHOD method_23869 binarySearch (Ljava/lang/Object;)I
+		ARG 1 object
+	METHOD method_23870 remove (I)V
+		ARG 1 index
+	METHOD method_23871 get (I)Ljava/lang/Object;
+		ARG 1 index


### PR DESCRIPTION
Replacement for https://github.com/FabricMC/yarn/pull/970 which currently has many problems (closes https://github.com/FabricMC/yarn/pull/970).

Here are the main differences:
 - `OrderedSet` -> `SortedArraySet`. Ordered just means that it has a certain order (for example a `LinkHashSet` is ordered in the insertion order). Sorted makes it clear that the elements are automatically being sorted as they are added using the given comparator. (*Edit:* As @liach mentioned, there's also `java.util.SortedSet`. Naming this one `SortedArraySet` since it acts exactly like an array-based implementation of `java.util.SortedSet`, but Mojang seems to have not bothered implementing all the methods).
 - `Itr` -> `SetIterator`. Matches JDK convention of naming interators `<type>Iterator`: `ArrayList.ListIterator`, `Map.KeyIterator`, etc.
 - `start` -> `lastIndex`. This is the index of the previously returned element (used by `remove`)
 - `index` -> `nextIndex`. This is the index of the next element to be returned
 - `sortingFunction` -> `comparator`. A "sorting function" could be understood to mean a function that actually does the sorting of the array. Here, it's just a `java.util.Comparator` comparing elements pairwise.
 - `addIfAbsent` -> `addAndGet`. The other `add` method also adds only if absent (as do all sets!). Calling this method is the same as doing an `add` followed by a `get`.
 - `spliceAdd` -> `add`. It's just adding an element at a given position...
 - `getDirect` -> `get`. Not sure what's "direct" about this, especially since there is no other "indirect" `get` method.