### PR TITLE
BlockBox names and overloads in BlockPos

### DIFF
--- a/mappings/net/minecraft/util/math/BlockBox.mapping
+++ b/mappings/net/minecraft/util/math/BlockBox.mapping
@@ -67,5 +67,5 @@ CLASS net/minecraft/class_3341 net/minecraft/util/math/BlockBox
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
-	METHOD method_22874 center ()Lnet/minecraft/class_2382;
+	METHOD method_22874 getCenter ()Lnet/minecraft/class_2382;
 		COMMENT @implNote Biased toward the minimum bound corner of the box.

--- a/mappings/net/minecraft/util/math/BlockBox.mapping
+++ b/mappings/net/minecraft/util/math/BlockBox.mapping
@@ -68,3 +68,4 @@ CLASS net/minecraft/class_3341 net/minecraft/util/math/BlockBox
 		ARG 2 y
 		ARG 3 z
 	METHOD method_22874 center ()Lnet/minecraft/class_2382;
+		COMMENT @implNote Biased toward the minimum bound corner of the box.

--- a/mappings/net/minecraft/util/math/BlockBox.mapping
+++ b/mappings/net/minecraft/util/math/BlockBox.mapping
@@ -67,3 +67,4 @@ CLASS net/minecraft/class_3341 net/minecraft/util/math/BlockBox
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
+	METHOD method_22874 center ()Lnet/minecraft/class_2382;

--- a/mappings/net/minecraft/util/math/BlockPos.mapping
+++ b/mappings/net/minecraft/util/math/BlockPos.mapping
@@ -103,6 +103,7 @@ CLASS net/minecraft/class_2338 net/minecraft/util/math/BlockPos
 	METHOD method_20437 stream (Lnet/minecraft/class_2338;Lnet/minecraft/class_2338;)Ljava/util/stream/Stream;
 		ARG 0 pos1
 		ARG 1 pos2
+	METHOD method_23627 stream (Lnet/minecraft/class_3341;)Ljava/util/stream/Stream;
 	CLASS 1
 		FIELD field_17676 connector Lnet/minecraft/class_3980;
 		FIELD field_18231 position Lnet/minecraft/class_2338$class_2339;

--- a/mappings/net/minecraft/util/math/BlockPos.mapping
+++ b/mappings/net/minecraft/util/math/BlockPos.mapping
@@ -104,6 +104,7 @@ CLASS net/minecraft/class_2338 net/minecraft/util/math/BlockPos
 		ARG 0 pos1
 		ARG 1 pos2
 	METHOD method_23627 stream (Lnet/minecraft/class_3341;)Ljava/util/stream/Stream;
+		ARG 0 box
 	CLASS 1
 		FIELD field_17676 connector Lnet/minecraft/class_3980;
 		FIELD field_18231 position Lnet/minecraft/class_2338$class_2339;


### PR DESCRIPTION
- method_23627 -> stream
  - New overload for `BlockBox` param  
- blockBox -> box
  - Shortened name  
- method_22874 -> center
  - Returns a `BlockPos` at the average of each axis bounds. Biased to the `min*` corner of the box.