### PR TITLE
Renamed `createBossBar` to the more appropriate `getBossBar`

### DIFF
--- a/mappings/net/minecraft/server/command/BossBarCommand.mapping
+++ b/mappings/net/minecraft/server/command/BossBarCommand.mapping
@@ -40,7 +40,7 @@ CLASS net/minecraft/class_3019 net/minecraft/server/command/BossBarCommand
 		ARG 2 style
 	METHOD method_13053 register (Lcom/mojang/brigadier/CommandDispatcher;)V
 		ARG 0 dispatcher
-	METHOD method_13054 createBossBar (Lcom/mojang/brigadier/context/CommandContext;)Lnet/minecraft/class_3002;
+	METHOD method_13054 getBossBar (Lcom/mojang/brigadier/context/CommandContext;)Lnet/minecraft/class_3002;
 		ARG 0 context
 	METHOD method_13056 getMaxValue (Lnet/minecraft/class_2168;Lnet/minecraft/class_3002;)I
 		ARG 0 source


### PR DESCRIPTION
`createBossBar` doesn't make a new Boss Bar, instead, it retrieves one from the `BossBarManager`.