### PR TITLE
Fix 2 incorrect names

### DIFF
--- a/mappings/net/minecraft/advancement/criterion/Criteria.mapping
+++ b/mappings/net/minecraft/advancement/criterion/Criteria.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_174 net/minecraft/advancement/criterion/Criterions
+CLASS net/minecraft/class_174 net/minecraft/advancement/criterion/Criteria
 	FIELD field_1180 ENTER_BLOCK Lnet/minecraft/class_2037;
 	FIELD field_1181 ENCHANTED_ITEM Lnet/minecraft/class_2030;
 	FIELD field_1182 SUMMONED_ENTITY Lnet/minecraft/class_2128;

--- a/mappings/net/minecraft/client/sound/SoundInstanceListener.mapping
+++ b/mappings/net/minecraft/client/sound/SoundInstanceListener.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_1145 net/minecraft/client/sound/ListenerSoundInstance
+CLASS net/minecraft/class_1145 net/minecraft/client/sound/SoundInstanceListener
 	METHOD method_4884 onSoundPlayed (Lnet/minecraft/class_1113;Lnet/minecraft/class_1146;)V
 		ARG 1 sound
 		ARG 2 soundSet


### PR DESCRIPTION
This fixes `ListenerSoundInstance` -> `SoundInstanceListener` due to the fact this is a listener, not a listener sound.

`Criterions` is incorrect, should be `Criteria`