### PR TITLE
Entity tracking mappings

### DIFF
--- a/mappings/net/minecraft/server/MinecraftServer.mapping
+++ b/mappings/net/minecraft/server/MinecraftServer.mapping
@@ -144,6 +144,7 @@ CLASS net/minecraft/server/MinecraftServer
 		ARG 1 flightEnabled
 	METHOD method_3747 stop (Z)V
 	METHOD method_3748 tick (Ljava/util/function/BooleanSupplier;)V
+		ARG 1 shouldKeepTicking
 	METHOD method_3749 getMaxWorldBorderRadius ()I
 	METHOD method_3750 isStopped ()Z
 	METHOD method_3752 reloadDataPacks (Lnet/minecraft/class_31;)V

--- a/mappings/net/minecraft/server/MinecraftServer.mapping
+++ b/mappings/net/minecraft/server/MinecraftServer.mapping
@@ -213,6 +213,7 @@ CLASS net/minecraft/server/MinecraftServer
 	METHOD method_3811 getUserName ()Ljava/lang/String;
 	METHOD method_3812 areCommandBlocksEnabled ()Z
 	METHOD method_3813 tickWorlds (Ljava/util/function/BooleanSupplier;)V
+		ARG 1 shouldKeepTicking
 	METHOD method_3814 hasGameDir ()Z
 	METHOD method_3815 setPvpEnabled (Z)V
 		ARG 1 pvpEnabled

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -26,3 +26,4 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	METHOD method_18758 sendSyncPacket (Lnet/minecraft/class_2596;)V
 	METHOD method_14306 syncEntityData ()V
 	METHOD method_18756 tick ()V
+	METHOD method_18761 storeEncodedCoordinates ()V

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -18,6 +18,7 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	FIELD field_18278 velocity Lnet/minecraft/class_243;
 	FIELD field_14043 updatesWithoutVehicle I
 	METHOD <init> (Lnet/minecraft/class_3218;Lnet/minecraft/class_1297;IZLjava/util/function/Consumer;)V
+		ARG 1 world
 		ARG 3 tickInterval
 		ARG 4 alwaysUpdateVelocity
 		ARG 5 receiver

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -23,6 +23,7 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	METHOD method_18757 sendPackets (Ljava/util/function/Consumer;)V
 		ARG 1 sender
 	METHOD method_18760 startTracking (Lnet/minecraft/class_3222;)V
+		ARG 1 player
 	METHOD method_18758 sendSyncPacket (Lnet/minecraft/class_2596;)V
 	METHOD method_14306 syncEntityData ()V
 	METHOD method_18756 tick ()V

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -27,3 +27,4 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	METHOD method_14306 syncEntityData ()V
 	METHOD method_18756 tick ()V
 	METHOD method_18761 storeEncodedCoordinates ()V
+	METHOD method_18759 getLastPos ()Lnet/minecraft/class_243;

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -20,6 +20,7 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	METHOD <init> (Lnet/minecraft/class_3218;Lnet/minecraft/class_1297;IZLjava/util/function/Consumer;)V
 		ARG 3 tickInterval
 		ARG 4 alwaysUpdateVelocity
+		ARG 5 receiver
 	METHOD method_14302 stopTracking (Lnet/minecraft/class_3222;)V
 		ARG 1 player
 	METHOD method_18757 sendPackets (Ljava/util/function/Consumer;)V

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -18,3 +18,4 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	METHOD method_18757 sendPackets (Ljava/util/function/Consumer;)V
 		ARG 1 sender
 	METHOD method_18760 startTracking (Lnet/minecraft/class_3222;)V
+	METHOD method_18758 sendSyncPacket (Lnet/minecraft/class_2596;)V

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -12,6 +12,7 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	FIELD field_14059 lastHeadPitch I
 	FIELD field_14060 lastYaw I
 	FIELD field_18259 receiver Ljava/util/function/Consumer;
+	FIELD field_14040 trackingTick I
 	METHOD <init> (Lnet/minecraft/class_3218;Lnet/minecraft/class_1297;IZLjava/util/function/Consumer;)V
 		ARG 3 tickInterval
 	METHOD method_14302 stopTracking (Lnet/minecraft/class_3222;)V

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -13,6 +13,7 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	FIELD field_14060 lastYaw I
 	FIELD field_18259 receiver Ljava/util/function/Consumer;
 	FIELD field_14040 trackingTick I
+	FIELD field_18258 world Lnet/minecraft/class_3218;
 	METHOD <init> (Lnet/minecraft/class_3218;Lnet/minecraft/class_1297;IZLjava/util/function/Consumer;)V
 		ARG 3 tickInterval
 	METHOD method_14302 stopTracking (Lnet/minecraft/class_3222;)V

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -11,6 +11,7 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	FIELD field_14050 lastX J
 	FIELD field_14059 lastHeadPitch I
 	FIELD field_14060 lastYaw I
+	FIELD field_18259 receiver Ljava/util/function/Consumer;
 	METHOD <init> (Lnet/minecraft/class_3218;Lnet/minecraft/class_1297;IZLjava/util/function/Consumer;)V
 		ARG 3 tickInterval
 	METHOD method_14302 stopTracking (Lnet/minecraft/class_3222;)V

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -20,6 +20,7 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	METHOD <init> (Lnet/minecraft/class_3218;Lnet/minecraft/class_1297;IZLjava/util/function/Consumer;)V
 		ARG 3 tickInterval
 	METHOD method_14302 stopTracking (Lnet/minecraft/class_3222;)V
+		ARG 1 player
 	METHOD method_18757 sendPackets (Ljava/util/function/Consumer;)V
 		ARG 1 sender
 	METHOD method_18760 startTracking (Lnet/minecraft/class_3222;)V

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -19,6 +19,7 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	FIELD field_14043 updatesWithoutVehicle I
 	METHOD <init> (Lnet/minecraft/class_3218;Lnet/minecraft/class_1297;IZLjava/util/function/Consumer;)V
 		ARG 3 tickInterval
+		ARG 4 alwaysUpdateVelocity
 	METHOD method_14302 stopTracking (Lnet/minecraft/class_3222;)V
 		ARG 1 player
 	METHOD method_18757 sendPackets (Ljava/util/function/Consumer;)V

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -14,7 +14,7 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	FIELD field_18259 receiver Ljava/util/function/Consumer;
 	FIELD field_14040 trackingTick I
 	FIELD field_18258 world Lnet/minecraft/class_3218;
-	FIELD field_14051 lastInVehicle Z
+	FIELD field_14051 hadVehicle Z
 	METHOD <init> (Lnet/minecraft/class_3218;Lnet/minecraft/class_1297;IZLjava/util/function/Consumer;)V
 		ARG 3 tickInterval
 	METHOD method_14302 stopTracking (Lnet/minecraft/class_3222;)V

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -16,6 +16,7 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	FIELD field_18258 world Lnet/minecraft/class_3218;
 	FIELD field_14051 hadVehicle Z
 	FIELD field_18278 velocity Lnet/minecraft/class_243;
+	FIELD field_14043 updatesWithoutVehicle I
 	METHOD <init> (Lnet/minecraft/class_3218;Lnet/minecraft/class_1297;IZLjava/util/function/Consumer;)V
 		ARG 3 tickInterval
 	METHOD method_14302 stopTracking (Lnet/minecraft/class_3222;)V

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -14,7 +14,7 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	FIELD field_18259 receiver Ljava/util/function/Consumer;
 	FIELD field_14040 trackingTick I
 	FIELD field_18258 world Lnet/minecraft/class_3218;
-	FIELD field_14051 hadVehicle Z
+	FIELD field_14051 lastInVehicle Z
 	METHOD <init> (Lnet/minecraft/class_3218;Lnet/minecraft/class_1297;IZLjava/util/function/Consumer;)V
 		ARG 3 tickInterval
 	METHOD method_14302 stopTracking (Lnet/minecraft/class_3222;)V

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -15,6 +15,7 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	FIELD field_14040 trackingTick I
 	FIELD field_18258 world Lnet/minecraft/class_3218;
 	FIELD field_14051 hadVehicle Z
+	FIELD field_18278 velocity Lnet/minecraft/class_243;
 	METHOD <init> (Lnet/minecraft/class_3218;Lnet/minecraft/class_1297;IZLjava/util/function/Consumer;)V
 		ARG 3 tickInterval
 	METHOD method_14302 stopTracking (Lnet/minecraft/class_3222;)V

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -14,7 +14,7 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	FIELD field_18259 receiver Ljava/util/function/Consumer;
 	FIELD field_14040 trackingTick I
 	FIELD field_18258 world Lnet/minecraft/class_3218;
-	FIELD field_14051 lastTickInVehicle Z
+	FIELD field_14051 hadVehicle Z
 	METHOD <init> (Lnet/minecraft/class_3218;Lnet/minecraft/class_1297;IZLjava/util/function/Consumer;)V
 		ARG 3 tickInterval
 	METHOD method_14302 stopTracking (Lnet/minecraft/class_3222;)V

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -14,6 +14,7 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	FIELD field_18259 receiver Ljava/util/function/Consumer;
 	FIELD field_14040 trackingTick I
 	FIELD field_18258 world Lnet/minecraft/class_3218;
+	FIELD field_14051 lastTickInVehicle Z
 	METHOD <init> (Lnet/minecraft/class_3218;Lnet/minecraft/class_1297;IZLjava/util/function/Consumer;)V
 		ARG 3 tickInterval
 	METHOD method_14302 stopTracking (Lnet/minecraft/class_3222;)V

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -19,3 +19,4 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 		ARG 1 sender
 	METHOD method_18760 startTracking (Lnet/minecraft/class_3222;)V
 	METHOD method_18758 sendSyncPacket (Lnet/minecraft/class_2596;)V
+	METHOD method_14306 syncEntityData ()V

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -20,3 +20,4 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	METHOD method_18760 startTracking (Lnet/minecraft/class_3222;)V
 	METHOD method_18758 sendSyncPacket (Lnet/minecraft/class_2596;)V
 	METHOD method_14306 syncEntityData ()V
+	METHOD method_18756 tick ()V

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -3,20 +3,20 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	FIELD field_14036 lastOnGround Z
 	FIELD field_14037 tickInterval I
 	FIELD field_14039 alwaysUpdateVelocity Z
+	FIELD field_14040 trackingTick I
 	FIELD field_14041 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_14043 updatesWithoutVehicle I
 	FIELD field_14045 lastPassengers Ljava/util/List;
 	FIELD field_14047 lastPitch I
 	FIELD field_14048 lastZ J
 	FIELD field_14049 entity Lnet/minecraft/class_1297;
 	FIELD field_14050 lastX J
+	FIELD field_14051 hadVehicle Z
 	FIELD field_14059 lastHeadPitch I
 	FIELD field_14060 lastYaw I
-	FIELD field_18259 receiver Ljava/util/function/Consumer;
-	FIELD field_14040 trackingTick I
 	FIELD field_18258 world Lnet/minecraft/class_3218;
-	FIELD field_14051 hadVehicle Z
+	FIELD field_18259 receiver Ljava/util/function/Consumer;
 	FIELD field_18278 velocity Lnet/minecraft/class_243;
-	FIELD field_14043 updatesWithoutVehicle I
 	METHOD <init> (Lnet/minecraft/class_3218;Lnet/minecraft/class_1297;IZLjava/util/function/Consumer;)V
 		ARG 1 world
 		ARG 3 tickInterval
@@ -24,12 +24,16 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 		ARG 5 receiver
 	METHOD method_14302 stopTracking (Lnet/minecraft/class_3222;)V
 		ARG 1 player
+	METHOD method_14306 syncEntityData ()V
+		COMMENT Synchronizes tracked data and attributes
+	METHOD method_18756 tick ()V
 	METHOD method_18757 sendPackets (Ljava/util/function/Consumer;)V
 		ARG 1 sender
+	METHOD method_18758 sendSyncPacket (Lnet/minecraft/class_2596;)V
+		COMMENT Sends a packet for synchronization with watcher and tracked player (if applicable)
+	METHOD method_18759 getLastPos ()Lnet/minecraft/class_243;
+		COMMENT Decodes lastX/Y/Z into a position vector
 	METHOD method_18760 startTracking (Lnet/minecraft/class_3222;)V
 		ARG 1 player
-	METHOD method_18758 sendSyncPacket (Lnet/minecraft/class_2596;)V
-	METHOD method_14306 syncEntityData ()V
-	METHOD method_18756 tick ()V
 	METHOD method_18761 storeEncodedCoordinates ()V
-	METHOD method_18759 getLastPos ()Lnet/minecraft/class_243;
+		COMMENT Stores the tracked entity's current coordinates encoded as lastX/Y/Z

--- a/mappings/net/minecraft/server/world/ServerWorld.mapping
+++ b/mappings/net/minecraft/server/world/ServerWorld.mapping
@@ -103,6 +103,7 @@ CLASS net/minecraft/class_3218 net/minecraft/server/world/ServerWorld
 	METHOD method_18764 unloadEntities (Lnet/minecraft/class_2818;)V
 		ARG 1 chunk
 	METHOD method_18765 tick (Ljava/util/function/BooleanSupplier;)V
+		ARG 1 shouldKeepTicking
 	METHOD method_18766 getPlayers (Ljava/util/function/Predicate;)Ljava/util/List;
 		ARG 1 predicate
 	METHOD method_18767 checkChunk (Lnet/minecraft/class_1297;)V

--- a/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
+++ b/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
@@ -130,6 +130,7 @@ CLASS net/minecraft/class_3898 net/minecraft/server/world/ThreadedAnvilChunkStor
 			ARG 1 packet
 		METHOD method_18736 updateCameraPosition (Lnet/minecraft/class_3222;)V
 			ARG 1 player
+		METHOD method_22844 getMaxTrackDistance ()I
 	CLASS class_3216 TicketManager
 		METHOD <init> (Lnet/minecraft/class_3898;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;)V
 			ARG 1 workerExecutor

--- a/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
+++ b/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
@@ -22,6 +22,7 @@ CLASS net/minecraft/class_3898 net/minecraft/server/world/ThreadedAnvilChunkStor
 	FIELD field_18242 entityTrackers Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
 	FIELD field_18243 watchDistance I
 	FIELD field_18808 pointOfInterestStorage Lnet/minecraft/class_4153;
+	FIELD field_18307 loadedChunks Lit/unimi/dsi/fastutil/longs/LongSet;
 	METHOD <init> (Lnet/minecraft/class_3218;Ljava/io/File;Lcom/mojang/datafixers/DataFixer;Lnet/minecraft/class_3485;Ljava/util/concurrent/Executor;Lnet/minecraft/class_1255;Lnet/minecraft/class_2823;Lnet/minecraft/class_2794;Lnet/minecraft/class_3949;Ljava/util/function/Supplier;I)V
 		ARG 1 world
 		ARG 3 dataFixer

--- a/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
+++ b/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
@@ -50,6 +50,7 @@ CLASS net/minecraft/class_3898 net/minecraft/server/world/ThreadedAnvilChunkStor
 		ARG 1 centerChunkTargetStatus
 		ARG 2 distance
 	METHOD method_17233 tick (Ljava/util/function/BooleanSupplier;)V
+		ARG 1 shouldKeepTicking
 	METHOD method_17235 createTickingFuture (Lnet/minecraft/class_3193;)Ljava/util/concurrent/CompletableFuture;
 	METHOD method_17236 createChunkFuture (Lnet/minecraft/class_3193;Lnet/minecraft/class_2806;)Ljava/util/concurrent/CompletableFuture;
 	METHOD method_17241 sendWatchPackets (Lnet/minecraft/class_3222;Lnet/minecraft/class_1923;[Lnet/minecraft/class_2596;ZZ)V

--- a/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
+++ b/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
@@ -129,7 +129,7 @@ CLASS net/minecraft/class_3898 net/minecraft/server/world/ThreadedAnvilChunkStor
 		METHOD method_18734 sendToNearbyPlayers (Lnet/minecraft/class_2596;)V
 			ARG 1 packet
 		METHOD method_18736 updateCameraPosition (Lnet/minecraft/class_3222;)V
-			ARG 1 players
+			ARG 1 player
 	CLASS class_3216 TicketManager
 		METHOD <init> (Lnet/minecraft/class_3898;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;)V
 			ARG 1 workerExecutor

--- a/mappings/net/minecraft/world/chunk/ChunkManager.mapping
+++ b/mappings/net/minecraft/world/chunk/ChunkManager.mapping
@@ -17,6 +17,7 @@ CLASS net/minecraft/class_2802 net/minecraft/world/chunk/ChunkManager
 		ARG 2 chunkZ
 		ARG 3 create
 	METHOD method_12127 tick (Ljava/util/function/BooleanSupplier;)V
+		ARG 1 shouldKeepTicking
 	METHOD method_12128 setMobSpawnOptions (ZZ)V
 		ARG 1 spawnMonsters
 		ARG 2 spawnAnimals

--- a/mappings/net/minecraft/world/storage/SerializingRegionBasedStorage.mapping
+++ b/mappings/net/minecraft/world/storage/SerializingRegionBasedStorage.mapping
@@ -17,6 +17,7 @@ CLASS net/minecraft/class_4180 net/minecraft/world/storage/SerializingRegionBase
 		ARG 1 pos
 	METHOD method_19289 loadDataAt (Lnet/minecraft/class_1923;)V
 	METHOD method_19290 tick (Ljava/util/function/BooleanSupplier;)V
+		ARG 1 shouldKeepTicking
 	METHOD method_19291 onLoad (J)V
 		ARG 1 pos
 	METHOD method_19292 isPosInvalid (Lnet/minecraft/class_4076;)Z


### PR DESCRIPTION
- EntityTrackerEntry%field_18259 -> receiver  
  - The receiver for all tracker packets  
- EntityTrackerEntry#method_18758(1) -> sendSyncPacket  
  - Sends a packet for synchronization with watcher and tracker player (if applicable)  
- EntityTrackerEntry#method_14306(0) -> syncEntityData  
  - Synchronizes tracked data and attributes  
- EntityTrackerEntry%field_14051 -> hadVehicle  
  - Used to check if the tracked entity had a vehicle last tick  
- EntityTrackerEntry%field_18278 -> velocity  
  - Used to send velocity update packets  
- EntityTrackerEntry#method_18761(0) -> storeEncodedCoordinates  
  - Stores the tracked entity's current coordinates encoded as lastX/Y/Z  
- EntityTrackerEntry#method_18759(0) -> getLastPos  
  - Decodes lastX/Y/Z into a position vector  
- ThreadedAnvilChunkStorage$EntityTracker#method_22844(0) -> getMaxTrackDistance  
  - Gets the maximum tracking distance from the tracked entity and its passengers  
- ThreadedAnvilChunkStorage%field_18307 -> loadedChunks  
  - A set containing loaded chunks, used to check if a chunk has already been loaded in the world  
- MinecraftServer#tick(1)[1 = <unnamed>] -> shouldKeepTicking  
  - Always called with a reference to MinecraftServer#shouldKeepTicking  
- MinecraftServer#tickWorlds(1)[1 = <unnamed>] -> shouldKeepTicking  
  - Always called with a reference to MinecraftServer#shouldKeepTicking