### PR TITLE
Change the cartography table's screen handler type field to CARTOGRAPHY

### DIFF
--- a/mappings/net/minecraft/screen/ScreenHandlerType.mapping
+++ b/mappings/net/minecraft/screen/ScreenHandlerType.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_3917 net/minecraft/screen/ScreenHandlerType
+	FIELD field_17343 CARTOGRAPHY Lnet/minecraft/class_3917;
 	FIELD field_17344 factory Lnet/minecraft/class_3917$class_3918;
 	METHOD <init> (Lnet/minecraft/class_3917$class_3918;)V
 		ARG 1 factory


### PR DESCRIPTION
This matches it with the crafting table's screen handler type identifier and field, as the background texture identifiers and screen class names of both use the 'table' suffix.