### PR TITLE
Map class 4966 and associated chunk generator stuff

### DIFF
--- a/mappings/net/minecraft/world/gen/chunk/ChunkGenerator.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/ChunkGenerator.mapping
@@ -11,6 +11,8 @@ CLASS net/minecraft/class_2794 net/minecraft/world/gen/chunk/ChunkGenerator
 		ARG 1 world
 		ARG 2 chunk
 	METHOD method_12097 hasStructure (Lnet/minecraft/class_1959;Lnet/minecraft/class_3195;)Z
+		ARG 1 biome
+		ARG 2 feature
 	METHOD method_12098 getBiomeSource ()Lnet/minecraft/class_1966;
 	METHOD method_12099 spawnEntities (Lnet/minecraft/class_3218;ZZ)V
 		ARG 1 world
@@ -35,6 +37,8 @@ CLASS net/minecraft/class_2794 net/minecraft/world/gen/chunk/ChunkGenerator
 	METHOD method_12108 carve (Lnet/minecraft/class_4543;Lnet/minecraft/class_2791;Lnet/minecraft/class_2893$class_2894;)V
 	METHOD method_12109 getConfig ()Lnet/minecraft/class_2888;
 	METHOD method_12110 buildSurface (Lnet/minecraft/class_3233;Lnet/minecraft/class_2791;)V
+		ARG 1 region
+		ARG 2 chunk
 	METHOD method_12113 getEntitySpawnList (Lnet/minecraft/class_1311;Lnet/minecraft/class_2338;)Ljava/util/List;
 		ARG 1 category
 		ARG 2 pos
@@ -42,7 +46,7 @@ CLASS net/minecraft/class_2794 net/minecraft/world/gen/chunk/ChunkGenerator
 	METHOD method_16130 addStructureReferences (Lnet/minecraft/class_1936;Lnet/minecraft/class_2791;)V
 		ARG 1 world
 		ARG 2 chunk
-	METHOD method_16397 getHeightOnGround (IILnet/minecraft/class_2902$class_2903;)I
+	METHOD method_16397 getHeight (IILnet/minecraft/class_2902$class_2903;)I
 		ARG 1 x
 		ARG 2 z
 		ARG 3 heightmapType
@@ -50,3 +54,13 @@ CLASS net/minecraft/class_2794 net/minecraft/world/gen/chunk/ChunkGenerator
 	METHOD method_16554 getDecorationBiome (Lnet/minecraft/class_4543;Lnet/minecraft/class_2338;)Lnet/minecraft/class_1959;
 		ARG 2 pos
 	METHOD method_18028 getHeightInGround (IILnet/minecraft/class_2902$class_2903;)I
+		ARG 1 x
+		ARG 2 z
+		ARG 3 heightmapType
+	METHOD method_20402 getHeightOnGround (IILnet/minecraft/class_2902$class_2903;)I
+		ARG 1 x
+		ARG 2 z
+		ARG 3 heightmapType
+	METHOD method_26261 getColumnSample (II)Lnet/minecraft/class_1922;
+		ARG 1 x
+		ARG 2 z

--- a/mappings/net/minecraft/world/gen/chunk/VerticalBlockSample.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/VerticalBlockSample.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_4966 net/minecraft/world/gen/chunk/VerticalBlockSample
+	FIELD field_23143 states [Lnet/minecraft/class_2680;
+	METHOD <init> ([Lnet/minecraft/class_2680;)V
+		ARG 1 states


### PR DESCRIPTION
Signed-off-by: liach <liach@users.noreply.github.com>

This renames `method_16397` to `getHeight` from `getHeightOnGround` and another method `method_20402` to `getHeightOnGround`. 20402 just calls 16397 and is used by structure generator (outside users). 16397 is only used by 20402 and 18028 `getHeightInGround` and is overridden by subclasses (though it's public), so I assume `16397` is intended for impl overrides and `20402` and `18028` are intended for users