### PR TITLE
1.15.2 EntityRenderer changes

### DIFF
--- a/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
@@ -15,8 +15,8 @@ CLASS net/minecraft/class_897 net/minecraft/client/render/entity/EntityRenderer
 		ARG 2 tickDelta
 	METHOD method_3921 hasLabel (Lnet/minecraft/class_1297;)Z
 		COMMENT Determines whether the passed entity should render with a nameplate above its head.
-		COMMENT
-		COMMENT Checks for a custom nametag on living entities, and for teams/team visibilities for players.
+		COMMENT 
+		COMMENT <p>Checks for a custom nametag on living entities, and for teams/team visibilities for players.</p>
 		ARG 1 entity
 	METHOD method_3926 renderLabelIfPresent (Lnet/minecraft/class_1297;Ljava/lang/String;Lnet/minecraft/class_4587;Lnet/minecraft/class_4597;I)V
 		ARG 1 entity

--- a/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
@@ -2,6 +2,8 @@ CLASS net/minecraft/class_897 net/minecraft/client/render/entity/EntityRenderer
 	FIELD field_4672 shadowDarkness F
 	FIELD field_4673 shadowSize F
 	FIELD field_4676 renderManager Lnet/minecraft/class_898;
+	METHOD <init> (Lnet/minecraft/class_898;)V
+		ARG 1 dispatcher
 	METHOD method_23169 getPositionOffset (Lnet/minecraft/class_1297;F)Lnet/minecraft/class_243;
 		ARG 1 entity
 		ARG 2 tickDelta
@@ -12,9 +14,13 @@ CLASS net/minecraft/class_897 net/minecraft/client/render/entity/EntityRenderer
 		ARG 1 entity
 		ARG 2 tickDelta
 	METHOD method_3921 hasLabel (Lnet/minecraft/class_1297;)Z
+		COMMENT Determines whether the passed entity should render with a nameplate above its head.
+		COMMENT
+		COMMENT Checks for a custom nametag on living entities, and for teams/team visibilities for players.
 		ARG 1 entity
 	METHOD method_3926 renderLabelIfPresent (Lnet/minecraft/class_1297;Ljava/lang/String;Lnet/minecraft/class_4587;Lnet/minecraft/class_4597;I)V
 		ARG 1 entity
+		ARG 3 matrices
 	METHOD method_3931 getTexture (Lnet/minecraft/class_1297;)Lnet/minecraft/class_2960;
 		ARG 1 entity
 	METHOD method_3932 getFontRenderer ()Lnet/minecraft/class_327;

--- a/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
@@ -19,7 +19,6 @@ CLASS net/minecraft/class_922 net/minecraft/client/render/entity/LivingEntityRen
 		COMMENT Gets the render layer appropriate for rendering the passed entity. Return null if the entity should not be rendered.
 		ARG 1 entity
 		ARG 2 showBody
-			COMMENT
 		ARG 3 translucent
 	METHOD method_4039 getLyingAngle (Lnet/minecraft/class_1309;)F
 		ARG 1 entity

--- a/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
@@ -12,11 +12,11 @@ CLASS net/minecraft/class_922 net/minecraft/client/render/entity/LivingEntityRen
 		ARG 1 entity
 		ARG 2 tickDelta
 	METHOD method_23622 getOverlay (Lnet/minecraft/class_1309;F)I
-		COMMENT Returns the packed overlay colour for an entity, determined by its death progress and whether it is flashing.
+		COMMENT Returns the packed overlay color for an entity, determined by its death progress and whether it is flashing.
 		ARG 0 entity
 		ARG 1 whiteOverlayProgress
 	METHOD method_24302 getRenderLayer (Lnet/minecraft/class_1309;ZZ)Lnet/minecraft/class_1921;
-		COMMENT Gets the render layer appropriate for rendering the passed entity. Return null if the entity should not be rendered.
+		COMMENT Gets the render layer appropriate for rendering the passed entity. Returnn null if the entity should not be rendered.
 		ARG 1 entity
 		ARG 2 showBody
 		ARG 3 translucent

--- a/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
@@ -16,7 +16,7 @@ CLASS net/minecraft/class_922 net/minecraft/client/render/entity/LivingEntityRen
 		ARG 0 entity
 		ARG 1 whiteOverlayProgress
 	METHOD method_24302 getRenderLayer (Lnet/minecraft/class_1309;ZZ)Lnet/minecraft/class_1921;
-		COMMENT Gets the render layer appropriate for rendering the passed entity. Returnn null if the entity should not be rendered.
+		COMMENT Gets the render layer appropriate for rendering the passed entity. Returns null if the entity should not be rendered.
 		ARG 1 entity
 		ARG 2 showBody
 		ARG 3 translucent

--- a/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
@@ -2,22 +2,46 @@ CLASS net/minecraft/class_922 net/minecraft/client/render/entity/LivingEntityRen
 	FIELD field_21011 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_4737 model Lnet/minecraft/class_583;
 	FIELD field_4738 features Ljava/util/List;
+	METHOD <init> (Lnet/minecraft/class_898;Lnet/minecraft/class_583;F)V
+		ARG 1 dispatcher
+		ARG 2 model
+		ARG 3 shadowSize
 	METHOD method_18656 getYaw (Lnet/minecraft/class_2350;)F
+		ARG 0 direction
 	METHOD method_23185 getWhiteOverlayProgress (Lnet/minecraft/class_1309;F)F
 		ARG 1 entity
 		ARG 2 tickDelta
 	METHOD method_23622 getOverlay (Lnet/minecraft/class_1309;F)I
+		COMMENT Returns the packed overlay colour for an entity, determined by its death progress and whether it is flashing.
 		ARG 0 entity
 		ARG 1 whiteOverlayProgress
+	METHOD method_24302 getRenderLayer (Lnet/minecraft/class_1309;ZZ)Lnet/minecraft/class_1921;
+		COMMENT Gets the render layer appropriate for rendering the passed entity. Return null if the entity should not be rendered.
+		ARG 1 entity
+		ARG 2 showBody
+			COMMENT
+		ARG 3 translucent
 	METHOD method_4039 getLyingAngle (Lnet/minecraft/class_1309;)F
+		ARG 1 entity
 	METHOD method_4042 scale (Lnet/minecraft/class_1309;Lnet/minecraft/class_4587;F)V
 		ARG 1 entity
+		ARG 2 matrices
+		ARG 3 tickDelta
 	METHOD method_4044 getHandSwingProgress (Lnet/minecraft/class_1309;F)F
 		ARG 1 entity
 		ARG 2 tickDelta
-	METHOD method_4045 getCustomAngle (Lnet/minecraft/class_1309;F)F
+	METHOD method_4045 getAnimationProgress (Lnet/minecraft/class_1309;F)F
+		COMMENT Typically just the sum of entity's age (in ticks) and the passed tickDelta.
+		COMMENT This value is passed to other methods when calculating angles for animation.
 		ARG 1 entity
 		ARG 2 tickDelta
 	METHOD method_4046 addFeature (Lnet/minecraft/class_3887;)Z
+		ARG 1 feature
+	METHOD method_4056 shouldRenderBody (Lnet/minecraft/class_1309;)Z
+		ARG 1 entity
 	METHOD method_4058 setupTransforms (Lnet/minecraft/class_1309;Lnet/minecraft/class_4587;FFF)V
 		ARG 1 entity
+		ARG 2 matrices
+		ARG 3 animationProgress
+		ARG 4 bodyYaw
+		ARG 5 tickDelta

--- a/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
@@ -30,8 +30,8 @@ CLASS net/minecraft/class_922 net/minecraft/client/render/entity/LivingEntityRen
 		ARG 1 entity
 		ARG 2 tickDelta
 	METHOD method_4045 getAnimationProgress (Lnet/minecraft/class_1309;F)F
-		COMMENT Typically just the sum of entity's age (in ticks) and the passed tickDelta.
 		COMMENT This value is passed to other methods when calculating angles for animation.
+		COMMENT It's typically just the sum of the entity's age (in ticks) and the passed in tickDelta.
 		ARG 1 entity
 		ARG 2 tickDelta
 	METHOD method_4046 addFeature (Lnet/minecraft/class_3887;)Z


### PR DESCRIPTION
Fills in a few missing names in `LivingEntityRenderer`.

I only realise now that this might conflict with my other PR, which hasn't been merged, but I can fix that if this one is merged first.