### PR TITLE
BlockWithEntity -> AbstractEntityBlock

### DIFF
--- a/mappings/net/minecraft/block/AbstractEntityBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractEntityBlock.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_2237 net/minecraft/block/AbstractEntityBlock
+	COMMENT This class is *not* necessary for BlockEntities; all you need is {@link BlockEntityProvider}.
+	COMMENT
+	COMMENT In fact, extending this class will have potentially unwanted side effects such as setting
+	COMMENT the render type to INVISIBLE, rather than the default of MODEL.

--- a/mappings/net/minecraft/block/AbstractEntityBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractEntityBlock.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_2237 net/minecraft/block/AbstractEntityBlock
-	COMMENT This class is *not* necessary for BlockEntities; all you need is {@link BlockEntityProvider}.
+	COMMENT This class is <b>not</b> necessary for BlockEntities; all you need is {@link BlockEntityProvider}.
 	COMMENT
 	COMMENT In fact, extending this class will have potentially unwanted side effects such as setting
 	COMMENT the render type to INVISIBLE, rather than the default of MODEL.

--- a/mappings/net/minecraft/block/BlockWithEntity.mapping
+++ b/mappings/net/minecraft/block/BlockWithEntity.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_2237 net/minecraft/block/BlockWithEntity


### PR DESCRIPTION
BlockWithEntity is a bit of an odd name because it doesn't follow the usual pattern for class names. Plus, it includes a javadoc clarifying that this isn't necessarily the class that a modder may want to use, even though it seems like it is at first.