### PR TITLE
Small change to whitelist field in net.minecraft.server.MinecraftServer

### DIFF
--- a/mappings/net/minecraft/server/MinecraftServer.mapping
+++ b/mappings/net/minecraft/server/MinecraftServer.mapping
@@ -35,7 +35,7 @@ CLASS net/minecraft/server/MinecraftServer
 	FIELD field_4567 advancementLoader Lnet/minecraft/class_2989;
 	FIELD field_4568 serverGuiTickables Ljava/util/List;
 	FIELD field_4569 bonusChest Z
-	FIELD field_4570 whitelistEnabled Z
+	FIELD field_4570 enforceWhitelist Z
 	FIELD field_4571 timeReference J
 	FIELD field_4572 ticks I
 	FIELD field_4573 lastTickLengths [J
@@ -119,10 +119,10 @@ CLASS net/minecraft/server/MinecraftServer
 	METHOD method_3727 hasGui ()Z
 	METHOD method_3728 kickNonWhitelistedPlayers (Lnet/minecraft/class_2168;)V
 		ARG 1 source
-	METHOD method_3729 isWhitelistEnabled ()Z
+	METHOD method_3729 isEnforceWhitelist ()Z
 	METHOD method_3730 setDemo (Z)V
 		ARG 1 demo
-	METHOD method_3731 setWhitelistEnabled (Z)V
+	METHOD method_3731 setEnforceWhitelist (Z)V
 		ARG 1 whitelistEnabled
 	METHOD method_3732 shouldBroadcastRconToOps ()Z
 	METHOD method_3734 getCommandManager ()Lnet/minecraft/class_2170;


### PR DESCRIPTION
The field changed is only used to check whether whitelist enforcement is enabled, not if the whitelist itself is enabled. Going with the naming convention of stick with minecraft terms, I've changed it to `enforceWhitelist` however this creates a strangely named getter.