### PR TITLE
Add Back Some Projectile Mappings

### DIFF
--- a/mappings/net/minecraft/entity/projectile/Projectile.mapping
+++ b/mappings/net/minecraft/entity/projectile/Projectile.mapping
@@ -1,4 +1,13 @@
 CLASS net/minecraft/class_1676 net/minecraft/entity/projectile/Projectile
+	FIELD field_22478 ownerUuid Ljava/util/UUID;
+	METHOD method_24919 setProperties (Lnet/minecraft/class_1297;FFFFF)V
+		ARG 1 user
+		ARG 2 pitch
+		ARG 3 yaw
+		ARG 4 roll
+		ARG 5 modifierZ
+		ARG 6 modifierXYZ
+	METHOD method_24921 getOwner ()Lnet/minecraft/class_1297;
 	METHOD method_7432 setOwner (Lnet/minecraft/class_1297;)V
 	METHOD method_7454 onEntityHit (Lnet/minecraft/class_3966;)V
 	METHOD method_7485 setVelocity (DDDFF)V


### PR DESCRIPTION
This PR restores a few projectile-related names that were removed in the 20w10a when they became obfuscated.