### PR TITLE
ContainerLock mappings

### DIFF
--- a/mappings/net/minecraft/container/ContainerLock.mapping
+++ b/mappings/net/minecraft/container/ContainerLock.mapping
@@ -1,7 +1,0 @@
-CLASS net/minecraft/class_1273 net/minecraft/container/ContainerLock
-	FIELD field_5817 NONE Lnet/minecraft/class_1273;
-	FIELD field_5818 key Ljava/lang/String;
-	METHOD method_5472 isEmpty (Lnet/minecraft/class_1799;)Z
-	METHOD method_5473 deserialize (Lnet/minecraft/class_2487;)Lnet/minecraft/class_1273;
-		ARG 0 tag
-	METHOD method_5474 serialize (Lnet/minecraft/class_2487;)V

--- a/mappings/net/minecraft/inventory/ContainerLock.mapping
+++ b/mappings/net/minecraft/inventory/ContainerLock.mapping
@@ -10,9 +10,10 @@ CLASS net/minecraft/class_1273 net/minecraft/inventory/ContainerLock
 		COMMENT An item stack is a valid key if the stack name matches the key string of this lock,
 		COMMENT or if the key string is empty.
 		ARG 1 stack
-			COMMENT
+			COMMENT the key item stack
 	METHOD method_5473 fromTag (Lnet/minecraft/class_2487;)Lnet/minecraft/class_1273;
 		COMMENT Creates a new {@code ContainerLock} from the {@code Lock} key of the compound tag.
+		COMMENT <p>
 		COMMENT If the {@code Lock} key is not present, returns an empty lock.
 		ARG 0 tag
 	METHOD method_5474 toTag (Lnet/minecraft/class_2487;)V

--- a/mappings/net/minecraft/inventory/ContainerLock.mapping
+++ b/mappings/net/minecraft/inventory/ContainerLock.mapping
@@ -1,0 +1,20 @@
+CLASS net/minecraft/class_1273 net/minecraft/inventory/ContainerLock
+	FIELD field_5817 EMPTY Lnet/minecraft/class_1273;
+		COMMENT An empty container lock that can always be opened.
+	FIELD field_5818 key Ljava/lang/String;
+	METHOD <init> (Ljava/lang/String;)V
+		ARG 1 key
+	METHOD method_5472 canOpen (Lnet/minecraft/class_1799;)Z
+		COMMENT Returns true if this lock can be opened with the key item stack.
+		COMMENT <p>
+		COMMENT An item stack is a valid key if the stack name matches the key string of this lock,
+		COMMENT or if the key string is empty.
+		ARG 1 stack
+			COMMENT
+	METHOD method_5473 fromTag (Lnet/minecraft/class_2487;)Lnet/minecraft/class_1273;
+		COMMENT Creates a new {@code ContainerLock} from the {@code Lock} key of the compound tag.
+		COMMENT If the {@code Lock} key is not present, returns an empty lock.
+		ARG 0 tag
+	METHOD method_5474 toTag (Lnet/minecraft/class_2487;)V
+		COMMENT Inserts the key string of this lock into the {@code Lock} key of the compound tag.
+		ARG 1 tag


### PR DESCRIPTION
- Moved `ContainerLock` to `net.minecraft.inventory` -- it has nothing to do with `Container`s
- `isEmpty` -> `canOpen` (closes #845)
- `NONE` -> `EMPTY`
- Added javadoc
- `(de)serialize` -> `fromTag`/`toTag`