### PR TITLE
LivingEntity#removeStatusEffect clarification

### DIFF
--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -182,7 +182,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6014 getItemUseTimeLeft ()I
 	METHOD method_6015 setAttacker (Lnet/minecraft/class_1309;)V
 		ARG 1 attacker
-	METHOD method_6016 tryRemoveStatusEffect (Lnet/minecraft/class_1291;)Z
+	METHOD method_6016 removeStatusEffect (Lnet/minecraft/class_1291;)Z
 		ARG 1 effect
 	METHOD method_6017 getSoundPitch ()F
 	METHOD method_6019 setCurrentHand (Lnet/minecraft/class_1268;)V

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -330,6 +330,10 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6110 getCurrentExperience (Lnet/minecraft/class_1657;)I
 		ARG 1 player
 	METHOD method_6111 removeStatusEffectInternal (Lnet/minecraft/class_1291;)Lnet/minecraft/class_1293;
+		COMMENT Removes a status effect from this entity.
+		COMMENT 
+		COMMENT <p> This method does not perform any cleanup or synchronization operation.
+		COMMENT Under most circumstances, calling {@link net.minecraft.entity.LivingEntity#tryRemoveStatusEffect(net.minecraft.entity.effect.StatusEffect)} is highly preferable.
 		ARG 1 effect
 	METHOD method_6112 getStatusEffect (Lnet/minecraft/class_1291;)Lnet/minecraft/class_1293;
 		ARG 1 effect

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -329,7 +329,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6109 isBaby ()Z
 	METHOD method_6110 getCurrentExperience (Lnet/minecraft/class_1657;)I
 		ARG 1 player
-	METHOD method_6111 removeStatusEffect (Lnet/minecraft/class_1291;)Lnet/minecraft/class_1293;
+	METHOD method_6111 removeStatusEffectInternal (Lnet/minecraft/class_1291;)Lnet/minecraft/class_1293;
 		ARG 1 effect
 	METHOD method_6112 getStatusEffect (Lnet/minecraft/class_1291;)Lnet/minecraft/class_1293;
 		ARG 1 effect

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -183,6 +183,12 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6015 setAttacker (Lnet/minecraft/class_1309;)V
 		ARG 1 attacker
 	METHOD method_6016 removeStatusEffect (Lnet/minecraft/class_1291;)Z
+		COMMENT Removes a status effect from this entity.
+		COMMENT 
+		COMMENT <p> Calling this method will call cleanup methods on the status effect and trigger synchronization of effect particles with watching clients. If this entity is a player,
+		COMMENT the change in the list of effects will also be synchronized with the corresponding client.
+		COMMENT 
+		COMMENT @return {@code true} if a {@link net.minecraft.entity.effect.StatusEffectInstance} with the given type was in effect before the removal.
 		ARG 1 effect
 	METHOD method_6017 getSoundPitch ()F
 	METHOD method_6019 setCurrentHand (Lnet/minecraft/class_1268;)V

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -336,10 +336,10 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6110 getCurrentExperience (Lnet/minecraft/class_1657;)I
 		ARG 1 player
 	METHOD method_6111 removeStatusEffectInternal (Lnet/minecraft/class_1291;)Lnet/minecraft/class_1293;
-		COMMENT Removes a status effect from this entity.
+		COMMENT Removes a status effect from this entity without calling any listener.
 		COMMENT 
 		COMMENT <p> This method does not perform any cleanup or synchronization operation.
-		COMMENT Under most circumstances, calling {@link net.minecraft.entity.LivingEntity#tryRemoveStatusEffect(net.minecraft.entity.effect.StatusEffect)} is highly preferable.
+		COMMENT Under most circumstances, calling {@link net.minecraft.entity.LivingEntity#removeStatusEffect(net.minecraft.entity.effect.StatusEffect)} is highly preferable.
 		ARG 1 type
 	METHOD method_6112 getStatusEffect (Lnet/minecraft/class_1291;)Lnet/minecraft/class_1293;
 		ARG 1 effect

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -189,7 +189,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		COMMENT the change in the list of effects will also be synchronized with the corresponding client.
 		COMMENT 
 		COMMENT @return {@code true} if a {@link net.minecraft.entity.effect.StatusEffectInstance} with the given type was in effect before the removal.
-		ARG 1 effect
+		ARG 1 type
 	METHOD method_6017 getSoundPitch ()F
 	METHOD method_6019 setCurrentHand (Lnet/minecraft/class_1268;)V
 		ARG 1 hand

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -340,7 +340,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		COMMENT 
 		COMMENT <p> This method does not perform any cleanup or synchronization operation.
 		COMMENT Under most circumstances, calling {@link net.minecraft.entity.LivingEntity#tryRemoveStatusEffect(net.minecraft.entity.effect.StatusEffect)} is highly preferable.
-		ARG 1 effect
+		ARG 1 type
 	METHOD method_6112 getStatusEffect (Lnet/minecraft/class_1291;)Lnet/minecraft/class_1293;
 		ARG 1 effect
 	METHOD method_6113 isSleeping ()Z


### PR DESCRIPTION
While the previous names were technically correct, they imply the most straightforward method you can call is the former `removeStatusEffect`. However, it seems to be an internal method, which doesn't execute any cleanup/sync operation.
Most modders should call tryRemoveStatusEffect in every case.
This has caused confusion in a few mods already ([example 1](https://github.com/Ladysnake/Requiem/blob/master/src/main/java/ladysnake/requiem/mixin/possession/player/PossessorServerPlayerEntityMixin.java#L172), [example 2](https://github.com/CottonMC/PracticalWitchcraft/blob/master/src/main/java/io/github/cottonmc/witchcraft/util/WitchcraftNetworking.java), [example 3](https://github.com/Yoghurt4C/OmenaMaitoTee/blob/05e84d8bce6fe8600f24e9b659801aa8960511bc/src/main/java/mods/omenamaito/potions/ImmunizationEffect.java#L32-L36), [example 4](https://github.com/grondag/adversity/blob/7f41400d7e313b54026b8db39c4058acbbc94fc6/src/main/java/grondag/adversity/item/SalvationPotion.java#L67)).