### PR TITLE
Move direction transformation and matrix3f to util math (need same package)

### DIFF
--- a/mappings/net/minecraft/util/BlockMirror.mapping
+++ b/mappings/net/minecraft/util/BlockMirror.mapping
@@ -1,6 +1,12 @@
 CLASS net/minecraft/class_2415 net/minecraft/util/BlockMirror
+	FIELD field_23263 directionTransformation Lnet/minecraft/class_4990;
+	METHOD <init> (Ljava/lang/String;ILnet/minecraft/class_4990;)V
+		ARG 3 directionTransformation
 	METHOD method_10343 apply (Lnet/minecraft/class_2350;)Lnet/minecraft/class_2350;
+		ARG 1 direction
 	METHOD method_10344 mirror (II)I
 		ARG 1 rotation
 		ARG 2 fullTurn
 	METHOD method_10345 getRotation (Lnet/minecraft/class_2350;)Lnet/minecraft/class_2470;
+		ARG 1 direction
+	METHOD method_26380 getDirectionTransformation ()Lnet/minecraft/class_4990;

--- a/mappings/net/minecraft/util/BlockRotation.mapping
+++ b/mappings/net/minecraft/util/BlockRotation.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/class_2470 net/minecraft/util/BlockRotation
+	FIELD field_23264 directionTransformation Lnet/minecraft/class_4990;
+	METHOD <init> (Ljava/lang/String;ILnet/minecraft/class_4990;)V
+		ARG 3 directionTransformation
 	METHOD method_10501 rotate (Lnet/minecraft/class_2470;)Lnet/minecraft/class_2470;
 		ARG 1 rotation
 	METHOD method_10502 rotate (II)I
@@ -10,3 +13,4 @@ CLASS net/minecraft/class_2470 net/minecraft/util/BlockRotation
 		ARG 0 random
 	METHOD method_16548 random (Ljava/util/Random;)Lnet/minecraft/class_2470;
 		ARG 0 random
+	METHOD method_26383 getDirectionTransformation ()Lnet/minecraft/class_4990;

--- a/mappings/net/minecraft/util/Language.mapping
+++ b/mappings/net/minecraft/util/Language.mapping
@@ -2,11 +2,15 @@ CLASS net/minecraft/class_2477 net/minecraft/util/Language
 	FIELD field_11486 INSTANCE Lnet/minecraft/class_2477;
 	FIELD field_11487 translations Ljava/util/Map;
 	FIELD field_11488 timeLoaded J
+	FIELD field_11489 TOKEN_PATTERN Ljava/util/regex/Pattern;
 	FIELD field_11490 LOGGER Lorg/apache/logging/log4j/Logger;
 	METHOD method_10515 load (Ljava/util/Map;)V
 		ARG 0 map
 	METHOD method_10516 hasTranslation (Ljava/lang/String;)Z
+		ARG 1 key
 	METHOD method_10517 getInstance ()Lnet/minecraft/class_2477;
 	METHOD method_10518 getTranslation (Ljava/lang/String;)Ljava/lang/String;
+		ARG 1 key
 	METHOD method_10519 getTimeLoaded ()J
 	METHOD method_10520 translate (Ljava/lang/String;)Ljava/lang/String;
+		ARG 1 key

--- a/mappings/net/minecraft/util/dynamic/GlobalPos.mapping
+++ b/mappings/net/minecraft/util/dynamic/GlobalPos.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4208 net/minecraft/util/GlobalPos
+CLASS net/minecraft/class_4208 net/minecraft/util/dynamic/GlobalPos
 	FIELD field_18790 dimension Lnet/minecraft/class_2874;
 	FIELD field_18791 pos Lnet/minecraft/class_2338;
 	METHOD equals (Ljava/lang/Object;)Z

--- a/mappings/net/minecraft/util/math/AxisTransformation.mapping
+++ b/mappings/net/minecraft/util/math/AxisTransformation.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4998 net/minecraft/util/AxisTransformation
+CLASS net/minecraft/class_4998 net/minecraft/util/math/AxisTransformation
 	FIELD field_23368 mappings [I
 	FIELD field_23369 matrix Lnet/minecraft/class_4581;
 	FIELD field_23370 COMBINATIONS [[Lnet/minecraft/class_4998;

--- a/mappings/net/minecraft/util/math/DirectionTransformation.mapping
+++ b/mappings/net/minecraft/util/math/DirectionTransformation.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4990 net/minecraft/util/DirectionTransformation
+CLASS net/minecraft/class_4990 net/minecraft/util/math/DirectionTransformation
 	FIELD field_23288 matrix Lnet/minecraft/class_4581;
 	FIELD field_23289 name Ljava/lang/String;
 	FIELD field_23290 mappings Ljava/util/Map;

--- a/mappings/net/minecraft/util/math/Matrix3f.mapping
+++ b/mappings/net/minecraft/util/math/Matrix3f.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4581 net/minecraft/client/util/math/Matrix3f
+CLASS net/minecraft/class_4581 net/minecraft/util/math/Matrix3f
 	FIELD field_20860 THREE_PLUS_TWO_SQRT_TWO F
 	FIELD field_20861 COS_PI_OVER_EIGHT F
 	FIELD field_20862 SIN_PI_OVER_EIGHT F

--- a/mappings/net/minecraft/util/math/Matrix4f.mapping
+++ b/mappings/net/minecraft/util/math/Matrix4f.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_1159 net/minecraft/client/util/math/Matrix4f
+CLASS net/minecraft/class_1159 net/minecraft/util/math/Matrix4f
 	FIELD field_21652 a00 F
 	FIELD field_21653 a01 F
 	FIELD field_21654 a02 F

--- a/mappings/net/minecraft/world/ChunkPosDistanceLevelPropagator.mapping
+++ b/mappings/net/minecraft/world/ChunkPosDistanceLevelPropagator.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3196 net/minecraft/util/ChunkPosDistanceLevelPropagator
+CLASS net/minecraft/class_3196 net/minecraft/world/ChunkPosDistanceLevelPropagator
 	METHOD method_14027 updateLevel (JIZ)V
 		ARG 1 chunkPos
 		ARG 3 distance


### PR DESCRIPTION
![image](https://cdn.discordapp.com/attachments/521545796882006027/692983432099135519/unknown.png)

move two matrices to non-client (as they are no longer client exclusive, see #978);
move two transformations to util math;
move globalpos to dynamic;
move propagator to world, fixes #947;
a few other util additions

Signed-off-by: liach <liach@users.noreply.github.com>