### PR TITLE
Tiny quaternion fixes

### DIFF
--- a/mappings/net/minecraft/client/util/math/Vector4f.mapping
+++ b/mappings/net/minecraft/client/util/math/Vector4f.mapping
@@ -23,8 +23,8 @@ CLASS net/minecraft/class_1162 net/minecraft/client/util/math/Vector4f
 		ARG 2 y
 		ARG 3 z
 		ARG 4 w
-	METHOD method_23852 setQuarternion (Lnet/minecraft/class_1158;)V
-		ARG 1 quarternion
+	METHOD method_23852 rotate (Lnet/minecraft/class_1158;)V
+		ARG 1 rotation
 	METHOD method_23853 getW ()F
 	METHOD method_4953 getX ()F
 	METHOD method_4954 multiplyComponentwise (Lnet/minecraft/class_1160;)V

--- a/mappings/net/minecraft/util/math/Quaternion.mapping
+++ b/mappings/net/minecraft/util/math/Quaternion.mapping
@@ -1,5 +1,8 @@
 CLASS net/minecraft/class_1158 net/minecraft/util/math/Quaternion
 	FIELD field_21493 IDENTITY Lnet/minecraft/class_1158;
+	FIELD field_21582 b F
+	FIELD field_21583 c F
+	FIELD field_21584 d F
 	FIELD field_21585 a F
 	METHOD <init> (FFFF)V
 		ARG 1 b


### PR DESCRIPTION
The `a`, `b` and `c` fields have all disappeared twice for unknown reasons [(1)](https://github.com/FabricMC/yarn/commit/b3d30237951ce83df670f0ca539d6d8f4de11170#diff-6a518f774394af9a224eb8959493ba98) [(2)](https://github.com/FabricMC/yarn/commit/7b3a61d7637fabb74de1250ed1af82bbce2526d2#diff-6a518f774394af9a224eb8959493ba98). This restores them, but I would like to know why this is happening and how we can stop this happening in the future.

Additionally, `Vector4f.setQuarternion` (now called `rotate`) matches `Vector3f.rotate`, so I gave it the same name. The previous name appears to have been an oversight.