### PR TITLE
LivingEntity rendering fix

### DIFF
--- a/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
@@ -36,3 +36,5 @@ CLASS net/minecraft/class_897 net/minecraft/client/render/entity/EntityRenderer
 		ARG 2 yaw
 	METHOD render (IIF)V
 		ARG 3 tickDelta
+	METHOD render (IIF)V
+		ARG 5 vertexConsumers

--- a/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
@@ -32,11 +32,3 @@ CLASS net/minecraft/class_897 net/minecraft/client/render/entity/EntityRenderer
 		ARG 5 vertexConsumers
 		ARG 6 light
 	METHOD method_3940 getRenderManager ()Lnet/minecraft/class_898;
-	METHOD render (IIF)V
-		ARG 2 yaw
-	METHOD render (IIF)V
-		ARG 3 tickDelta
-	METHOD render (IIF)V
-		ARG 5 vertexConsumers
-	METHOD render (IIF)V
-		ARG 6 light

--- a/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
@@ -34,3 +34,5 @@ CLASS net/minecraft/class_897 net/minecraft/client/render/entity/EntityRenderer
 	METHOD method_3940 getRenderManager ()Lnet/minecraft/class_898;
 	METHOD render (IIF)V
 		ARG 2 yaw
+	METHOD render (IIF)V
+		ARG 3 tickDelta

--- a/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
@@ -38,3 +38,5 @@ CLASS net/minecraft/class_897 net/minecraft/client/render/entity/EntityRenderer
 		ARG 3 tickDelta
 	METHOD render (IIF)V
 		ARG 5 vertexConsumers
+	METHOD render (IIF)V
+		ARG 6 light

--- a/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
@@ -32,3 +32,5 @@ CLASS net/minecraft/class_897 net/minecraft/client/render/entity/EntityRenderer
 		ARG 5 vertexConsumers
 		ARG 6 light
 	METHOD method_3940 getRenderManager ()Lnet/minecraft/class_898;
+	METHOD render (IIF)V
+		ARG 2 yaw

--- a/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
@@ -9,10 +9,6 @@ CLASS net/minecraft/class_922 net/minecraft/client/render/entity/LivingEntityRen
 	METHOD method_23622 getOverlay (Lnet/minecraft/class_1309;F)I
 		ARG 0 entity
 		ARG 1 whiteOverlayProgress
-	METHOD method_24302 getEntityRenderLayer (Lnet/minecraft/class_1309;ZZ)Lnet/minecraft/class_1921;
-		ARG 1 renderedEntity
-		ARG 2 fullyVisible
-		ARG 3 invisibilityRevealed
 	METHOD method_4039 getLyingAngle (Lnet/minecraft/class_1309;)F
 	METHOD method_4042 scale (Lnet/minecraft/class_1309;Lnet/minecraft/class_4587;F)V
 		ARG 1 entity

--- a/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
@@ -21,3 +21,4 @@ CLASS net/minecraft/class_922 net/minecraft/client/render/entity/LivingEntityRen
 	METHOD method_4046 addFeature (Lnet/minecraft/class_3887;)Z
 	METHOD method_4058 setupTransforms (Lnet/minecraft/class_1309;Lnet/minecraft/class_4587;FFF)V
 		ARG 1 entity
+	METHOD method_4056 shouldRender (Lnet/minecraft/class_1309;Z)Z

--- a/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
@@ -9,6 +9,10 @@ CLASS net/minecraft/class_922 net/minecraft/client/render/entity/LivingEntityRen
 	METHOD method_23622 getOverlay (Lnet/minecraft/class_1309;F)I
 		ARG 0 entity
 		ARG 1 whiteOverlayProgress
+	METHOD method_24302 getEntityRenderLayer (Lnet/minecraft/class_1309;ZZ)Lnet/minecraft/class_1921;
+		ARG 1 renderedEntity
+		ARG 2 fullyVisible
+		ARG 3 invisibilityRevealed
 	METHOD method_4039 getLyingAngle (Lnet/minecraft/class_1309;)F
 	METHOD method_4042 scale (Lnet/minecraft/class_1309;Lnet/minecraft/class_4587;F)V
 		ARG 1 entity
@@ -19,7 +23,7 @@ CLASS net/minecraft/class_922 net/minecraft/client/render/entity/LivingEntityRen
 		ARG 1 entity
 		ARG 2 tickDelta
 	METHOD method_4046 addFeature (Lnet/minecraft/class_3887;)Z
+	METHOD method_4056 isVisible (Lnet/minecraft/class_1309;)Z
+	METHOD method_4056 isVisible (Lnet/minecraft/class_1309;Z)Z
 	METHOD method_4058 setupTransforms (Lnet/minecraft/class_1309;Lnet/minecraft/class_4587;FFF)V
 		ARG 1 entity
-	METHOD method_4056 shouldRender (Lnet/minecraft/class_1309;Z)Z
-	METHOD method_4056 isVisible (Lnet/minecraft/class_1309;Z)Z

--- a/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
@@ -23,11 +23,6 @@ CLASS net/minecraft/class_922 net/minecraft/client/render/entity/LivingEntityRen
 		ARG 1 entity
 		ARG 2 tickDelta
 	METHOD method_4046 addFeature (Lnet/minecraft/class_3887;)Z
-<<<<<<< HEAD
-	METHOD method_4056 isVisible (Lnet/minecraft/class_1309;)Z
-	METHOD method_4056 isVisible (Lnet/minecraft/class_1309;Z)Z
-=======
 	METHOD method_4056 isFullyVisible (Lnet/minecraft/class_1309;)Z
->>>>>>> df0a08738... Remove overlaps
 	METHOD method_4058 setupTransforms (Lnet/minecraft/class_1309;Lnet/minecraft/class_4587;FFF)V
 		ARG 1 entity

--- a/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
@@ -22,3 +22,4 @@ CLASS net/minecraft/class_922 net/minecraft/client/render/entity/LivingEntityRen
 	METHOD method_4058 setupTransforms (Lnet/minecraft/class_1309;Lnet/minecraft/class_4587;FFF)V
 		ARG 1 entity
 	METHOD method_4056 shouldRender (Lnet/minecraft/class_1309;Z)Z
+	METHOD method_4056 isVisible (Lnet/minecraft/class_1309;Z)Z

--- a/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
@@ -23,7 +23,11 @@ CLASS net/minecraft/class_922 net/minecraft/client/render/entity/LivingEntityRen
 		ARG 1 entity
 		ARG 2 tickDelta
 	METHOD method_4046 addFeature (Lnet/minecraft/class_3887;)Z
+<<<<<<< HEAD
 	METHOD method_4056 isVisible (Lnet/minecraft/class_1309;)Z
 	METHOD method_4056 isVisible (Lnet/minecraft/class_1309;Z)Z
+=======
+	METHOD method_4056 isFullyVisible (Lnet/minecraft/class_1309;)Z
+>>>>>>> df0a08738... Remove overlaps
 	METHOD method_4058 setupTransforms (Lnet/minecraft/class_1309;Lnet/minecraft/class_4587;FFF)V
 		ARG 1 entity

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -459,7 +459,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_5753 isFireImmune ()Z
 	METHOD method_5754 teleportRequested ()Z
 	METHOD method_5755 getMovementDirection ()Lnet/minecraft/class_2350;
-	METHOD method_5756 canSeePlayer (Lnet/minecraft/class_1657;)Z
+	METHOD method_5756 isInvisibleTo (Lnet/minecraft/class_1657;)Z
 		ARG 1 player
 	METHOD method_5757 isInsideWall ()Z
 	METHOD method_5758 equip (ILnet/minecraft/class_1799;)Z


### PR DESCRIPTION
Renamed `Entity#canSeePlayer` to `isInvisibleTo`.
It returns true if an entity is invisible and not revealed by spectator mode or scoreboard team setting, and is used by LivingEntityRenderer to check if an entity should be rendered as translucent.
The other names were previously unmapped.
