### PR TITLE
BasicInventory -> SimpleInventory

### DIFF
--- a/mappings/net/minecraft/inventory/SimpleInventory.mapping
+++ b/mappings/net/minecraft/inventory/SimpleInventory.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_1277 net/minecraft/inventory/BasicInventory
+CLASS net/minecraft/class_1277 net/minecraft/inventory/SimpleInventory
 	FIELD field_5828 stacks Lnet/minecraft/class_2371;
 	FIELD field_5829 listeners Ljava/util/List;
 	FIELD field_5831 size I


### PR DESCRIPTION
This is because this is a simple implementation of an inventory rather than a "basic" implementation which sounds like an incomplete/barebones implementation.