### PR TITLE
EnderCrystal -> EndCrystal, #1163 improvements

### DIFF
--- a/mappings/net/minecraft/client/render/entity/EndCrystalEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EndCrystalEntityRenderer.mapping
@@ -1,10 +1,10 @@
-CLASS net/minecraft/class_892 net/minecraft/client/render/entity/EnderCrystalEntityRenderer
-	FIELD field_21002 SINE_FOURTY_FIVE_DEGREES F
+CLASS net/minecraft/class_892 net/minecraft/client/render/entity/EndCrystalEntityRenderer
+	FIELD field_21002 SINE_45_DEGREES F
 	FIELD field_21003 core Lnet/minecraft/class_630;
 	FIELD field_21004 frame Lnet/minecraft/class_630;
 	FIELD field_21005 bottom Lnet/minecraft/class_630;
-	FIELD field_21736 ENDER_CRYSTAL Lnet/minecraft/class_1921;
-	FIELD field_4663 SKIN Lnet/minecraft/class_2960;
+	FIELD field_21736 END_CRYSTAL Lnet/minecraft/class_1921;
+	FIELD field_4663 TEXTURE Lnet/minecraft/class_2960;
 	METHOD method_23155 getYOffset (Lnet/minecraft/class_1511;F)F
 		ARG 0 crystal
 		ARG 1 tickDelta

--- a/mappings/net/minecraft/client/render/entity/EnderDragonEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EnderDragonEntityRenderer.mapping
@@ -1,13 +1,13 @@
 CLASS net/minecraft/class_895 net/minecraft/client/render/entity/EnderDragonEntityRenderer
-	FIELD field_21006 EYES_TEX Lnet/minecraft/class_2960;
-	FIELD field_21007 SINE_SIXTY_DEGREES F
+	FIELD field_21006 EYE_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_21007 HALF_SQRT_3 F
 	FIELD field_21008 model Lnet/minecraft/class_895$class_625;
 	FIELD field_21737 DRAGON_CUTOUT Lnet/minecraft/class_1921;
 	FIELD field_21738 DRAGON_DECAL Lnet/minecraft/class_1921;
 	FIELD field_21739 DRAGON_EYES Lnet/minecraft/class_1921;
 	FIELD field_21740 CRYSTAL_BEAM_LAYER Lnet/minecraft/class_1921;
-	FIELD field_4668 CRYSTAL_BEAM_TEX Lnet/minecraft/class_2960;
-	FIELD field_4669 EXPLOSION_TEX Lnet/minecraft/class_2960;
+	FIELD field_4668 CRYSTAL_BEAM_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_4669 EXPLOSION_TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_4670 SKIN Lnet/minecraft/class_2960;
 	METHOD method_23156 (Lnet/minecraft/class_4588;Lnet/minecraft/class_1159;FF)V
 		ARG 0 vertexConsumer

--- a/mappings/net/minecraft/client/render/entity/feature/StuckObjectsFeatureRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/StuckObjectsFeatureRenderer.mapping
@@ -6,9 +6,9 @@ CLASS net/minecraft/class_4507 net/minecraft/client/render/entity/feature/StuckO
 		ARG 2 vertexConsumers
 		ARG 3 light
 		ARG 4 entity
-		ARG 5 dirX
-		ARG 6 dirY
-		ARG 7 dirZ
+		ARG 5 directionX
+		ARG 6 directionY
+		ARG 7 directionZ
 		ARG 8 tickDelta
 	METHOD method_22134 getObjectCount (Lnet/minecraft/class_1309;)I
 		ARG 1 entity

--- a/mappings/net/minecraft/entity/decoration/EndCrystalEntity.mapping
+++ b/mappings/net/minecraft/entity/decoration/EndCrystalEntity.mapping
@@ -1,8 +1,9 @@
-CLASS net/minecraft/class_1511 net/minecraft/entity/decoration/EnderCrystalEntity
+CLASS net/minecraft/class_1511 net/minecraft/entity/decoration/EndCrystalEntity
 	FIELD field_7033 BEAM_TARGET Lnet/minecraft/class_2940;
-	FIELD field_7034 enderCrystalAge I
+	FIELD field_7034 endCrystalAge I
 	FIELD field_7035 SHOW_BOTTOM Lnet/minecraft/class_2940;
 	METHOD <init> (Lnet/minecraft/class_1937;DDD)V
+		ARG 1 world
 		ARG 2 x
 		ARG 4 y
 		ARG 6 z

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -232,7 +232,7 @@ CLASS net/minecraft/class_1657 net/minecraft/entity/player/PlayerEntity
 	METHOD method_7356 getShoulderEntityLeft ()Lnet/minecraft/class_2487;
 	METHOD method_7357 getItemCooldownManager ()Lnet/minecraft/class_1796;
 	METHOD method_7358 wakeUp (ZZ)V
-		ARG 2 shouldUpdate
+		ARG 2 updateSleepingPlayers
 	CLASS class_1658 SleepFailureReason
 		FIELD field_18593 text Lnet/minecraft/class_2561;
 		METHOD <init> (Ljava/lang/String;ILnet/minecraft/class_2561;)V

--- a/mappings/net/minecraft/server/world/ServerWorld.mapping
+++ b/mappings/net/minecraft/server/world/ServerWorld.mapping
@@ -147,6 +147,6 @@ CLASS net/minecraft/class_3218 net/minecraft/server/world/ServerWorld
 	METHOD method_8414 init (Lnet/minecraft/class_1940;)V
 		ARG 1 levelInfo
 	METHOD method_8416 addLightning (Lnet/minecraft/class_1538;)V
-	METHOD method_8448 updatePlayersSleeping ()V
+	METHOD method_8448 updateSleepingPlayers ()V
 	METHOD method_8468 checkSessionLock ()V
 	METHOD method_8487 locateStructure (Ljava/lang/String;Lnet/minecraft/class_2338;IZ)Lnet/minecraft/class_2338;


### PR DESCRIPTION
The end crystal entity is registered as `minecraft:end_crystal`.