### PR TITLE
Fix missing mapping RuleTest in 1.15.2

### DIFF
--- a/mappings/net/minecraft/structure/rule/RuleTest.mapping
+++ b/mappings/net/minecraft/structure/rule/RuleTest.mapping
@@ -1,0 +1,10 @@
+CLASS net/minecraft/class_3825 net/minecraft/structure/rule/RuleTest
+	COMMENT Rule tests are used in structure generation to check if a block state matches some condition.
+	METHOD method_16766 getType ()Lnet/minecraft/class_3827;
+	METHOD method_16767 serializeWithId (Lcom/mojang/datafixers/types/DynamicOps;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 ops
+	METHOD method_16768 test (Lnet/minecraft/class_2680;Ljava/util/Random;)Z
+		ARG 1 state
+		ARG 2 random
+	METHOD method_16769 serialize (Lcom/mojang/datafixers/types/DynamicOps;)Lcom/mojang/datafixers/Dynamic;
+		ARG 1 ops


### PR DESCRIPTION
The mapping got accidentally deleted in #1103. 