### PR TITLE
Mapped the missing fields in HeldItemRenderer

### DIFF
--- a/mappings/net/minecraft/client/render/item/HeldItemRenderer.mapping
+++ b/mappings/net/minecraft/client/render/item/HeldItemRenderer.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_759 net/minecraft/client/render/item/HeldItemRenderer
+	FIELD field_21807 MAP_BACKGROUND Lnet/minecraft/class_1921;
+	FIELD field_21808 MAP_BACKGROUND_CHECKERBOARD Lnet/minecraft/class_1921;
 	FIELD field_4043 equipProgressMainHand F
 	FIELD field_4044 itemRenderer Lnet/minecraft/class_918;
 	FIELD field_4046 renderManager Lnet/minecraft/class_898;


### PR DESCRIPTION
Tiny PR for some fields I happened upon by chance.

field_21807 -> MAP_BACKGROUND
field_21808 -> MAP_BACKGROUND_CHECKERBOARD

```
MAP_BACKGROUND = RenderLayer.getText(new Identifier("textures/map/map_background.png"));
MAP_BACKGROUND_CHECKERBOARD = RenderLayer.getText(new Identifier("textures/map/map_background_checkerboard.png"));
```