### PR TITLE
EntityContext -> ShapeContext, EntityContextImpl -> EntityShapeContext

### DIFF
--- a/mappings/net/minecraft/block/EntityShapeContext.mapping
+++ b/mappings/net/minecraft/block/EntityShapeContext.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3727 net/minecraft/entity/EntityContextImpl
+CLASS net/minecraft/class_3727 net/minecraft/block/EntityShapeContext
 	FIELD field_16450 minY D
 	FIELD field_16451 descending Z
 	FIELD field_17593 ABSENT Lnet/minecraft/class_3726;

--- a/mappings/net/minecraft/block/ShapeContext.mapping
+++ b/mappings/net/minecraft/block/ShapeContext.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3726 net/minecraft/entity/EntityContext
+CLASS net/minecraft/class_3726 net/minecraft/block/ShapeContext
 	METHOD method_16192 isAbove (Lnet/minecraft/class_265;Lnet/minecraft/class_2338;Z)Z
 		ARG 1 shape
 		ARG 2 pos


### PR DESCRIPTION
Fixes #908.

This context is exclusively used by block's 3 shape checking methods.
For its usage outside of blocks, it is used to be eventually passed to call one of the shape checking methods (as in CollisionView#canPlace or RayTraceContext)

Signed-off-by: liach <liach@users.noreply.github.com>