### PR TITLE
Improve Loot Table mappings

### DIFF
--- a/mappings/net/minecraft/data/server/BlockLootTableGenerator.mapping
+++ b/mappings/net/minecraft/data/server/BlockLootTableGenerator.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_2430 net/minecraft/data/server/BlockLootTableGenerator
 	FIELD field_11338 JUNGLE_SAPLING_DROP_CHANCE [F
 	FIELD field_11339 SAPLING_DROP_CHANCE [F
 	FIELD field_11340 EXPLOSION_IMMUNE Ljava/util/Set;
-	FIELD field_11341 WITHOUT_SILK_TOUCH_AND_SHEARS Lnet/minecraft/class_4570$class_210;
+	FIELD field_11341 WITHOUT_SILK_TOUCH_NOR_SHEARS Lnet/minecraft/class_4570$class_210;
 	FIELD field_11342 WITH_SILK_TOUCH_OR_SHEARS Lnet/minecraft/class_4570$class_210;
 	FIELD field_11343 WITH_SHEARS Lnet/minecraft/class_4570$class_210;
 	FIELD field_16493 lootTables Ljava/util/Map;

--- a/mappings/net/minecraft/data/server/BlockLootTableGenerator.mapping
+++ b/mappings/net/minecraft/data/server/BlockLootTableGenerator.mapping
@@ -1,67 +1,104 @@
 CLASS net/minecraft/class_2430 net/minecraft/data/server/BlockLootTableGenerator
-	FIELD field_11336 NEEDS_SILK_TOUCH Lnet/minecraft/class_4570$class_210;
-	FIELD field_11337 DOESNT_NEED_SILK_TOUCH Lnet/minecraft/class_4570$class_210;
-	FIELD field_11338 JUNGLE_SAPLING_DROP_CHANCES_FROM_LEAVES [F
-	FIELD field_11339 SAPLING_DROP_CHANCES_FROM_LEAVES [F
-	FIELD field_11340 ALWAYS_DROPPED_FROM_EXPLOSION Ljava/util/Set;
-	FIELD field_11341 DOESNT_NEED_SILK_TOUCH_SHEARS Lnet/minecraft/class_4570$class_210;
-	FIELD field_11342 NEEDS_SILK_TOUCH_SHEARS Lnet/minecraft/class_4570$class_210;
-	FIELD field_11343 NEEDS_SHEARS Lnet/minecraft/class_4570$class_210;
+	FIELD field_11336 WITH_SILK_TOUCH Lnet/minecraft/class_4570$class_210;
+	FIELD field_11337 WITHOUT_SILK_TOUCH Lnet/minecraft/class_4570$class_210;
+	FIELD field_11338 JUNGLE_SAPLING_DROP_CHANCE [F
+	FIELD field_11339 SAPLING_DROP_CHANCE [F
+	FIELD field_11340 EXPLOSION_IMMUNE Ljava/util/Set;
+	FIELD field_11341 WITHOUT_SILK_TOUCH_SHEARS Lnet/minecraft/class_4570$class_210;
+	FIELD field_11342 WITH_SILK_TOUCH_SHEARS Lnet/minecraft/class_4570$class_210;
+	FIELD field_11343 WITH_SHEARS Lnet/minecraft/class_4570$class_210;
 	FIELD field_16493 lootTables Ljava/util/Map;
-	METHOD method_10371 createForTallGrass (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
-	METHOD method_10372 createForBlockNeedingShears (Lnet/minecraft/class_1935;)Lnet/minecraft/class_52$class_53;
-	METHOD method_10373 createForNeedingSilkTouch (Lnet/minecraft/class_1935;)Lnet/minecraft/class_52$class_53;
-	METHOD method_10375 createForMultiblock (Lnet/minecraft/class_2248;Lnet/minecraft/class_2769;Ljava/lang/Comparable;)Lnet/minecraft/class_52$class_53;
-	METHOD method_10377 createForOreWithSingleItemDrop (Lnet/minecraft/class_2248;Lnet/minecraft/class_1792;)Lnet/minecraft/class_52$class_53;
-	METHOD method_10378 createForOakLeaves (Lnet/minecraft/class_2248;Lnet/minecraft/class_2248;[F)Lnet/minecraft/class_52$class_53;
-	METHOD method_10380 createForNeedingShears (Lnet/minecraft/class_2248;Lnet/minecraft/class_79$class_80;)Lnet/minecraft/class_52$class_53;
+	METHOD method_10371 grassDrops (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
+		ARG 0 dropWithShears
+	METHOD method_10372 dropsWithShears (Lnet/minecraft/class_1935;)Lnet/minecraft/class_52$class_53;
+		ARG 0 drop
+	METHOD method_10373 dropsWithSilkTouch (Lnet/minecraft/class_1935;)Lnet/minecraft/class_52$class_53;
+		ARG 0 drop
+	METHOD method_10375 dropsWithProperty (Lnet/minecraft/class_2248;Lnet/minecraft/class_2769;Ljava/lang/Comparable;)Lnet/minecraft/class_52$class_53;
+		ARG 0 drop
+	METHOD method_10377 oreDrops (Lnet/minecraft/class_2248;Lnet/minecraft/class_1792;)Lnet/minecraft/class_52$class_53;
+		ARG 0 dropWithSilkTouch
+		ARG 1 drop
+	METHOD method_10378 oakLeavesDrop (Lnet/minecraft/class_2248;Lnet/minecraft/class_2248;[F)Lnet/minecraft/class_52$class_53;
+		ARG 0 leaves
+		ARG 1 drop
+		ARG 2 chance
+	METHOD method_10380 dropsWithShears (Lnet/minecraft/class_2248;Lnet/minecraft/class_79$class_80;)Lnet/minecraft/class_52$class_53;
+		ARG 0 drop
 		ARG 1 child
-	METHOD method_10381 create (Lnet/minecraft/class_2248;Lnet/minecraft/class_4570$class_210;Lnet/minecraft/class_79$class_80;)Lnet/minecraft/class_52$class_53;
+	METHOD method_10381 drops (Lnet/minecraft/class_2248;Lnet/minecraft/class_4570$class_210;Lnet/minecraft/class_79$class_80;)Lnet/minecraft/class_52$class_53;
+		ARG 0 drop
 		ARG 1 conditionBuilder
 		ARG 2 child
-	METHOD method_10382 createForBlockWithItemDrops (Lnet/minecraft/class_2248;Lnet/minecraft/class_1935;)Lnet/minecraft/class_52$class_53;
-		ARG 1 lootWithoutSilkTouch
-	METHOD method_10383 createForSlabs (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
-	METHOD method_10384 create (Lnet/minecraft/class_1935;Lnet/minecraft/class_59;)Lnet/minecraft/class_52$class_53;
+	METHOD method_10382 drops (Lnet/minecraft/class_2248;Lnet/minecraft/class_1935;)Lnet/minecraft/class_52$class_53;
+		ARG 0 dropWithSilkTouch
+		ARG 1 drop
+	METHOD method_10383 slabDrops (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
+		ARG 0 drop
+	METHOD method_10384 drops (Lnet/minecraft/class_1935;Lnet/minecraft/class_59;)Lnet/minecraft/class_52$class_53;
+		ARG 0 drop
 		ARG 1 count
-	METHOD method_10385 createForLargeMushroomBlock (Lnet/minecraft/class_2248;Lnet/minecraft/class_1935;)Lnet/minecraft/class_52$class_53;
-		ARG 1 loot
-	METHOD method_10386 createForBlockWithItemDrops (Lnet/minecraft/class_2248;Lnet/minecraft/class_1935;Lnet/minecraft/class_59;)Lnet/minecraft/class_52$class_53;
-		ARG 1 lootWithoutSilkTouch
+	METHOD method_10385 mushroomBlockDrops (Lnet/minecraft/class_2248;Lnet/minecraft/class_1935;)Lnet/minecraft/class_52$class_53;
+		ARG 0 dropWithSilkTouch
+		ARG 1 drop
+	METHOD method_10386 drops (Lnet/minecraft/class_2248;Lnet/minecraft/class_1935;Lnet/minecraft/class_59;)Lnet/minecraft/class_52$class_53;
+		ARG 0 dropWithSilkTouch
+		ARG 1 drop
 		ARG 2 count
-	METHOD method_10387 createForCropStem (Lnet/minecraft/class_2248;Lnet/minecraft/class_1792;)Lnet/minecraft/class_52$class_53;
-		ARG 1 seeds
-	METHOD method_10388 createForNeedingSilkTouchShears (Lnet/minecraft/class_2248;Lnet/minecraft/class_79$class_80;)Lnet/minecraft/class_52$class_53;
+	METHOD method_10387 cropStemDrops (Lnet/minecraft/class_2248;Lnet/minecraft/class_1792;)Lnet/minecraft/class_52$class_53;
+		ARG 0 stem
+		ARG 1 drop
+	METHOD method_10388 dropsWithSilkTouchShears (Lnet/minecraft/class_2248;Lnet/minecraft/class_79$class_80;)Lnet/minecraft/class_52$class_53;
+		ARG 0 drop
 		ARG 1 child
-	METHOD method_10389 createForPottedPlant (Lnet/minecraft/class_1935;)Lnet/minecraft/class_52$class_53;
-	METHOD method_10390 createForLeaves (Lnet/minecraft/class_2248;Lnet/minecraft/class_2248;[F)Lnet/minecraft/class_52$class_53;
-		ARG 0 leafBlock
-		ARG 1 sapling
-		ARG 2 saplingDropChances
-	METHOD method_10391 createForCrops (Lnet/minecraft/class_2248;Lnet/minecraft/class_1792;Lnet/minecraft/class_1792;Lnet/minecraft/class_4570$class_210;)Lnet/minecraft/class_52$class_53;
-		ARG 1 food
+	METHOD method_10389 pottedPlantDrops (Lnet/minecraft/class_1935;)Lnet/minecraft/class_52$class_53;
+		ARG 0 plant
+	METHOD method_10390 leavesDrop (Lnet/minecraft/class_2248;Lnet/minecraft/class_2248;[F)Lnet/minecraft/class_52$class_53;
+		ARG 0 leaves
+		ARG 1 drop
+		ARG 2 chance
+	METHOD method_10391 cropDrops (Lnet/minecraft/class_2248;Lnet/minecraft/class_1792;Lnet/minecraft/class_1792;Lnet/minecraft/class_4570$class_210;)Lnet/minecraft/class_52$class_53;
+		ARG 0 crop
+		ARG 1 product
 		ARG 2 seeds
 		ARG 3 condition
-	METHOD method_10392 addSurvivesExplosionLootCondition (Lnet/minecraft/class_1935;Lnet/minecraft/class_192;)Ljava/lang/Object;
-	METHOD method_10393 addExplosionDecayLootFunction (Lnet/minecraft/class_1935;Lnet/minecraft/class_116;)Ljava/lang/Object;
-	METHOD method_10394 create (Lnet/minecraft/class_1935;)Lnet/minecraft/class_52$class_53;
-	METHOD method_10395 createEmpty ()Lnet/minecraft/class_52$class_53;
-	METHOD method_10396 createForNameableContainer (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
-	METHOD method_10397 createForNeedingSilkTouch (Lnet/minecraft/class_2248;Lnet/minecraft/class_79$class_80;)Lnet/minecraft/class_52$class_53;
+	METHOD method_10392 addSurvivesExplosionCondition (Lnet/minecraft/class_1935;Lnet/minecraft/class_192;)Ljava/lang/Object;
+		ARG 0 drop
+		ARG 1 builder
+	METHOD method_10393 applyExplosionDecay (Lnet/minecraft/class_1935;Lnet/minecraft/class_116;)Ljava/lang/Object;
+		ARG 0 drop
+		ARG 1 builder
+	METHOD method_10394 drops (Lnet/minecraft/class_1935;)Lnet/minecraft/class_52$class_53;
+		ARG 0 drop
+	METHOD method_10395 dropsNothing ()Lnet/minecraft/class_52$class_53;
+	METHOD method_10396 nameableContainerDrops (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
+		ARG 0 drop
+	METHOD method_10397 dropsWithSilkTouch (Lnet/minecraft/class_2248;Lnet/minecraft/class_79$class_80;)Lnet/minecraft/class_52$class_53;
+		ARG 0 drop
 		ARG 1 child
-	METHOD method_16238 registerForNeedingSilkTouch (Lnet/minecraft/class_2248;Lnet/minecraft/class_2248;)V
+	METHOD method_16238 addDropWithSilkTouch (Lnet/minecraft/class_2248;Lnet/minecraft/class_2248;)V
 		ARG 1 block
-		ARG 2 droppedBlock
-	METHOD method_16256 register (Lnet/minecraft/class_2248;Lnet/minecraft/class_1935;)V
-		ARG 2 loot
-	METHOD method_16258 register (Lnet/minecraft/class_2248;Lnet/minecraft/class_52$class_53;)V
-	METHOD method_16262 registerForNeedingSilkTouch (Lnet/minecraft/class_2248;)V
-	METHOD method_16285 registerForPottedPlant (Lnet/minecraft/class_2248;)V
-	METHOD method_16293 registerWithFunction (Lnet/minecraft/class_2248;Ljava/util/function/Function;)V
-	METHOD method_16329 registerForSelfDrop (Lnet/minecraft/class_2248;)V
-	METHOD method_16876 createForShulkerBox (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
-	METHOD method_16877 createForBanner (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
-	METHOD method_22142 createForBeeNest (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
-	METHOD method_22143 createForBeehive (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
-	METHOD method_23229 createForAttachedCropStem (Lnet/minecraft/class_2248;Lnet/minecraft/class_1792;)Lnet/minecraft/class_52$class_53;
-		ARG 1 seeds
+		ARG 2 drop
+	METHOD method_16256 addDrop (Lnet/minecraft/class_2248;Lnet/minecraft/class_1935;)V
+		ARG 2 drop
+	METHOD method_16258 addDrop (Lnet/minecraft/class_2248;Lnet/minecraft/class_52$class_53;)V
+		ARG 2 lootTable
+	METHOD method_16262 addDropWithSilkTouch (Lnet/minecraft/class_2248;)V
+	METHOD method_16285 addPottedPlantDrop (Lnet/minecraft/class_2248;)V
+	METHOD method_16293 addDrop (Lnet/minecraft/class_2248;Ljava/util/function/Function;)V
+	METHOD method_16329 addDrop (Lnet/minecraft/class_2248;)V
+	METHOD method_16876 shulkerBoxDrops (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
+		ARG 0 drop
+	METHOD method_16877 bannerDrops (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
+		ARG 0 drop
+	METHOD method_22142 beeNestDrops (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
+		ARG 0 drop
+	METHOD method_22143 beehiveDrops (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
+		ARG 0 drop
+	METHOD method_23229 attachedCropStemDrops (Lnet/minecraft/class_2248;Lnet/minecraft/class_1792;)Lnet/minecraft/class_52$class_53;
+		ARG 0 stem
+		ARG 1 drop
+	METHOD method_24817 addDoorDrop (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
+	METHOD method_26000 addVinePlantDrop (Lnet/minecraft/class_2248;Lnet/minecraft/class_2248;)V
+		ARG 1 block
+		ARG 2 drop

--- a/mappings/net/minecraft/data/server/BlockLootTableGenerator.mapping
+++ b/mappings/net/minecraft/data/server/BlockLootTableGenerator.mapping
@@ -4,8 +4,8 @@ CLASS net/minecraft/class_2430 net/minecraft/data/server/BlockLootTableGenerator
 	FIELD field_11338 JUNGLE_SAPLING_DROP_CHANCE [F
 	FIELD field_11339 SAPLING_DROP_CHANCE [F
 	FIELD field_11340 EXPLOSION_IMMUNE Ljava/util/Set;
-	FIELD field_11341 WITHOUT_SILK_TOUCH_SHEARS Lnet/minecraft/class_4570$class_210;
-	FIELD field_11342 WITH_SILK_TOUCH_SHEARS Lnet/minecraft/class_4570$class_210;
+	FIELD field_11341 WITHOUT_SILK_TOUCH_AND_SHEARS Lnet/minecraft/class_4570$class_210;
+	FIELD field_11342 WITH_SILK_TOUCH_OR_SHEARS Lnet/minecraft/class_4570$class_210;
 	FIELD field_11343 WITH_SHEARS Lnet/minecraft/class_4570$class_210;
 	FIELD field_16493 lootTables Ljava/util/Map;
 	METHOD method_10371 grassDrops (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;

--- a/mappings/net/minecraft/loot/LootChoice.mapping
+++ b/mappings/net/minecraft/loot/LootChoice.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_82 net/minecraft/loot/LootChoice
-	METHOD method_426 drop (Ljava/util/function/Consumer;Lnet/minecraft/class_47;)V
+	METHOD method_426 generateLoot (Ljava/util/function/Consumer;Lnet/minecraft/class_47;)V
 		ARG 1 itemDropper
 		ARG 2 context
 	METHOD method_427 getWeight (F)I

--- a/mappings/net/minecraft/loot/LootChoice.mapping
+++ b/mappings/net/minecraft/loot/LootChoice.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_82 net/minecraft/loot/LootChoice
 	METHOD method_426 generateLoot (Ljava/util/function/Consumer;Lnet/minecraft/class_47;)V
-		ARG 1 itemDropper
+		ARG 1 lootConsumer
 		ARG 2 context
 	METHOD method_427 getWeight (F)I
 		ARG 1 luck

--- a/mappings/net/minecraft/loot/LootManager.mapping
+++ b/mappings/net/minecraft/loot/LootManager.mapping
@@ -10,7 +10,7 @@ CLASS net/minecraft/class_60 net/minecraft/loot/LootManager
 	METHOD method_368 (Ljava/lang/String;Ljava/lang/String;)V
 		ARG 0 key
 		ARG 1 value
-	METHOD method_369 check (Lnet/minecraft/class_58;Lnet/minecraft/class_2960;Lnet/minecraft/class_52;)V
+	METHOD method_369 validate (Lnet/minecraft/class_58;Lnet/minecraft/class_2960;Lnet/minecraft/class_52;)V
 		ARG 0 reporter
 		ARG 1 id
 		ARG 2 table

--- a/mappings/net/minecraft/loot/LootPool.mapping
+++ b/mappings/net/minecraft/loot/LootPool.mapping
@@ -13,12 +13,12 @@ CLASS net/minecraft/class_55 net/minecraft/loot/LootPool
 		ARG 4 rolls
 		ARG 5 bonusRolls
 	METHOD method_341 addGeneratedLoot (Ljava/util/function/Consumer;Lnet/minecraft/class_47;)V
-		ARG 1 itemDropper
+		ARG 1 lootConsumer
 		ARG 2 context
 	METHOD method_342 (Lnet/minecraft/class_47;Ljava/util/List;Lorg/apache/commons/lang3/mutable/MutableInt;Lnet/minecraft/class_82;)V
 		ARG 3 choice
 	METHOD method_345 supplyOnce (Ljava/util/function/Consumer;Lnet/minecraft/class_47;)V
-		ARG 1 itemDropper
+		ARG 1 lootConsumer
 		ARG 2 context
 	METHOD method_347 builder ()Lnet/minecraft/class_55$class_56;
 	METHOD method_349 validate (Lnet/minecraft/class_58;)V

--- a/mappings/net/minecraft/loot/LootPool.mapping
+++ b/mappings/net/minecraft/loot/LootPool.mapping
@@ -4,15 +4,15 @@ CLASS net/minecraft/class_55 net/minecraft/loot/LootPool
 	FIELD field_954 conditions [Lnet/minecraft/class_4570;
 	FIELD field_955 predicate Ljava/util/function/Predicate;
 	FIELD field_956 functions [Lnet/minecraft/class_117;
-	FIELD field_957 rollsRange Lnet/minecraft/class_59;
-	FIELD field_958 bonusRollsRange Lnet/minecraft/class_61;
+	FIELD field_957 rolls Lnet/minecraft/class_59;
+	FIELD field_958 bonusRolls Lnet/minecraft/class_61;
 	METHOD <init> ([Lnet/minecraft/class_79;[Lnet/minecraft/class_4570;[Lnet/minecraft/class_117;Lnet/minecraft/class_59;Lnet/minecraft/class_61;)V
 		ARG 1 entries
 		ARG 2 conditions
 		ARG 3 functions
-		ARG 4 rollsRange
-		ARG 5 bonusRollsRange
-	METHOD method_341 drop (Ljava/util/function/Consumer;Lnet/minecraft/class_47;)V
+		ARG 4 rolls
+		ARG 5 bonusRolls
+	METHOD method_341 addGeneratedLoot (Ljava/util/function/Consumer;Lnet/minecraft/class_47;)V
 		ARG 1 itemDropper
 		ARG 2 context
 	METHOD method_342 (Lnet/minecraft/class_47;Ljava/util/List;Lorg/apache/commons/lang3/mutable/MutableInt;Lnet/minecraft/class_82;)V
@@ -21,17 +21,17 @@ CLASS net/minecraft/class_55 net/minecraft/loot/LootPool
 		ARG 1 itemDropper
 		ARG 2 context
 	METHOD method_347 builder ()Lnet/minecraft/class_55$class_56;
-	METHOD method_349 check (Lnet/minecraft/class_58;)V
+	METHOD method_349 validate (Lnet/minecraft/class_58;)V
 	CLASS class_56 Builder
-		FIELD field_959 rollsRange Lnet/minecraft/class_59;
+		FIELD field_959 rolls Lnet/minecraft/class_59;
 		FIELD field_960 entries Ljava/util/List;
 		FIELD field_961 functions Ljava/util/List;
 		FIELD field_962 bonusRollsRange Lnet/minecraft/class_61;
 		FIELD field_963 conditions Ljava/util/List;
-		METHOD method_351 withEntry (Lnet/minecraft/class_79$class_80;)Lnet/minecraft/class_55$class_56;
-			ARG 1 entryBuilder
-		METHOD method_352 withRolls (Lnet/minecraft/class_59;)Lnet/minecraft/class_55$class_56;
-			ARG 1 rollsRange
+		METHOD method_351 with (Lnet/minecraft/class_79$class_80;)Lnet/minecraft/class_55$class_56;
+			ARG 1 entry
+		METHOD method_352 rolls (Lnet/minecraft/class_59;)Lnet/minecraft/class_55$class_56;
+			ARG 1 rolls
 		METHOD method_355 build ()Lnet/minecraft/class_55;
 	CLASS class_57 Serializer
 		METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;

--- a/mappings/net/minecraft/loot/LootTable.mapping
+++ b/mappings/net/minecraft/loot/LootTable.mapping
@@ -10,28 +10,28 @@ CLASS net/minecraft/class_52 net/minecraft/loot/LootTable
 		ARG 1 type
 		ARG 2 pools
 		ARG 3 functions
-	METHOD method_319 getDrops (Lnet/minecraft/class_47;)Ljava/util/List;
+	METHOD method_319 generateLoot (Lnet/minecraft/class_47;)Ljava/util/List;
 		ARG 1 context
-	METHOD method_320 dropLimited (Lnet/minecraft/class_47;Ljava/util/function/Consumer;)V
+	METHOD method_320 generateLoot (Lnet/minecraft/class_47;Ljava/util/function/Consumer;)V
 		ARG 1 context
-		ARG 2 dropItemConsumer
+		ARG 2 lootConsumer
 	METHOD method_321 getFreeSlots (Lnet/minecraft/class_1263;Ljava/util/Random;)Ljava/util/List;
 		ARG 1 inventory
 		ARG 2 random
 	METHOD method_322 getType ()Lnet/minecraft/class_176;
 	METHOD method_324 builder ()Lnet/minecraft/class_52$class_53;
-	METHOD method_328 drop (Lnet/minecraft/class_47;Ljava/util/function/Consumer;)V
+	METHOD method_328 generateUnprocessedLoot (Lnet/minecraft/class_47;Ljava/util/function/Consumer;)V
 		ARG 1 context
-		ARG 2 itemDropper
+		ARG 2 lootConsumer
 	METHOD method_329 supplyInventory (Lnet/minecraft/class_1263;Lnet/minecraft/class_47;)V
 		ARG 1 inventory
 		ARG 2 context
-	METHOD method_330 check (Lnet/minecraft/class_58;)V
+	METHOD method_330 validate (Lnet/minecraft/class_58;)V
 		ARG 1 reporter
 	METHOD method_331 (Ljava/util/function/Consumer;Lnet/minecraft/class_1799;)V
 		ARG 1 stack
-	METHOD method_332 limitedConsumer (Ljava/util/function/Consumer;)Ljava/util/function/Consumer;
-		ARG 0 itemDropper
+	METHOD method_332 processStacks (Ljava/util/function/Consumer;)Ljava/util/function/Consumer;
+		ARG 0 lootConsumer
 	METHOD method_333 shuffle (Ljava/util/List;ILjava/util/Random;)V
 		ARG 1 drops
 		ARG 2 freeSlots
@@ -40,11 +40,11 @@ CLASS net/minecraft/class_52 net/minecraft/loot/LootTable
 		FIELD field_949 pools Ljava/util/List;
 		FIELD field_950 type Lnet/minecraft/class_176;
 		FIELD field_951 functions Ljava/util/List;
-		METHOD method_334 withType (Lnet/minecraft/class_176;)Lnet/minecraft/class_52$class_53;
+		METHOD method_334 type (Lnet/minecraft/class_176;)Lnet/minecraft/class_52$class_53;
 			ARG 1 context
-		METHOD method_336 withPool (Lnet/minecraft/class_55$class_56;)Lnet/minecraft/class_52$class_53;
+		METHOD method_336 pool (Lnet/minecraft/class_55$class_56;)Lnet/minecraft/class_52$class_53;
 			ARG 1 poolBuilder
-		METHOD method_338 create ()Lnet/minecraft/class_52;
+		METHOD method_338 build ()Lnet/minecraft/class_52;
 	CLASS class_54 Serializer
 		METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 			ARG 1 json

--- a/mappings/net/minecraft/loot/LootTableReporter.mapping
+++ b/mappings/net/minecraft/loot/LootTableReporter.mapping
@@ -19,7 +19,7 @@ CLASS net/minecraft/class_58 net/minecraft/loot/LootTableReporter
 		ARG 1 contextType
 		ARG 2 conditionGetter
 		ARG 3 tableFactory
-	METHOD method_22567 checkContext (Lnet/minecraft/class_46;)V
+	METHOD method_22567 validateContext (Lnet/minecraft/class_46;)V
 		ARG 1 contextAware
 	METHOD method_22568 withContextType (Lnet/minecraft/class_176;)Lnet/minecraft/class_58;
 		ARG 1 contextType

--- a/mappings/net/minecraft/loot/condition/BlockStatePropertyLootCondition.mapping
+++ b/mappings/net/minecraft/loot/condition/BlockStatePropertyLootCondition.mapping
@@ -13,4 +13,5 @@ CLASS net/minecraft/class_212 net/minecraft/loot/condition/BlockStatePropertyLoo
 		FIELD field_1291 propertyValues Lnet/minecraft/class_4559;
 		METHOD <init> (Lnet/minecraft/class_2248;)V
 			ARG 1 block
+		METHOD method_22584 properties (Lnet/minecraft/class_4559$class_4560;)Lnet/minecraft/class_212$class_213;
 	CLASS class_214 Factory

--- a/mappings/net/minecraft/loot/condition/LootCondition.mapping
+++ b/mappings/net/minecraft/loot/condition/LootCondition.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_4570 net/minecraft/loot/condition/LootCondition
 	CLASS class_210 Builder
 		METHOD method_16780 invert ()Lnet/minecraft/class_4570$class_210;
-		METHOD method_893 withCondition (Lnet/minecraft/class_4570$class_210;)Lnet/minecraft/class_186$class_187;
+		METHOD method_893 or (Lnet/minecraft/class_4570$class_210;)Lnet/minecraft/class_186$class_187;
 			ARG 1 condition
 	CLASS class_211 Factory
 		FIELD field_1284 id Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/loot/condition/LootConditionConsumingBuilder.mapping
+++ b/mappings/net/minecraft/loot/condition/LootConditionConsumingBuilder.mapping
@@ -1,4 +1,4 @@
 CLASS net/minecraft/class_192 net/minecraft/loot/condition/LootConditionConsumingBuilder
 	METHOD method_512 getThis ()Ljava/lang/Object;
-	METHOD method_840 withCondition (Lnet/minecraft/class_4570$class_210;)Ljava/lang/Object;
-		ARG 1 builder
+	METHOD method_840 conditionally (Lnet/minecraft/class_4570$class_210;)Ljava/lang/Object;
+		ARG 1 condition

--- a/mappings/net/minecraft/loot/context/LootContext.mapping
+++ b/mappings/net/minecraft/loot/context/LootContext.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/class_47 net/minecraft/loot/context/LootContext
 	FIELD field_924 tableGetter Ljava/util/function/Function;
 	FIELD field_925 parameters Ljava/util/Map;
 	FIELD field_926 luck F
-	FIELD field_927 tables Ljava/util/Set;
+	FIELD field_927 activeTables Ljava/util/Set;
 	FIELD field_928 world Lnet/minecraft/class_3218;
 	FIELD field_929 drops Ljava/util/Map;
 	METHOD <init> (Ljava/util/Random;FLnet/minecraft/class_3218;Ljava/util/function/Function;Ljava/util/function/Function;Ljava/util/Map;Ljava/util/Map;)V
@@ -25,15 +25,15 @@ CLASS net/minecraft/class_47 net/minecraft/loot/context/LootContext
 	METHOD method_22558 getCondition (Lnet/minecraft/class_2960;)Lnet/minecraft/class_4570;
 		ARG 1 id
 	METHOD method_294 getRandom ()Ljava/util/Random;
-	METHOD method_295 removeDrop (Lnet/minecraft/class_52;)V
-		ARG 1 supplier
+	METHOD method_295 markInactive (Lnet/minecraft/class_52;)V
+		ARG 1 table
 	METHOD method_296 get (Lnet/minecraft/class_169;)Ljava/lang/Object;
 		ARG 1 parameter
 	METHOD method_297 drop (Lnet/minecraft/class_2960;Ljava/util/function/Consumer;)V
 		ARG 1 id
 		ARG 2 itemDropper
-	METHOD method_298 addDrop (Lnet/minecraft/class_52;)Z
-		ARG 1 supplier
+	METHOD method_298 markActive (Lnet/minecraft/class_52;)Z
+		ARG 1 table
 	METHOD method_299 getWorld ()Lnet/minecraft/class_3218;
 	METHOD method_300 hasParameter (Lnet/minecraft/class_169;)Z
 		ARG 1 parameter
@@ -46,13 +46,13 @@ CLASS net/minecraft/class_47 net/minecraft/loot/context/LootContext
 		FIELD field_934 random Ljava/util/Random;
 		METHOD <init> (Lnet/minecraft/class_3218;)V
 			ARG 1 world
-		METHOD method_303 setLuck (F)Lnet/minecraft/class_47$class_48;
+		METHOD method_303 luck (F)Lnet/minecraft/class_47$class_48;
 			ARG 1 luck
-		METHOD method_304 setRandom (J)Lnet/minecraft/class_47$class_48;
+		METHOD method_304 random (J)Lnet/minecraft/class_47$class_48;
 			ARG 1 seed
 		METHOD method_305 getNullable (Lnet/minecraft/class_169;)Ljava/lang/Object;
 			ARG 1 parameter
-		METHOD method_306 putNullable (Lnet/minecraft/class_169;Ljava/lang/Object;)Lnet/minecraft/class_47$class_48;
+		METHOD method_306 optionalParameter (Lnet/minecraft/class_169;Ljava/lang/Object;)Lnet/minecraft/class_47$class_48;
 			ARG 1 key
 			ARG 2 value
 		METHOD method_307 putDrop (Lnet/minecraft/class_2960;Lnet/minecraft/class_47$class_49;)Lnet/minecraft/class_47$class_48;
@@ -62,12 +62,12 @@ CLASS net/minecraft/class_47 net/minecraft/loot/context/LootContext
 			ARG 1 parameter
 		METHOD method_309 build (Lnet/minecraft/class_176;)Lnet/minecraft/class_47;
 			ARG 1 type
-		METHOD method_310 setRandom (JLjava/util/Random;)Lnet/minecraft/class_47$class_48;
+		METHOD method_310 random (JLjava/util/Random;)Lnet/minecraft/class_47$class_48;
 			ARG 1 seed
 			ARG 3 random
-		METHOD method_311 setRandom (Ljava/util/Random;)Lnet/minecraft/class_47$class_48;
+		METHOD method_311 random (Ljava/util/Random;)Lnet/minecraft/class_47$class_48;
 			ARG 1 random
-		METHOD method_312 put (Lnet/minecraft/class_169;Ljava/lang/Object;)Lnet/minecraft/class_47$class_48;
+		METHOD method_312 parameter (Lnet/minecraft/class_169;Ljava/lang/Object;)Lnet/minecraft/class_47$class_48;
 			ARG 1 key
 			ARG 2 value
 		METHOD method_313 getWorld ()Lnet/minecraft/class_3218;

--- a/mappings/net/minecraft/loot/context/LootContext.mapping
+++ b/mappings/net/minecraft/loot/context/LootContext.mapping
@@ -31,7 +31,7 @@ CLASS net/minecraft/class_47 net/minecraft/loot/context/LootContext
 		ARG 1 parameter
 	METHOD method_297 drop (Lnet/minecraft/class_2960;Ljava/util/function/Consumer;)V
 		ARG 1 id
-		ARG 2 itemDropper
+		ARG 2 lootConsumer
 	METHOD method_298 markActive (Lnet/minecraft/class_52;)Z
 		ARG 1 table
 	METHOD method_299 getWorld ()Lnet/minecraft/class_3218;

--- a/mappings/net/minecraft/loot/context/LootContextAware.mapping
+++ b/mappings/net/minecraft/loot/context/LootContextAware.mapping
@@ -1,4 +1,4 @@
 CLASS net/minecraft/class_46 net/minecraft/loot/context/LootContextAware
-	METHOD method_292 check (Lnet/minecraft/class_58;)V
+	METHOD method_292 validate (Lnet/minecraft/class_58;)V
 		ARG 1 reporter
 	METHOD method_293 getRequiredParameters ()Ljava/util/Set;

--- a/mappings/net/minecraft/loot/context/LootContextType.mapping
+++ b/mappings/net/minecraft/loot/context/LootContextType.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_176 net/minecraft/loot/context/LootContextType
 	METHOD <init> (Ljava/util/Set;Ljava/util/Set;)V
 		ARG 1 required
 		ARG 2 allowed
-	METHOD method_776 check (Lnet/minecraft/class_58;Lnet/minecraft/class_46;)V
+	METHOD method_776 validate (Lnet/minecraft/class_58;Lnet/minecraft/class_46;)V
 		ARG 1 reporter
 		ARG 2 parameterConsumer
 	METHOD method_777 getAllowed ()Ljava/util/Set;

--- a/mappings/net/minecraft/loot/entry/ItemEntry.mapping
+++ b/mappings/net/minecraft/loot/entry/ItemEntry.mapping
@@ -12,5 +12,5 @@ CLASS net/minecraft/class_77 net/minecraft/loot/entry/ItemEntry
 		ARG 3 conditions
 		ARG 4 functions
 	METHOD method_411 builder (Lnet/minecraft/class_1935;)Lnet/minecraft/class_85$class_86;
-		ARG 0 itemProvider
+		ARG 0 drop
 	CLASS class_78 Serializer

--- a/mappings/net/minecraft/loot/entry/LeafEntry.mapping
+++ b/mappings/net/minecraft/loot/entry/LeafEntry.mapping
@@ -10,7 +10,7 @@ CLASS net/minecraft/class_85 net/minecraft/loot/entry/LeafEntry
 		ARG 3 conditions
 		ARG 4 functions
 	METHOD method_433 generateLoot (Ljava/util/function/Consumer;Lnet/minecraft/class_47;)V
-		ARG 1 itemDropper
+		ARG 1 lootConsumer
 		ARG 2 context
 	METHOD method_434 builder (Lnet/minecraft/class_85$class_89;)Lnet/minecraft/class_85$class_86;
 		ARG 0 factory

--- a/mappings/net/minecraft/loot/entry/LeafEntry.mapping
+++ b/mappings/net/minecraft/loot/entry/LeafEntry.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_85 net/minecraft/loot/entry/LeafEntry
 		ARG 2 quality
 		ARG 3 conditions
 		ARG 4 functions
-	METHOD method_433 drop (Ljava/util/function/Consumer;Lnet/minecraft/class_47;)V
+	METHOD method_433 generateLoot (Ljava/util/function/Consumer;Lnet/minecraft/class_47;)V
 		ARG 1 itemDropper
 		ARG 2 context
 	METHOD method_434 builder (Lnet/minecraft/class_85$class_89;)Lnet/minecraft/class_85$class_86;
@@ -18,9 +18,9 @@ CLASS net/minecraft/class_85 net/minecraft/loot/entry/LeafEntry
 		FIELD field_1000 quality I
 		FIELD field_1001 weight I
 		FIELD field_999 functions Ljava/util/List;
-		METHOD method_436 setQuality (I)Lnet/minecraft/class_85$class_86;
+		METHOD method_436 quality (I)Lnet/minecraft/class_85$class_86;
 			ARG 1 quality
-		METHOD method_437 setWeight (I)Lnet/minecraft/class_85$class_86;
+		METHOD method_437 weight (I)Lnet/minecraft/class_85$class_86;
 			ARG 1 weight
 		METHOD method_439 getFunctions ()[Lnet/minecraft/class_117;
 	CLASS class_87 BasicBuilder

--- a/mappings/net/minecraft/loot/entry/LootEntry.mapping
+++ b/mappings/net/minecraft/loot/entry/LootEntry.mapping
@@ -5,11 +5,11 @@ CLASS net/minecraft/class_79 net/minecraft/loot/entry/LootEntry
 		ARG 1 conditions
 	METHOD method_414 test (Lnet/minecraft/class_47;)Z
 		ARG 1 context
-	METHOD method_415 check (Lnet/minecraft/class_58;)V
+	METHOD method_415 validate (Lnet/minecraft/class_58;)V
 		ARG 1 reporter
 	CLASS class_80 Builder
 		FIELD field_990 conditions Ljava/util/List;
-		METHOD method_417 withChild (Lnet/minecraft/class_79$class_80;)Lnet/minecraft/class_65$class_66;
+		METHOD method_417 alternatively (Lnet/minecraft/class_79$class_80;)Lnet/minecraft/class_65$class_66;
 			ARG 1 builder
 		METHOD method_418 getThisBuilder ()Lnet/minecraft/class_79$class_80;
 		METHOD method_419 build ()Lnet/minecraft/class_79;

--- a/mappings/net/minecraft/loot/function/LootFunction.mapping
+++ b/mappings/net/minecraft/loot/function/LootFunction.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_117 net/minecraft/loot/function/LootFunction
 	METHOD method_513 apply (Ljava/util/function/BiFunction;Ljava/util/function/Consumer;Lnet/minecraft/class_47;)Ljava/util/function/Consumer;
 		ARG 0 itemApplier
-		ARG 1 itemDropper
+		ARG 1 lootConsumer
 		ARG 2 context
 	METHOD method_514 (Ljava/util/function/Consumer;Ljava/util/function/BiFunction;Lnet/minecraft/class_47;Lnet/minecraft/class_1799;)V
 		ARG 3 stack

--- a/mappings/net/minecraft/loot/function/LootFunctionConsumingBuilder.mapping
+++ b/mappings/net/minecraft/loot/function/LootFunctionConsumingBuilder.mapping
@@ -1,4 +1,4 @@
 CLASS net/minecraft/class_116 net/minecraft/loot/function/LootFunctionConsumingBuilder
-	METHOD method_511 withFunction (Lnet/minecraft/class_117$class_118;)Ljava/lang/Object;
-		ARG 1 lootFunctionBuilder
+	METHOD method_511 apply (Lnet/minecraft/class_117$class_118;)Ljava/lang/Object;
+		ARG 1 function
 	METHOD method_512 getThis ()Ljava/lang/Object;


### PR DESCRIPTION
Some of the old ones were wrong, others just could be improved. 

A few names in particular I'd like some other eyes/opinions on are the LootTable#processStacks, LootTable#generateUnprocessedLoot, and LootTable#generateLoot. I think they're already improvements on the old ones but they are kinda confusing in decompiled form so please double-check those.