### PR TITLE
Rename Gson fields in some classes to GSON

### DIFF
--- a/mappings/net/minecraft/data/report/BlockListProvider.mapping
+++ b/mappings/net/minecraft/data/report/BlockListProvider.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/class_2422 net/minecraft/data/report/BlockListProvider
 	FIELD field_11307 root Lnet/minecraft/class_2403;
+	FIELD field_17168 GSON Lcom/google/gson/Gson;

--- a/mappings/net/minecraft/data/report/CommandSyntaxProvider.mapping
+++ b/mappings/net/minecraft/data/report/CommandSyntaxProvider.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/class_2425 net/minecraft/data/report/CommandSyntaxProvider
 	FIELD field_11321 root Lnet/minecraft/class_2403;
+	FIELD field_17169 GSON Lcom/google/gson/Gson;

--- a/mappings/net/minecraft/data/report/ItemListProvider.mapping
+++ b/mappings/net/minecraft/data/report/ItemListProvider.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/class_2427 net/minecraft/data/report/ItemListProvider
 	FIELD field_11323 root Lnet/minecraft/class_2403;
+	FIELD field_17170 GSON Lcom/google/gson/Gson;


### PR DESCRIPTION
The fields of type `com.google.gson.Gson` in `net.minecraft.data.report.{BlockListProvider, CommandSyntaxProvider, ItemListProvider` have been renamed to `GSON`.