### PR TITLE
Tiny Vector3f fixes

### DIFF
--- a/mappings/net/minecraft/client/util/math/Vector3f.mapping
+++ b/mappings/net/minecraft/client/util/math/Vector3f.mapping
@@ -25,9 +25,9 @@ CLASS net/minecraft/class_1160 net/minecraft/client/util/math/Vector3f
 		ARG 1 angle
 	METHOD method_23846 add (Lnet/minecraft/class_1160;)V
 		ARG 1 vector
-	METHOD method_23847 multiplyComponentwise (Lnet/minecraft/class_1160;F)V
+	METHOD method_23847 lerp (Lnet/minecraft/class_1160;F)V
 		ARG 1 vector
-		ARG 2 ratio
+		ARG 2 delta
 	METHOD method_23848 modify (Lit/unimi/dsi/fastutil/floats/Float2FloatFunction;)V
 		ARG 1 function
 	METHOD method_23849 piecewiseMultiply (FFF)V

--- a/mappings/net/minecraft/client/util/math/Vector3f.mapping
+++ b/mappings/net/minecraft/client/util/math/Vector3f.mapping
@@ -30,7 +30,7 @@ CLASS net/minecraft/class_1160 net/minecraft/client/util/math/Vector3f
 		ARG 2 delta
 	METHOD method_23848 modify (Lit/unimi/dsi/fastutil/floats/Float2FloatFunction;)V
 		ARG 1 function
-	METHOD method_23849 piecewiseMultiply (FFF)V
+	METHOD method_23849 multiplyComponentwise (FFF)V
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z


### PR DESCRIPTION
`multiplyComponentWise` is an in-place componentwise linear interpolation, not multiplication, so I named it `lerp`.

To match the naming standard agreed upon for Vector4f, I also changed `Vector3f.piecewiseMultiply` to match `Vector4f.multiplyComponentwise`.