### PR TITLE
Clarify Minecart sounds, fixes #918

### DIFF
--- a/mappings/net/minecraft/client/sound/MinecartInsideSoundInstance.mapping
+++ b/mappings/net/minecraft/client/sound/MinecartInsideSoundInstance.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_1107 net/minecraft/client/sound/MinecartInsideSoundInstance
-	COMMENT A sound instance played when a player is riding a Minecart.
+	COMMENT A sound instance played when a player is riding a minecart.
 	FIELD field_5456 minecart Lnet/minecraft/class_1688;
 	FIELD field_5457 player Lnet/minecraft/class_1657;
 	METHOD <init> (Lnet/minecraft/class_1657;Lnet/minecraft/class_1688;)V

--- a/mappings/net/minecraft/client/sound/MinecartInsideSoundInstance.mapping
+++ b/mappings/net/minecraft/client/sound/MinecartInsideSoundInstance.mapping
@@ -1,4 +1,5 @@
-CLASS net/minecraft/class_1107 net/minecraft/client/sound/MinecartSoundInstance
+CLASS net/minecraft/class_1107 net/minecraft/client/sound/MinecartInsideSoundInstance
+	COMMENT A sound instance played when a player is riding a Minecart.
 	FIELD field_5456 minecart Lnet/minecraft/class_1688;
 	FIELD field_5457 player Lnet/minecraft/class_1657;
 	METHOD <init> (Lnet/minecraft/class_1657;Lnet/minecraft/class_1688;)V

--- a/mappings/net/minecraft/client/sound/MovingMinecartSoundInstance.mapping
+++ b/mappings/net/minecraft/client/sound/MovingMinecartSoundInstance.mapping
@@ -1,0 +1,6 @@
+CLASS net/minecraft/class_1108 net/minecraft/client/sound/MovingMinecartSoundInstance
+	COMMENT A sound instance played when a minecart is moving.
+	FIELD field_5458 minecart Lnet/minecraft/class_1688;
+	FIELD field_5459 distance F
+	METHOD <init> (Lnet/minecraft/class_1688;)V
+		ARG 1 minecart

--- a/mappings/net/minecraft/client/sound/RidingMinecartSoundInstance.mapping
+++ b/mappings/net/minecraft/client/sound/RidingMinecartSoundInstance.mapping
@@ -1,5 +1,0 @@
-CLASS net/minecraft/class_1108 net/minecraft/client/sound/RidingMinecartSoundInstance
-	FIELD field_5458 minecart Lnet/minecraft/class_1688;
-	FIELD field_5459 distance F
-	METHOD <init> (Lnet/minecraft/class_1688;)V
-		ARG 1 minecart

--- a/mappings/net/minecraft/client/sound/SoundInstance.mapping
+++ b/mappings/net/minecraft/client/sound/SoundInstance.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_1113 net/minecraft/client/sound/SoundInstance
+	METHOD method_26273 canPlay ()Z
 	METHOD method_4774 getCategory ()Lnet/minecraft/class_3419;
 	METHOD method_4775 getId ()Lnet/minecraft/class_2960;
 	METHOD method_4776 getSound ()Lnet/minecraft/class_1111;


### PR DESCRIPTION
Closes #918

The sound event `entity.minecart.riding` used by `class_1108` is the sound of minecart moving, created when a minecart is spawned on client.
the sound event `entity.minecart.inside` used by `class_1107` is the sound when player is inside minecart, created when the controlled client player starts riding a minecart.

Renamed the classes based on their actual usage than their sound event names.