### PR TITLE
Document changed UUID serialization methods

### DIFF
--- a/mappings/net/minecraft/nbt/CompoundTag.mapping
+++ b/mappings/net/minecraft/nbt/CompoundTag.mapping
@@ -101,8 +101,8 @@ CLASS net/minecraft/class_2487 net/minecraft/nbt/CompoundTag
 		ARG 1 key
 		ARG 2 value
 	METHOD method_10576 containsUuidOld (Ljava/lang/String;)Z
-		COMMENT @deprecated use {@link #containsUuid} for newly added deserialization methods.
-		COMMENT Other places may keep calling this as well as {@link #containsUuid} to ensure a smooth transition for old worlds.
+		COMMENT @deprecated use {@link #containsUuidNew} for newly added deserialization methods.
+		COMMENT Other places may keep calling this as well as {@link #containsUuidNew} to ensure a smooth transition for old worlds.
 		ARG 1 key
 	METHOD method_10577 getBoolean (Ljava/lang/String;)Z
 		ARG 1 key
@@ -122,24 +122,24 @@ CLASS net/minecraft/class_2487 net/minecraft/nbt/CompoundTag
 	METHOD method_10583 getFloat (Ljava/lang/String;)F
 		ARG 1 key
 	METHOD method_10584 getUuidOld (Ljava/lang/String;)Ljava/util/UUID;
-		COMMENT @deprecated use {@link #getUuid} for newly added deserialization methods.
-		COMMENT Other places may keep calling this as well as {@link #getUuid} to ensure a smooth transition for old worlds.
+		COMMENT @deprecated use {@link #getUuidNew} for newly added deserialization methods.
+		COMMENT Other places may keep calling this as well as {@link #getUuidNew} to ensure a smooth transition for old worlds.
 		ARG 1 key
 	METHOD method_22421 removeUuidOld (Ljava/lang/String;)V
 		COMMENT @deprecated use {@link #remove} to remove a UUID serialized using the new {@link #putUuid} method.
 		ARG 1 key
-	METHOD method_25926 getUuid (Ljava/lang/String;)Ljava/util/UUID;
+	METHOD method_25926 getUuidNew (Ljava/lang/String;)Ljava/util/UUID;
 		COMMENT Reads a {@link UUID} from its NBT representation in this {@code CompoundTag}.
 		COMMENT
 		COMMENT @since 20w10a
 		ARG 1 key
-	METHOD method_25927 putUuid (Ljava/lang/String;Ljava/util/UUID;)V
-		COMMENT Writes the NBT representation of a {@link UUID} into this {@code CompoundTag}.
+	METHOD method_25927 putUuidNew (Ljava/lang/String;Ljava/util/UUID;)V
+		COMMENT Reads a {@link UUID} from its NBT representation in this {@code CompoundTag}.
 		COMMENT
 		COMMENT @since 20w10a
 		ARG 1 key
 		ARG 2 value
-	METHOD method_25928 containsUuid (Ljava/lang/String;)Z
+	METHOD method_25928 containsUuidNew (Ljava/lang/String;)Z
 		COMMENT Returns {@code true} if this {@code CompoundTag} contains a valid UUID representation associated with the given key.
 		COMMENT A valid UUID is represented by an int array of length 4.
 		COMMENT

--- a/mappings/net/minecraft/nbt/CompoundTag.mapping
+++ b/mappings/net/minecraft/nbt/CompoundTag.mapping
@@ -60,7 +60,8 @@ CLASS net/minecraft/class_2487 net/minecraft/nbt/CompoundTag
 		ARG 1 key
 	METHOD method_10559 createCrashReport (Ljava/lang/String;Lnet/minecraft/class_4614;Ljava/lang/ClassCastException;)Lnet/minecraft/class_128;
 		ARG 1 key
-	METHOD method_10560 putUuid (Ljava/lang/String;Ljava/util/UUID;)V
+	METHOD method_10560 putUuidOld (Ljava/lang/String;Ljava/util/UUID;)V
+		COMMENT @deprecated use {@link #putUuid}.
 		ARG 1 key
 		ARG 2 uuid
 	METHOD method_10561 getIntArray (Ljava/lang/String;)[I
@@ -99,7 +100,9 @@ CLASS net/minecraft/class_2487 net/minecraft/nbt/CompoundTag
 	METHOD method_10575 putShort (Ljava/lang/String;S)V
 		ARG 1 key
 		ARG 2 value
-	METHOD method_10576 containsUuid (Ljava/lang/String;)Z
+	METHOD method_10576 containsUuidOld (Ljava/lang/String;)Z
+		COMMENT @deprecated use {@link #containsUuid} for newly added deserialization methods.
+		COMMENT Other places may keep calling this as well as {@link #containsUuid} to ensure a smooth transition for old worlds.
 		ARG 1 key
 	METHOD method_10577 getBoolean (Ljava/lang/String;)Z
 		ARG 1 key
@@ -118,7 +121,27 @@ CLASS net/minecraft/class_2487 net/minecraft/nbt/CompoundTag
 		ARG 2 value
 	METHOD method_10583 getFloat (Ljava/lang/String;)F
 		ARG 1 key
-	METHOD method_10584 getUuid (Ljava/lang/String;)Ljava/util/UUID;
+	METHOD method_10584 getUuidOld (Ljava/lang/String;)Ljava/util/UUID;
+		COMMENT @deprecated use {@link #getUuid} for newly added deserialization methods.
+		COMMENT Other places may keep calling this as well as {@link #getUuid} to ensure a smooth transition for old worlds.
 		ARG 1 key
-	METHOD method_22421 removeUuid (Ljava/lang/String;)V
+	METHOD method_22421 removeUuidOld (Ljava/lang/String;)V
+		COMMENT @deprecated use {@link #remove} to remove a UUID serialized using the new {@link #putUuid} method.
+		ARG 1 key
+	METHOD method_25926 getUuid (Ljava/lang/String;)Ljava/util/UUID;
+		COMMENT Reads a {@link UUID} from its NBT representation in this {@code CompoundTag}.
+		COMMENT
+		COMMENT @since 20w10a
+		ARG 1 key
+	METHOD method_25927 putUuid (Ljava/lang/String;Ljava/util/UUID;)V
+		COMMENT Writes the NBT representation of a {@link UUID} into this {@code CompoundTag}.
+		COMMENT
+		COMMENT @since 20w10a
+		ARG 1 key
+		ARG 2 value
+	METHOD method_25928 containsUuid (Ljava/lang/String;)Z
+		COMMENT Returns {@code true} if this {@code CompoundTag} contains a valid UUID representation associated with the given key.
+		COMMENT A valid UUID is represented by an int array of length 4.
+		COMMENT
+		COMMENT @since 20w10a
 		ARG 1 key

--- a/mappings/net/minecraft/nbt/NbtHelper.mapping
+++ b/mappings/net/minecraft/nbt/NbtHelper.mapping
@@ -27,9 +27,12 @@ CLASS net/minecraft/class_2512 net/minecraft/nbt/NbtHelper
 		ARG 1 fixTypes
 		ARG 2 tag
 		ARG 3 oldVersion
-	METHOD method_10689 fromUuid (Ljava/util/UUID;)Lnet/minecraft/class_2487;
+	METHOD method_10689 fromUuidOld (Ljava/util/UUID;)Lnet/minecraft/class_2487;
+		COMMENT @deprecated use {@link #fromUuid}.
 		ARG 0 uuid
-	METHOD method_10690 toUuid (Lnet/minecraft/class_2487;)Ljava/util/UUID;
+	METHOD method_10690 toUuidOld (Lnet/minecraft/class_2487;)Ljava/util/UUID;
+		COMMENT @deprecated use {@link #toUuid} for newly added deserialization methods.
+		COMMENT Other places may keep calling this besides {@link #toUuid} to ensure a smooth transition for old worlds.
 		ARG 0 tag
 	METHOD method_10691 toBlockPos (Lnet/minecraft/class_2487;)Lnet/minecraft/class_2338;
 		ARG 0 tag
@@ -41,3 +44,15 @@ CLASS net/minecraft/class_2512 net/minecraft/nbt/NbtHelper
 		ARG 2 tag
 		ARG 3 oldVersion
 		ARG 4 currentVersion
+	METHOD method_25929 fromUuid (Ljava/util/UUID;)Lnet/minecraft/class_2495;
+		COMMENT Serializes a {@link UUID} into its equivalent NBT representation.
+		COMMENT
+		COMMENT @since 20w10a
+		ARG 0 uuid
+	METHOD method_25930 toUuid (Lnet/minecraft/class_2520;)Ljava/util/UUID;
+		COMMENT Deserializes a tag into a {@link UUID}.
+		COMMENT The tag's data must have the same structure as the output of {@link #fromUuid}.
+		COMMENT
+		COMMENT @throws IllegalArgumentException if {@code tag} is not a valid representation of a UUID
+		COMMENT @since 20w10a
+		ARG 0 tag

--- a/mappings/net/minecraft/nbt/NbtHelper.mapping
+++ b/mappings/net/minecraft/nbt/NbtHelper.mapping
@@ -28,11 +28,11 @@ CLASS net/minecraft/class_2512 net/minecraft/nbt/NbtHelper
 		ARG 2 tag
 		ARG 3 oldVersion
 	METHOD method_10689 fromUuidOld (Ljava/util/UUID;)Lnet/minecraft/class_2487;
-		COMMENT @deprecated use {@link #fromUuid}.
+		COMMENT @deprecated use {@link #fromUuidNew}.
 		ARG 0 uuid
 	METHOD method_10690 toUuidOld (Lnet/minecraft/class_2487;)Ljava/util/UUID;
-		COMMENT @deprecated use {@link #toUuid} for newly added deserialization methods.
-		COMMENT Other places may keep calling this besides {@link #toUuid} to ensure a smooth transition for old worlds.
+		COMMENT @deprecated use {@link #toUuidNew} for newly added deserialization methods.
+		COMMENT Other places may keep calling this besides {@link #toUuidNew} to ensure a smooth transition for old worlds.
 		ARG 0 tag
 	METHOD method_10691 toBlockPos (Lnet/minecraft/class_2487;)Lnet/minecraft/class_2338;
 		ARG 0 tag
@@ -44,12 +44,12 @@ CLASS net/minecraft/class_2512 net/minecraft/nbt/NbtHelper
 		ARG 2 tag
 		ARG 3 oldVersion
 		ARG 4 currentVersion
-	METHOD method_25929 fromUuid (Ljava/util/UUID;)Lnet/minecraft/class_2495;
+	METHOD method_25929 fromUuidNew (Ljava/util/UUID;)Lnet/minecraft/class_2495;
 		COMMENT Serializes a {@link UUID} into its equivalent NBT representation.
 		COMMENT
 		COMMENT @since 20w10a
 		ARG 0 uuid
-	METHOD method_25930 toUuid (Lnet/minecraft/class_2520;)Ljava/util/UUID;
+	METHOD method_25930 toUuidNew (Lnet/minecraft/class_2520;)Ljava/util/UUID;
 		COMMENT Deserializes a tag into a {@link UUID}.
 		COMMENT The tag's data must have the same structure as the output of {@link #fromUuid}.
 		COMMENT


### PR DESCRIPTION
This PR names and document the UUID serialization methods added to `CompoundTag` and `NbtHelper` in 20w10a. It also documents the deprecation of the methods they replace.