### PR TITLE
Improved Window names

### DIFF
--- a/mappings/net/minecraft/client/util/Window.mapping
+++ b/mappings/net/minecraft/client/util/Window.mapping
@@ -4,6 +4,7 @@ CLASS net/minecraft/class_1041 net/minecraft/client/util/Window
 	FIELD field_5174 windowedWidth I
 	FIELD field_5175 windowedX I
 	FIELD field_5176 eventHandler Lnet/minecraft/class_3678;
+	FIELD field_5177 currentFullscreen Z
 	FIELD field_5178 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_5179 scaleFactor D
 	FIELD field_5180 scaledWidth I
@@ -31,8 +32,9 @@ CLASS net/minecraft/class_1041 net/minecraft/client/util/Window
 		ARG 5 title
 	METHOD method_15997 setScaleFactor (D)V
 		ARG 1 scaleFactor
-	METHOD method_15998 setFullscreen ()V
+	METHOD method_15998 swapBuffers ()V
 	METHOD method_15999 setFramerateLimit (I)V
+		ARG 1 limit
 	METHOD method_16000 getFramerateLimit ()I
 	METHOD method_20831 getMonitor ()Lnet/minecraft/class_313;
 	METHOD method_21668 setRawMouseMotion (Z)V
@@ -41,17 +43,24 @@ CLASS net/minecraft/class_1041 net/minecraft/client/util/Window
 	METHOD method_22093 shouldClose ()Z
 	METHOD method_4474 setPhase (Ljava/lang/String;)V
 		ARG 1 phase
+	METHOD method_4475 applyVideoMode ()V
 	METHOD method_4476 calculateScaleFactor (IZ)I
 		ARG 1 guiScale
 		ARG 2 forceUnicodeFont
 	METHOD method_4477 getY ()I
 	METHOD method_4478 onWindowPosChanged (JII)V
+		ARG 1 window
+		ARG 3 x
+		ARG 4 y
+	METHOD method_4479 updateWindowRegion ()V
 	METHOD method_4480 getWidth ()I
 	METHOD method_4481 throwOnGlError ()V
 	METHOD method_4482 logGlError (IJ)V
 		ARG 1 error
 		ARG 2 description
 	METHOD method_4483 updateFramebufferSize ()V
+	METHOD method_4485 updateFullscreen (Z)V
+		ARG 1 vsync
 	METHOD method_4486 getScaledWidth ()I
 	METHOD method_4488 onWindowSizeChanged (JII)V
 		ARG 1 window

--- a/mappings/net/minecraft/client/util/Window.mapping
+++ b/mappings/net/minecraft/client/util/Window.mapping
@@ -34,7 +34,7 @@ CLASS net/minecraft/class_1041 net/minecraft/client/util/Window
 		ARG 1 scaleFactor
 	METHOD method_15998 swapBuffers ()V
 	METHOD method_15999 setFramerateLimit (I)V
-		ARG 1 limit
+		ARG 1 framerateLimit
 	METHOD method_16000 getFramerateLimit ()I
 	METHOD method_20831 getMonitor ()Lnet/minecraft/class_313;
 	METHOD method_21668 setRawMouseMotion (Z)V


### PR DESCRIPTION
I added some more names in Window, and changed the name for `setFullscreen` to `swapBuffers`, as it actually calls `RenderSystem.flipFrame` (a blaze3d method, that calls `GLFW.glfwSwapBuffers`), and while it does update the screen to reflect the set fullscreen value, it is called every frame regardless of whether the fullscreen value has changed.