### PR TITLE
IWorld -> GenerationView

### DIFF
--- a/mappings/net/minecraft/world/GenerationView.mapping
+++ b/mappings/net/minecraft/world/GenerationView.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_1936 net/minecraft/world/IWorld
+CLASS net/minecraft/class_1936 net/minecraft/world/GenerationView
 	METHOD method_20290 playLevelEvent (ILnet/minecraft/class_2338;I)V
 		ARG 1 eventId
 		ARG 2 pos


### PR DESCRIPTION
This resolves the years old conflict of what `IWorld` should become.

Why `GenerationView`?

Commonly used in world gen

Implemented by `ChunkRegion`, which is used in world gen

Could represent a view of a world that is thread safe within the confines of world gen

(This is related to #1133)