### PR TITLE
TextRenderer.getStringWidth(Text) -> getWidth()

### DIFF
--- a/mappings/net/minecraft/client/font/TextRenderer.mapping
+++ b/mappings/net/minecraft/client/font/TextRenderer.mapping
@@ -141,7 +141,7 @@ CLASS net/minecraft/class_327 net/minecraft/client/font/TextRenderer
 		ARG 1 text
 		ARG 2 maxWidth
 		ARG 3 backwards
-	METHOD method_27525 getStringWidth (Lnet/minecraft/class_2561;)I
+	METHOD method_27525 getWidth (Lnet/minecraft/class_2561;)I
 		ARG 1 text
 	METHOD method_27526 getFontStorage (Lnet/minecraft/class_2960;)Lnet/minecraft/class_377;
 		ARG 1 id


### PR DESCRIPTION
For consistency with `getWidth(String)`.