### PR TITLE
Block Action -> Synced Block Event. Level Event -> Synced World Event

### DIFF
--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -363,7 +363,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		METHOD method_26176 getComparatorOutput (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)I
 			ARG 1 world
 			ARG 2 pos
-		METHOD method_26177 onBlockAction (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;II)Z
+		METHOD method_26177 onSyncedBlockEvent (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;II)Z
 			ARG 1 world
 			ARG 2 pos
 			ARG 3 channel

--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -152,12 +152,12 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		ARG 2 world
 		ARG 3 pos
 		ARG 4 random
-	METHOD method_9592 onBlockAction (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;II)Z
+	METHOD method_9592 onSyncedBlockEvent (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;II)Z
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-		ARG 4 channel
-		ARG 5 value
+		ARG 4 type
+		ARG 5 data
 	METHOD method_9594 calcBlockBreakingDelta (Lnet/minecraft/class_2680;Lnet/minecraft/class_1657;Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)F
 		ARG 1 state
 		ARG 2 player
@@ -366,8 +366,8 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		METHOD method_26177 onSyncedBlockEvent (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;II)Z
 			ARG 1 world
 			ARG 2 pos
-			ARG 3 channel
-			ARG 4 value
+			ARG 3 type
+			ARG 4 data
 		METHOD method_26178 onEntityCollision (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_1297;)V
 			ARG 1 world
 			ARG 2 pos

--- a/mappings/net/minecraft/block/entity/BlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntity.mapping
@@ -19,7 +19,9 @@ CLASS net/minecraft/class_2586 net/minecraft/block/entity/BlockEntity
 		ARG 1 mirror
 	METHOD method_11002 hasWorld ()Z
 	METHOD method_11003 populateCrashReport (Lnet/minecraft/class_129;)V
-	METHOD method_11004 onBlockAction (II)Z
+	METHOD method_11004 onSyncedBlockEvent (II)Z
+		ARG 1 type
+		ARG 2 data
 	METHOD method_11005 createFromTag (Lnet/minecraft/class_2680;Lnet/minecraft/class_2487;)Lnet/minecraft/class_2586;
 		ARG 0 state
 		ARG 1 tag

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -259,7 +259,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 		ARG 2 pos
 	METHOD method_8567 processWorldEvent (Lnet/minecraft/class_1657;ILnet/minecraft/class_2338;I)V
 		ARG 1 source
-		ARG 2 type
+		ARG 2 eventId
 		ARG 3 pos
 		ARG 4 data
 	METHOD method_8568 addParticle (Lnet/minecraft/class_2394;ZDDDDDD)V

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -254,10 +254,10 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 		ARG 10 velocityX
 		ARG 12 velocityY
 		ARG 14 velocityZ
-	METHOD method_8564 playGlobalEvent (ILnet/minecraft/class_2338;I)V
+	METHOD method_8564 processGlobalEvent (ILnet/minecraft/class_2338;I)V
 		ARG 1 eventId
 		ARG 2 pos
-	METHOD method_8567 playLevelEvent (Lnet/minecraft/class_1657;ILnet/minecraft/class_2338;I)V
+	METHOD method_8567 processWorldEvent (Lnet/minecraft/class_1657;ILnet/minecraft/class_2338;I)V
 		ARG 1 source
 		ARG 2 type
 		ARG 3 pos

--- a/mappings/net/minecraft/network/listener/ClientPlayPacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ClientPlayPacketListener.mapping
@@ -161,7 +161,7 @@ CLASS net/minecraft/class_2602 net/minecraft/network/listener/ClientPlayPacketLi
 		ARG 1 packet
 	METHOD method_11157 onPlayerPositionLook (Lnet/minecraft/class_2708;)V
 		ARG 1 packet
-	METHOD method_11158 onBlockAction (Lnet/minecraft/class_2623;)V
+	METHOD method_11158 onBlockEvent (Lnet/minecraft/class_2623;)V
 		ARG 1 packet
 	METHOD method_11159 onScoreboardDisplay (Lnet/minecraft/class_2736;)V
 		ARG 1 packet

--- a/mappings/net/minecraft/network/packet/s2c/play/BlockEventS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/BlockEventS2CPacket.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2623 net/minecraft/network/packet/s2c/play/BlockActionS2CPacket
+CLASS net/minecraft/class_2623 net/minecraft/network/packet/s2c/play/BlockEventS2CPacket
 	FIELD field_12041 data I
 	FIELD field_12042 type I
 	FIELD field_12043 block Lnet/minecraft/class_2248;

--- a/mappings/net/minecraft/network/packet/s2c/play/WorldEventS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/WorldEventS2CPacket.mapping
@@ -11,4 +11,4 @@ CLASS net/minecraft/class_2673 net/minecraft/network/packet/s2c/play/WorldEventS
 	METHOD method_11531 getPos ()Lnet/minecraft/class_2338;
 	METHOD method_11532 getEventId ()I
 	METHOD method_11533 isGlobal ()Z
-	METHOD method_11534 getEffectData ()I
+	METHOD method_11534 getData ()I

--- a/mappings/net/minecraft/server/world/BlockEvent.mapping
+++ b/mappings/net/minecraft/server/world/BlockEvent.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_1919 net/minecraft/server/world/BlockAction
+CLASS net/minecraft/class_1919 net/minecraft/server/world/BlockEvent
 	FIELD field_9170 data I
 	FIELD field_9171 type I
 	FIELD field_9172 block Lnet/minecraft/class_2248;

--- a/mappings/net/minecraft/server/world/ServerWorld.mapping
+++ b/mappings/net/minecraft/server/world/ServerWorld.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_3218 net/minecraft/server/world/ServerWorld
 	FIELD field_13948 idleTimeout I
 	FIELD field_13949 blockTickScheduler Lnet/minecraft/class_1949;
-	FIELD field_13950 pendingBlockActions Lit/unimi/dsi/fastutil/objects/ObjectLinkedOpenHashSet;
+	FIELD field_13950 syncedBlockEventQueue Lit/unimi/dsi/fastutil/objects/ObjectLinkedOpenHashSet;
 	FIELD field_13951 fluidTickScheduler Lnet/minecraft/class_1949;
 	FIELD field_13952 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_13953 inBlockTick Z
@@ -40,6 +40,8 @@ CLASS net/minecraft/class_3218 net/minecraft/server/world/ServerWorld
 	METHOD method_14171 tickFluid (Lnet/minecraft/class_1954;)V
 		ARG 1 tick
 	METHOD method_14173 getPortalForcer ()Lnet/minecraft/class_1946;
+	METHOD method_14174 processBlockEvent (Lnet/minecraft/class_1919;)Z
+		ARG 1 event
 	METHOD method_14175 addEntity (Lnet/minecraft/class_1297;)Z
 		ARG 1 entity
 	METHOD method_14176 save (Lnet/minecraft/class_3536;ZZ)V
@@ -58,7 +60,7 @@ CLASS net/minecraft/class_3218 net/minecraft/server/world/ServerWorld
 		ARG 5 y
 		ARG 7 z
 		ARG 9 packet
-	METHOD method_14192 sendBlockActions ()V
+	METHOD method_14192 processSyncedBlockEvents ()V
 	METHOD method_14195 resetWeather ()V
 	METHOD method_14197 resetIdleTimeout ()V
 	METHOD method_14199 spawnParticles (Lnet/minecraft/class_2394;DDDIDDDD)I

--- a/mappings/net/minecraft/world/IWorld.mapping
+++ b/mappings/net/minecraft/world/IWorld.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_1936 net/minecraft/world/IWorld
-	METHOD method_20290 playLevelEvent (ILnet/minecraft/class_2338;I)V
+	METHOD method_20290 syncWorldEvent (ILnet/minecraft/class_2338;I)V
 		ARG 1 eventId
 		ARG 2 pos
 		ARG 3 data
@@ -36,7 +36,7 @@ CLASS net/minecraft/class_1936 net/minecraft/world/IWorld
 	METHOD method_8409 getRandom ()Ljava/util/Random;
 	METHOD method_8410 getWorld ()Lnet/minecraft/class_1937;
 	METHOD method_8412 getSeed ()J
-	METHOD method_8444 playLevelEvent (Lnet/minecraft/class_1657;ILnet/minecraft/class_2338;I)V
+	METHOD method_8444 syncWorldEvent (Lnet/minecraft/class_1657;ILnet/minecraft/class_2338;I)V
 		ARG 1 player
 		ARG 2 eventId
 		ARG 3 pos

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -83,7 +83,7 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 1 box
 	METHOD method_8426 getPendingBlockEntity (Lnet/minecraft/class_2338;)Lnet/minecraft/class_2586;
 		ARG 1 pos
-	METHOD method_8427 addBlockAction (Lnet/minecraft/class_2338;Lnet/minecraft/class_2248;II)V
+	METHOD method_8427 addSyncedBlockEvent (Lnet/minecraft/class_2338;Lnet/minecraft/class_2248;II)V
 		ARG 1 pos
 		ARG 2 block
 		ARG 3 type
@@ -153,7 +153,7 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 13 velocityZ
 	METHOD method_8469 getEntityById (I)Lnet/minecraft/class_1297;
 		ARG 1 id
-	METHOD method_8474 playGlobalEvent (ILnet/minecraft/class_2338;I)V
+	METHOD method_8474 syncGlobalEvent (ILnet/minecraft/class_2338;I)V
 		ARG 1 type
 		ARG 2 pos
 		ARG 3 data

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -154,7 +154,7 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 	METHOD method_8469 getEntityById (I)Lnet/minecraft/class_1297;
 		ARG 1 id
 	METHOD method_8474 syncGlobalEvent (ILnet/minecraft/class_2338;I)V
-		ARG 1 type
+		ARG 1 eventId
 		ARG 2 pos
 		ARG 3 data
 	METHOD method_8475 getBlockState (Lnet/minecraft/class_238;Lnet/minecraft/class_2248;)Lnet/minecraft/class_2680;


### PR DESCRIPTION
Closes #1319, please read that issue before commenting on this pull request. Also renames level event to synced world event for consistency.

You may notice a difference between `addSyncedBlockEvent` and `syncWorldEvent`. This is because the former adds it to a queue, to be processed on both the client and the server, while the latter is only processed on the client.