### PR TITLE
Random worldgen things

### DIFF
--- a/mappings/net/minecraft/structure/rule/AbstractRuleTest.mapping
+++ b/mappings/net/minecraft/structure/rule/AbstractRuleTest.mapping
@@ -1,4 +1,0 @@
-CLASS net/minecraft/class_3825 net/minecraft/structure/rule/AbstractRuleTest
-	METHOD method_16766 getRuleTest ()Lnet/minecraft/class_3827;
-	METHOD method_16768 test (Lnet/minecraft/class_2680;Ljava/util/Random;)Z
-	METHOD method_16769 serialize (Lcom/mojang/datafixers/types/DynamicOps;)Lcom/mojang/datafixers/Dynamic;

--- a/mappings/net/minecraft/structure/rule/RuleTest.mapping
+++ b/mappings/net/minecraft/structure/rule/RuleTest.mapping
@@ -1,4 +1,9 @@
-CLASS net/minecraft/class_3827 net/minecraft/structure/rule/RuleTest
-	METHOD method_16821 register (Ljava/lang/String;Lnet/minecraft/class_3827;)Lnet/minecraft/class_3827;
-		ARG 0 id
-		ARG 1 test
+CLASS net/minecraft/class_3825 net/minecraft/structure/rule/RuleTest
+	METHOD method_16766 getType ()Lnet/minecraft/class_3827;
+	METHOD method_16767 serializeWithId (Lcom/mojang/datafixers/types/DynamicOps;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 ops
+	METHOD method_16768 test (Lnet/minecraft/class_2680;Ljava/util/Random;)Z
+		ARG 1 state
+		ARG 2 random
+	METHOD method_16769 serialize (Lcom/mojang/datafixers/types/DynamicOps;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 ops

--- a/mappings/net/minecraft/structure/rule/RuleTest.mapping
+++ b/mappings/net/minecraft/structure/rule/RuleTest.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_3825 net/minecraft/structure/rule/RuleTest
+	COMMENT Rule tests are used in structure generation to check if a block state matches some condition.
 	METHOD method_16766 getType ()Lnet/minecraft/class_3827;
 	METHOD method_16767 serializeWithId (Lcom/mojang/datafixers/types/DynamicOps;)Lcom/mojang/datafixers/Dynamic;
 		ARG 1 ops

--- a/mappings/net/minecraft/structure/rule/RuleTestType.mapping
+++ b/mappings/net/minecraft/structure/rule/RuleTestType.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_3827 net/minecraft/structure/rule/RuleTestType
+	METHOD method_16821 register (Ljava/lang/String;Lnet/minecraft/class_3827;)Lnet/minecraft/class_3827;
+		ARG 0 id
+		ARG 1 test

--- a/mappings/net/minecraft/world/gen/decorator/TreeDecorator.mapping
+++ b/mappings/net/minecraft/world/gen/decorator/TreeDecorator.mapping
@@ -1,5 +1,22 @@
 CLASS net/minecraft/class_4662 net/minecraft/world/gen/decorator/TreeDecorator
+	COMMENT Tree decorators can add additional blocks to trees, such as vines or beehives.
+	FIELD field_21319 type Lnet/minecraft/class_4663;
+	METHOD <init> (Lnet/minecraft/class_4663;)V
+		ARG 1 type
 	METHOD method_23469 generate (Lnet/minecraft/class_1936;Ljava/util/Random;Ljava/util/List;Ljava/util/List;Ljava/util/Set;Lnet/minecraft/class_3341;)V
 		ARG 1 world
 		ARG 2 random
+		ARG 3 logPositions
+		ARG 4 leavesPositions
 		ARG 6 box
+	METHOD method_23470 setBlockStateAndEncompassPosition (Lnet/minecraft/class_1945;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Ljava/util/Set;Lnet/minecraft/class_3341;)V
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 state
+		ARG 5 box
+	METHOD method_23471 placeVine (Lnet/minecraft/class_1945;Lnet/minecraft/class_2338;Lnet/minecraft/class_2746;Ljava/util/Set;Lnet/minecraft/class_3341;)V
+		COMMENT
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 directionProperty
+		ARG 5 box

--- a/mappings/net/minecraft/world/gen/decorator/TreeDecorator.mapping
+++ b/mappings/net/minecraft/world/gen/decorator/TreeDecorator.mapping
@@ -15,7 +15,6 @@ CLASS net/minecraft/class_4662 net/minecraft/world/gen/decorator/TreeDecorator
 		ARG 3 state
 		ARG 5 box
 	METHOD method_23471 placeVine (Lnet/minecraft/class_1945;Lnet/minecraft/class_2338;Lnet/minecraft/class_2746;Ljava/util/Set;Lnet/minecraft/class_3341;)V
-		COMMENT
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 directionProperty

--- a/mappings/net/minecraft/world/gen/stateprovider/BlockStateProvider.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/BlockStateProvider.mapping
@@ -1,6 +1,7 @@
-CLASS net/minecraft/class_4655 net/minecraft/world/gen/stateprovider/BlockStateProvider
-	FIELD field_21313 block Lnet/minecraft/class_2248;
-	METHOD <init> (Lcom/mojang/datafixers/Dynamic;)V
-		ARG 1 configDeserializer
-	METHOD <init> (Lnet/minecraft/class_2248;)V
-		ARG 1 block
+CLASS net/minecraft/class_4651 net/minecraft/world/gen/stateprovider/BlockStateProvider
+	FIELD field_21304 stateProvider Lnet/minecraft/class_4652;
+	METHOD <init> (Lnet/minecraft/class_4652;)V
+		ARG 1 stateProvider
+	METHOD method_23455 getBlockState (Ljava/util/Random;Lnet/minecraft/class_2338;)Lnet/minecraft/class_2680;
+		ARG 1 random
+		ARG 2 pos

--- a/mappings/net/minecraft/world/gen/stateprovider/BlockStateProviderType.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/BlockStateProviderType.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4652 net/minecraft/world/gen/stateprovider/StateProviderType
+CLASS net/minecraft/class_4652 net/minecraft/world/gen/stateprovider/BlockStateProviderType
 	FIELD field_21309 configDeserializer Ljava/util/function/Function;
 	METHOD <init> (Ljava/util/function/Function;)V
 		ARG 1 configDeserializer

--- a/mappings/net/minecraft/world/gen/stateprovider/ForestFlowerBlockStateProvider.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/ForestFlowerBlockStateProvider.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4653 net/minecraft/world/gen/stateprovider/ForestFlowerStateProvider
+CLASS net/minecraft/class_4653 net/minecraft/world/gen/stateprovider/ForestFlowerBlockStateProvider
 	FIELD field_21310 flowers [Lnet/minecraft/class_2680;
 	METHOD <init> (Lcom/mojang/datafixers/Dynamic;)V
 		ARG 1 configDeserializer

--- a/mappings/net/minecraft/world/gen/stateprovider/PillarBlockStateProvider.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/PillarBlockStateProvider.mapping
@@ -1,0 +1,6 @@
+CLASS net/minecraft/class_4655 net/minecraft/world/gen/stateprovider/PillarBlockStateProvider
+	FIELD field_21313 block Lnet/minecraft/class_2248;
+	METHOD <init> (Lcom/mojang/datafixers/Dynamic;)V
+		ARG 1 configDeserializer
+	METHOD <init> (Lnet/minecraft/class_2248;)V
+		ARG 1 block

--- a/mappings/net/minecraft/world/gen/stateprovider/PlainsFlowerBlockStateProvider.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/PlainsFlowerBlockStateProvider.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4654 net/minecraft/world/gen/stateprovider/PlainsFlowerStateProvider
+CLASS net/minecraft/class_4654 net/minecraft/world/gen/stateprovider/PlainsFlowerBlockStateProvider
 	FIELD field_21311 tulips [Lnet/minecraft/class_2680;
 	FIELD field_21312 flowers [Lnet/minecraft/class_2680;
 	METHOD <init> (Lcom/mojang/datafixers/Dynamic;)V

--- a/mappings/net/minecraft/world/gen/stateprovider/SimpleBlockStateProvider.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/SimpleBlockStateProvider.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4656 net/minecraft/world/gen/stateprovider/SimpleStateProvider
+CLASS net/minecraft/class_4656 net/minecraft/world/gen/stateprovider/SimpleBlockStateProvider
 	FIELD field_21314 state Lnet/minecraft/class_2680;
 	METHOD <init> (Lcom/mojang/datafixers/Dynamic;)V
 		ARG 1 configDeserializer

--- a/mappings/net/minecraft/world/gen/stateprovider/StateProvider.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/StateProvider.mapping
@@ -1,7 +1,0 @@
-CLASS net/minecraft/class_4651 net/minecraft/world/gen/stateprovider/StateProvider
-	FIELD field_21304 stateProvider Lnet/minecraft/class_4652;
-	METHOD <init> (Lnet/minecraft/class_4652;)V
-		ARG 1 stateProvider
-	METHOD method_23455 getBlockState (Ljava/util/Random;Lnet/minecraft/class_2338;)Lnet/minecraft/class_2680;
-		ARG 1 random
-		ARG 2 pos

--- a/mappings/net/minecraft/world/gen/stateprovider/WeightedBlockStateProvider.mapping
+++ b/mappings/net/minecraft/world/gen/stateprovider/WeightedBlockStateProvider.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4657 net/minecraft/world/gen/stateprovider/WeightedStateProvider
+CLASS net/minecraft/class_4657 net/minecraft/world/gen/stateprovider/WeightedBlockStateProvider
 	FIELD field_21315 states Lnet/minecraft/class_4131;
 	METHOD <init> (Lcom/mojang/datafixers/Dynamic;)V
 		ARG 1 configDeserializer


### PR DESCRIPTION
- Renamed:
  - `AbstractRuleTest` -> `RuleTest`
  - `RuleTest` -> `RuleTestType`
    - Closes #1102.
  - `StateProvider` -> `BlockStateProvider` + subclasses
    - It specifically provides block states, and they're registered in a "block state provider type" registry.
  - `BlockStateProvider` -> `PillarBlockStateProvider`
    - Closes #1037.
    - It provides a pillar and sets the `PillarBlock.AXIS` to a random axis.
    - Note that this rename makes the diff a bit weird because `StateProvider` was renamed to `BlockStateProvider`.
- Added javadocs for rule tests and tree decorators.
- Mapped some tree decorator methods.