### PR TITLE
Model transformation mode

### DIFF
--- a/mappings/net/minecraft/client/render/item/HeldItemRenderer.mapping
+++ b/mappings/net/minecraft/client/render/item/HeldItemRenderer.mapping
@@ -80,7 +80,7 @@ CLASS net/minecraft/class_759 net/minecraft/client/render/item/HeldItemRenderer
 	METHOD method_3233 renderItem (Lnet/minecraft/class_1309;Lnet/minecraft/class_1799;Lnet/minecraft/class_809$class_811;ZLnet/minecraft/class_4587;Lnet/minecraft/class_4597;I)V
 		ARG 1 entity
 		ARG 2 stack
-		ARG 3 transformationType
+		ARG 3 renderMode
 		ARG 4 leftHanded
 		ARG 5 matrices
 		ARG 6 vertexConsumers

--- a/mappings/net/minecraft/client/render/item/ItemRenderer.mapping
+++ b/mappings/net/minecraft/client/render/item/ItemRenderer.mapping
@@ -12,7 +12,7 @@ CLASS net/minecraft/class_918 net/minecraft/client/render/item/ItemRenderer
 	METHOD method_23177 renderItem (Lnet/minecraft/class_1309;Lnet/minecraft/class_1799;Lnet/minecraft/class_809$class_811;ZLnet/minecraft/class_4587;Lnet/minecraft/class_4597;Lnet/minecraft/class_1937;II)V
 		ARG 1 entity
 		ARG 2 item
-		ARG 3 transformationType
+		ARG 3 renderMode
 		ARG 4 leftHanded
 		ARG 5 matrices
 		ARG 6 vertexConsumers
@@ -28,7 +28,7 @@ CLASS net/minecraft/class_918 net/minecraft/client/render/item/ItemRenderer
 		ARG 6 vertexConsumers
 	METHOD method_23179 renderItem (Lnet/minecraft/class_1799;Lnet/minecraft/class_809$class_811;ZLnet/minecraft/class_4587;Lnet/minecraft/class_4597;IILnet/minecraft/class_1087;)V
 		ARG 1 stack
-		ARG 2 transformationType
+		ARG 2 renderMode
 		ARG 3 leftHanded
 		ARG 4 matrices
 		ARG 5 vertexConsumers

--- a/mappings/net/minecraft/client/render/model/json/JsonUnbakedModel.mapping
+++ b/mappings/net/minecraft/client/render/model/json/JsonUnbakedModel.mapping
@@ -19,17 +19,21 @@ CLASS net/minecraft/class_793 net/minecraft/client/render/model/json/JsonUnbaked
 		ARG 5 depthInGui
 		ARG 6 transformations
 		ARG 7 overrides
+	METHOD method_24077 resolveSprite (Ljava/lang/String;)Lnet/minecraft/class_4730;
+		ARG 1 spriteName
 	METHOD method_3430 deserialize (Ljava/lang/String;)Lnet/minecraft/class_793;
-		ARG 0 string
+		ARG 0 json
 	METHOD method_3431 getRootModel ()Lnet/minecraft/class_793;
 	METHOD method_3432 textureExists (Ljava/lang/String;)Z
 		ARG 1 name
 	METHOD method_3433 getElements ()Ljava/util/List;
 	METHOD method_3434 getOverrides ()Ljava/util/List;
 	METHOD method_3437 deserialize (Ljava/io/Reader;)Lnet/minecraft/class_793;
-		ARG 0 reader
+		ARG 0 input
 	METHOD method_3438 getTransformation (Lnet/minecraft/class_809$class_811;)Lnet/minecraft/class_804;
+		ARG 1 renderMode
 	METHOD method_3439 isTextureReference (Ljava/lang/String;)Z
+		ARG 0 reference
 	METHOD method_3440 compileOverrides (Lnet/minecraft/class_1088;Lnet/minecraft/class_793;)Lnet/minecraft/class_806;
 		ARG 1 modelLoader
 		ARG 2 parent
@@ -43,20 +47,29 @@ CLASS net/minecraft/class_793 net/minecraft/client/render/model/json/JsonUnbaked
 		ARG 2 parent
 		ARG 3 textureGetter
 		ARG 4 settings
+		ARG 5 id
 	METHOD method_3447 createQuad (Lnet/minecraft/class_785;Lnet/minecraft/class_783;Lnet/minecraft/class_1058;Lnet/minecraft/class_2350;Lnet/minecraft/class_3665;Lnet/minecraft/class_2960;)Lnet/minecraft/class_777;
 		ARG 0 element
 		ARG 1 elementFace
 		ARG 2 sprite
 		ARG 3 side
 		ARG 4 settings
+		ARG 5 id
 	CLASS class_795 Deserializer
+		METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
+			ARG 1 element
+			ARG 2 unused
+			ARG 3 ctx
+		METHOD method_24079 resolveReference (Lnet/minecraft/class_2960;Ljava/lang/String;)Lcom/mojang/datafixers/util/Either;
+			ARG 0 id
+			ARG 1 name
 		METHOD method_3448 deserializeTextures (Lcom/google/gson/JsonObject;)Ljava/util/Map;
 			ARG 1 object
 		METHOD method_3449 deserializeElements (Lcom/google/gson/JsonDeserializationContext;Lcom/google/gson/JsonObject;)Ljava/util/List;
 			ARG 1 context
-			ARG 2 object
+			ARG 2 json
 		METHOD method_3450 deserializeParent (Lcom/google/gson/JsonObject;)Ljava/lang/String;
-			ARG 1 object
+			ARG 1 json
 		METHOD method_3451 (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lnet/minecraft/class_793;
 			ARG 1 element
 			ARG 2 type
@@ -65,4 +78,4 @@ CLASS net/minecraft/class_793 net/minecraft/client/render/model/json/JsonUnbaked
 			ARG 1 context
 			ARG 2 object
 		METHOD method_3453 deserializeAmbientOcclusion (Lcom/google/gson/JsonObject;)Z
-			ARG 1 object
+			ARG 1 json

--- a/mappings/net/minecraft/client/render/model/json/ModelTransformation.mapping
+++ b/mappings/net/minecraft/client/render/model/json/ModelTransformation.mapping
@@ -20,9 +20,9 @@ CLASS net/minecraft/class_809 net/minecraft/client/render/model/json/ModelTransf
 	METHOD <init> (Lnet/minecraft/class_809;)V
 		ARG 1 other
 	METHOD method_3501 isTransformationDefined (Lnet/minecraft/class_809$class_811;)Z
-		ARG 1 type
+		ARG 1 renderMode
 	METHOD method_3503 getTransformation (Lnet/minecraft/class_809$class_811;)Lnet/minecraft/class_804;
-		ARG 1 type
+		ARG 1 renderMode
 	CLASS class_810 Deserializer
 		METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 			ARG 1 functionJson
@@ -36,4 +36,4 @@ CLASS net/minecraft/class_809 net/minecraft/client/render/model/json/ModelTransf
 			ARG 1 element
 			ARG 2 type
 			ARG 3 context
-	CLASS class_811 Type
+	CLASS class_811 Mode

--- a/mappings/net/minecraft/client/render/model/json/Transformation.mapping
+++ b/mappings/net/minecraft/client/render/model/json/Transformation.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_804 net/minecraft/client/render/model/json/Transformation
-	FIELD field_4284 NONE Lnet/minecraft/class_804;
+	FIELD field_4284 IDENTITY Lnet/minecraft/class_804;
 	FIELD field_4285 scale Lnet/minecraft/class_1160;
 	FIELD field_4286 translation Lnet/minecraft/class_1160;
 	FIELD field_4287 rotation Lnet/minecraft/class_1160;


### PR DESCRIPTION
As Liach suggested, here's a PR renaming `ModelTransformation.Type` to `ModelTransformation.Mode`.

As a preliminary change I've also renamed all parameters of that type to `renderMode` because it makes sense, though I'm open to calling it just `mode` if people take issue with the `render` part.