### PR TITLE
Fix method name in VoronoiBiomeAccessType

### DIFF
--- a/mappings/net/minecraft/world/biome/source/VoronoiBiomeAccessType.mapping
+++ b/mappings/net/minecraft/world/biome/source/VoronoiBiomeAccessType.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_4546 net/minecraft/world/biome/source/VoronoiBiomeAcce
 		ARG 0 d
 	METHOD method_22398 distribute (J)D
 		ARG 0 seed
-	METHOD method_22399 calcChance (JIIIDDD)D
+	METHOD method_22399 calcSqrDistance (JIIIDDD)D
 		ARG 0 seed
 		ARG 2 x
 		ARG 3 y

--- a/mappings/net/minecraft/world/biome/source/VoronoiBiomeAccessType.mapping
+++ b/mappings/net/minecraft/world/biome/source/VoronoiBiomeAccessType.mapping
@@ -1,9 +1,9 @@
 CLASS net/minecraft/class_4546 net/minecraft/world/biome/source/VoronoiBiomeAccessType
-	METHOD method_22397 sqr (D)D
+	METHOD method_22397 square (D)D
 		ARG 0 d
 	METHOD method_22398 distribute (J)D
 		ARG 0 seed
-	METHOD method_22399 calcSqrDistance (JIIIDDD)D
+	METHOD method_22399 calcSquaredDistance (JIIIDDD)D
 		ARG 0 seed
 		ARG 2 x
 		ARG 3 y


### PR DESCRIPTION
Changes the `calcChance` to `calcSqrDistance` as the old name didn't make sense. 