### PR TITLE
AbstractBlock.Settings.dropTableId -> lootTableId

### DIFF
--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -202,7 +202,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		FIELD field_10663 luminance Ljava/util/function/ToIntFunction;
 		FIELD field_10664 collidable Z
 		FIELD field_10665 soundGroup Lnet/minecraft/class_2498;
-		FIELD field_10666 dropTableId Lnet/minecraft/class_2960;
+		FIELD field_10666 lootTableId Lnet/minecraft/class_2960;
 		FIELD field_10667 slipperiness F
 		FIELD field_10668 material Lnet/minecraft/class_3614;
 		FIELD field_10669 hardness F


### PR DESCRIPTION
Changes the name in the settings to match the new name from #1274.