### PR TITLE
Map GameMenuScreen field and parameter to showMenu

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/GameMenuScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/GameMenuScreen.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/class_433 net/minecraft/client/gui/screen/GameMenuScreen
+	FIELD field_19319 showMenu Z
+	METHOD <init> (Z)V
+		ARG 1 showMenu
 	METHOD method_20543 initWidgets ()V
 	METHOD render (IIF)V
 		ARG 1 mouseX


### PR DESCRIPTION
This parameter/field is used to determine whether the pause menu with buttons (normal) or overlay (<kbd>F3</kbd>+<kbd>Escape</kbd>) will be shown.