### PR TITLE
Made some entity renderer and model fields and parameters consistent

### DIFF
--- a/mappings/net/minecraft/client/render/entity/ArmorStandEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/ArmorStandEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_877 net/minecraft/client/render/entity/ArmorStandEntityRenderer
-	FIELD field_4642 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4642 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/ArrowEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/ArrowEntityRenderer.mapping
@@ -1,3 +1,3 @@
 CLASS net/minecraft/class_954 net/minecraft/client/render/entity/ArrowEntityRenderer
-	FIELD field_4794 TIPPED_SKIN Lnet/minecraft/class_2960;
-	FIELD field_4795 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4794 TIPPED_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_4795 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/BatEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/BatEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_879 net/minecraft/client/render/entity/BatEntityRenderer
-	FIELD field_4645 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4645 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/BeeEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/BeeEntityRenderer.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_4505 net/minecraft/client/render/entity/BeeEntityRenderer
-	FIELD field_20524 ANGRY_SKIN Lnet/minecraft/class_2960;
-	FIELD field_20525 ANGRY_NECTAR_SKIN Lnet/minecraft/class_2960;
-	FIELD field_20526 PASSIVE_SKIN Lnet/minecraft/class_2960;
-	FIELD field_20527 NECTAR_SKIN Lnet/minecraft/class_2960;
+	FIELD field_20524 ANGRY_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_20525 ANGRY_NECTAR_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_20526 PASSIVE_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_20527 NECTAR_TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/BipedEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/BipedEntityRenderer.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_909 net/minecraft/client/render/entity/BipedEntityRenderer
-	FIELD field_4713 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4713 TEXTURE Lnet/minecraft/class_2960;
 	METHOD <init> (Lnet/minecraft/class_898;Lnet/minecraft/class_572;F)V
-		ARG 1 renderManager
+		ARG 1 dispatcher
 		ARG 2 model

--- a/mappings/net/minecraft/client/render/entity/BlazeEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/BlazeEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_878 net/minecraft/client/render/entity/BlazeEntityRenderer
-	FIELD field_4644 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4644 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/BoatEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/BoatEntityRenderer.mapping
@@ -1,3 +1,3 @@
 CLASS net/minecraft/class_881 net/minecraft/client/render/entity/BoatEntityRenderer
 	FIELD field_4647 model Lnet/minecraft/class_554;
-	FIELD field_4648 SKIN [Lnet/minecraft/class_2960;
+	FIELD field_4648 TEXTURES [Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/CaveSpiderEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/CaveSpiderEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_880 net/minecraft/client/render/entity/CaveSpiderEntityRenderer
-	FIELD field_4646 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4646 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/ChickenEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/ChickenEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_882 net/minecraft/client/render/entity/ChickenEntityRenderer
-	FIELD field_4649 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4649 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/CodEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/CodEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_885 net/minecraft/client/render/entity/CodEntityRenderer
-	FIELD field_4652 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4652 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/CowEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/CowEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_884 net/minecraft/client/render/entity/CowEntityRenderer
-	FIELD field_4651 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4651 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/CreeperEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/CreeperEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_887 net/minecraft/client/render/entity/CreeperEntityRenderer
-	FIELD field_4653 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4653 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/DolphinEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/DolphinEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_888 net/minecraft/client/render/entity/DolphinEntityRenderer
-	FIELD field_4654 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4654 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/DragonFireballEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/DragonFireballEntityRenderer.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_891 net/minecraft/client/render/entity/DragonFireballEntityRenderer
 	FIELD field_21735 LAYER Lnet/minecraft/class_1921;
-	FIELD field_4661 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4661 TEXTURE Lnet/minecraft/class_2960;
 	METHOD method_23837 produceVertex (Lnet/minecraft/class_4588;Lnet/minecraft/class_1159;Lnet/minecraft/class_4581;IFIII)V
 		ARG 0 vertexConsumer
 		ARG 1 modelMatrix

--- a/mappings/net/minecraft/client/render/entity/DrownedEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/DrownedEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_890 net/minecraft/client/render/entity/DrownedEntityRenderer
-	FIELD field_4659 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4659 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/ElderGuardianEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/ElderGuardianEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_893 net/minecraft/client/render/entity/ElderGuardianEntityRenderer
-	FIELD field_4665 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4665 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/EnderDragonEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EnderDragonEntityRenderer.mapping
@@ -8,7 +8,7 @@ CLASS net/minecraft/class_895 net/minecraft/client/render/entity/EnderDragonEnti
 	FIELD field_21740 CRYSTAL_BEAM_LAYER Lnet/minecraft/class_1921;
 	FIELD field_4668 CRYSTAL_BEAM_TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_4669 EXPLOSION_TEXTURE Lnet/minecraft/class_2960;
-	FIELD field_4670 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4670 TEXTURE Lnet/minecraft/class_2960;
 	METHOD method_23156 (Lnet/minecraft/class_4588;Lnet/minecraft/class_1159;FF)V
 		ARG 0 vertexConsumer
 		ARG 1 vertexTransform

--- a/mappings/net/minecraft/client/render/entity/EndermanEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EndermanEntityRenderer.mapping
@@ -1,3 +1,3 @@
 CLASS net/minecraft/class_894 net/minecraft/client/render/entity/EndermanEntityRenderer
-	FIELD field_4666 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4666 TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_4667 random Ljava/util/Random;

--- a/mappings/net/minecraft/client/render/entity/EndermiteEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EndermiteEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_896 net/minecraft/client/render/entity/EndermiteEntityRenderer
-	FIELD field_4671 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4671 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_897 net/minecraft/client/render/entity/EntityRenderer
 	FIELD field_4672 shadowDarkness F
 	FIELD field_4673 shadowSize F
-	FIELD field_4676 renderManager Lnet/minecraft/class_898;
+	FIELD field_4676 dispatcher Lnet/minecraft/class_898;
 	METHOD <init> (Lnet/minecraft/class_898;)V
 		ARG 1 dispatcher
 	METHOD method_23169 getPositionOffset (Lnet/minecraft/class_1297;F)Lnet/minecraft/class_243;

--- a/mappings/net/minecraft/client/render/entity/EvokerEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EvokerEntityRenderer.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_899 net/minecraft/client/render/entity/EvokerEntityRenderer
+	FIELD field_4697 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/EvokerFangsEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EvokerFangsEntityRenderer.mapping
@@ -1,3 +1,3 @@
 CLASS net/minecraft/class_900 net/minecraft/client/render/entity/EvokerFangsEntityRenderer
-	FIELD field_4699 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4699 TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_4700 model Lnet/minecraft/class_568;

--- a/mappings/net/minecraft/client/render/entity/EvokerIllagerEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EvokerIllagerEntityRenderer.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/class_899 net/minecraft/client/render/entity/EvokerIllagerEntityRenderer
-	FIELD field_4697 EVOKER_TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/ExperienceOrbEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/ExperienceOrbEntityRenderer.mapping
@@ -1,3 +1,3 @@
 CLASS net/minecraft/class_902 net/minecraft/client/render/entity/ExperienceOrbEntityRenderer
-	FIELD field_21741 TEXTURE_LAYER Lnet/minecraft/class_1921;
-	FIELD field_4701 SKIN Lnet/minecraft/class_2960;
+	FIELD field_21741 LAYER Lnet/minecraft/class_1921;
+	FIELD field_4701 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/FireworkEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/FireworkEntityRenderer.mapping
@@ -1,2 +1,5 @@
 CLASS net/minecraft/class_903 net/minecraft/client/render/entity/FireworkEntityRenderer
 	FIELD field_4703 itemRenderer Lnet/minecraft/class_918;
+	METHOD <init> (Lnet/minecraft/class_898;Lnet/minecraft/class_918;)V
+		ARG 1 dispatcher
+		ARG 2 itemRenderer

--- a/mappings/net/minecraft/client/render/entity/FishingBobberEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/FishingBobberEntityRenderer.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/class_906 net/minecraft/client/render/entity/FishingBobberEntityRenderer
-	FIELD field_4707 SKIN Lnet/minecraft/class_2960;
+	FIELD field_21742 LAYER Lnet/minecraft/class_1921;
+	FIELD field_4707 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/FlyingItemEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/FlyingItemEntityRenderer.mapping
@@ -1,6 +1,12 @@
 CLASS net/minecraft/class_953 net/minecraft/client/render/entity/FlyingItemEntityRenderer
 	FIELD field_17147 scale F
-	FIELD field_4792 item Lnet/minecraft/class_918;
+	FIELD field_21745 lit Z
+	FIELD field_4792 itemRenderer Lnet/minecraft/class_918;
+	METHOD <init> (Lnet/minecraft/class_898;Lnet/minecraft/class_918;)V
+		ARG 1 dispatcher
+		ARG 2 itemRenderer
 	METHOD <init> (Lnet/minecraft/class_898;Lnet/minecraft/class_918;FZ)V
-		ARG 1 renderManager
+		ARG 1 dispatcher
+		ARG 2 itemRenderer
 		ARG 3 scale
+		ARG 4 lit

--- a/mappings/net/minecraft/client/render/entity/FoxEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/FoxEntityRenderer.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_4042 net/minecraft/client/render/entity/FoxEntityRenderer
-	FIELD field_18026 SKIN Lnet/minecraft/class_2960;
-	FIELD field_18027 SLEEPING_SKIN Lnet/minecraft/class_2960;
-	FIELD field_18028 SNOW_SKIN Lnet/minecraft/class_2960;
-	FIELD field_18029 SLEEPING_SNOW_SKIN Lnet/minecraft/class_2960;
+	FIELD field_18026 TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_18027 SLEEPING_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_18028 SNOW_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_18029 SLEEPING_SNOW_TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/GhastEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/GhastEntityRenderer.mapping
@@ -1,3 +1,3 @@
 CLASS net/minecraft/class_905 net/minecraft/client/render/entity/GhastEntityRenderer
-	FIELD field_4705 SKIN Lnet/minecraft/class_2960;
-	FIELD field_4706 ANGRY_SKIN Lnet/minecraft/class_2960;
+	FIELD field_4705 TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_4706 ANGRY_TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/GiantEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/GiantEntityRenderer.mapping
@@ -1,3 +1,5 @@
 CLASS net/minecraft/class_908 net/minecraft/client/render/entity/GiantEntityRenderer
-	FIELD field_4710 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4710 TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_4711 scale F
+	METHOD <init> (Lnet/minecraft/class_898;F)V
+		ARG 1 dispatcher

--- a/mappings/net/minecraft/client/render/entity/GuardianEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/GuardianEntityRenderer.mapping
@@ -1,6 +1,9 @@
 CLASS net/minecraft/class_907 net/minecraft/client/render/entity/GuardianEntityRenderer
-	FIELD field_4708 SKIN Lnet/minecraft/class_2960;
-	FIELD field_4709 EXPLOSION_BEAM_TEX Lnet/minecraft/class_2960;
+	FIELD field_21743 LAYER Lnet/minecraft/class_1921;
+	FIELD field_4708 TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_4709 EXPLOSION_BEAM_TEXTURE Lnet/minecraft/class_2960;
+	METHOD <init> (Lnet/minecraft/class_898;F)V
+		ARG 1 dispatcher
 	METHOD method_3979 fromLerpedPosition (Lnet/minecraft/class_1309;DF)Lnet/minecraft/class_243;
 		ARG 1 entity
 		ARG 2 yOffset

--- a/mappings/net/minecraft/client/render/entity/HoglinEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/HoglinEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_4798 net/minecraft/client/render/entity/HoglinEntityRenderer
-	FIELD field_22244 SKIN Lnet/minecraft/class_2960;
+	FIELD field_22244 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/HorseEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/HorseEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_910 net/minecraft/client/render/entity/HorseEntityRenderer
-	FIELD field_4714 SKINS Ljava/util/Map;
+	FIELD field_4714 TEXTURES Ljava/util/Map;

--- a/mappings/net/minecraft/client/render/entity/HuskEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/HuskEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_912 net/minecraft/client/render/entity/HuskEntityRenderer
-	FIELD field_4716 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4716 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/IllagerEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/IllagerEntityRenderer.mapping
@@ -1,1 +1,4 @@
 CLASS net/minecraft/class_3729 net/minecraft/client/render/entity/IllagerEntityRenderer
+	METHOD <init> (Lnet/minecraft/class_898;Lnet/minecraft/class_575;F)V
+		ARG 1 dispatcher
+		ARG 2 model

--- a/mappings/net/minecraft/client/render/entity/IllusionerEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/IllusionerEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_914 net/minecraft/client/render/entity/IllusionerEntityRenderer
-	FIELD field_4718 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4718 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/IronGolemEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/IronGolemEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_913 net/minecraft/client/render/entity/IronGolemEntityRenderer
-	FIELD field_4717 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4717 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/ItemEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/ItemEntityRenderer.mapping
@@ -3,6 +3,6 @@ CLASS net/minecraft/class_916 net/minecraft/client/render/entity/ItemEntityRende
 	FIELD field_4726 itemRenderer Lnet/minecraft/class_918;
 	METHOD <init> (Lnet/minecraft/class_898;Lnet/minecraft/class_918;)V
 		ARG 1 dispatcher
-		ARG 2 renderer
+		ARG 2 itemRenderer
 	METHOD method_3998 getRenderedAmount (Lnet/minecraft/class_1799;)I
 		ARG 1 stack

--- a/mappings/net/minecraft/client/render/entity/ItemFrameEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/ItemFrameEntityRenderer.mapping
@@ -4,4 +4,5 @@ CLASS net/minecraft/class_915 net/minecraft/client/render/entity/ItemFrameEntity
 	FIELD field_4723 MAP_FRAME Lnet/minecraft/class_1091;
 	FIELD field_4724 client Lnet/minecraft/class_310;
 	METHOD <init> (Lnet/minecraft/class_898;Lnet/minecraft/class_918;)V
-		ARG 1 renderManager
+		ARG 1 dispatcher
+		ARG 2 itemRenderer

--- a/mappings/net/minecraft/client/render/entity/LeashKnotEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/LeashKnotEntityRenderer.mapping
@@ -1,3 +1,3 @@
 CLASS net/minecraft/class_920 net/minecraft/client/render/entity/LeashKnotEntityRenderer
-	FIELD field_4734 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4734 TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_4735 model Lnet/minecraft/class_579;

--- a/mappings/net/minecraft/client/render/entity/LlamaSpitEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/LlamaSpitEntityRenderer.mapping
@@ -1,3 +1,3 @@
 CLASS net/minecraft/class_923 net/minecraft/client/render/entity/LlamaSpitEntityRenderer
 	FIELD field_4744 model Lnet/minecraft/class_581;
-	FIELD field_4745 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4745 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/MagmaCubeEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/MagmaCubeEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_917 net/minecraft/client/render/entity/MagmaCubeEntityRenderer
-	FIELD field_4727 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4727 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/MinecartEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/MinecartEntityRenderer.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_925 net/minecraft/client/render/entity/MinecartEntityRenderer
-	FIELD field_4746 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4746 TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_4747 model Lnet/minecraft/class_583;
 	METHOD method_4064 renderBlock (Lnet/minecraft/class_1688;FLnet/minecraft/class_2680;Lnet/minecraft/class_4587;Lnet/minecraft/class_4597;I)V
 		ARG 2 delta

--- a/mappings/net/minecraft/client/render/entity/MooshroomEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/MooshroomEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_926 net/minecraft/client/render/entity/MooshroomEntityRenderer
-	FIELD field_4748 SKIN Ljava/util/Map;
+	FIELD field_4748 TEXTURES Ljava/util/Map;

--- a/mappings/net/minecraft/client/render/entity/OcelotEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/OcelotEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_3683 net/minecraft/client/render/entity/OcelotEntityRenderer
-	FIELD field_16259 SKIN Lnet/minecraft/class_2960;
+	FIELD field_16259 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/PandaEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/PandaEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_931 net/minecraft/client/render/entity/PandaEntityRenderer
-	FIELD field_17595 SKIN_MAP Ljava/util/Map;
+	FIELD field_17595 TEXTURES Ljava/util/Map;

--- a/mappings/net/minecraft/client/render/entity/ParrotEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/ParrotEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_930 net/minecraft/client/render/entity/ParrotEntityRenderer
-	FIELD field_4754 SKINS [Lnet/minecraft/class_2960;
+	FIELD field_4754 TEXTURES [Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/PhantomEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/PhantomEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_933 net/minecraft/client/render/entity/PhantomEntityRenderer
-	FIELD field_4756 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4756 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/PigEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/PigEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_932 net/minecraft/client/render/entity/PigEntityRenderer
-	FIELD field_4755 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4755 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/PillagerEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/PillagerEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_934 net/minecraft/client/render/entity/PillagerEntityRenderer
-	FIELD field_4757 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4757 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/PlayerEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/PlayerEntityRenderer.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_1007 net/minecraft/client/render/entity/PlayerEntityRenderer
+	METHOD <init> (Lnet/minecraft/class_898;Z)V
+		ARG 1 dispatcher
 	METHOD method_23205 renderArm (Lnet/minecraft/class_4587;Lnet/minecraft/class_4597;ILnet/minecraft/class_742;Lnet/minecraft/class_630;Lnet/minecraft/class_630;)V
 		ARG 1 matrices
 		ARG 2 vertexConsumers

--- a/mappings/net/minecraft/client/render/entity/PolarBearEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/PolarBearEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_937 net/minecraft/client/render/entity/PolarBearEntityRenderer
-	FIELD field_4766 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4766 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/PufferfishEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/PufferfishEntityRenderer.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_936 net/minecraft/client/render/entity/PufferfishEntityRenderer
 	FIELD field_4761 smallModel Lnet/minecraft/class_594;
-	FIELD field_4762 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4762 TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_4763 largeModel Lnet/minecraft/class_592;
 	FIELD field_4764 mediumModel Lnet/minecraft/class_595;
 	FIELD field_4765 modelSize I

--- a/mappings/net/minecraft/client/render/entity/RabbitEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/RabbitEntityRenderer.mapping
@@ -1,9 +1,9 @@
 CLASS net/minecraft/class_939 net/minecraft/client/render/entity/RabbitEntityRenderer
-	FIELD field_4768 GOLD_SKIN Lnet/minecraft/class_2960;
-	FIELD field_4769 CAERBANNOG_SKIN Lnet/minecraft/class_2960;
-	FIELD field_4770 BROWN_SKIN Lnet/minecraft/class_2960;
-	FIELD field_4771 TOAST_SKIN Lnet/minecraft/class_2960;
-	FIELD field_4772 WHITE_SPOTTED_SKIN Lnet/minecraft/class_2960;
-	FIELD field_4773 WHITE_SKIN Lnet/minecraft/class_2960;
-	FIELD field_4774 SALT_SKIN Lnet/minecraft/class_2960;
-	FIELD field_4775 BLACK_SKIN Lnet/minecraft/class_2960;
+	FIELD field_4768 GOLD_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_4769 CAERBANNOG_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_4770 BROWN_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_4771 TOAST_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_4772 WHITE_SPOTTED_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_4773 WHITE_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_4774 SALT_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_4775 BLACK_TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/RavagerEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/RavagerEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_911 net/minecraft/client/render/entity/RavagerEntityRenderer
-	FIELD field_4715 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4715 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/SalmonEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/SalmonEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_938 net/minecraft/client/render/entity/SalmonEntityRenderer
-	FIELD field_4767 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4767 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/SheepEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/SheepEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_941 net/minecraft/client/render/entity/SheepEntityRenderer
-	FIELD field_4778 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4778 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/ShulkerBulletEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/ShulkerBulletEntityRenderer.mapping
@@ -1,3 +1,4 @@
 CLASS net/minecraft/class_940 net/minecraft/client/render/entity/ShulkerBulletEntityRenderer
-	FIELD field_4776 SKIN Lnet/minecraft/class_2960;
+	FIELD field_21744 LAYER Lnet/minecraft/class_1921;
+	FIELD field_4776 TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_4777 model Lnet/minecraft/class_603;

--- a/mappings/net/minecraft/client/render/entity/ShulkerEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/ShulkerEntityRenderer.mapping
@@ -1,3 +1,3 @@
 CLASS net/minecraft/class_943 net/minecraft/client/render/entity/ShulkerEntityRenderer
-	FIELD field_4780 TEXTURE_COLOR [Lnet/minecraft/class_2960;
+	FIELD field_4780 COLORED_TEXTURES [Lnet/minecraft/class_2960;
 	FIELD field_4781 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/ShulkerEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/ShulkerEntityRenderer.mapping
@@ -1,3 +1,3 @@
 CLASS net/minecraft/class_943 net/minecraft/client/render/entity/ShulkerEntityRenderer
-	FIELD field_4780 SKIN_COLOR [Lnet/minecraft/class_2960;
-	FIELD field_4781 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4780 TEXTURE_COLOR [Lnet/minecraft/class_2960;
+	FIELD field_4781 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/SilverfishEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/SilverfishEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_942 net/minecraft/client/render/entity/SilverfishEntityRenderer
-	FIELD field_4779 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4779 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/SkeletonEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/SkeletonEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_946 net/minecraft/client/render/entity/SkeletonEntityRenderer
-	FIELD field_4785 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4785 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/SlimeEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/SlimeEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_945 net/minecraft/client/render/entity/SlimeEntityRenderer
-	FIELD field_4784 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4784 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/SnowGolemEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/SnowGolemEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_948 net/minecraft/client/render/entity/SnowGolemEntityRenderer
-	FIELD field_4788 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4788 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/SpectralArrowEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/SpectralArrowEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_947 net/minecraft/client/render/entity/SpectralArrowEntityRenderer
-	FIELD field_4787 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4787 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/SpiderEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/SpiderEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_949 net/minecraft/client/render/entity/SpiderEntityRenderer
-	FIELD field_4789 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4789 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/SquidEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/SquidEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_951 net/minecraft/client/render/entity/SquidEntityRenderer
-	FIELD field_4791 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4791 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/StrayEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/StrayEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_950 net/minecraft/client/render/entity/StrayEntityRenderer
-	FIELD field_4790 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4790 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/TridentEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/TridentEntityRenderer.mapping
@@ -1,3 +1,3 @@
 CLASS net/minecraft/class_955 net/minecraft/client/render/entity/TridentEntityRenderer
-	FIELD field_4796 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4796 TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_4797 model Lnet/minecraft/class_613;

--- a/mappings/net/minecraft/client/render/entity/TurtleEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/TurtleEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_958 net/minecraft/client/render/entity/TurtleEntityRenderer
-	FIELD field_4798 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4798 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/VillagerEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/VillagerEntityRenderer.mapping
@@ -1,2 +1,4 @@
 CLASS net/minecraft/class_963 net/minecraft/client/render/entity/VillagerEntityRenderer
-	FIELD field_4807 VILLAGER_SKIN Lnet/minecraft/class_2960;
+	FIELD field_4807 TEXTURE Lnet/minecraft/class_2960;
+	METHOD <init> (Lnet/minecraft/class_898;Lnet/minecraft/class_3296;)V
+		ARG 1 dispatcher

--- a/mappings/net/minecraft/client/render/entity/VindicatorEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/VindicatorEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_962 net/minecraft/client/render/entity/VindicatorEntityRenderer
-	FIELD field_4804 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4804 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/WitchEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/WitchEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_965 net/minecraft/client/render/entity/WitchEntityRenderer
-	FIELD field_4814 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4814 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/WitherEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/WitherEntityRenderer.mapping
@@ -1,3 +1,3 @@
 CLASS net/minecraft/class_964 net/minecraft/client/render/entity/WitherEntityRenderer
-	FIELD field_4812 INVINCIBLE_SKIN Lnet/minecraft/class_2960;
-	FIELD field_4813 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4812 INVINCIBLE_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_4813 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/WitherEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/WitherEntityRenderer.mapping
@@ -1,3 +1,3 @@
 CLASS net/minecraft/class_964 net/minecraft/client/render/entity/WitherEntityRenderer
-	FIELD field_4812 INVINCIBLE_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_4812 INVULNERABLE_TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_4813 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/WitherSkeletonEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/WitherSkeletonEntityRenderer.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_967 net/minecraft/client/render/entity/WitherSkeletonEntityRenderer
-	FIELD field_4818 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4818 TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/WitherSkullEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/WitherSkullEntityRenderer.mapping
@@ -1,4 +1,4 @@
 CLASS net/minecraft/class_966 net/minecraft/client/render/entity/WitherSkullEntityRenderer
-	FIELD field_4815 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4815 TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_4816 model Lnet/minecraft/class_607;
-	FIELD field_4817 INVINCIBLE_SKIN Lnet/minecraft/class_2960;
+	FIELD field_4817 INVINCIBLE_TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/WitherSkullEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/WitherSkullEntityRenderer.mapping
@@ -1,4 +1,4 @@
 CLASS net/minecraft/class_966 net/minecraft/client/render/entity/WitherSkullEntityRenderer
 	FIELD field_4815 TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_4816 model Lnet/minecraft/class_607;
-	FIELD field_4817 INVINCIBLE_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_4817 INVULNERABLE_TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/WolfEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/WolfEntityRenderer.mapping
@@ -1,4 +1,4 @@
 CLASS net/minecraft/class_969 net/minecraft/client/render/entity/WolfEntityRenderer
-	FIELD field_4821 WILD_SKIN Lnet/minecraft/class_2960;
-	FIELD field_4822 TAMED_SKIN Lnet/minecraft/class_2960;
-	FIELD field_4823 ANGRY_SKIN Lnet/minecraft/class_2960;
+	FIELD field_4821 WILD_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_4822 TAMED_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_4823 ANGRY_TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/ZombieBaseEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/ZombieBaseEntityRenderer.mapping
@@ -1,2 +1,4 @@
 CLASS net/minecraft/class_968 net/minecraft/client/render/entity/ZombieBaseEntityRenderer
-	FIELD field_4819 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4819 TEXTURE Lnet/minecraft/class_2960;
+	METHOD <init> (Lnet/minecraft/class_898;Lnet/minecraft/class_623;Lnet/minecraft/class_623;Lnet/minecraft/class_623;)V
+		ARG 1 dispatcher

--- a/mappings/net/minecraft/client/render/entity/ZombieVillagerEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/ZombieVillagerEntityRenderer.mapping
@@ -1,2 +1,4 @@
 CLASS net/minecraft/class_971 net/minecraft/client/render/entity/ZombieVillagerEntityRenderer
-	FIELD field_4835 SKIN Lnet/minecraft/class_2960;
+	FIELD field_4835 TEXTURE Lnet/minecraft/class_2960;
+	METHOD <init> (Lnet/minecraft/class_898;Lnet/minecraft/class_3296;)V
+		ARG 1 dispatcher

--- a/mappings/net/minecraft/client/render/entity/model/DragonHeadEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/DragonHeadEntityModel.mapping
@@ -1,3 +1,5 @@
 CLASS net/minecraft/class_626 net/minecraft/client/render/entity/model/DragonHeadEntityModel
 	FIELD field_3638 head Lnet/minecraft/class_630;
 	FIELD field_3639 jaw Lnet/minecraft/class_630;
+	METHOD <init> (F)V
+		ARG 1 scale

--- a/mappings/net/minecraft/client/render/entity/model/GiantEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/GiantEntityModel.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_3969 net/minecraft/client/render/entity/model/GiantEntityModel
+	METHOD <init> (FZ)V
+		ARG 1 scale

--- a/mappings/net/minecraft/client/render/entity/model/HorseEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/HorseEntityModel.mapping
@@ -6,3 +6,5 @@ CLASS net/minecraft/class_549 net/minecraft/client/render/entity/model/HorseEnti
 	FIELD field_3306 leftBackLeg Lnet/minecraft/class_630;
 	FIELD field_3307 head Lnet/minecraft/class_630;
 	FIELD field_3308 rightFrontLeg Lnet/minecraft/class_630;
+	METHOD <init> (F)V
+		ARG 1 scale

--- a/mappings/net/minecraft/client/render/entity/model/IllagerEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/IllagerEntityModel.mapping
@@ -7,3 +7,8 @@ CLASS net/minecraft/class_575 net/minecraft/client/render/entity/model/IllagerEn
 	FIELD field_3423 arms Lnet/minecraft/class_630;
 	FIELD field_3425 torso Lnet/minecraft/class_630;
 	FIELD field_3426 rightAttackingArm Lnet/minecraft/class_630;
+	METHOD <init> (FFII)V
+		ARG 1 scale
+		ARG 2 pivotY
+		ARG 3 textureWidth
+		ARG 4 textureHeight

--- a/mappings/net/minecraft/client/render/entity/model/LargeTropicalFishEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/LargeTropicalFishEntityModel.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_615 net/minecraft/client/render/entity/model/LargeTropicalFishEntityModel
+	METHOD <init> (F)V
+		ARG 1 scale

--- a/mappings/net/minecraft/client/render/entity/model/LeashKnotEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/LeashKnotEntityModel.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_579 net/minecraft/client/render/entity/model/LeashKnotEntityModel
+	FIELD field_3431 leashKnot Lnet/minecraft/class_630;

--- a/mappings/net/minecraft/client/render/entity/model/LlamaEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/LlamaEntityModel.mapping
@@ -7,3 +7,5 @@ CLASS net/minecraft/class_578 net/minecraft/client/render/entity/model/LlamaEnti
 	FIELD field_20940 leftFrontLeg Lnet/minecraft/class_630;
 	FIELD field_3429 leftChest Lnet/minecraft/class_630;
 	FIELD field_3430 rightChest Lnet/minecraft/class_630;
+	METHOD <init> (F)V
+		ARG 1 scale

--- a/mappings/net/minecraft/client/render/entity/model/LlamaSpitEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/LlamaSpitEntityModel.mapping
@@ -1,1 +1,4 @@
 CLASS net/minecraft/class_581 net/minecraft/client/render/entity/model/LlamaSpitEntityModel
+	FIELD field_3433 spit Lnet/minecraft/class_630;
+	METHOD <init> (F)V
+		ARG 1 scale

--- a/mappings/net/minecraft/client/render/entity/model/PandaEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/PandaEntityModel.mapping
@@ -2,3 +2,6 @@ CLASS net/minecraft/class_586 net/minecraft/client/render/entity/model/PandaEnti
 	FIELD field_3468 playAnimationProgress F
 	FIELD field_3469 lieOnBackAnimationProgress F
 	FIELD field_3470 scaredAnimationProgress F
+	METHOD <init> (IF)V
+		ARG 1 legHeight
+		ARG 2 scale

--- a/mappings/net/minecraft/client/render/entity/model/PigEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/PigEntityModel.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_587 net/minecraft/client/render/entity/model/PigEntityModel
+	METHOD <init> (F)V
+		ARG 1 scale

--- a/mappings/net/minecraft/client/render/entity/model/ShulkerBulletEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/ShulkerBulletEntityModel.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_603 net/minecraft/client/render/entity/model/ShulkerBulletEntityModel
+	FIELD field_3556 bullet Lnet/minecraft/class_630;

--- a/mappings/net/minecraft/client/render/entity/model/SkullOverlayEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SkullOverlayEntityModel.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_569 net/minecraft/client/render/entity/model/SkullOverlayEntityModel
+	FIELD field_3377 skullOverlay Lnet/minecraft/class_630;

--- a/mappings/net/minecraft/client/render/entity/model/SlimeEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SlimeEntityModel.mapping
@@ -3,3 +3,5 @@ CLASS net/minecraft/class_609 net/minecraft/client/render/entity/model/SlimeEnti
 	FIELD field_3571 innerCube Lnet/minecraft/class_630;
 	FIELD field_3572 leftEye Lnet/minecraft/class_630;
 	FIELD field_3573 rightEye Lnet/minecraft/class_630;
+	METHOD <init> (I)V
+		ARG 1 size

--- a/mappings/net/minecraft/client/render/entity/model/SmallTropicalFishEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SmallTropicalFishEntityModel.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_612 net/minecraft/client/render/entity/model/SmallTropicalFishEntityModel
+	METHOD <init> (F)V
+		ARG 1 scale

--- a/mappings/net/minecraft/client/render/entity/model/TurtleEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/TurtleEntityModel.mapping
@@ -1,1 +1,4 @@
 CLASS net/minecraft/class_614 net/minecraft/client/render/entity/model/TurtleEntityModel
+	FIELD field_3594 tail Lnet/minecraft/class_630;
+	METHOD <init> (F)V
+		ARG 1 scale

--- a/mappings/net/minecraft/client/render/entity/model/WitherEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/WitherEntityModel.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_621 net/minecraft/client/render/entity/model/WitherEntityModel
+	METHOD <init> (F)V
+		ARG 1 scale

--- a/mappings/net/minecraft/client/render/entity/model/ZombieEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/ZombieEntityModel.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_623 net/minecraft/client/render/entity/model/ZombieEntityModel
+	METHOD <init> (FZ)V
+		ARG 1 scale

--- a/mappings/net/minecraft/client/render/entity/model/ZombieVillagerEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/ZombieVillagerEntityModel.mapping
@@ -1,2 +1,4 @@
 CLASS net/minecraft/class_619 net/minecraft/client/render/entity/model/ZombieVillagerEntityModel
 	FIELD field_17144 hat Lnet/minecraft/class_630;
+	METHOD <init> (FZ)V
+		ARG 1 scale


### PR DESCRIPTION
- Changed all `SKIN` occurences to `TEXTURE`, as it just makes more sense. This change closes #821 
- Named all parameters of type EntityRendererDispatcher to `dispatcher`, for consistency
- Named all parameters of type ItemRenderer to `itemRenderer`, for consistency
- Renamed `EvokerIllagerEntityRenderer` to `EvokerEntityRenderer`, as the entity is just called "evoker", not "evoker illager"
- Also mapped some fields and constructor parameters in entity model classes