### PR TITLE
Use serialized names for Biome.MixedNoisePoint fields

### DIFF
--- a/mappings/net/minecraft/world/biome/Biome.mapping
+++ b/mappings/net/minecraft/world/biome/Biome.mapping
@@ -172,20 +172,20 @@ CLASS net/minecraft/class_1959 net/minecraft/world/biome/Biome
 		COMMENT to other point values.
 		FIELD field_22043 temperature F
 		FIELD field_22044 humidity F
-		FIELD field_22045 hilliness F
-		FIELD field_22046 style F
-		FIELD field_22047 rarityPotential F
+		FIELD field_22045 altitude F
+		FIELD field_22046 weirdness F
+		FIELD field_22047 weight F
 			COMMENT This value awards another point with value farthest from this one; i.e.
 			COMMENT unlike other points where closer distance is better, for this value the
 			COMMENT farther the better. The result of the different values can be
 			COMMENT approximately modeled by a hyperbola weight=cosh(peak-1) as used by the
 			COMMENT mixed-noise generator.
 		METHOD <init> (FFFFF)V
-			ARG 1 heat
+			ARG 1 temperature
 			ARG 2 humidity
-			ARG 3 hilliness
-			ARG 4 style
-			ARG 5 rarityPotential
+			ARG 3 altitude
+			ARG 4 weirdness
+			ARG 5 weight
 		METHOD method_24381 calculateDistanceTo (Lnet/minecraft/class_1959$class_4762;)F
 			COMMENT Calculates the distance from this noise point to another one. The
 			COMMENT distance is a squared distance in a multi-dimensional cartesian plane
@@ -201,3 +201,5 @@ CLASS net/minecraft/class_1959 net/minecraft/world/biome/Biome
 			COMMENT biome that offers a closest point to its arbitrary point.
 			ARG 1 other
 				COMMENT the other noise point
+		METHOD method_26457 serialize (Lcom/mojang/datafixers/types/DynamicOps;)Lcom/mojang/datafixers/Dynamic;
+			ARG 1 ops


### PR DESCRIPTION
A `serialize` method was added in 20w14∞, and we should use the names in it to match serialization output.

Serialized name | Current Yarn name
----------------|--------------------
`temperature`   | `temperature`
`humidity`        | `humidity`
`altitude`          | `hilliness`
`weight`           | `rarityPotential`
`weirdness`      | `style`