### PR TITLE
Map FallibleItemDispenserBehavior.success accessors

### DIFF
--- a/mappings/net/minecraft/block/dispenser/FallibleItemDispenserBehavior.mapping
+++ b/mappings/net/minecraft/block/dispenser/FallibleItemDispenserBehavior.mapping
@@ -1,2 +1,5 @@
 CLASS net/minecraft/class_2969 net/minecraft/block/dispenser/FallibleItemDispenserBehavior
 	FIELD field_13364 success Z
+	METHOD method_27954 isSuccess ()Z
+	METHOD method_27955 setSuccess (Z)V
+		ARG 1 success


### PR DESCRIPTION
These were added in some 1.16 snapshot.