### PR TITLE
2 df classes and some render layer stuff

### DIFF
--- a/mappings/net/minecraft/client/render/OutlineVertexConsumerProvider.mapping
+++ b/mappings/net/minecraft/client/render/OutlineVertexConsumerProvider.mapping
@@ -11,7 +11,7 @@ CLASS net/minecraft/class_4618 net/minecraft/client/render/OutlineVertexConsumer
 		ARG 2 green
 		ARG 3 blue
 		ARG 4 alpha
-	CLASS class_4586 VertexConsumer
+	CLASS class_4586 OutlineVertexConsumer
 		FIELD field_20897 delegate Lnet/minecraft/class_4588;
 		FIELD field_21064 x D
 		FIELD field_21065 y D

--- a/mappings/net/minecraft/client/render/RenderLayer.mapping
+++ b/mappings/net/minecraft/client/render/RenderLayer.mapping
@@ -1,18 +1,10 @@
 CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 	FIELD field_20806 expectedBufferSize I
-	FIELD field_20964 LEASH Lnet/minecraft/class_1921;
-	FIELD field_20965 WATER_MASK Lnet/minecraft/class_1921;
-	FIELD field_20967 GLINT Lnet/minecraft/class_1921;
-	FIELD field_20968 ENTITY_GLINT Lnet/minecraft/class_1921;
-	FIELD field_20970 LIGHTNING Lnet/minecraft/class_1921;
 	FIELD field_20972 vertexFormat Lnet/minecraft/class_293;
 	FIELD field_20973 drawMode I
 	FIELD field_20975 hasCrumbling Z
 	FIELD field_21402 translucent Z
-	FIELD field_9174 CUTOUT Lnet/minecraft/class_1921;
-	FIELD field_9175 CUTOUT_MIPPED Lnet/minecraft/class_1921;
-	FIELD field_9178 SOLID Lnet/minecraft/class_1921;
-	FIELD field_9179 TRANSLUCENT Lnet/minecraft/class_1921;
+	FIELD field_21850 optionalThis Ljava/util/Optional;
 	METHOD <init> (Ljava/lang/String;Lnet/minecraft/class_293;IIZZLjava/lang/Runnable;Ljava/lang/Runnable;)V
 		ARG 1 name
 		ARG 2 vertexFormat
@@ -43,7 +35,7 @@ CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 	METHOD method_23033 getDrawMode ()I
 	METHOD method_23287 getOutline (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
 		ARG 0 texture
-	METHOD method_23289 getTexture ()Ljava/util/Optional;
+	METHOD method_23289 getAffectedOutline ()Ljava/util/Optional;
 	METHOD method_23570 getBlockBreaking (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
 		ARG 0 texture
 	METHOD method_23572 getEntitySolid (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
@@ -96,11 +88,20 @@ CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 		ARG 5 translucent
 		ARG 6 phases
 	METHOD method_24051 createTranslucentPhaseData ()Lnet/minecraft/class_1921$class_4688;
+	METHOD method_24293 getCutoutNoCull (Lnet/minecraft/class_2960;Z)Lnet/minecraft/class_1921;
+		ARG 0 texture
+		ARG 1 affectsOutline
+	METHOD method_24294 getEntityTranslucent (Lnet/minecraft/class_2960;Z)Lnet/minecraft/class_1921;
+		ARG 0 texture
+		ARG 1 affectsOutline
+	METHOD method_24295 isOutline ()Z
+	METHOD method_24296 asOptional ()Ljava/util/Optional;
 	CLASS class_4687 MultiPhase
 		FIELD field_21403 phases Lnet/minecraft/class_1921$class_4688;
 		FIELD field_21404 hash I
 		FIELD field_21696 CACHE Lit/unimi/dsi/fastutil/objects/ObjectOpenCustomHashSet;
-		FIELD field_21697 texture Ljava/util/Optional;
+		FIELD field_21697 affectedOutline Ljava/util/Optional;
+		FIELD field_21851 outline Z
 		METHOD <init> (Ljava/lang/String;Lnet/minecraft/class_293;IIZZLnet/minecraft/class_1921$class_4688;)V
 			ARG 1 name
 			ARG 2 vertexFormat
@@ -135,6 +136,7 @@ CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 		FIELD field_21419 writeMaskState Lnet/minecraft/class_4668$class_4686;
 		FIELD field_21420 lineWidth Lnet/minecraft/class_4668$class_4677;
 		FIELD field_21422 phases Lcom/google/common/collect/ImmutableList;
+		FIELD field_21852 outlineMode Lnet/minecraft/class_1921$class_4750;
 		METHOD <init> (Lnet/minecraft/class_4668$class_4683;Lnet/minecraft/class_4668$class_4685;Lnet/minecraft/class_4668$class_4673;Lnet/minecraft/class_4668$class_4681;Lnet/minecraft/class_4668$class_4669;Lnet/minecraft/class_4668$class_4672;Lnet/minecraft/class_4668$class_4671;Lnet/minecraft/class_4668$class_4676;Lnet/minecraft/class_4668$class_4679;Lnet/minecraft/class_4668$class_4674;Lnet/minecraft/class_4668$class_4675;Lnet/minecraft/class_4668$class_4678;Lnet/minecraft/class_4668$class_4684;Lnet/minecraft/class_4668$class_4686;Lnet/minecraft/class_4668$class_4677;Lnet/minecraft/class_1921$class_4750;)V
 			ARG 1 texture
 			ARG 2 transparency
@@ -151,6 +153,7 @@ CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 			ARG 13 texturing
 			ARG 14 writeMaskState
 			ARG 15 lineWidth
+			ARG 16 outlineMode
 		METHOD method_23598 builder ()Lnet/minecraft/class_1921$class_4688$class_4689;
 		CLASS class_4689 Builder
 			FIELD field_21423 texture Lnet/minecraft/class_4668$class_4683;
@@ -199,4 +202,7 @@ CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 			METHOD method_23616 writeMaskState (Lnet/minecraft/class_4668$class_4686;)Lnet/minecraft/class_1921$class_4688$class_4689;
 				ARG 1 writeMaskState
 			METHOD method_23617 build (Z)Lnet/minecraft/class_1921$class_4688;
-				ARG 1 textured
+				ARG 1 affectsOutline
+			METHOD method_24297 build (Lnet/minecraft/class_1921$class_4750;)Lnet/minecraft/class_1921$class_4688;
+				ARG 1 outlineMode
+	CLASS class_4750 OutlineMode

--- a/mappings/net/minecraft/datafixer/fix/AdvancementRenameFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/AdvancementRenameFix.mapping
@@ -1,0 +1,6 @@
+CLASS net/minecraft/class_4744 net/minecraft/datafixer/fix/AdvancementRenameFix
+	FIELD field_21814 name Ljava/lang/String;
+	FIELD field_21815 renamer Ljava/util/function/Function;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;ZLjava/lang/String;Ljava/util/function/Function;)V
+		ARG 3 name
+		ARG 4 renamer

--- a/mappings/net/minecraft/datafixer/fix/RecipeRenameFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/RecipeRenameFix.mapping
@@ -1,0 +1,6 @@
+CLASS net/minecraft/class_4745 net/minecraft/datafixer/fix/RecipeRenameFix
+	FIELD field_21816 name Ljava/lang/String;
+	FIELD field_21817 renamer Ljava/util/function/Function;
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;ZLjava/lang/String;Ljava/util/function/Function;)V
+		ARG 3 name
+		ARG 4 renamer


### PR DESCRIPTION
render layer fields can be inferred
outlinevertexconsumer: better decompiled code (see ff genSources result); package level, doesn't affect mods
render layer outline: map one new package enum and change stuff to refer to outline etc.

Signed-off-by: liach <liach@users.noreply.github.com>