### PR TITLE
Fix VertexConsumerProvider parameters

### DIFF
--- a/mappings/net/minecraft/client/render/VertexConsumerProvider.mapping
+++ b/mappings/net/minecraft/client/render/VertexConsumerProvider.mapping
@@ -2,16 +2,18 @@ CLASS net/minecraft/class_4597 net/minecraft/client/render/VertexConsumerProvide
 	METHOD getBuffer (Lnet/minecraft/class_1921;)Lnet/minecraft/class_4588;
 		ARG 1 layer
 	METHOD method_22991 immediate (Lnet/minecraft/class_287;)Lnet/minecraft/class_4597$class_4598;
-		ARG 0 builder
+		ARG 0 buffer
 	METHOD method_22992 immediate (Ljava/util/Map;Lnet/minecraft/class_287;)Lnet/minecraft/class_4597$class_4598;
-		ARG 1 layerBuffers
+		ARG 0 layerBuffers
+		ARG 1 fallbackBuffer
 	CLASS class_4598 Immediate
 		FIELD field_20952 fallbackBuffer Lnet/minecraft/class_287;
 		FIELD field_20953 layerBuffers Ljava/util/Map;
 		FIELD field_20954 currentLayer Ljava/util/Optional;
 		FIELD field_20955 activeConsumers Ljava/util/Set;
 		METHOD <init> (Lnet/minecraft/class_287;Ljava/util/Map;)V
-			ARG 1 layerBuffers
+			ARG 1 fallbackBuffer
+			ARG 2 layerBuffers
 		METHOD method_22993 draw ()V
 		METHOD method_22994 draw (Lnet/minecraft/class_1921;)V
 			ARG 1 layer


### PR DESCRIPTION
Something went wrong in the authoring of the VertexConsumerProvider mappings. [A fix was attempted](https://github.com/FabricMC/yarn/pull/986/commits/5258c311a575ba5946afe69d0699d6bc44f0d847#diff-957dfd49045a753010f2d602930c4f58) but did not quite resolve it. [The 1.15-pre4 update ended up trimming some of the parameter names](https://github.com/FabricMC/yarn/commit/b3d30237951ce83df670f0ca539d6d8f4de11170#diff-957dfd49045a753010f2d602930c4f58) because the ordinals were incorrect.

This restores the parameters to what was originally intended.