### PR TITLE
Backport of latest changes in 20w06a to 1.15.2.

### DIFF
--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -159,7 +159,7 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos
-		ARG 4 ePos
+		ARG 4 context
 	METHOD method_9531 getStateFromRawId (I)Lnet/minecraft/class_2680;
 		ARG 0 stateId
 	METHOD method_9533 shouldDropItemsOnExplosion (Lnet/minecraft/class_1927;)Z
@@ -211,7 +211,7 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 		ARG 1 state
 		ARG 2 view
 		ARG 3 pos
-		ARG 4 ePos
+		ARG 4 context
 	METHOD method_9552 shouldPostProcess (Lnet/minecraft/class_2680;Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z
 		ARG 1 state
 		ARG 2 view

--- a/mappings/net/minecraft/block/BlockState.mapping
+++ b/mappings/net/minecraft/block/BlockState.mapping
@@ -170,7 +170,7 @@ CLASS net/minecraft/class_2680 net/minecraft/block/BlockState
 	METHOD method_16337 getCollisionShape (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_3726;)Lnet/minecraft/class_265;
 		ARG 1 view
 		ARG 2 pos
-		ARG 3 ePos
+		ARG 3 context
 	METHOD method_16384 getCullingFace (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Lnet/minecraft/class_265;
 		ARG 1 view
 		ARG 2 pos

--- a/mappings/net/minecraft/block/HorizontalConnectingBlock.mapping
+++ b/mappings/net/minecraft/block/HorizontalConnectingBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2310 net/minecraft/block/HorizontalConnectedBlock
+CLASS net/minecraft/class_2310 net/minecraft/block/HorizontalConnectingBlock
 	FIELD field_10900 WATERLOGGED Lnet/minecraft/class_2746;
 	FIELD field_10901 collisionShapes [Lnet/minecraft/class_265;
 	FIELD field_10902 FACING_PROPERTIES Ljava/util/Map;

--- a/mappings/net/minecraft/client/MinecraftClient.mapping
+++ b/mappings/net/minecraft/client/MinecraftClient.mapping
@@ -57,7 +57,7 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 	FIELD field_1743 skipGameRender Z
 	FIELD field_1744 connectedToRealms Z
 	FIELD field_1745 resourceManager Lnet/minecraft/class_3296;
-	FIELD field_1746 clientConnection Lnet/minecraft/class_2535;
+	FIELD field_1746 connection Lnet/minecraft/class_2535;
 	FIELD field_1747 crashReport Lnet/minecraft/class_128;
 	FIELD field_1748 levelStorage Lnet/minecraft/class_32;
 	FIELD field_1749 ALT_TEXT_RENDERER_ID Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/network/ClientAdvancementManager.mapping
+++ b/mappings/net/minecraft/client/network/ClientAdvancementManager.mapping
@@ -6,10 +6,13 @@ CLASS net/minecraft/class_632 net/minecraft/client/network/ClientAdvancementMana
 	FIELD field_3685 selectedTab Lnet/minecraft/class_161;
 	FIELD field_3686 LOGGER Lorg/apache/logging/log4j/Logger;
 	METHOD method_2861 onAdvancements (Lnet/minecraft/class_2779;)V
+		ARG 1 packet
 	METHOD method_2862 setListener (Lnet/minecraft/class_632$class_633;)V
 		ARG 1 listener
 	METHOD method_2863 getManager ()Lnet/minecraft/class_163;
 	METHOD method_2864 selectTab (Lnet/minecraft/class_161;Z)V
+		ARG 1 tab
+		ARG 2 local
 	CLASS class_633 Listener
 		METHOD method_2865 setProgress (Lnet/minecraft/class_161;Lnet/minecraft/class_167;)V
 			ARG 1 advancement

--- a/mappings/net/minecraft/client/network/ClientCommandSource.mapping
+++ b/mappings/net/minecraft/client/network/ClientCommandSource.mapping
@@ -4,8 +4,12 @@ CLASS net/minecraft/class_637 net/minecraft/client/network/ClientCommandSource
 	FIELD field_3724 completionId I
 	FIELD field_3725 client Lnet/minecraft/class_310;
 	METHOD <init> (Lnet/minecraft/class_634;Lnet/minecraft/class_310;)V
-		ARG 1 client
-	METHOD method_2929 formatDouble (D)Ljava/lang/String;
-	METHOD method_2930 formatInt (I)Ljava/lang/String;
+		ARG 1 networkHandler
+		ARG 2 client
+	METHOD method_2929 format (D)Ljava/lang/String;
+		ARG 0 d
+	METHOD method_2930 format (I)Ljava/lang/String;
+		ARG 0 i
 	METHOD method_2931 onCommandSuggestions (ILcom/mojang/brigadier/suggestion/Suggestions;)V
 		ARG 1 completionId
+		ARG 2 suggestions

--- a/mappings/net/minecraft/client/network/ClientPlayNetworkHandler.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayNetworkHandler.mapping
@@ -12,18 +12,33 @@ CLASS net/minecraft/class_634 net/minecraft/client/network/ClientPlayNetworkHand
 	FIELD field_3695 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_3696 commandDispatcher Lcom/mojang/brigadier/CommandDispatcher;
 	FIELD field_3697 profile Lcom/mojang/authlib/GameProfile;
+	FIELD field_3698 positionLookSetup Z
 	FIELD field_3699 world Lnet/minecraft/class_638;
 	FIELD field_3700 advancementHandler Lnet/minecraft/class_632;
 	FIELD field_3701 loginScreen Lnet/minecraft/class_437;
 	METHOD <init> (Lnet/minecraft/class_310;Lnet/minecraft/class_437;Lnet/minecraft/class_2535;Lcom/mojang/authlib/GameProfile;)V
 		ARG 1 client
+		ARG 2 screen
+		ARG 3 connection
+		ARG 4 profile
 	METHOD method_16690 getSessionId ()Ljava/util/UUID;
+	METHOD method_19691 getActiveTotemOfUndying (Lnet/minecraft/class_1657;)Lnet/minecraft/class_1799;
+		ARG 0 player
 	METHOD method_2867 getTagManager ()Lnet/minecraft/class_3505;
 	METHOD method_2868 clearWorld ()V
 	METHOD method_2869 getAdvancementHandler ()Lnet/minecraft/class_632;
+	METHOD method_2870 updateLighting (IILnet/minecraft/class_3568;Lnet/minecraft/class_1944;IILjava/util/Iterator;)V
+		ARG 1 chunkX
+		ARG 2 chunkZ
+		ARG 3 provider
+		ARG 4 type
+		ARG 5 mask
+		ARG 6 filledMask
+		ARG 7 updates
 	METHOD method_2871 getPlayerListEntry (Ljava/util/UUID;)Lnet/minecraft/class_640;
 		ARG 1 uuid
 	METHOD method_2873 sendResourcePackStatus (Lnet/minecraft/class_2856$class_2857;)V
+		ARG 1 packStatus
 	METHOD method_2874 getPlayerListEntry (Ljava/lang/String;)Lnet/minecraft/class_640;
 		ARG 1 profileName
 	METHOD method_2875 getCommandSource ()Lnet/minecraft/class_637;
@@ -32,6 +47,10 @@ CLASS net/minecraft/class_634 net/minecraft/client/network/ClientPlayNetworkHand
 	METHOD method_2879 getProfile ()Lcom/mojang/authlib/GameProfile;
 	METHOD method_2880 getPlayerList ()Ljava/util/Collection;
 	METHOD method_2883 sendPacket (Lnet/minecraft/class_2596;)V
+		ARG 1 packet
+	METHOD method_2885 feedbackAfterDownload (Ljava/util/concurrent/CompletableFuture;)V
+		ARG 1 downloadFuture
 	METHOD method_2886 getCommandDispatcher ()Lcom/mojang/brigadier/CommandDispatcher;
 	METHOD method_2888 validateResourcePackUrl (Ljava/lang/String;)Z
+		ARG 1 url
 	METHOD method_2890 getWorld ()Lnet/minecraft/class_638;

--- a/mappings/net/minecraft/client/network/ClientPlayerInteractionManager.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerInteractionManager.mapping
@@ -14,8 +14,13 @@ CLASS net/minecraft/class_636 net/minecraft/client/network/ClientPlayerInteracti
 	METHOD method_21705 processPlayerActionResponse (Lnet/minecraft/class_638;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2846$class_2847;Z)V
 		ARG 1 world
 		ARG 2 pos
+		ARG 3 state
+		ARG 4 action
 		ARG 5 approved
 	METHOD method_21706 sendPlayerAction (Lnet/minecraft/class_2846$class_2847;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)V
+		ARG 1 action
+		ARG 2 pos
+		ARG 3 direction
 	METHOD method_2895 hasRidingInventory ()Z
 	METHOD method_2896 interactBlock (Lnet/minecraft/class_746;Lnet/minecraft/class_638;Lnet/minecraft/class_1268;Lnet/minecraft/class_3965;)Lnet/minecraft/class_1269;
 		ARG 1 player
@@ -25,6 +30,7 @@ CLASS net/minecraft/class_636 net/minecraft/client/network/ClientPlayerInteracti
 	METHOD method_2897 stopUsingItem (Lnet/minecraft/class_1657;)V
 		ARG 1 player
 	METHOD method_2899 breakBlock (Lnet/minecraft/class_2338;)Z
+		ARG 1 pos
 	METHOD method_2900 clickButton (II)V
 		ARG 1 syncId
 		ARG 2 buttonId
@@ -33,7 +39,10 @@ CLASS net/minecraft/class_636 net/minecraft/client/network/ClientPlayerInteracti
 		ARG 2 stateHandler
 		ARG 3 recipeBook
 	METHOD method_2902 updateBlockBreakingProgress (Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Z
+		ARG 1 pos
+		ARG 2 direction
 	METHOD method_2903 copyAbilities (Lnet/minecraft/class_1657;)V
+		ARG 1 player
 	METHOD method_2904 getReachDistance ()F
 	METHOD method_2905 interactEntity (Lnet/minecraft/class_1657;Lnet/minecraft/class_1297;Lnet/minecraft/class_1268;)Lnet/minecraft/class_1269;
 		ARG 1 player
@@ -46,12 +55,14 @@ CLASS net/minecraft/class_636 net/minecraft/client/network/ClientPlayerInteracti
 		ARG 4 actionType
 		ARG 5 player
 	METHOD method_2907 setGameMode (Lnet/minecraft/class_1934;)V
+		ARG 1 gameMode
 	METHOD method_2908 hasStatusBars ()Z
 	METHOD method_2909 clickCreativeStack (Lnet/minecraft/class_1799;I)V
 		ARG 1 stack
 		ARG 2 slotId
 	METHOD method_2910 attackBlock (Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Z
 		ARG 1 pos
+		ARG 2 direction
 	METHOD method_2911 syncSelectedSlot ()V
 	METHOD method_2912 clickRecipe (ILnet/minecraft/class_1860;Z)V
 		ARG 1 syncId
@@ -70,8 +81,15 @@ CLASS net/minecraft/class_636 net/minecraft/client/network/ClientPlayerInteracti
 		ARG 1 player
 		ARG 2 target
 	METHOD method_2919 interactItem (Lnet/minecraft/class_1657;Lnet/minecraft/class_1937;Lnet/minecraft/class_1268;)Lnet/minecraft/class_1269;
+		ARG 1 player
+		ARG 2 world
+		ARG 3 hand
 	METHOD method_2920 getCurrentGameMode ()Lnet/minecraft/class_1934;
 	METHOD method_2921 breakBlockOrFire (Lnet/minecraft/class_310;Lnet/minecraft/class_636;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)V
+		ARG 0 client
+		ARG 1 interactionManager
+		ARG 2 pos
+		ARG 3 direction
 	METHOD method_2922 isCurrentlyBreaking (Lnet/minecraft/class_2338;)Z
 		ARG 1 pos
 	METHOD method_2923 isBreakingBlock ()Z

--- a/mappings/net/minecraft/client/network/DataQueryHandler.mapping
+++ b/mappings/net/minecraft/client/network/DataQueryHandler.mapping
@@ -1,8 +1,15 @@
 CLASS net/minecraft/class_300 net/minecraft/client/network/DataQueryHandler
 	FIELD field_1640 networkHandler Lnet/minecraft/class_634;
 	FIELD field_1641 expectedTransactionId I
-	FIELD field_1642 queryConsumer Ljava/util/function/Consumer;
-	METHOD method_1402 setNextQueryConsumer (Ljava/util/function/Consumer;)I
+	FIELD field_1642 callback Ljava/util/function/Consumer;
+	METHOD method_1402 nextQuery (Ljava/util/function/Consumer;)I
+		ARG 1 callback
 	METHOD method_1403 queryBlockNbt (Lnet/minecraft/class_2338;Ljava/util/function/Consumer;)V
+		ARG 1 pos
+		ARG 2 callback
 	METHOD method_1404 handleQueryResponse (ILnet/minecraft/class_2487;)Z
+		ARG 1 transactionId
+		ARG 2 tag
 	METHOD method_1405 queryEntityNbt (ILjava/util/function/Consumer;)V
+		ARG 1 entityNetworkId
+		ARG 2 callback

--- a/mappings/net/minecraft/client/network/LanServerInfo.mapping
+++ b/mappings/net/minecraft/client/network/LanServerInfo.mapping
@@ -4,6 +4,7 @@ CLASS net/minecraft/class_1131 net/minecraft/client/network/LanServerInfo
 	FIELD field_5517 addressPort Ljava/lang/String;
 	METHOD <init> (Ljava/lang/String;Ljava/lang/String;)V
 		ARG 1 motd
+		ARG 2 addressPort
 	METHOD method_4812 getAddressPort ()Ljava/lang/String;
 	METHOD method_4813 getMotd ()Ljava/lang/String;
 	METHOD method_4814 updateLastTime ()V

--- a/mappings/net/minecraft/client/particle/LargeFireSmokeParticle.mapping
+++ b/mappings/net/minecraft/client/particle/LargeFireSmokeParticle.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_696 net/minecraft/client/particle/FireSmokeLargeParticle
+CLASS net/minecraft/class_696 net/minecraft/client/particle/LargeFireSmokeParticle
 	METHOD <init> (Lnet/minecraft/class_1937;DDDDDDLnet/minecraft/class_4002;)V
 		ARG 1 world
 		ARG 2 x

--- a/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
@@ -15,7 +15,7 @@ CLASS net/minecraft/class_897 net/minecraft/client/render/entity/EntityRenderer
 		ARG 2 tickDelta
 	METHOD method_3921 hasLabel (Lnet/minecraft/class_1297;)Z
 		COMMENT Determines whether the passed entity should render with a nameplate above its head.
-		COMMENT 
+		COMMENT
 		COMMENT <p>Checks for a custom nametag on living entities, and for teams/team visibilities for players.</p>
 		ARG 1 entity
 	METHOD method_3926 renderLabelIfPresent (Lnet/minecraft/class_1297;Ljava/lang/String;Lnet/minecraft/class_4587;Lnet/minecraft/class_4597;I)V

--- a/mappings/net/minecraft/client/world/ClientWorld.mapping
+++ b/mappings/net/minecraft/client/world/ClientWorld.mapping
@@ -79,6 +79,7 @@ CLASS net/minecraft/class_638 net/minecraft/client/world/ClientWorld
 		ARG 4 radius
 		ARG 5 random
 		ARG 6 spawnBarrierParticles
+		ARG 7 pos
 	METHOD method_2944 setScoreboard (Lnet/minecraft/class_269;)V
 		ARG 1 scoreboard
 	METHOD method_2945 removeEntity (I)V

--- a/mappings/net/minecraft/datafixer/fix/EntityPaintingMotiveFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/EntityPaintingMotiveFix.mapping
@@ -3,3 +3,5 @@ CLASS net/minecraft/class_3607 net/minecraft/datafixer/fix/EntityPaintingMotiveF
 	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
 		ARG 1 outputSchema
 		ARG 2 changesType
+	METHOD method_15723 renameMotive (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 dynamic

--- a/mappings/net/minecraft/datafixer/fix/StructureReferenceFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/StructureReferenceFix.mapping
@@ -1,2 +1,2 @@
-CLASS net/minecraft/class_4695 net/minecraft/datafixer/StructureReferenceFixer
+CLASS net/minecraft/class_4695 net/minecraft/datafixer/fix/StructureReferenceFix
 	METHOD method_23661 updateReferences (Lcom/mojang/datafixers/Dynamic;)Lcom/mojang/datafixers/Dynamic;

--- a/mappings/net/minecraft/datafixer/schema/IdentifierNormalizingSchema.mapping
+++ b/mappings/net/minecraft/datafixer/schema/IdentifierNormalizingSchema.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_1220 net/minecraft/datafixer/schema/IdentifierNormalizingSchema
+	METHOD method_5193 normalize (Ljava/lang/String;)Ljava/lang/String;
+		ARG 0 id

--- a/mappings/net/minecraft/datafixer/schema/Schema100.mapping
+++ b/mappings/net/minecraft/datafixer/schema/Schema100.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_1222 net/minecraft/datafixer/schema/Schema100
+	METHOD method_5195 targetEntity (Lcom/mojang/datafixers/schemas/Schema;Ljava/util/Map;Ljava/lang/String;)V
+	METHOD method_5196 targetItems (Lcom/mojang/datafixers/schemas/Schema;)Lcom/mojang/datafixers/types/templates/TypeTemplate;

--- a/mappings/net/minecraft/datafixer/schema/SchemaIdentifierNormalize.mapping
+++ b/mappings/net/minecraft/datafixer/schema/SchemaIdentifierNormalize.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/class_1220 net/minecraft/datafixer/schema/SchemaIdentifierNormalize
-	METHOD method_5193 normalize (Ljava/lang/String;)Ljava/lang/String;

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -246,7 +246,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		ARG 1 yaw
 	METHOD method_5637 isWet ()Z
 		COMMENT Returns whether this entity is touching water, or is being rained on, or is inside a bubble column...
-		COMMENT 
+		COMMENT
 		COMMENT @see net.minecraft.entity.Entity#isTouchingWater() 
 		COMMENT @see net.minecraft.entity.Entity#isBeingRainedOn() 
 		COMMENT @see net.minecraft.entity.Entity#isInsideBubbleColumn() 

--- a/mappings/net/minecraft/entity/ItemEntity.mapping
+++ b/mappings/net/minecraft/entity/ItemEntity.mapping
@@ -23,6 +23,17 @@ CLASS net/minecraft/class_1542 net/minecraft/entity/ItemEntity
 		ARG 2 sourceEntity
 		ARG 3 sourceStack
 	METHOD method_20397 canMerge ()Z
+	METHOD method_24016 merge (Lnet/minecraft/class_1542;Lnet/minecraft/class_1799;Lnet/minecraft/class_1799;)V
+		ARG 0 targetEntity
+		ARG 1 stack1
+		ARG 2 stack2
+	METHOD method_24017 canMerge (Lnet/minecraft/class_1799;Lnet/minecraft/class_1799;)Z
+		ARG 0 stack1
+		ARG 1 stack2
+	METHOD method_24018 merge (Lnet/minecraft/class_1799;Lnet/minecraft/class_1799;I)Lnet/minecraft/class_1799;
+		ARG 0 stack1
+		ARG 1 stack2
+		ARG 2 maxCount
 	METHOD method_6972 tryMerge (Lnet/minecraft/class_1542;)V
 		ARG 1 other
 	METHOD method_6973 tryMerge ()V

--- a/mappings/net/minecraft/entity/ai/pathing/EntityNavigation.mapping
+++ b/mappings/net/minecraft/entity/ai/pathing/EntityNavigation.mapping
@@ -10,6 +10,9 @@ CLASS net/minecraft/class_1408 net/minecraft/entity/ai/pathing/EntityNavigation
 	FIELD field_6678 nodeMaker Lnet/minecraft/class_8;
 	FIELD field_6679 shouldRecalculate Z
 	FIELD field_6681 currentPath Lnet/minecraft/class_11;
+	FIELD field_6683 nodeReachProximity F
+		COMMENT If the Chebyshev distance from the entity to the next node is less than
+		COMMENT or equal to this value, the entity is considered "reached" the node.
 	FIELD field_6684 entity Lnet/minecraft/class_1308;
 	FIELD field_6685 lastRecalculateTime J
 	METHOD method_18416 findPathToAny (Ljava/util/Set;IZI)Lnet/minecraft/class_11;

--- a/mappings/net/minecraft/entity/decoration/AbstractDecorationEntity.mapping
+++ b/mappings/net/minecraft/entity/decoration/AbstractDecorationEntity.mapping
@@ -1,12 +1,19 @@
 CLASS net/minecraft/class_1530 net/minecraft/entity/decoration/AbstractDecorationEntity
+	FIELD field_7097 obstructionCheckCounter I
 	FIELD field_7098 PREDICATE Ljava/util/function/Predicate;
 	FIELD field_7099 facing Lnet/minecraft/class_2350;
-	FIELD field_7100 blockPos Lnet/minecraft/class_2338;
+	FIELD field_7100 attachmentPos Lnet/minecraft/class_2338;
 	METHOD <init> (Lnet/minecraft/class_1299;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)V
-		ARG 1 world
+		ARG 1 type
+		ARG 2 world
+		ARG 3 pos
+	METHOD method_6888 canStayAttached ()Z
 	METHOD method_6889 onBreak (Lnet/minecraft/class_1297;)V
+		ARG 1 entity
 	METHOD method_6891 getHeightPixels ()I
 	METHOD method_6892 setFacing (Lnet/minecraft/class_2350;)V
+		ARG 1 facing
 	METHOD method_6894 onPlace ()V
+	METHOD method_6895 updateAttachmentPosition ()V
 	METHOD method_6896 getDecorationBlockPos ()Lnet/minecraft/class_2338;
 	METHOD method_6897 getWidthPixels ()I

--- a/mappings/net/minecraft/entity/decoration/painting/PaintingEntity.mapping
+++ b/mappings/net/minecraft/entity/decoration/painting/PaintingEntity.mapping
@@ -3,3 +3,4 @@ CLASS net/minecraft/class_1534 net/minecraft/entity/decoration/painting/Painting
 	METHOD <init> (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)V
 		ARG 1 world
 		ARG 2 pos
+		ARG 3 direction

--- a/mappings/net/minecraft/entity/decoration/painting/PaintingMotive.mapping
+++ b/mappings/net/minecraft/entity/decoration/painting/PaintingMotive.mapping
@@ -1,6 +1,12 @@
 CLASS net/minecraft/class_1535 net/minecraft/entity/decoration/painting/PaintingMotive
 	FIELD field_7137 height I
 	FIELD field_7151 width I
+	METHOD <init> (II)V
+		ARG 1 width
+		ARG 2 height
 	METHOD method_6943 getHeight ()I
 	METHOD method_6944 register (Ljava/lang/String;II)Lnet/minecraft/class_1535;
+		ARG 0 id
+		ARG 1 width
+		ARG 2 height
 	METHOD method_6945 getWidth ()I

--- a/mappings/net/minecraft/entity/passive/IronGolemEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/IronGolemEntity.mapping
@@ -8,7 +8,7 @@ CLASS net/minecraft/class_1439 net/minecraft/entity/passive/IronGolemEntity
 	METHOD method_6497 setLookingAtVillager (Z)V
 		ARG 1 lookingAtVillager
 	METHOD method_6499 setPlayerCreated (Z)V
-		ARG 1 playerCrated
+		ARG 1 playerCreated
 	METHOD method_6501 getAttackTicksLeft ()I
 	METHOD method_6502 getLookingAtVillagerTicks ()I
 	CLASS class_4621 Crack

--- a/mappings/net/minecraft/entity/passive/WolfEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/WolfEntity.mapping
@@ -12,7 +12,7 @@ CLASS net/minecraft/class_1493 net/minecraft/entity/passive/WolfEntity
 		COMMENT Returns this wolf's brightness multiplier based on the fur wetness.
 		COMMENT <p>
 		COMMENT The brightness multiplier represents how much darker the wolf gets while its fur is wet. The multiplier changes (from 0.75 to 1.0 incrementally) when a wolf shakes.
-		COMMENT 
+		COMMENT
 		COMMENT @param tickDelta Progress for linearly interpolating between the previous and current game state.
 		COMMENT @return Brightness as a float value between 0.75 and 1.0.
 		COMMENT @see net.minecraft.client.render.entity.model.TintableAnimalModel#setColorMultiplier(float, float, float)

--- a/mappings/net/minecraft/entity/player/ItemCooldownManager.mapping
+++ b/mappings/net/minecraft/entity/player/ItemCooldownManager.mapping
@@ -4,11 +4,15 @@ CLASS net/minecraft/class_1796 net/minecraft/entity/player/ItemCooldownManager
 	METHOD method_7900 remove (Lnet/minecraft/class_1792;)V
 		ARG 1 item
 	METHOD method_7901 onCooldownUpdate (Lnet/minecraft/class_1792;)V
+		ARG 1 item
 	METHOD method_7902 onCooldownUpdate (Lnet/minecraft/class_1792;I)V
 		ARG 1 item
+		ARG 2 duration
 	METHOD method_7903 update ()V
 	METHOD method_7904 isCoolingDown (Lnet/minecraft/class_1792;)Z
+		ARG 1 item
 	METHOD method_7905 getCooldownProgress (Lnet/minecraft/class_1792;F)F
+		ARG 1 item
 		ARG 2 partialTicks
 	METHOD method_7906 set (Lnet/minecraft/class_1792;I)V
 		ARG 1 item

--- a/mappings/net/minecraft/fluid/BaseFluid.mapping
+++ b/mappings/net/minecraft/fluid/BaseFluid.mapping
@@ -6,8 +6,12 @@ CLASS net/minecraft/class_3609 net/minecraft/fluid/BaseFluid
 		ARG 1 world
 		ARG 2 fluidPos
 		ARG 3 state
+	METHOD method_15726 getSpread (Lnet/minecraft/class_4538;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)Ljava/util/Map;
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 state
 	METHOD method_15727 getUpdatedState (Lnet/minecraft/class_4538;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)Lnet/minecraft/class_3610;
-		ARG 1 view
+		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
 	METHOD method_15728 getFlowing (IZ)Lnet/minecraft/class_3610;
@@ -28,18 +32,19 @@ CLASS net/minecraft/class_3609 net/minecraft/fluid/BaseFluid
 		ARG 6 fromState
 	METHOD method_15737 isInfinite ()Z
 	METHOD method_15738 canFlow (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2350;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3610;Lnet/minecraft/class_3611;)Z
-		ARG 1 view
+		ARG 1 world
 		ARG 2 fluidPos
 		ARG 3 fluidBlockState
 		ARG 4 flowDirection
 		ARG 5 flowTo
 		ARG 6 flowToBlockState
 	METHOD method_15739 getLevelDecreasePerBlock (Lnet/minecraft/class_4538;)I
-		ARG 1 view
+		ARG 1 world
 	METHOD method_15745 flow (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2350;Lnet/minecraft/class_3610;)V
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
+		ARG 4 direction
 		ARG 5 fluidState
 	METHOD method_15750 getFlowing ()Lnet/minecraft/class_3611;
 	METHOD method_15751 getStill ()Lnet/minecraft/class_3611;
@@ -50,5 +55,21 @@ CLASS net/minecraft/class_3609 net/minecraft/fluid/BaseFluid
 		ARG 4 newState
 	METHOD method_17774 isFluidAboveEqual (Lnet/minecraft/class_3610;Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z
 		ARG 0 state
-		ARG 1 view
+		ARG 1 world
 		ARG 2 pos
+	METHOD method_15746 canFlowThrough (Lnet/minecraft/class_1922;Lnet/minecraft/class_3611;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2350;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3610;)Z
+		ARG 1 world
+		ARG 2 fluid
+		ARG 3 pos
+		ARG 4 state
+		ARG 5 face
+		ARG 6 fromPos
+		ARG 7 fromState
+		ARG 8 fluidState
+	METHOD method_15752 isMatchingAndStill (Lnet/minecraft/class_3610;)Z
+		ARG 1 state
+	METHOD method_15754 canFill (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3611;)Z
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 state
+		ARG 4 fluid

--- a/mappings/net/minecraft/fluid/Fluid.mapping
+++ b/mappings/net/minecraft/fluid/Fluid.mapping
@@ -5,13 +5,26 @@ CLASS net/minecraft/class_3611 net/minecraft/fluid/Fluid
 	METHOD method_15774 getBucketItem ()Lnet/minecraft/class_1792;
 	METHOD method_15775 appendProperties (Lnet/minecraft/class_2689$class_2690;)V
 	METHOD method_15776 randomDisplayTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_3610;Ljava/util/Random;)V
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 state
+		ARG 4 random
+	METHOD method_15777 canBeReplacedWith (Lnet/minecraft/class_3610;Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_3611;Lnet/minecraft/class_2350;)Z
+		ARG 1 state
+		ARG 2 world
+		ARG 3 pos
+		ARG 4 fluid
+		ARG 5 direction
 	METHOD method_15778 onScheduledTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_3610;)V
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state
 	METHOD method_15779 getLevel (Lnet/minecraft/class_3610;)I
+		ARG 1 state
 	METHOD method_15780 matchesType (Lnet/minecraft/class_3611;)Z
+		ARG 1 fluid
 	METHOD method_15781 setDefaultState (Lnet/minecraft/class_3610;)V
+		ARG 1 state
 	METHOD method_15782 getVelocity (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_3610;)Lnet/minecraft/class_243;
 		ARG 1 world
 		ARG 2 pos
@@ -21,12 +34,26 @@ CLASS net/minecraft/class_3611 net/minecraft/fluid/Fluid
 	METHOD method_15785 getDefaultState ()Lnet/minecraft/class_3610;
 	METHOD method_15787 getParticle ()Lnet/minecraft/class_2394;
 	METHOD method_15788 getHeight (Lnet/minecraft/class_3610;Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)F
+		ARG 1 state
+		ARG 2 world
+		ARG 3 pos
 	METHOD method_15789 getTickRate (Lnet/minecraft/class_4538;)I
+		ARG 1 world
 	METHOD method_15790 toBlockState (Lnet/minecraft/class_3610;)Lnet/minecraft/class_2680;
+		ARG 1 state
 	METHOD method_15791 matches (Lnet/minecraft/class_3494;)Z
+		ARG 1 tag
 	METHOD method_15792 onRandomTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_3610;Ljava/util/Random;)V
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 state
 	METHOD method_15793 isStill (Lnet/minecraft/class_3610;)Z
+		ARG 1 state
 	METHOD method_15794 isEmpty ()Z
 	METHOD method_15795 hasRandomTicks ()Z
 	METHOD method_17775 getShape (Lnet/minecraft/class_3610;Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Lnet/minecraft/class_265;
+		ARG 1 state
+		ARG 2 world
+		ARG 3 pos
 	METHOD method_20784 getHeight (Lnet/minecraft/class_3610;)F
+		ARG 1 state

--- a/mappings/net/minecraft/fluid/FluidState.mapping
+++ b/mappings/net/minecraft/fluid/FluidState.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_3610 net/minecraft/fluid/FluidState
 	METHOD method_15756 (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z
-		ARG 1 view
+		ARG 1 world
 		ARG 2 pos
 	METHOD method_15757 onRandomTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Ljava/util/Random;)V
 		ARG 1 world
@@ -13,10 +13,13 @@ CLASS net/minecraft/class_3610 net/minecraft/fluid/FluidState
 	METHOD method_15760 getBlastResistance ()F
 	METHOD method_15761 getLevel ()I
 	METHOD method_15763 getHeight (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)F
+		ARG 1 world
+		ARG 2 pos
 	METHOD method_15765 deserialize (Lcom/mojang/datafixers/Dynamic;)Lnet/minecraft/class_3610;
 		ARG 0 dynamic
 	METHOD method_15766 getParticle ()Lnet/minecraft/class_2394;
 	METHOD method_15767 matches (Lnet/minecraft/class_3494;)Z
+		ARG 1 tag
 	METHOD method_15768 randomDisplayTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Ljava/util/Random;)V
 		ARG 1 world
 		ARG 2 pos
@@ -32,4 +35,6 @@ CLASS net/minecraft/class_3610 net/minecraft/fluid/FluidState
 		ARG 0 ops
 		ARG 1 state
 	METHOD method_17776 getShape (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Lnet/minecraft/class_265;
+		ARG 1 world
+		ARG 2 pos
 	METHOD method_20785 getHeight ()F

--- a/mappings/net/minecraft/fluid/LavaFluid.mapping
+++ b/mappings/net/minecraft/fluid/LavaFluid.mapping
@@ -1,3 +1,12 @@
 CLASS net/minecraft/class_3616 net/minecraft/fluid/LavaFluid
+	METHOD method_15817 hasBurnableBlock (Lnet/minecraft/class_4538;Lnet/minecraft/class_2338;)Z
+		ARG 1 world
+		ARG 2 pos
+	METHOD method_15818 playExtinguishEvent (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;)V
+		ARG 1 world
+		ARG 2 pos
+	METHOD method_15819 canLightFire (Lnet/minecraft/class_4538;Lnet/minecraft/class_2338;)Z
+		ARG 1 world
+		ARG 2 pos
 	CLASS class_3617 Flowing
 	CLASS class_3618 Still

--- a/mappings/net/minecraft/network/ClientConnection.mapping
+++ b/mappings/net/minecraft/network/ClientConnection.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_2535 net/minecraft/network/ClientConnection
 	FIELD field_11639 MARKER_NETWORK_PACKETS Lorg/apache/logging/log4j/Marker;
+	FIELD field_11640 errored Z
 	FIELD field_11641 MARKER_NETWORK Lorg/apache/logging/log4j/Marker;
 	FIELD field_11642 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_11643 side Lnet/minecraft/class_2598;
@@ -28,10 +29,11 @@ CLASS net/minecraft/class_2535 net/minecraft/network/ClientConnection
 		ARG 1 disconnectReason
 	METHOD method_10748 getDisconnectReason ()Lnet/minecraft/class_2561;
 	METHOD method_10750 setState (Lnet/minecraft/class_2539;)V
+		ARG 1 state
 	METHOD method_10751 sendQueuedPackets ()V
 	METHOD method_10752 send (Lnet/minecraft/class_2596;Lio/netty/util/concurrent/GenericFutureListener;)V
 		ARG 1 packet
-		ARG 2 listener
+		ARG 2 callback
 	METHOD method_10753 connect (Ljava/net/InetAddress;IZ)Lnet/minecraft/class_2535;
 		ARG 0 address
 		ARG 1 port
@@ -44,12 +46,14 @@ CLASS net/minecraft/class_2535 net/minecraft/network/ClientConnection
 	METHOD method_10759 handlePacket (Lnet/minecraft/class_2596;Lnet/minecraft/class_2547;)V
 		ARG 0 packet
 		ARG 1 listener
-	METHOD method_10760 setMinCompressedSize (I)V
+	METHOD method_10760 setCompressionThreshold (I)V
+		ARG 1 compressionThreshold
 	METHOD method_10762 getAveragePacketsReceived ()F
 	METHOD method_10763 setPacketListener (Lnet/minecraft/class_2547;)V
+		ARG 1 listener
 	METHOD method_10764 sendImmediately (Lnet/minecraft/class_2596;Lio/netty/util/concurrent/GenericFutureListener;)V
 		ARG 1 packet
-		ARG 2 listener
+		ARG 2 callback
 	METHOD method_10768 handleDisconnection ()V
 	METHOD method_10769 connectLocal (Ljava/net/SocketAddress;)Lnet/minecraft/class_2535;
 		ARG 0 address

--- a/mappings/net/minecraft/network/NetworkState.mapping
+++ b/mappings/net/minecraft/network/NetworkState.mapping
@@ -5,10 +5,12 @@ CLASS net/minecraft/class_2539 net/minecraft/network/NetworkState
 	FIELD field_20595 packetHandlers Ljava/util/Map;
 	METHOD method_10781 getPacketId (Lnet/minecraft/class_2598;Lnet/minecraft/class_2596;)Ljava/lang/Integer;
 		ARG 1 side
+		ARG 2 packet
 	METHOD method_10782 byId (I)Lnet/minecraft/class_2539;
 		ARG 0 id
 	METHOD method_10783 getPacketHandler (Lnet/minecraft/class_2598;I)Lnet/minecraft/class_2596;
 		ARG 1 side
+		ARG 2 packetId
 	METHOD method_10785 getId ()I
 	METHOD method_10786 getPacketHandlerState (Lnet/minecraft/class_2596;)Lnet/minecraft/class_2539;
 		ARG 0 handler

--- a/mappings/net/minecraft/network/NetworkThreadUtils.mapping
+++ b/mappings/net/minecraft/network/NetworkThreadUtils.mapping
@@ -1,4 +1,10 @@
 CLASS net/minecraft/class_2600 net/minecraft/network/NetworkThreadUtils
+	FIELD field_20318 LOGGER Lorg/apache/logging/log4j/Logger;
 	METHOD method_11073 forceMainThread (Lnet/minecraft/class_2596;Lnet/minecraft/class_2547;Lnet/minecraft/class_3218;)V
+		ARG 0 packet
+		ARG 1 listener
+		ARG 2 world
 	METHOD method_11074 forceMainThread (Lnet/minecraft/class_2596;Lnet/minecraft/class_2547;Lnet/minecraft/class_1255;)V
-		ARG 2 thread
+		ARG 0 packet
+		ARG 1 listener
+		ARG 2 engine

--- a/mappings/net/minecraft/network/Packet.mapping
+++ b/mappings/net/minecraft/network/Packet.mapping
@@ -1,5 +1,7 @@
 CLASS net/minecraft/class_2596 net/minecraft/network/Packet
-	METHOD method_11051 isErrorFatal ()Z
+	METHOD method_11051 isWritingErrorSkippable ()Z
+		COMMENT Returns whether a throwable in writing of this packet allows the
+		COMMENT connection to simply skip the packet's sending than disconnecting.
 	METHOD method_11052 write (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD method_11053 read (Lnet/minecraft/class_2540;)V

--- a/mappings/net/minecraft/network/PacketInflater.mapping
+++ b/mappings/net/minecraft/network/PacketInflater.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_2532 net/minecraft/network/PacketInflater
 	FIELD field_11622 inflater Ljava/util/zip/Inflater;
-	FIELD field_11623 minCompressedSize I
+	FIELD field_11623 compressionThreshold I
 	METHOD method_10739 setCompressionThreshold (I)V
+		ARG 1 compressionThreshold

--- a/mappings/net/minecraft/network/listener/ClientLoginPacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ClientLoginPacketListener.mapping
@@ -8,3 +8,4 @@ CLASS net/minecraft/class_2896 net/minecraft/network/listener/ClientLoginPacketL
 	METHOD method_12587 onHello (Lnet/minecraft/class_2905;)V
 		ARG 1 packet
 	METHOD method_12588 onLoginSuccess (Lnet/minecraft/class_2901;)V
+		ARG 1 packet

--- a/mappings/net/minecraft/network/listener/ClientQueryPacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ClientQueryPacketListener.mapping
@@ -1,3 +1,5 @@
 CLASS net/minecraft/class_2921 net/minecraft/network/listener/ClientQueryPacketListener
 	METHOD method_12666 onPong (Lnet/minecraft/class_2923;)V
+		ARG 1 packet
 	METHOD method_12667 onResponse (Lnet/minecraft/class_2924;)V
+		ARG 1 packet

--- a/mappings/net/minecraft/network/listener/ServerHandshakePacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ServerHandshakePacketListener.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/class_2890 net/minecraft/network/listener/ServerHandshakePacketListener
 	METHOD method_12576 onHandshake (Lnet/minecraft/class_2889;)V
+		ARG 1 packet

--- a/mappings/net/minecraft/network/listener/ServerLoginPacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ServerLoginPacketListener.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/class_2911 net/minecraft/network/listener/ServerLoginPacketListener
 	METHOD method_12640 onQueryResponse (Lnet/minecraft/class_2913;)V
+		ARG 1 packet
 	METHOD method_12641 onHello (Lnet/minecraft/class_2915;)V
+		ARG 1 packet
 	METHOD method_12642 onKey (Lnet/minecraft/class_2917;)V
+		ARG 1 packet

--- a/mappings/net/minecraft/network/listener/ServerPlayPacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ServerPlayPacketListener.mapping
@@ -82,4 +82,6 @@ CLASS net/minecraft/class_2792 net/minecraft/network/listener/ServerPlayPacketLi
 	METHOD method_16383 onJigsawUpdate (Lnet/minecraft/class_3753;)V
 		ARG 1 packet
 	METHOD method_19475 onUpdateDifficulty (Lnet/minecraft/class_4210;)V
+		ARG 1 packet
 	METHOD method_19476 onUpdateDifficultyLock (Lnet/minecraft/class_4211;)V
+		ARG 1 packet

--- a/mappings/net/minecraft/network/listener/ServerQueryPacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ServerQueryPacketListener.mapping
@@ -1,3 +1,5 @@
 CLASS net/minecraft/class_2933 net/minecraft/network/listener/ServerQueryPacketListener
 	METHOD method_12697 onPing (Lnet/minecraft/class_2935;)V
+		ARG 1 packet
 	METHOD method_12698 onRequest (Lnet/minecraft/class_2937;)V
+		ARG 1 packet

--- a/mappings/net/minecraft/network/packet/c2s/handshake/HandshakeC2SPacket.mapping
+++ b/mappings/net/minecraft/network/packet/c2s/handshake/HandshakeC2SPacket.mapping
@@ -1,10 +1,11 @@
 CLASS net/minecraft/class_2889 net/minecraft/network/packet/c2s/handshake/HandshakeC2SPacket
-	FIELD field_13156 state Lnet/minecraft/class_2539;
+	FIELD field_13156 intendedState Lnet/minecraft/class_2539;
 	FIELD field_13157 port I
-	FIELD field_13158 version I
+	FIELD field_13158 protocolVersion I
 	FIELD field_13159 address Ljava/lang/String;
 	METHOD <init> (Ljava/lang/String;ILnet/minecraft/class_2539;)V
 		ARG 1 address
 		ARG 2 port
+		ARG 3 intendedState
 	METHOD method_12573 getIntendedState ()Lnet/minecraft/class_2539;
 	METHOD method_12574 getProtocolVersion ()I

--- a/mappings/net/minecraft/network/packet/s2c/play/PaintingSpawnS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/PaintingSpawnS2CPacket.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_2612 net/minecraft/network/packet/s2c/play/PaintingSpawnS2CPacket
 	FIELD field_12008 pos Lnet/minecraft/class_2338;
 	FIELD field_12009 uuid Ljava/util/UUID;
-	FIELD field_12010 motive I
+	FIELD field_12010 motiveId I
 	FIELD field_12011 facing Lnet/minecraft/class_2350;
 	FIELD field_12012 id I
 	METHOD <init> (Lnet/minecraft/class_1534;)V

--- a/mappings/net/minecraft/network/packet/s2c/play/PlayerRespawnS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/PlayerRespawnS2CPacket.mapping
@@ -2,8 +2,13 @@ CLASS net/minecraft/class_2724 net/minecraft/network/packet/s2c/play/PlayerRespa
 	FIELD field_12431 dimension Lnet/minecraft/class_2874;
 	FIELD field_12432 generatorType Lnet/minecraft/class_1942;
 	FIELD field_12434 gameMode Lnet/minecraft/class_1934;
+	FIELD field_20667 sha256Seed J
 	METHOD <init> (Lnet/minecraft/class_2874;JLnet/minecraft/class_1942;Lnet/minecraft/class_1934;)V
 		ARG 1 dimension
+		ARG 2 sha256Seed
+		ARG 4 generatorType
+		ARG 5 gameMode
 	METHOD method_11779 getDimension ()Lnet/minecraft/class_2874;
 	METHOD method_11780 getGameMode ()Lnet/minecraft/class_1934;
 	METHOD method_11781 getGeneratorType ()Lnet/minecraft/class_1942;
+	METHOD method_22425 getSha256Seed ()J

--- a/mappings/net/minecraft/network/packet/s2c/play/SetTradeOffersS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/SetTradeOffersS2CPacket.mapping
@@ -17,3 +17,4 @@ CLASS net/minecraft/class_3943 net/minecraft/network/packet/s2c/play/SetTradeOff
 	METHOD method_19458 getLevelProgress ()I
 	METHOD method_19459 getExperience ()I
 	METHOD method_19460 isLeveled ()Z
+	METHOD method_20722 isRefreshable ()Z

--- a/mappings/net/minecraft/server/command/TestCommand.mapping
+++ b/mappings/net/minecraft/server/command/TestCommand.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_4527 net/minecraft/server/command/TestCommand
 	METHOD method_22264 executePos (Lnet/minecraft/class_2168;Ljava/lang/String;)I
 		ARG 0 source
+		ARG 1 variableName
 	METHOD method_22265 executeClearAll (Lnet/minecraft/class_2168;I)I
 		ARG 0 source
 		ARG 1 radius
@@ -48,6 +49,8 @@ CLASS net/minecraft/class_4527 net/minecraft/server/command/TestCommand
 		ARG 0 source
 		ARG 1 structure
 	METHOD method_23647 setWorld (Lnet/minecraft/class_4529;Lnet/minecraft/class_3218;)V
+		ARG 0 testFunction
+		ARG 1 world
 	CLASS class_4528 Listener
 		FIELD field_20581 world Lnet/minecraft/class_3218;
 		FIELD field_20582 tests Lnet/minecraft/class_4524;

--- a/mappings/net/minecraft/server/network/DebugInfoSender.mapping
+++ b/mappings/net/minecraft/server/network/DebugInfoSender.mapping
@@ -1,14 +1,34 @@
-CLASS net/minecraft/class_4209 net/minecraft/client/network/DebugRendererInfoManager
+CLASS net/minecraft/class_4209 net/minecraft/server/network/DebugInfoSender
 	FIELD field_18961 LOGGER Lorg/apache/logging/log4j/Logger;
 	METHOD method_19469 sendGoalSelector (Lnet/minecraft/class_1937;Lnet/minecraft/class_1308;Lnet/minecraft/class_1355;)V
 		ARG 0 world
 		ARG 1 mob
 		ARG 2 goalSelector
 	METHOD method_19470 sendPathfindingData (Lnet/minecraft/class_1937;Lnet/minecraft/class_1308;Lnet/minecraft/class_11;F)V
+		ARG 0 world
+		ARG 1 mob
+		ARG 2 path
+		ARG 3 nodeReachProximity
 	METHOD method_19472 sendNeighborUpdate (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)V
+		ARG 0 world
+		ARG 1 pos
 	METHOD method_19474 sendStructureStart (Lnet/minecraft/class_1936;Lnet/minecraft/class_3449;)V
+		ARG 0 world
+		ARG 1 structureStart
 	METHOD method_19774 sendVillagerAiDebugData (Lnet/minecraft/class_1309;)V
+		ARG 0 living
+	METHOD method_19775 sendChunkWatchingChange (Lnet/minecraft/class_3218;Lnet/minecraft/class_1923;)V
+		ARG 0 world
+		ARG 1 pos
+	METHOD method_19776 sendPoiAddition (Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;)V
+		ARG 0 world
+		ARG 1 pos
+	METHOD method_19777 sendPoiRemoval (Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;)V
+		ARG 0 world
+		ARG 1 pos
 	METHOD method_19778 sendPointOfInterest (Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;)V
+		ARG 0 world
+		ARG 1 pos
 	METHOD method_20575 sendRaids (Lnet/minecraft/class_3218;Ljava/util/Collection;)V
 		ARG 0 server
 		ARG 1 raids
@@ -20,5 +40,11 @@ CLASS net/minecraft/class_4209 net/minecraft/client/network/DebugRendererInfoMan
 		ARG 2 message
 		ARG 3 color
 		ARG 4 duration
+	METHOD method_22319 sendToAll (Lnet/minecraft/class_3218;Lnet/minecraft/class_2540;Lnet/minecraft/class_2960;)V
+		ARG 0 world
+		ARG 1 buf
+		ARG 2 channel
 	METHOD method_23855 sendBeeDebugData (Lnet/minecraft/class_4466;)V
+		ARG 0 bee
 	METHOD method_23856 sendBeehiveDebugData (Lnet/minecraft/class_4482;)V
+		ARG 0 beehive

--- a/mappings/net/minecraft/server/network/DemoServerPlayerInteractionManager.mapping
+++ b/mappings/net/minecraft/server/network/DemoServerPlayerInteractionManager.mapping
@@ -1,3 +1,6 @@
 CLASS net/minecraft/class_3201 net/minecraft/server/network/DemoServerPlayerInteractionManager
+	FIELD field_13887 tick I
+	FIELD field_13888 reminderTicks I
 	FIELD field_13889 demoEnded Z
+	FIELD field_13890 sentHelp Z
 	METHOD method_14031 sendDemoReminder ()V

--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -19,6 +19,7 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	FIELD field_18278 velocity Lnet/minecraft/class_243;
 	METHOD <init> (Lnet/minecraft/class_3218;Lnet/minecraft/class_1297;IZLjava/util/function/Consumer;)V
 		ARG 1 world
+		ARG 2 entity
 		ARG 3 tickInterval
 		ARG 4 alwaysUpdateVelocity
 		ARG 5 receiver

--- a/mappings/net/minecraft/server/network/IntegratedServerHandshakeNetworkHandler.mapping
+++ b/mappings/net/minecraft/server/network/IntegratedServerHandshakeNetworkHandler.mapping
@@ -1,3 +1,3 @@
 CLASS net/minecraft/class_3240 net/minecraft/server/network/IntegratedServerHandshakeNetworkHandler
-	FIELD field_14103 client Lnet/minecraft/class_2535;
+	FIELD field_14103 connection Lnet/minecraft/class_2535;
 	FIELD field_14104 server Lnet/minecraft/server/MinecraftServer;

--- a/mappings/net/minecraft/server/network/ServerHandshakeNetworkHandler.mapping
+++ b/mappings/net/minecraft/server/network/ServerHandshakeNetworkHandler.mapping
@@ -1,3 +1,3 @@
 CLASS net/minecraft/class_3246 net/minecraft/server/network/ServerHandshakeNetworkHandler
-	FIELD field_14153 client Lnet/minecraft/class_2535;
+	FIELD field_14153 connection Lnet/minecraft/class_2535;
 	FIELD field_14154 server Lnet/minecraft/server/MinecraftServer;

--- a/mappings/net/minecraft/server/network/ServerLoginNetworkHandler.mapping
+++ b/mappings/net/minecraft/server/network/ServerLoginNetworkHandler.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_3248 net/minecraft/server/network/ServerLoginNetworkHandler
 	FIELD field_14156 loginTicks I
 	FIELD field_14157 authenticatorThreadId Ljava/util/concurrent/atomic/AtomicInteger;
-	FIELD field_14158 client Lnet/minecraft/class_2535;
+	FIELD field_14158 connection Lnet/minecraft/class_2535;
 	FIELD field_14159 secretKey Ljavax/crypto/SecretKey;
 	FIELD field_14160 profile Lcom/mojang/authlib/GameProfile;
 	FIELD field_14161 clientEntity Lnet/minecraft/class_3222;
@@ -11,6 +11,7 @@ CLASS net/minecraft/class_3248 net/minecraft/server/network/ServerLoginNetworkHa
 	FIELD field_14166 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_14167 nonce [B
 	METHOD method_14375 toOfflineProfile (Lcom/mojang/authlib/GameProfile;)Lcom/mojang/authlib/GameProfile;
+		ARG 1 profile
 	METHOD method_14380 disconnect (Lnet/minecraft/class_2561;)V
 		ARG 1 reason
 	METHOD method_14383 getConnectionInfo ()Ljava/lang/String;

--- a/mappings/net/minecraft/server/network/ServerPlayNetworkHandler.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayNetworkHandler.mapping
@@ -10,7 +10,7 @@ CLASS net/minecraft/class_3244 net/minecraft/server/network/ServerPlayNetworkHan
 	FIELD field_14124 lastTickRiddenY D
 	FIELD field_14125 waitingForKeepAlive Z
 	FIELD field_14126 updatedY D
-	FIELD field_14127 client Lnet/minecraft/class_2535;
+	FIELD field_14127 connection Lnet/minecraft/class_2535;
 	FIELD field_14128 lastTickZ D
 	FIELD field_14129 ridingEntity Z
 	FIELD field_14130 lastTickX D
@@ -47,6 +47,7 @@ CLASS net/minecraft/class_3244 net/minecraft/server/network/ServerPlayNetworkHan
 		ARG 8 pitch
 	METHOD method_14364 sendPacket (Lnet/minecraft/class_2596;)V
 	METHOD method_14367 disconnect (Lnet/minecraft/class_2561;)V
+		ARG 1 reason
 	METHOD method_14369 sendPacket (Lnet/minecraft/class_2596;Lio/netty/util/concurrent/GenericFutureListener;)V
 	METHOD method_14370 executeCommand (Ljava/lang/String;)V
 	METHOD method_14371 validateVehicleMove (Lnet/minecraft/class_2833;)Z

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -73,6 +73,7 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	METHOD method_14245 moveToSpawn (Lnet/minecraft/class_3218;)V
 		ARG 1 world
 	METHOD method_14246 sendUnloadChunkPacket (Lnet/minecraft/class_1923;)V
+	METHOD method_14247 closeCurrentScreen ()V
 	METHOD method_14248 getStatHandler ()Lnet/minecraft/class_3442;
 	METHOD method_14249 onStoppedTracking (Lnet/minecraft/class_1297;)V
 	METHOD method_14251 teleport (Lnet/minecraft/class_3218;DDDFF)V

--- a/mappings/net/minecraft/server/network/ServerPlayerInteractionManager.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerInteractionManager.mapping
@@ -14,6 +14,10 @@ CLASS net/minecraft/class_3225 net/minecraft/server/network/ServerPlayerInteract
 	METHOD <init> (Lnet/minecraft/class_3218;)V
 		ARG 1 world
 	METHOD method_14256 interactItem (Lnet/minecraft/class_1657;Lnet/minecraft/class_1937;Lnet/minecraft/class_1799;Lnet/minecraft/class_1268;)Lnet/minecraft/class_1269;
+		ARG 1 player
+		ARG 2 world
+		ARG 3 stack
+		ARG 4 hand
 	METHOD method_14257 getGameMode ()Lnet/minecraft/class_1934;
 	METHOD method_14259 setWorld (Lnet/minecraft/class_3218;)V
 		ARG 1 world
@@ -27,6 +31,8 @@ CLASS net/minecraft/class_3225 net/minecraft/server/network/ServerPlayerInteract
 		ARG 5 hitResult
 	METHOD method_14263 processBlockBreakingAction (Lnet/minecraft/class_2338;Lnet/minecraft/class_2846$class_2847;Lnet/minecraft/class_2350;I)V
 		ARG 1 pos
+		ARG 2 action
+		ARG 3 direction
 		ARG 4 worldHeight
 	METHOD method_14264 update ()V
 	METHOD method_14266 tryBreakBlock (Lnet/minecraft/class_2338;)Z

--- a/mappings/net/minecraft/server/network/ServerQueryNetworkHandler.mapping
+++ b/mappings/net/minecraft/server/network/ServerQueryNetworkHandler.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_3251 net/minecraft/server/network/ServerQueryNetworkHandler
 	FIELD field_14177 responseSent Z
-	FIELD field_14178 client Lnet/minecraft/class_2535;
+	FIELD field_14178 connection Lnet/minecraft/class_2535;
 	FIELD field_14179 REQUEST_HANDLED Lnet/minecraft/class_2561;
 	FIELD field_14180 server Lnet/minecraft/server/MinecraftServer;

--- a/mappings/net/minecraft/server/network/ServerRecipeBook.mapping
+++ b/mappings/net/minecraft/server/network/ServerRecipeBook.mapping
@@ -2,8 +2,20 @@ CLASS net/minecraft/class_3441 net/minecraft/server/network/ServerRecipeBook
 	FIELD field_15303 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_15304 manager Lnet/minecraft/class_1863;
 	METHOD method_14899 sendUnlockRecipesPacket (Lnet/minecraft/class_2713$class_2714;Lnet/minecraft/class_3222;Ljava/util/List;)V
+		ARG 1 action
+		ARG 2 player
+		ARG 3 recipeIds
 	METHOD method_14900 lockRecipes (Ljava/util/Collection;Lnet/minecraft/class_3222;)I
+		ARG 1 recipes
+		ARG 2 player
 	METHOD method_14901 fromTag (Lnet/minecraft/class_2487;)V
+		ARG 1 tag
 	METHOD method_14902 toTag ()Lnet/minecraft/class_2487;
 	METHOD method_14903 unlockRecipes (Ljava/util/Collection;Lnet/minecraft/class_3222;)I
+		ARG 1 recipes
+		ARG 2 player
 	METHOD method_14904 sendInitRecipesPacket (Lnet/minecraft/class_3222;)V
+		ARG 1 player
+	METHOD method_20732 handleList (Lnet/minecraft/class_2499;Ljava/util/function/Consumer;)V
+		ARG 1 list
+		ARG 2 handler

--- a/mappings/net/minecraft/structure/StructurePiece.mapping
+++ b/mappings/net/minecraft/structure/StructurePiece.mapping
@@ -65,6 +65,10 @@ CLASS net/minecraft/class_3443 net/minecraft/structure/StructurePiece
 		ARG 8 lootTbaleId
 	METHOD method_14931 generate (Lnet/minecraft/class_1936;Lnet/minecraft/class_2794;Ljava/util/Random;Lnet/minecraft/class_3341;Lnet/minecraft/class_1923;)Z
 		ARG 1 world
+		ARG 2 generator
+		ARG 3 random
+		ARG 4 box
+		ARG 5 pos
 	METHOD method_14933 fillWithOutlineUnderSealevel (Lnet/minecraft/class_1936;Lnet/minecraft/class_3341;Ljava/util/Random;FIIIIIILnet/minecraft/class_2680;Lnet/minecraft/class_2680;ZZ)V
 		ARG 3 random
 	METHOD method_14934 getFacing ()Lnet/minecraft/class_2350;

--- a/mappings/net/minecraft/structure/StructureStart.mapping
+++ b/mappings/net/minecraft/structure/StructureStart.mapping
@@ -8,8 +8,11 @@ CLASS net/minecraft/class_3449 net/minecraft/structure/StructureStart
 	FIELD field_16714 feature Lnet/minecraft/class_3195;
 	FIELD field_16715 random Lnet/minecraft/class_2919;
 	METHOD <init> (Lnet/minecraft/class_3195;IILnet/minecraft/class_3341;IJ)V
+		ARG 1 feature
 		ARG 2 chunkX
 		ARG 3 chunkZ
+		ARG 4 box
+		ARG 5 references
 	METHOD method_14962 getPos ()Lnet/minecraft/class_2338;
 	METHOD method_14963 getChildren ()Ljava/util/List;
 	METHOD method_14964 incrementReferences ()V
@@ -32,6 +35,7 @@ CLASS net/minecraft/class_3449 net/minecraft/structure/StructureStart
 		ARG 5 biome
 	METHOD method_16656 getFeature ()Lnet/minecraft/class_3195;
 	METHOD method_16657 hasChildren ()Z
+	METHOD method_23676 getReferences ()I
 	CLASS 1
 		METHOD <init> (Lnet/minecraft/class_3195;IILnet/minecraft/class_3341;IJ)V
 			ARG 2 chunkX

--- a/mappings/net/minecraft/structure/rule/AbstractRuleTest.mapping
+++ b/mappings/net/minecraft/structure/rule/AbstractRuleTest.mapping
@@ -1,4 +1,0 @@
-CLASS net/minecraft/class_3825 net/minecraft/structure/rule/AbstractRuleTest
-	METHOD method_16766 getRuleTest ()Lnet/minecraft/class_3827;
-	METHOD method_16768 test (Lnet/minecraft/class_2680;Ljava/util/Random;)Z
-	METHOD method_16769 serialize (Lcom/mojang/datafixers/types/DynamicOps;)Lcom/mojang/datafixers/Dynamic;

--- a/mappings/net/minecraft/structure/rule/RuleTestType.mapping
+++ b/mappings/net/minecraft/structure/rule/RuleTestType.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3827 net/minecraft/structure/rule/RuleTest
+CLASS net/minecraft/class_3827 net/minecraft/structure/rule/RuleTestType
 	METHOD method_16821 register (Ljava/lang/String;Lnet/minecraft/class_3827;)Lnet/minecraft/class_3827;
 		ARG 0 id
 		ARG 1 test

--- a/mappings/net/minecraft/util/ActionResult.mapping
+++ b/mappings/net/minecraft/util/ActionResult.mapping
@@ -1,3 +1,18 @@
 CLASS net/minecraft/class_1269 net/minecraft/util/ActionResult
+	FIELD field_21466 CONSUME Lnet/minecraft/class_1269;
+		COMMENT Indicates an action is performed but no animation should accompany the
+		COMMENT performance.
+	FIELD field_5811 PASS Lnet/minecraft/class_1269;
+		COMMENT Indicates an action is not performed but allows other actions to
+		COMMENT perform.
+	FIELD field_5812 SUCCESS Lnet/minecraft/class_1269;
+		COMMENT Indicates an action is performed and the actor's hand should swing to
+		COMMENT indicate the performance.
+	FIELD field_5814 FAIL Lnet/minecraft/class_1269;
+		COMMENT Indicates that an action is not performed and prevents other actions
+		COMMENT from performing.
 	METHOD method_23665 isAccepted ()Z
+		COMMENT Returns whether an action is performed.
 	METHOD method_23666 shouldSwingHand ()Z
+		COMMENT Returns whether an actor should have a hand-swinging animation on
+		COMMENT action performance.

--- a/mappings/net/minecraft/util/registry/Registry.mapping
+++ b/mappings/net/minecraft/util/registry/Registry.mapping
@@ -2,6 +2,8 @@ CLASS net/minecraft/class_2378 net/minecraft/util/registry/Registry
 	FIELD field_11139 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_11140 DEFAULT_ENTRIES Ljava/util/Map;
 	FIELD field_11144 REGISTRIES Lnet/minecraft/class_2385;
+	FIELD field_11150 PAINTING_MOTIVE Lnet/minecraft/class_2348;
+		COMMENT The painting motive (theme, motif) registry
 	FIELD field_11159 STATUS_EFFECT Lnet/minecraft/class_2378;
 	FIELD field_17429 CONTAINER Lnet/minecraft/class_2378;
 	METHOD method_10220 stream ()Ljava/util/stream/Stream;

--- a/mappings/net/minecraft/world/biome/DefaultBiomeFeatures.mapping
+++ b/mappings/net/minecraft/world/biome/DefaultBiomeFeatures.mapping
@@ -118,6 +118,10 @@ CLASS net/minecraft/class_3864 net/minecraft/world/biome/DefaultBiomeFeatures
 	FIELD field_21204 LILY_OF_THE_VALLEY_CONFIG Lnet/minecraft/class_4638;
 	FIELD field_21205 BLUE_ORCHID_CONFIG Lnet/minecraft/class_4638;
 	FIELD field_21206 DEFAULT_FLOWER_CONFIG Lnet/minecraft/class_4638;
+	FIELD field_21833 BIRCH_TREE_WITH_RARE_BEEHIVES_CONFIG Lnet/minecraft/class_4640;
+	FIELD field_21834 FANCY_TREE_WITH_RARE_BEEHIVES_CONFIG Lnet/minecraft/class_4640;
+	FIELD field_21835 OAK_TREE_WITH_RARE_BEEHIVES_CONFIG Lnet/minecraft/class_4640;
+	FIELD field_21836 BIRCH_TREE_WITH_MORE_BEEHIVES_CONFIG Lnet/minecraft/class_4640;
 	METHOD method_16957 addMountainTrees (Lnet/minecraft/class_1959;)V
 		ARG 0 biome
 	METHOD method_16958 addExtraMountainTrees (Lnet/minecraft/class_1959;)V

--- a/mappings/net/minecraft/world/gen/decorator/TreeDecorator.mapping
+++ b/mappings/net/minecraft/world/gen/decorator/TreeDecorator.mapping
@@ -1,5 +1,19 @@
 CLASS net/minecraft/class_4662 net/minecraft/world/gen/decorator/TreeDecorator
+	COMMENT Tree decorators can add additional blocks to trees, such as vines or beehives.
+	FIELD field_21319 type Lnet/minecraft/class_4663;
 	METHOD method_23469 generate (Lnet/minecraft/class_1936;Ljava/util/Random;Ljava/util/List;Ljava/util/List;Ljava/util/Set;Lnet/minecraft/class_3341;)V
 		ARG 1 world
 		ARG 2 random
+		ARG 3 logPositions
+		ARG 4 leavesPositions
 		ARG 6 box
+	METHOD method_23470 setBlockStateAndEncompassPosition (Lnet/minecraft/class_1945;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Ljava/util/Set;Lnet/minecraft/class_3341;)V
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 state
+		ARG 5 box
+	METHOD method_23471 placeVine (Lnet/minecraft/class_1945;Lnet/minecraft/class_2338;Lnet/minecraft/class_2746;Ljava/util/Set;Lnet/minecraft/class_3341;)V
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 directionProperty
+		ARG 5 box

--- a/mappings/net/minecraft/world/gen/feature/BlockPileFeatureConfig.mapping
+++ b/mappings/net/minecraft/world/gen/feature/BlockPileFeatureConfig.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/class_4634 net/minecraft/world/gen/feature/BlockPileFeatureConfig
+	FIELD field_21229 stateProvider Lnet/minecraft/class_4651;
 	METHOD method_23406 deserialize (Lcom/mojang/datafixers/Dynamic;)Lnet/minecraft/class_4634;

--- a/mappings/net/minecraft/world/gen/stateprovider/BlockStateProvider.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/BlockStateProvider.mapping
@@ -1,6 +1,7 @@
-CLASS net/minecraft/class_4655 net/minecraft/world/gen/stateprovider/BlockStateProvider
-	FIELD field_21313 block Lnet/minecraft/class_2248;
-	METHOD <init> (Lcom/mojang/datafixers/Dynamic;)V
-		ARG 1 configDeserializer
-	METHOD <init> (Lnet/minecraft/class_2248;)V
-		ARG 1 block
+CLASS net/minecraft/class_4651 net/minecraft/world/gen/stateprovider/BlockStateProvider
+	FIELD field_21304 stateProvider Lnet/minecraft/class_4652;
+	METHOD <init> (Lnet/minecraft/class_4652;)V
+		ARG 1 stateProvider
+	METHOD method_23455 getBlockState (Ljava/util/Random;Lnet/minecraft/class_2338;)Lnet/minecraft/class_2680;
+		ARG 1 random
+		ARG 2 pos

--- a/mappings/net/minecraft/world/gen/stateprovider/BlockStateProviderType.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/BlockStateProviderType.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4652 net/minecraft/world/gen/stateprovider/StateProviderType
+CLASS net/minecraft/class_4652 net/minecraft/world/gen/stateprovider/BlockStateProviderType
 	FIELD field_21309 configDeserializer Ljava/util/function/Function;
 	METHOD <init> (Ljava/util/function/Function;)V
 		ARG 1 configDeserializer

--- a/mappings/net/minecraft/world/gen/stateprovider/ForestFlowerBlockStateProvider.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/ForestFlowerBlockStateProvider.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4653 net/minecraft/world/gen/stateprovider/ForestFlowerStateProvider
+CLASS net/minecraft/class_4653 net/minecraft/world/gen/stateprovider/ForestFlowerBlockStateProvider
 	FIELD field_21310 flowers [Lnet/minecraft/class_2680;
 	METHOD <init> (Lcom/mojang/datafixers/Dynamic;)V
 		ARG 1 configDeserializer

--- a/mappings/net/minecraft/world/gen/stateprovider/PillarBlockStateProvider.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/PillarBlockStateProvider.mapping
@@ -1,0 +1,6 @@
+CLASS net/minecraft/class_4655 net/minecraft/world/gen/stateprovider/PillarBlockStateProvider
+	FIELD field_21313 block Lnet/minecraft/class_2248;
+	METHOD <init> (Lcom/mojang/datafixers/Dynamic;)V
+		ARG 1 configDeserializer
+	METHOD <init> (Lnet/minecraft/class_2248;)V
+		ARG 1 block

--- a/mappings/net/minecraft/world/gen/stateprovider/PlainsFlowerBlockStateProvider.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/PlainsFlowerBlockStateProvider.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4654 net/minecraft/world/gen/stateprovider/PlainsFlowerStateProvider
+CLASS net/minecraft/class_4654 net/minecraft/world/gen/stateprovider/PlainsFlowerBlockStateProvider
 	FIELD field_21311 tulips [Lnet/minecraft/class_2680;
 	FIELD field_21312 flowers [Lnet/minecraft/class_2680;
 	METHOD <init> (Lcom/mojang/datafixers/Dynamic;)V

--- a/mappings/net/minecraft/world/gen/stateprovider/SimpleBlockStateProvider.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/SimpleBlockStateProvider.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4656 net/minecraft/world/gen/stateprovider/SimpleStateProvider
+CLASS net/minecraft/class_4656 net/minecraft/world/gen/stateprovider/SimpleBlockStateProvider
 	FIELD field_21314 state Lnet/minecraft/class_2680;
 	METHOD <init> (Lcom/mojang/datafixers/Dynamic;)V
 		ARG 1 configDeserializer

--- a/mappings/net/minecraft/world/gen/stateprovider/StateProvider.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/StateProvider.mapping
@@ -1,7 +1,0 @@
-CLASS net/minecraft/class_4651 net/minecraft/world/gen/stateprovider/StateProvider
-	FIELD field_21304 stateProvider Lnet/minecraft/class_4652;
-	METHOD <init> (Lnet/minecraft/class_4652;)V
-		ARG 1 stateProvider
-	METHOD method_23455 getBlockState (Ljava/util/Random;Lnet/minecraft/class_2338;)Lnet/minecraft/class_2680;
-		ARG 1 random
-		ARG 2 pos

--- a/mappings/net/minecraft/world/gen/stateprovider/WeightedBlockStateProvider.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/WeightedBlockStateProvider.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4657 net/minecraft/world/gen/stateprovider/WeightedStateProvider
+CLASS net/minecraft/class_4657 net/minecraft/world/gen/stateprovider/WeightedBlockStateProvider
 	FIELD field_21315 states Lnet/minecraft/class_4131;
 	METHOD <init> (Lcom/mojang/datafixers/Dynamic;)V
 		ARG 1 configDeserializer


### PR DESCRIPTION
A simple backport.

What is included:
 - The argument mapping in `ClientWorld` from #1087 
 - Some feature fields from #1088 which are compatible with 1.15.2
 - `HorizontalConnectingBlock` refactor from #1089 
 - `ItemEntity` mappings from #1091 which are compatible with 1.15.2
 - Compatible refactors from #1092
 - #1095 
 - `StructureStart#getReferences` from #1097
 - #1101
 - Should be everything included.

What is not included:
 - Mappings for 1.16 exclusive content. (exclude file: https://gist.github.com/LambdAurora/04608dac389e91cb5c41553641f6b8d2#file-excludes_1_15_2-json)