### PR TITLE
Drop invalid mappings

### DIFF
--- a/mappings/net/minecraft/block/SlimeBlock.mapping
+++ b/mappings/net/minecraft/block/SlimeBlock.mapping
@@ -1,5 +1,3 @@
 CLASS net/minecraft/class_2490 net/minecraft/block/SlimeBlock
-	METHOD <init> (Lnet/minecraft/class_2248$class_2251;)V
-		ARG 1 settings
 	METHOD method_21847 bounce (Lnet/minecraft/class_1297;)V
 		ARG 1 entity

--- a/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
+++ b/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
@@ -146,6 +146,3 @@ CLASS net/minecraft/class_3898 net/minecraft/server/world/ThreadedAnvilChunkStor
 		METHOD <init> (Lnet/minecraft/class_3898;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;)V
 			ARG 1 workerExecutor
 			ARG 2 mainThreadExecutor
-		METHOD <init> (Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;)V
-			ARG 1 workerExecutor
-			ARG 2 mainThreadExecutor


### PR DESCRIPTION
As I noticed the main branch contains invalid mappings, and since every PR is going to end up containing them in some way or another, I decided to just make a PR to get rid of them and nothing else.

Someone will have to verify `ThreadedAnvilChunkStorage` because the method is gone, but I can't view the class in Enigma to verify that it wasn't just changed and needs a remap.