### PR TITLE
Map method_22120 to hasMovementInput

### DIFF
--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -56,3 +56,4 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 	METHOD method_3149 getLastAutoJump ()Z
 	METHOD method_3150 cannotFitAt (Lnet/minecraft/class_2338;)Z
 		ARG 1 pos
+	METHOD method_22120 hasMovementInput ()Z

--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -57,3 +57,6 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 	METHOD method_3150 cannotFitAt (Lnet/minecraft/class_2338;)Z
 		ARG 1 pos
 	METHOD method_22120 hasMovementInput ()Z
+		COMMENT Returns whether the player has movement input.
+		COMMENT 
+		COMMENT @return True if the player has movement input, else false.


### PR DESCRIPTION
Mapping the method `method_22120` to `hasMovementInput` in `ClientPlayerEntity` as the method gets the movement input vector and returns if it's a non-null vector.