### PR TITLE
A couple of block class renamings

### DIFF
--- a/mappings/net/minecraft/block/BeehiveBlock.mapping
+++ b/mappings/net/minecraft/block/BeehiveBlock.mapping
@@ -6,6 +6,11 @@ CLASS net/minecraft/class_4481 net/minecraft/block/BeehiveBlock
 		ARG 1 player
 	METHOD method_21840 addHoneyParticle (Lnet/minecraft/class_1937;DDDDD)V
 		ARG 1 world
+		ARG 2 minX
+		ARG 4 maxX
+		ARG 6 minZ
+		ARG 8 maxZ
+		ARG 10 height
 	METHOD method_21841 takeHoney (Lnet/minecraft/class_1937;Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;Lnet/minecraft/class_1657;Lnet/minecraft/class_4482$class_4484;)V
 		ARG 1 world
 		ARG 2 state
@@ -21,6 +26,8 @@ CLASS net/minecraft/class_4481 net/minecraft/block/BeehiveBlock
 	METHOD method_21844 addHoneyParticle (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_265;D)V
 		ARG 1 world
 		ARG 2 pos
+		ARG 3 shape
+		ARG 4 height
 	METHOD method_23754 takeHoney (Lnet/minecraft/class_1937;Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;)V
 		ARG 1 world
 		ARG 2 state

--- a/mappings/net/minecraft/block/ConnectingBlock.mapping
+++ b/mappings/net/minecraft/block/ConnectingBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2429 net/minecraft/block/ConnectedPlantBlock
+CLASS net/minecraft/class_2429 net/minecraft/block/ConnectingBlock
 	FIELD field_11327 UP Lnet/minecraft/class_2746;
 	FIELD field_11328 WEST Lnet/minecraft/class_2746;
 	FIELD field_11329 FACING_PROPERTIES Ljava/util/Map;

--- a/mappings/net/minecraft/block/Stainable.mapping
+++ b/mappings/net/minecraft/block/Stainable.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_4275 net/minecraft/block/Stainable
+	METHOD method_10622 getColor ()Lnet/minecraft/class_1767;

--- a/mappings/net/minecraft/client/block/ColoredBlock.mapping
+++ b/mappings/net/minecraft/client/block/ColoredBlock.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/class_4275 net/minecraft/client/block/ColoredBlock
-	METHOD method_10622 getColor ()Lnet/minecraft/class_1767;


### PR DESCRIPTION
Fixes #867 , #997 , #995 

`ColoredBlock` has been renamed to `Stainable`, to match the other interfaces implemented by block classes (`Fertilizable`, `Waterloggable`, etc).

Also mapped missing parameters in `BeehiveBlock`.