### PR TITLE
Improve confusing names in entities classes.

### DIFF
--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -245,7 +245,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_5636 setYaw (F)V
 		ARG 1 yaw
 	METHOD method_5637 isWet ()Z
-		COMMENT Returns whether this entity is touching water or is being rained on or is inside a bubble column.
+		COMMENT Returns whether this entity is touching water or is being rained on or is inside a bubble column, etc...
 		COMMENT 
 		COMMENT @see net.minecraft.entity.Entity#isTouchingWater() 
 		COMMENT @see net.minecraft.entity.Entity#isBeingRainedOn() 

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -11,7 +11,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	FIELD field_5954 trackedZ J
 	FIELD field_5955 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_5956 fireTicks I
-	FIELD field_5957 insideWater Z
+	FIELD field_5957 touchingWater Z
 	FIELD field_5958 glowing Z
 	FIELD field_5959 chunkY I
 	FIELD field_5960 noClip Z
@@ -48,7 +48,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	FIELD field_5995 NO_GRAVITY Lnet/minecraft/class_2940;
 	FIELD field_5996 pistonMovementTick J
 	FIELD field_5999 renderDistanceMultiplier D
-	FIELD field_6000 inWater Z
+	FIELD field_6000 submergedInWater Z
 	FIELD field_6001 trackedX J
 	FIELD field_6002 world Lnet/minecraft/class_1937;
 	FIELD field_6003 nextStepSoundDistance F
@@ -233,7 +233,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_5628 getEntityId ()I
 	METHOD method_5629 doesNotCollide (Lnet/minecraft/class_238;)Z
 		ARG 1 box
-	METHOD method_5630 updateWetState ()V
+	METHOD method_5630 updateSubmergedInWaterState ()V
 	METHOD method_5631 getRotationVector (FF)Lnet/minecraft/class_243;
 		ARG 1 pitch
 		ARG 2 yaw
@@ -244,7 +244,12 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_5634 getSoundCategory ()Lnet/minecraft/class_3419;
 	METHOD method_5636 setYaw (F)V
 		ARG 1 yaw
-	METHOD method_5637 isTouchingWater ()Z
+	METHOD method_5637 isWet ()Z
+		COMMENT Returns whether this entity is touching water or is being rained on or is inside a bubble column.
+		COMMENT 
+		COMMENT @see net.minecraft.entity.Entity#isTouchingWater() 
+		COMMENT @see net.minecraft.entity.Entity#isBeingRainedOn() 
+		COMMENT @see net.minecraft.entity.Entity#isInsideBubbleColumn() 
 	METHOD method_5638 shouldSetPositionOnLoad ()Z
 	METHOD method_5639 setOnFireFor (I)V
 		ARG 1 seconds
@@ -388,7 +393,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_5719 copyPositionAndRotation (Lnet/minecraft/class_1297;)V
 		ARG 1 entity
 	METHOD method_5720 getRotationVector ()Lnet/minecraft/class_243;
-	METHOD method_5721 isInsideWaterOrRain ()Z
+	METHOD method_5721 isTouchingWaterOrRain ()Z
 	METHOD method_5722 isTeammate (Lnet/minecraft/class_1297;)Z
 		ARG 1 other
 	METHOD method_5723 dealDamage (Lnet/minecraft/class_1309;Lnet/minecraft/class_1297;)V
@@ -528,7 +533,8 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_5796 setSwimming (Z)V
 		ARG 1 swimming
 	METHOD method_5798 isInsideBubbleColumn ()Z
-	METHOD method_5799 isInsideWater ()Z
+	METHOD method_5799 isTouchingWater ()Z
+		COMMENT Returns whether this entity's hitbox is touching water fluid.
 	METHOD method_5800 onStruckByLightning (Lnet/minecraft/class_1538;)V
 		ARG 1 lightning
 	METHOD method_5801 playFlySound (F)F
@@ -636,7 +642,8 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_5868 collectPassengers (ZLjava/util/Set;)V
 		ARG 1 playersOnly
 		ARG 2 output
-	METHOD method_5869 isInWater ()Z
+	METHOD method_5869 isSubmergedInWater ()Z
+		COMMENT Returns whether this entity's hitbox is fully submerged in water.
 	METHOD method_5870 dropItem (Lnet/minecraft/class_1935;I)Lnet/minecraft/class_1542;
 		ARG 1 item
 		ARG 2 yOffset
@@ -651,7 +658,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		ARG 1 other
 	METHOD method_5875 setNoGravity (Z)V
 		ARG 1 noGravity
-	METHOD method_5876 updateInWater ()V
+	METHOD method_5876 updateWaterState ()V
 	METHOD method_5877 getItemsHand ()Ljava/lang/Iterable;
 	METHOD method_5878 copyFrom (Lnet/minecraft/class_1297;)V
 		ARG 1 original

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -245,7 +245,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_5636 setYaw (F)V
 		ARG 1 yaw
 	METHOD method_5637 isWet ()Z
-		COMMENT Returns whether this entity is touching water or is being rained on or is inside a bubble column, etc...
+		COMMENT Returns whether this entity is touching water, or is being rained on, or is inside a bubble column...
 		COMMENT 
 		COMMENT @see net.minecraft.entity.Entity#isTouchingWater() 
 		COMMENT @see net.minecraft.entity.Entity#isBeingRainedOn() 

--- a/mappings/net/minecraft/entity/passive/WolfEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/WolfEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_1493 net/minecraft/entity/passive/WolfEntity
 	FIELD field_18004 FOLLOW_TAMED_PREDICATE Ljava/util/function/Predicate;
-	FIELD field_6944 wet Z
+	FIELD field_6944 furWet Z
 	FIELD field_6945 lastShakeProgress F
 	FIELD field_6946 BEGGING Lnet/minecraft/class_2940;
 	FIELD field_6947 shakeProgress F
@@ -8,13 +8,23 @@ CLASS net/minecraft/class_1493 net/minecraft/entity/passive/WolfEntity
 	FIELD field_6950 COLLAR_COLOR Lnet/minecraft/class_2940;
 	FIELD field_6951 canShakeWaterOff Z
 	FIELD field_6952 begAnimationProgress F
-	METHOD method_6707 getWetBrightnessMultiplier (F)F
+	METHOD method_6707 getFurWetBrightnessMultiplier (F)F
+		COMMENT Returns this wolf's brightness multiplier based on the fur wetness.
+		COMMENT <p>
+		COMMENT The brightness multiplier represents how much darker the wolf gets while its fur is wet. The multiplier changes (from 0.75 to 1.0 incrementally) when a wolf shakes.
+		COMMENT 
+		COMMENT @param tickDelta Progress for linearly interpolating between the previous and current game state.
+		COMMENT @return Brightness as a float value between 0.75 and 1.0.
+		COMMENT @see net.minecraft.client.render.entity.model.TintableAnimalModel#setColorMultiplier(float, float, float)
 		ARG 1 tickDelta
 	METHOD method_6708 setCollarColor (Lnet/minecraft/class_1767;)V
 		ARG 1 color
 	METHOD method_6709 isAngry ()Z
 	METHOD method_6710 isBegging ()Z
-	METHOD method_6711 isWet ()Z
+	METHOD method_6711 isFurWet ()Z
+		COMMENT Returns whether this wolf's fur is wet.
+		COMMENT <p>
+		COMMENT The wolf's fur will remain wet until the wolf shakes.
 	METHOD method_6712 setBegging (Z)V
 		ARG 1 begging
 	METHOD method_6713 getCollarColor ()Lnet/minecraft/class_1767;

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -114,7 +114,7 @@ CLASS net/minecraft/class_1657 net/minecraft/entity/player/PlayerEntity
 	METHOD method_7292 getLuck ()F
 	METHOD method_7293 vanishCursedItems ()V
 	METHOD method_7294 canModifyWorld ()Z
-	METHOD method_7295 updateSubmergedInWater ()Z
+	METHOD method_7295 updateWaterSubmersionState ()Z
 	METHOD method_7297 getSleepTimer ()I
 	METHOD method_7298 addShoulderEntity (Lnet/minecraft/class_2487;)Z
 		ARG 1 tag

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/class_1657 net/minecraft/entity/player/PlayerEntity
 	FIELD field_7486 enderChestInventory Lnet/minecraft/class_1730;
 	FIELD field_7487 sleepTimer I
 	FIELD field_7488 MAIN_ARM Lnet/minecraft/class_2940;
-	FIELD field_7490 isInWater Z
+	FIELD field_7490 isSubmergedInWater Z
 	FIELD field_7491 ABSORPTION_AMOUNT Lnet/minecraft/class_2940;
 	FIELD field_7493 hungerManager Lnet/minecraft/class_1702;
 	FIELD field_7494 enchantmentTableSeed I
@@ -114,7 +114,7 @@ CLASS net/minecraft/class_1657 net/minecraft/entity/player/PlayerEntity
 	METHOD method_7292 getLuck ()F
 	METHOD method_7293 vanishCursedItems ()V
 	METHOD method_7294 canModifyWorld ()Z
-	METHOD method_7295 updateInWater ()Z
+	METHOD method_7295 updateSubmergedInWater ()Z
 	METHOD method_7297 getSleepTimer ()I
 	METHOD method_7298 addShoulderEntity (Lnet/minecraft/class_2487;)Z
 		ARG 1 tag


### PR DESCRIPTION
This pull request aims to solve #954 `Entity#isInWater, Entity#isTouchingWater and Entity#isInsideWater are confusing names.`

Changes:
 - `Entity#insideWater` -> `Entity#touchingWater`
 - `Entity#inWater` -> `Entity#submergedInWater`
 - `Entity#updateWetState()` -> `Entity#updateSubmergedInWaterState()` for consistency
 - `Entity#isTouchingWater()` -> `Entity#isWet()` to avoid conflict
 - `Entity#isInsideWaterOrRain()` -> `Entity#isTouchingWaterOrRain()` for consistency
 - `Entity#isInsideWater()` -> `Entity#isTouchingWater()`
 - `Entity#isInWater()` -> `Entity#isSubmergedInWater()`
 - `Entity#updateInWater()` -> `Entity#updateWaterState` misleading names as it wasn't only updating the inWater field but other things too, and for consistency
 - `PlayerEntity#isInWater` -> `PlayerEntity#isSubmergedInWater` for consistency
 - `PlayerEntity#updateInWater()` -> `PlayerEntity#updateSubmergedInWater()` for consistency
 - `WolfEntity#wet` -> `WolfEntity#furWet` for consistency
 - `WolfEntity#getWetBrightnessMultiplier()` -> `WolfEntity#getFurWetBrightnessMultiplier()` for consistency
 - `WolfEntity#isWet()` -> `WolfEntity#isFurWet()` to avoid conflict

Javadoc changes:
 - Added Javadoc for `WolfEntity#getFurWetBrightnessMultiplier()` as the method is very confusing on what it returns and why.
 - Added Javadoc for `WolfEntity#isFurWet()` to avoid confusion with `Entity#isWet()`.
 - Added Javadoc for `Entity#isSubmergedInWater()` to avoid confusion.
 - Added Javadoc for `Entity#isTouchingWater()` to avoid confusion.
 - Added Javadoc for `Entity#isWet()` to avoid confusion.