### PR TITLE
Vector3f.reciprocal -> normalize

### DIFF
--- a/mappings/net/minecraft/client/util/math/Vector3f.mapping
+++ b/mappings/net/minecraft/client/util/math/Vector3f.mapping
@@ -57,4 +57,4 @@ CLASS net/minecraft/class_1160 net/minecraft/client/util/math/Vector3f
 		ARG 1 other
 	METHOD method_4951 cross (Lnet/minecraft/class_1160;)V
 		ARG 1 vector
-	METHOD method_4952 reciprocal ()Z
+	METHOD method_4952 normalize ()Z


### PR DESCRIPTION
#442 was probably correct at the time, but the method must have been modified since then. The old method probably had a bug. It now computes a (fast) inverse square root of the sum of squares instead of the inverse of the sum of squares, which amounts to normalization.