### PR TITLE
Effectiveness 2

### DIFF
--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -156,8 +156,14 @@ CLASS net/minecraft/class_1657 net/minecraft/entity/player/PlayerEntity
 		ARG 1 structureBlock
 	METHOD method_7304 addEnchantedHitParticles (Lnet/minecraft/class_1297;)V
 		ARG 1 target
-	METHOD method_7305 isUsingEffectiveTool (Lnet/minecraft/class_2680;)Z
-		ARG 1 block
+	METHOD method_7305 canHarvest (Lnet/minecraft/class_2680;)Z
+		COMMENT Determines whether the player is able to harvest drops from the specified block state.
+		COMMENT If a block requires a special tool, it will check
+		COMMENT whether the held item is effective for that block, otherwise
+		COMMENT it returns {@code true}.
+		COMMENT
+		COMMENT @see Item#isEfficientOn
+		ARG 1 state
 	METHOD method_7308 getShoulderEntityRight ()Lnet/minecraft/class_2487;
 	METHOD method_7310 getOfflinePlayerUuid (Ljava/lang/String;)Ljava/util/UUID;
 		ARG 0 nickname

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -162,7 +162,7 @@ CLASS net/minecraft/class_1657 net/minecraft/entity/player/PlayerEntity
 		COMMENT whether the held item is effective for that block, otherwise
 		COMMENT it returns {@code true}.
 		COMMENT
-		COMMENT @see Item#isEfficientOn
+		COMMENT @see Item#isSuitableFor
 		ARG 1 state
 	METHOD method_7308 getShoulderEntityRight ()Lnet/minecraft/class_2487;
 	METHOD method_7310 getOfflinePlayerUuid (Ljava/lang/String;)Ljava/util/UUID;

--- a/mappings/net/minecraft/entity/player/PlayerInventory.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerInventory.mapping
@@ -24,6 +24,8 @@ CLASS net/minecraft/class_1661 net/minecraft/entity/player/PlayerInventory
 	METHOD method_7368 getHotbarSize ()I
 	METHOD method_7370 getBlockBreakingSpeed (Lnet/minecraft/class_2680;)F
 		ARG 1 block
+	METHOD method_7371 indexOf (Lnet/minecraft/class_1799;)I
+		ARG 1 stack
 	METHOD method_7372 getArmorStack (I)Lnet/minecraft/class_1799;
 		ARG 1 slot
 	METHOD method_7373 scrollInHotbar (D)V

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -96,8 +96,6 @@ CLASS net/minecraft/class_1792 net/minecraft/item/Item
 	METHOD method_7853 getUseAction (Lnet/minecraft/class_1799;)Lnet/minecraft/class_1839;
 		ARG 1 stack
 	METHOD method_7854 getDefaultStack ()Lnet/minecraft/class_1799;
-	METHOD method_7855 isIn (Lnet/minecraft/class_3494;)Z
-		ARG 1 tag
 	METHOD method_7856 isSuitableFor (Lnet/minecraft/class_2680;)Z
 		COMMENT Determines whether this item can be used as a suitable tool for mining the specified block.
 		COMMENT Depending on block implementation, when combined together, the correct item and block may achieve a better mining speed and yield

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -101,7 +101,7 @@ CLASS net/minecraft/class_1792 net/minecraft/item/Item
 	METHOD method_7856 isSuitableFor (Lnet/minecraft/class_2680;)Z
 		COMMENT <p>
 		COMMENT Determines whether this item can be used as a suitable tool for mining the specified block.
-		COMMENT Dependent on block implementation, when combined together, the correct item and block may achieve better mining speed and yield
+		COMMENT Depending on block implementation, when combined together, the correct item and block may achieve a better mining speed and yield
 		COMMENT drops that would otherwise not be obtained when mining otherwise.
 		COMMENT </p>
 		COMMENT <p>

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -99,16 +99,15 @@ CLASS net/minecraft/class_1792 net/minecraft/item/Item
 	METHOD method_7855 isIn (Lnet/minecraft/class_3494;)Z
 		ARG 1 tag
 	METHOD method_7856 isSuitableFor (Lnet/minecraft/class_2680;)Z
-		COMMENT <p>
 		COMMENT Determines whether this item can be used as a suitable tool for mining the specified block.
 		COMMENT Depending on block implementation, when combined together, the correct item and block may achieve a better mining speed and yield
-		COMMENT drops that would otherwise not be obtained when mining otherwise.
-		COMMENT </p>
+		COMMENT drops that would not be obtained when mining otherwise.
 		COMMENT <p>
 		COMMENT Note that this is not the <b>only</b> way to achieve "effectiveness" when mining.
 		COMMENT Other items, such as shears on string, may use their own logic
 		COMMENT and calls to this method might not return a value consistent to this rule for those items.
 		COMMENT </p>
+		ARG 1 state
 	METHOD method_7857 hasRecipeRemainder ()Z
 		COMMENT Checks if this item has a remainder item that is left behind when used as a crafting ingredient.
 	METHOD method_7858 getRecipeRemainder ()Lnet/minecraft/class_1792;

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -96,8 +96,19 @@ CLASS net/minecraft/class_1792 net/minecraft/item/Item
 	METHOD method_7853 getUseAction (Lnet/minecraft/class_1799;)Lnet/minecraft/class_1839;
 		ARG 1 stack
 	METHOD method_7854 getDefaultStack ()Lnet/minecraft/class_1799;
-	METHOD method_7856 isEffectiveOn (Lnet/minecraft/class_2680;)Z
-		ARG 1 state
+	METHOD method_7855 isIn (Lnet/minecraft/class_3494;)Z
+		ARG 1 tag
+	METHOD method_7856 isSuitableFor (Lnet/minecraft/class_2680;)Z
+		COMMENT <p>
+		COMMENT Determines whether this item can be used as a suitable tool for mining the specified block.
+		COMMENT Dependent on block implementation, when combined together, the correct item and block may achieve better mining speed and yield
+		COMMENT drops that would otherwise not be obtained when mining otherwise.
+		COMMENT </p>
+		COMMENT <p>
+		COMMENT Note that this is not the <b>only</b> way to achieve "effectiveness" when mining.
+		COMMENT Other items, such as shears on string, may use their own logic
+		COMMENT and calls to this method might not return a value consistent to this rule for those items.
+		COMMENT </p>
 	METHOD method_7857 hasRecipeRemainder ()Z
 		COMMENT Checks if this item has a remainder item that is left behind when used as a crafting ingredient.
 	METHOD method_7858 getRecipeRemainder ()Lnet/minecraft/class_1792;

--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -127,7 +127,7 @@ CLASS net/minecraft/class_1799 net/minecraft/item/ItemStack
 		ARG 2 context
 	METHOD method_7951 isSuitableFor (Lnet/minecraft/class_2680;)Z
 		COMMENT Determines whether this item can be used as a suitable tool for mining the specified block.
-		COMMENT Dependent on block implementation, when combined together, the correct item and block may achieve better mining speed and yield
+		COMMENT Depending on block implementation, when combined together, the correct item and block may achieve a better mining speed and yield
 		COMMENT drops that would otherwise not be obtained when mining otherwise.
 		COMMENT
 		COMMENT @return Values consistent with calls to {@link Item#isSuitableFor}

--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -127,10 +127,11 @@ CLASS net/minecraft/class_1799 net/minecraft/item/ItemStack
 		ARG 2 context
 	METHOD method_7951 isSuitableFor (Lnet/minecraft/class_2680;)Z
 		COMMENT Determines whether this item can be used as a suitable tool for mining the specified block.
+		COMMENT <p>
 		COMMENT Depending on block implementation, when combined together, the correct item and block may achieve a better mining speed and yield
-		COMMENT drops that would otherwise not be obtained when mining otherwise.
-		COMMENT
-		COMMENT @return Values consistent with calls to {@link Item#isSuitableFor}
+		COMMENT drops that would not be obtained when mining otherwise.
+		COMMENT </p>
+		COMMENT @return values consistent with calls to {@link Item#isSuitableFor}
 		COMMENT @see Item#isSuitableFor
 		ARG 1 state
 	METHOD method_7952 postMine (Lnet/minecraft/class_1937;Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;Lnet/minecraft/class_1657;)V

--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -125,7 +125,13 @@ CLASS net/minecraft/class_1799 net/minecraft/item/ItemStack
 	METHOD method_7950 getTooltip (Lnet/minecraft/class_1657;Lnet/minecraft/class_1836;)Ljava/util/List;
 		ARG 1 player
 		ARG 2 context
-	METHOD method_7951 isEffectiveOn (Lnet/minecraft/class_2680;)Z
+	METHOD method_7951 isSuitableFor (Lnet/minecraft/class_2680;)Z
+		COMMENT Determines whether this item can be used as a suitable tool for mining the specified block.
+		COMMENT Dependent on block implementation, when combined together, the correct item and block may achieve better mining speed and yield
+		COMMENT drops that would otherwise not be obtained when mining otherwise.
+		COMMENT
+		COMMENT @return Values consistent with calls to {@link Item#isSuitableFor}
+		COMMENT @see Item#isSuitableFor
 		ARG 1 state
 	METHOD method_7952 postMine (Lnet/minecraft/class_1937;Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;Lnet/minecraft/class_1657;)V
 		ARG 1 world


### PR DESCRIPTION
~PR for #1140 that changes `isUsingEffectiveTool` to `canMineEffectively`.~

That's all.

Edit: State after the 1.16 rebase:

`isUsingEffectiveTool` -> `canHarvest`
`isEffectiveOn` -> `isSuitableFor`

What I didn't mention in the original PR description (as I'd assumed we were on agreement about the change after discussion in the issue I linked) is that I've included detailed Javadocs describing what the methods actually are for, and accounting for some items (Shears) breaking that contract.