### PR TITLE
onBlockRemoved -> onStateReplaced

### DIFF
--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -92,7 +92,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		ARG 1 state
 		ARG 2 pos
 	METHOD method_9536 onStateReplaced (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Z)V
-		COMMENT Check if block is removed and perform cleaning operations here. Drop inventories here. Don't forget to call parent when you're done
+		COMMENT Called in setBlockState() if newState is different from state. Vanilla blocks perform removal cleanups here.
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos

--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -91,7 +91,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 	METHOD method_9535 getRenderingSeed (Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;)J
 		ARG 1 state
 		ARG 2 pos
-	METHOD method_9536 onBlockRemoved (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Z)V
+	METHOD method_9536 onStateReplaced (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Z)V
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
@@ -434,7 +434,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		METHOD method_26196 createScreenHandlerFactory (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)Lnet/minecraft/class_3908;
 			ARG 1 world
 			ARG 2 pos
-		METHOD method_26197 onBlockRemoved (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Z)V
+		METHOD method_26197 onStateReplaced (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Z)V
 			ARG 1 world
 			ARG 2 pos
 			ARG 3 state

--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -92,7 +92,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		ARG 1 state
 		ARG 2 pos
 	METHOD method_9536 onStateReplaced (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Z)V
-		COMMENT Called in {@link World#setBlockState()} if {@code newState} is different from {@code state}. Vanilla blocks perform removal cleanups here.
+		COMMENT Called in {@link net.minecraft.world.chunk.WorldChunk#setBlockState(BlockPos, BlockState, boolean)} if {@code newState} is different from {@code state}. Vanilla blocks perform removal cleanups here.
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos

--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -92,6 +92,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		ARG 1 state
 		ARG 2 pos
 	METHOD method_9536 onStateReplaced (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Z)V
+		COMMENT Check if block is removed and perform cleaning operations here. Drop inventories here. Don't forget to call parent when you're done
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos

--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -92,7 +92,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		ARG 1 state
 		ARG 2 pos
 	METHOD method_9536 onStateReplaced (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Z)V
-		COMMENT Called in setBlockState() if newState is different from state. Vanilla blocks perform removal cleanups here.
+		COMMENT Called in {@link World#setBlockState()} if {@code newState} is different from {@code state}. Vanilla blocks perform removal cleanups here.
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos

--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -92,7 +92,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		ARG 1 state
 		ARG 2 pos
 	METHOD method_9536 onStateReplaced (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Z)V
-		COMMENT Check if block is removed and perform cleaning operations here. Drop inventories here. Don't forget to call parent when you're done
+		COMMENT Check if block is removed and perform cleaning operations here. Drop inventories here. Don't forget to call super when you're done.
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos


### PR DESCRIPTION
Currently `WorldChunk.setBlockState()`:
1. Sets the state
2. If new state equals old state does nothing
3. Otherwise it updates lighting, heightmaps and calls onBlockRemoved
4. If the block at said position equals block that is being set, then it calls onBlockAdded

That's ignoring BlockEntity refreshing code
`onBlockRemoved` is being called on any state replacement, not only when the block is removed (replaced with air). Vanilla implementations explicitly check for removal

Other suggested name is `onStateRemoved`, but that also implies that state is being replaced with air