### PR TITLE
Naming inconsistency in ChunkGeneratorConfig

### DIFF
--- a/mappings/net/minecraft/world/gen/chunk/ChunkGeneratorConfig.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/ChunkGeneratorConfig.mapping
@@ -1,19 +1,19 @@
 CLASS net/minecraft/class_2888 net/minecraft/world/gen/chunk/ChunkGeneratorConfig
 	FIELD field_13137 templeSeparation I
-	FIELD field_13139 templeDistance I
+	FIELD field_13139 templeSpacing I
 	FIELD field_13140 strongholdSpread I
 	FIELD field_13141 strongholdCount I
-	FIELD field_13142 strongholdDistance I
+	FIELD field_13142 strongholdSpacing I
 	FIELD field_13143 oceanMonumentSeparation I
 	FIELD field_13144 oceanMonumentSpacing I
 	FIELD field_13145 villageSeparation I
-	FIELD field_13146 villageDistance I
+	FIELD field_13146 villageSpacing I
 	FIELD field_13147 mansionSeparation I
-	FIELD field_13148 mansionDistance I
+	FIELD field_13148 mansionSpacing I
 	FIELD field_13149 oceanRuinSeparation I
 	FIELD field_13150 oceanRuinSpacing I
 	FIELD field_13151 endCitySeparation I
-	FIELD field_13152 endCityDistance I
+	FIELD field_13152 endCitySpacing I
 	FIELD field_13153 shipwreckSeparation I
 	FIELD field_13155 shipwreckSpacing I
 	FIELD field_23987 netherStructureSpacing I
@@ -23,20 +23,20 @@ CLASS net/minecraft/class_2888 net/minecraft/world/gen/chunk/ChunkGeneratorConfi
 	FIELD field_24508 ruinedPortalSeparation I
 	METHOD method_12552 getMansionSeparation ()I
 	METHOD method_12553 getOceanMonumentSpacing ()I
-	METHOD method_12554 getEndCityDistance ()I
+	METHOD method_12554 getEndCitySpacing ()I
 	METHOD method_12555 getOceanRuinSeparation ()I
 	METHOD method_12556 getOceanMonumentSeparation ()I
 	METHOD method_12557 getEndCitySeparation ()I
-	METHOD method_12558 getVillageDistance ()I
+	METHOD method_12558 getVillageSpacing ()I
 	METHOD method_12559 getVillageSeparation ()I
-	METHOD method_12560 getMansionDistance ()I
+	METHOD method_12560 getMansionSpacing ()I
 	METHOD method_12561 getStrongholdCount ()I
 	METHOD method_12562 getShipwreckSeparation ()I
-	METHOD method_12563 getStrongholdDistance ()I
+	METHOD method_12563 getStrongholdSpacing ()I
 	METHOD method_12564 getOceanRuinSpacing ()I
 	METHOD method_12565 getStrongholdSpread ()I
 	METHOD method_12566 getShipwreckSpacing ()I
-	METHOD method_12567 getTempleDistance ()I
+	METHOD method_12567 getTempleSpacing ()I
 	METHOD method_12568 getTempleSeparation ()I
 	METHOD method_27193 getNetherStructureSpacing ()I
 	METHOD method_27194 getRuinedPortalSpacing ()I


### PR DESCRIPTION
Although the spacing and distance values are used in the same way, they have different names. 

In `AbstractTempleFeature`, `getSpacing()` calls `getTempleDistance()` from `ChunkGeneratorConfig`.

"distance" was simply replaced with "spacing" to make consistent with the other structure types.

For example, in `getStart()` in both `VillageFeature` and `OceanMonumentFeature`, `getSpacing()`/`getDistance()` is used in the same way but with different names.