### PR TITLE
Screen fixes and drawTexture docs

### DIFF
--- a/mappings/net/minecraft/client/gui/DrawableHelper.mapping
+++ b/mappings/net/minecraft/client/gui/DrawableHelper.mapping
@@ -8,9 +8,53 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawableHelper
 	FIELD field_22737 GUI_ICONS_TEXTURE Lnet/minecraft/class_2960;
 		COMMENT The texture of various icons and widgets used for rendering ingame indicators.
 	METHOD method_25290 drawTexture (Lnet/minecraft/class_4587;IIFFIIII)V
+		COMMENT Draws a textured rectangle from a region in a texture.
+		COMMENT
+		COMMENT <p>The width and height of the region are the same as
+		COMMENT the dimensions of the rectangle.
 		ARG 0 matrices
+			COMMENT the matrix stack used for rendering
+		ARG 1 x
+			COMMENT the X coordinate of the rectangle
+		ARG 2 y
+			COMMENT the Y coordinate of the rectangle
+		ARG 3 u
+			COMMENT the left-most coordinate of the texture region
+		ARG 4 v
+			COMMENT the top-most coordinate of the texture region
+		ARG 5 width
+			COMMENT the width of the rectangle
+		ARG 6 height
+			COMMENT the height of the rectangle
+		ARG 7 textureWidth
+			COMMENT the width of the entire texture
+		ARG 8 textureHeight
+			COMMENT the height of the entire texture
 	METHOD method_25291 drawTexture (Lnet/minecraft/class_4587;IIIFFIIII)V
+		COMMENT Draws a textured rectangle from a region in a texture.
+		COMMENT
+		COMMENT <p>The width and height of the region are the same as
+		COMMENT the dimensions of the rectangle.
 		ARG 0 matrices
+			COMMENT the matrix stack used for rendering
+		ARG 1 x
+			COMMENT the X coordinate of the rectangle
+		ARG 2 y
+			COMMENT the Y coordinate of the rectangle
+		ARG 3 z
+			COMMENT the Z coordinate of the rectangle
+		ARG 4 u
+			COMMENT the left-most coordinate of the texture region
+		ARG 5 v
+			COMMENT the top-most coordinate of the texture region
+		ARG 6 width
+			COMMENT the width of the rectangle
+		ARG 7 height
+			COMMENT the height of the rectangle
+		ARG 8 textureHeight
+			COMMENT the height of the entire texture
+		ARG 9 textureWidth
+			COMMENT the width of the entire texture
 	METHOD method_25292 drawHorizontalLine (Lnet/minecraft/class_4587;IIII)V
 		ARG 1 matrices
 		ARG 2 x1
@@ -18,7 +62,29 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawableHelper
 		ARG 4 y
 		ARG 5 color
 	METHOD method_25293 drawTexture (Lnet/minecraft/class_4587;IIIIFFIIII)V
+		COMMENT Draws a textured rectangle from a region in a texture.
 		ARG 0 matrices
+			COMMENT the matrix stack used for rendering
+		ARG 1 x
+			COMMENT the X coordinate of the rectangle
+		ARG 2 y
+			COMMENT the Y coordinate of the rectangle
+		ARG 3 width
+			COMMENT the width of the rectangle
+		ARG 4 height
+			COMMENT the height of the rectangle
+		ARG 5 u
+			COMMENT the left-most coordinate of the texture region
+		ARG 6 v
+			COMMENT the top-most coordinate of the texture region
+		ARG 7 regionWidth
+			COMMENT the width of the texture region
+		ARG 8 regionHeight
+			COMMENT the height of the texture region
+		ARG 9 textureWidth
+			COMMENT the width of the entire texture
+		ARG 10 textureHeight
+			COMMENT the height of the entire texture
 	METHOD method_25294 fill (Lnet/minecraft/class_4587;IIIII)V
 		ARG 0 matrices
 		ARG 1 x1
@@ -28,6 +94,15 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawableHelper
 		ARG 5 color
 	METHOD method_25295 drawTexturedQuad (Lnet/minecraft/class_1159;IIIIIFFFF)V
 		ARG 0 matrices
+		ARG 1 x0
+		ARG 2 x1
+		ARG 3 y0
+		ARG 4 y1
+		ARG 5 z
+		ARG 6 u0
+		ARG 7 u1
+		ARG 8 v0
+		ARG 9 v1
 	METHOD method_25296 fillGradient (Lnet/minecraft/class_4587;IIIIII)V
 		ARG 1 matrices
 		ARG 2 xStart
@@ -38,8 +113,32 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawableHelper
 		ARG 7 colorEnd
 	METHOD method_25297 drawTexture (Lnet/minecraft/class_4587;IIIIIIIFFII)V
 		ARG 0 matrices
+		ARG 1 x0
+		ARG 2 y0
+		ARG 3 x1
+		ARG 4 y1
+		ARG 5 z
+		ARG 6 regionWidth
+		ARG 7 regionHeight
+		ARG 8 u
+		ARG 9 v
+		ARG 10 textureWidth
+		ARG 11 textureHeight
 	METHOD method_25298 drawSprite (Lnet/minecraft/class_4587;IIIIILnet/minecraft/class_1058;)V
+		COMMENT
 		ARG 0 matrices
+			COMMENT
+		ARG 1 x
+			COMMENT
+		ARG 2 y
+			COMMENT
+		ARG 3 z
+			COMMENT
+		ARG 4 width
+			COMMENT
+		ARG 5 height
+			COMMENT
+		ARG 6 sprite
 	METHOD method_25299 fill (Lnet/minecraft/class_1159;IIIII)V
 		ARG 0 matrix
 		ARG 1 x1
@@ -53,6 +152,7 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawableHelper
 		ARG 3 text
 		ARG 4 x
 		ARG 5 y
+		ARG 6 color
 	METHOD method_25301 drawVerticalLine (Lnet/minecraft/class_4587;IIII)V
 		ARG 1 matrices
 		ARG 2 x
@@ -60,12 +160,33 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawableHelper
 		ARG 4 y2
 		ARG 5 color
 	METHOD method_25302 drawTexture (Lnet/minecraft/class_4587;IIIIII)V
+		COMMENT Draws a textured rectangle from a region in a 256x256 texture.
+		COMMENT
+		COMMENT <p>The Z coordinate of the rectangle is {@link #zOffset}.
+		COMMENT
+		COMMENT <p>The width and height of the region are the same as
+		COMMENT the dimensions of the rectangle.
 		ARG 1 matrices
+			COMMENT the matrix stack used for rendering
 		ARG 2 x
+			COMMENT the X coordinate of the rectangle
 		ARG 3 y
-	METHOD method_25303 drawString (Lnet/minecraft/class_4587;Lnet/minecraft/class_327;Ljava/lang/String;III)V
+			COMMENT the Y coordinate of the rectangle
+		ARG 4 u
+			COMMENT the left-most coordinate of the texture region
+		ARG 5 v
+			COMMENT the top-most coordinate of the texture region
+		ARG 6 width
+			COMMENT the width
+		ARG 7 height
+			COMMENT the height
+	METHOD method_25303 drawStringWithShadow (Lnet/minecraft/class_4587;Lnet/minecraft/class_327;Ljava/lang/String;III)V
 		ARG 1 matrices
+		ARG 2 textRenderer
 		ARG 3 text
+		ARG 4 x
+		ARG 5 y
+		ARG 6 color
 	METHOD method_25304 setZOffset (I)V
 		ARG 1 zOffset
 	METHOD method_25305 getZOffset ()I
@@ -77,9 +198,17 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawableHelper
 		ARG 5 yEnd
 		ARG 6 colorStart
 		ARG 7 colorEnd
-	METHOD method_27534 drawStringWithShadow (Lnet/minecraft/class_4587;Lnet/minecraft/class_327;Lnet/minecraft/class_2561;III)V
+	METHOD method_27534 drawCenteredText (Lnet/minecraft/class_4587;Lnet/minecraft/class_327;Lnet/minecraft/class_2561;III)V
 		ARG 1 matrices
 		ARG 2 textRenderer
 		ARG 3 text
-	METHOD method_27535 (Lnet/minecraft/class_4587;Lnet/minecraft/class_327;Lnet/minecraft/class_2561;III)V
+		ARG 4 x
+		ARG 5 y
+		ARG 6 color
+	METHOD method_27535 drawTextWithShadow (Lnet/minecraft/class_4587;Lnet/minecraft/class_327;Lnet/minecraft/class_2561;III)V
 		ARG 1 matrices
+		ARG 2 textRenderer
+		ARG 3 text
+		ARG 4 x
+		ARG 5 y
+		ARG 6 color

--- a/mappings/net/minecraft/client/gui/DrawableHelper.mapping
+++ b/mappings/net/minecraft/client/gui/DrawableHelper.mapping
@@ -125,19 +125,12 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawableHelper
 		ARG 10 textureWidth
 		ARG 11 textureHeight
 	METHOD method_25298 drawSprite (Lnet/minecraft/class_4587;IIIIILnet/minecraft/class_1058;)V
-		COMMENT
 		ARG 0 matrices
-			COMMENT
 		ARG 1 x
-			COMMENT
 		ARG 2 y
-			COMMENT
 		ARG 3 z
-			COMMENT
 		ARG 4 width
-			COMMENT
 		ARG 5 height
-			COMMENT
 		ARG 6 sprite
 	METHOD method_25299 fill (Lnet/minecraft/class_1159;IIIII)V
 		ARG 0 matrix

--- a/mappings/net/minecraft/client/gui/screen/Screen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/Screen.mapping
@@ -88,7 +88,7 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 		ARG 2 vOffset
 			COMMENT an offset applied to the V coordinate of the background texture
 	METHOD method_25434 renderBackgroundTexture (I)V
-		COMMENT Renders the {@linkplain #BACKGROUND_TEXTURE background texture} of this screen.
+		COMMENT Renders the fullscreen {@linkplain #BACKGROUND_TEXTURE background texture} of this screen.
 		ARG 1 vOffset
 			COMMENT an offset applied to the V coordinate of the background texture
 	METHOD method_25435 getNarrationMessage ()Ljava/lang/String;

--- a/mappings/net/minecraft/client/gui/screen/Screen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/Screen.mapping
@@ -49,6 +49,10 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 		ARG 2 text
 	METHOD method_25419 onClose ()V
 	METHOD method_25420 renderBackground (Lnet/minecraft/class_4587;)V
+		COMMENT Renders the background of this screen.
+		COMMENT
+		COMMENT <p>If the client is in a world, renders the translucent background gradient.
+		COMMENT Otherwise {@linkplain #renderBackgroundTexture(int) renders the background texture}.
 		ARG 1 matrices
 	METHOD method_25421 isPauseScreen ()Z
 	METHOD method_25422 shouldCloseOnEsc ()Z
@@ -76,10 +80,17 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 	METHOD method_25431 tick ()V
 	METHOD method_25432 removed ()V
 	METHOD method_25433 renderBackground (Lnet/minecraft/class_4587;I)V
+		COMMENT Renders the background of this screen.
+		COMMENT
+		COMMENT <p>If the client is in a world, renders the translucent background gradient.
+		COMMENT Otherwise {@linkplain #renderBackgroundTexture(int) renders the background texture}.
 		ARG 1 matrices
 		ARG 2 vOffset
+			COMMENT an offset applied to the V coordinate of the background texture
 	METHOD method_25434 renderBackgroundTexture (I)V
+		COMMENT Renders the {@linkplain #BACKGROUND_TEXTURE background texture} of this screen.
 		ARG 1 vOffset
+			COMMENT an offset applied to the V coordinate of the background texture
 	METHOD method_25435 getNarrationMessage ()Ljava/lang/String;
 	METHOD method_25436 isCut (I)Z
 		ARG 0 code

--- a/mappings/net/minecraft/client/gui/screen/Screen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/Screen.mapping
@@ -77,9 +77,9 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 	METHOD method_25432 removed ()V
 	METHOD method_25433 renderBackground (Lnet/minecraft/class_4587;I)V
 		ARG 1 matrices
-		ARG 2 alpha
+		ARG 2 vOffset
 	METHOD method_25434 renderDirtBackground (I)V
-		ARG 1 alpha
+		ARG 1 vOffset
 	METHOD method_25435 getNarrationMessage ()Ljava/lang/String;
 	METHOD method_25436 isCut (I)Z
 		ARG 0 code

--- a/mappings/net/minecraft/client/gui/screen/Screen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/Screen.mapping
@@ -78,7 +78,7 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 	METHOD method_25433 renderBackground (Lnet/minecraft/class_4587;I)V
 		ARG 1 matrices
 		ARG 2 vOffset
-	METHOD method_25434 renderDirtBackground (I)V
+	METHOD method_25434 renderBackgroundTexture (I)V
 		ARG 1 vOffset
 	METHOD method_25435 getNarrationMessage ()Ljava/lang/String;
 	METHOD method_25436 isCut (I)Z


### PR DESCRIPTION
- `DrawableHelper`
  - Added docs for all public `drawTexture` overloads
  - `method_27534`: `drawStringWithShadow` -> `drawCenteredText`
  - `method_27535` -> `drawTextWithShadow`
  - `method_25303`: `drawString` -> `drawStringWithShadow`
- `Screen`
  - `renderDirtBackground` -> `renderBackgroundTexture`
    - The file is called `options_background.png`. It just happens to be dirt in the default resources.
  - Renamed the `alpha` parameter in `renderBackground` and `renderBackgroundTexture` to `vOffset`. It offsets the V position of the background texture, and does not affect any alpha values.