### PR TITLE
New shulker and Item related mappings [20w06a]

### DIFF
--- a/mappings/net/minecraft/entity/mob/ShulkerLidCollisions.mapping
+++ b/mappings/net/minecraft/entity/mob/ShulkerLidCollisions.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_4759 net/minecraft/entity/mob/ShulkerLidCollisions
+	METHOD method_24344 getLidCollisionBox (Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Lnet/minecraft/class_238;

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_1792 net/minecraft/item/Item
 	FIELD field_18672 foodComponent Lnet/minecraft/class_4174;
+	FIELD field_21979 unburnable Z
 	FIELD field_8000 DAMAGE_PROPERTY_GETTER Lnet/minecraft/class_1800;
 	FIELD field_8001 ATTACK_SPEED_MODIFIER_UUID Ljava/util/UUID;
 	FIELD field_8002 CUSTOM_DATA_PROPERTY_GETTER Lnet/minecraft/class_1800;
@@ -23,6 +24,8 @@ CLASS net/minecraft/class_1792 net/minecraft/item/Item
 	METHOD method_19264 getFoodComponent ()Lnet/minecraft/class_4174;
 	METHOD method_21830 getEatSound ()Lnet/minecraft/class_3414;
 	METHOD method_21831 getDrinkSound ()Lnet/minecraft/class_3414;
+	METHOD method_24357 shouldBurn (Lnet/minecraft/class_1282;)Z
+	METHOD method_24358 isUnburnable ()Z
 	METHOD method_7836 use (Lnet/minecraft/class_1937;Lnet/minecraft/class_1657;Lnet/minecraft/class_1268;)Lnet/minecraft/class_1271;
 		ARG 1 world
 		ARG 2 user
@@ -163,6 +166,7 @@ CLASS net/minecraft/class_1792 net/minecraft/item/Item
 		ARG 5 selected
 	CLASS class_1793 Settings
 		FIELD field_18673 foodComponent Lnet/minecraft/class_4174;
+		FIELD field_21980 unburnable Z
 		FIELD field_8016 rarity Lnet/minecraft/class_1814;
 		FIELD field_8017 group Lnet/minecraft/class_1761;
 		FIELD field_8018 recipeRemainder Lnet/minecraft/class_1792;
@@ -170,6 +174,7 @@ CLASS net/minecraft/class_1792 net/minecraft/item/Item
 		FIELD field_8020 maxCount I
 		METHOD method_19265 food (Lnet/minecraft/class_4174;)Lnet/minecraft/class_1792$class_1793;
 			ARG 1 foodComponent
+		METHOD method_24359 unburnable ()Lnet/minecraft/class_1792$class_1793;
 		METHOD method_7889 maxCount (I)Lnet/minecraft/class_1792$class_1793;
 			ARG 1 maxCount
 		METHOD method_7892 group (Lnet/minecraft/class_1761;)Lnet/minecraft/class_1792$class_1793;


### PR DESCRIPTION
Adds new mapping for where the Shulker box/entity lid collision box is calculated (mainly used to check if the shulker can physically open) and names item settings which determine if an item should not burn.