### PR TITLE
Fix client/server being swapped in InventoryS2CPacket's docs

### DIFF
--- a/mappings/net/minecraft/network/packet/s2c/play/InventoryS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/InventoryS2CPacket.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_2649 net/minecraft/network/packet/s2c/play/InventoryS2CPacket
 	COMMENT Represents the contents of a block or entity inventory being synchronized
-	COMMENT from the client to the server.
+	COMMENT from the server to the client.
 	FIELD field_12146 syncId I
 		COMMENT The {@link net.minecraft.screen.ScreenHandler#syncId} of a screen handler.
 	FIELD field_12147 contents Ljava/util/List;


### PR DESCRIPTION
I made a little mistake in #1194 :tiny_potato: