### PR TITLE
Util unification

### DIFF
--- a/mappings/com/mojang/realmsclient/util/RealmsJsonUtil.mapping
+++ b/mappings/com/mojang/realmsclient/util/RealmsJsonUtil.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4431 com/mojang/realmsclient/util/JsonUtils
+CLASS net/minecraft/class_4431 com/mojang/realmsclient/util/RealmsJsonUtil
 	METHOD method_21544 getDateOr (Ljava/lang/String;Lcom/google/gson/JsonObject;)Ljava/util/Date;
 		ARG 0 key
 		ARG 1 node

--- a/mappings/com/mojang/realmsclient/util/TextRenderingUtil.mapping
+++ b/mappings/com/mojang/realmsclient/util/TextRenderingUtil.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4450 com/mojang/realmsclient/util/TextRenderingUtils
+CLASS net/minecraft/class_4450 com/mojang/realmsclient/util/TextRenderingUtil
 	METHOD method_21575 lineBreak (Ljava/lang/String;)Ljava/util/List;
 		ARG 0 text
 	METHOD method_21576 split (Ljava/lang/String;Ljava/lang/String;)Ljava/util/List;

--- a/mappings/net/minecraft/block/RailPlacementUtil.mapping
+++ b/mappings/net/minecraft/block/RailPlacementUtil.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2452 net/minecraft/block/RailPlacementHelper
+CLASS net/minecraft/class_2452 net/minecraft/block/RailPlacementUtil
 	FIELD field_11406 state Lnet/minecraft/class_2680;
 	FIELD field_11407 neighbors Ljava/util/List;
 	FIELD field_11408 allowCurves Z

--- a/mappings/net/minecraft/client/gui/DrawableUtil.mapping
+++ b/mappings/net/minecraft/client/gui/DrawableUtil.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawableHelper
+CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawableUtil
 	FIELD field_22734 zOffset I
 		COMMENT The z offset used by {@link DrawableHelper}.
 	FIELD field_22735 BACKGROUND_TEXTURE Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/gui/hud/BackgroundUtil.mapping
+++ b/mappings/net/minecraft/client/gui/hud/BackgroundUtil.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_5253 net/minecraft/client/gui/hud/BackgroundHelper
+CLASS net/minecraft/class_5253 net/minecraft/client/gui/hud/BackgroundUtil
 	CLASS class_5254 ColorMixer
 		METHOD method_27762 getAlpha (I)I
 			ARG 0 argb

--- a/mappings/net/minecraft/client/texture/MipmapUtil.mapping
+++ b/mappings/net/minecraft/client/texture/MipmapUtil.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4725 net/minecraft/client/texture/MipmapHelper
+CLASS net/minecraft/class_4725 net/minecraft/client/texture/MipmapUtil
 	FIELD field_21747 COLOR_FRACTIONS [F
 	METHOD method_24099 getColorFraction (I)F
 		ARG 0 value

--- a/mappings/net/minecraft/client/util/DefaultPlayerSkins.mapping
+++ b/mappings/net/minecraft/client/util/DefaultPlayerSkins.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_1068 net/minecraft/client/util/DefaultSkinHelper
+CLASS net/minecraft/class_1068 net/minecraft/client/util/DefaultPlayerSkins
 	FIELD field_5300 ALEX_SKIN Lnet/minecraft/class_2960;
 	FIELD field_5301 STEVE_SKIN Lnet/minecraft/class_2960;
 	METHOD method_4647 getModel (Ljava/util/UUID;)Ljava/lang/String;

--- a/mappings/net/minecraft/client/util/GlAllocationUtil.mapping
+++ b/mappings/net/minecraft/client/util/GlAllocationUtil.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_311 net/minecraft/client/util/GlAllocationUtils
+CLASS net/minecraft/class_311 net/minecraft/client/util/GlAllocationUtil
 	METHOD method_1596 allocateByteBuffer (I)Ljava/nio/ByteBuffer;
 		ARG 0 size
 	METHOD method_1597 allocateFloatBuffer (I)Ljava/nio/FloatBuffer;

--- a/mappings/net/minecraft/client/util/NetworkUtil.mapping
+++ b/mappings/net/minecraft/client/util/NetworkUtil.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3521 net/minecraft/client/util/NetworkUtils
+CLASS net/minecraft/class_3521 net/minecraft/client/util/NetworkUtil
 	FIELD field_15664 downloadExecutor Lcom/google/common/util/concurrent/ListeningExecutorService;
 	FIELD field_15665 LOGGER Lorg/apache/logging/log4j/Logger;
 	METHOD method_15301 download (Ljava/io/File;Ljava/lang/String;Ljava/util/Map;ILnet/minecraft/class_3536;Ljava/net/Proxy;)Ljava/util/concurrent/CompletableFuture;

--- a/mappings/net/minecraft/client/util/ScreenshotUtil.mapping
+++ b/mappings/net/minecraft/client/util/ScreenshotUtil.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_318 net/minecraft/client/util/ScreenshotUtils
+CLASS net/minecraft/class_318 net/minecraft/client/util/ScreenshotUtil
 	FIELD field_1973 DATE_FORMAT Ljava/text/DateFormat;
 	FIELD field_1974 LOGGER Lorg/apache/logging/log4j/Logger;
 	METHOD method_1659 saveScreenshot (Ljava/io/File;IILnet/minecraft/class_276;Ljava/util/function/Consumer;)V

--- a/mappings/net/minecraft/enchantment/EnchantmentUtil.mapping
+++ b/mappings/net/minecraft/enchantment/EnchantmentUtil.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_1890 net/minecraft/enchantment/EnchantmentHelper
+CLASS net/minecraft/class_1890 net/minecraft/enchantment/EnchantmentUtil
 	METHOD method_17884 (Ljava/util/Map;Lnet/minecraft/class_2487;Lnet/minecraft/class_1887;)V
 		ARG 2 enchantment
 	METHOD method_22445 fromTag (Lnet/minecraft/class_2499;)Ljava/util/Map;

--- a/mappings/net/minecraft/nbt/NbtUtil.mapping
+++ b/mappings/net/minecraft/nbt/NbtUtil.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2512 net/minecraft/nbt/NbtHelper
+CLASS net/minecraft/class_2512 net/minecraft/nbt/NbtUtil
 	FIELD field_11582 LOGGER Lorg/apache/logging/log4j/Logger;
 	METHOD method_10681 toBlockState (Lnet/minecraft/class_2487;)Lnet/minecraft/class_2680;
 		ARG 0 tag

--- a/mappings/net/minecraft/network/NetworkEncryptionUtil.mapping
+++ b/mappings/net/minecraft/network/NetworkEncryptionUtil.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3515 net/minecraft/network/NetworkEncryptionUtils
+CLASS net/minecraft/class_3515 net/minecraft/network/NetworkEncryptionUtil
 	FIELD field_15652 LOGGER Lorg/apache/logging/log4j/Logger;
 	METHOD method_15234 decryptSecretKey (Ljava/security/PrivateKey;[B)Ljavax/crypto/SecretKey;
 		ARG 0 privateKey

--- a/mappings/net/minecraft/network/NetworkThreadUtil.mapping
+++ b/mappings/net/minecraft/network/NetworkThreadUtil.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2600 net/minecraft/network/NetworkThreadUtils
+CLASS net/minecraft/class_2600 net/minecraft/network/NetworkThreadUtil
 	FIELD field_20318 LOGGER Lorg/apache/logging/log4j/Logger;
 	METHOD method_11073 forceMainThread (Lnet/minecraft/class_2596;Lnet/minecraft/class_2547;Lnet/minecraft/class_3218;)V
 		ARG 0 packet

--- a/mappings/net/minecraft/server/rcon/BufferUtil.mapping
+++ b/mappings/net/minecraft/server/rcon/BufferUtil.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3347 net/minecraft/server/rcon/BufferHelper
+CLASS net/minecraft/class_3347 net/minecraft/server/rcon/BufferUtil
 	FIELD field_14398 HEX_CHARS_LOOKUP [C
 	METHOD method_14695 getIntLE ([BI)I
 		ARG 0 buf

--- a/mappings/net/minecraft/util/JsonUtil.mapping
+++ b/mappings/net/minecraft/util/JsonUtil.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3518 net/minecraft/util/JsonHelper
+CLASS net/minecraft/class_3518 net/minecraft/util/JsonUtil
 	FIELD field_15657 GSON Lcom/google/gson/Gson;
 	METHOD method_15252 asArray (Lcom/google/gson/JsonElement;Ljava/lang/String;)Lcom/google/gson/JsonArray;
 		ARG 0 element

--- a/mappings/net/minecraft/util/math/MathUtil.mapping
+++ b/mappings/net/minecraft/util/math/MathUtil.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3532 net/minecraft/util/math/MathHelper
+CLASS net/minecraft/class_3532 net/minecraft/util/math/MathUtil
 	FIELD field_15722 COSINE_TABLE [D
 	FIELD field_15723 MULTIPLY_DE_BRUIJN_BIT_POSITION [I
 	FIELD field_15724 SQUARE_ROOT_OF_TWO F

--- a/mappings/net/minecraft/world/SpawnUtil.mapping
+++ b/mappings/net/minecraft/world/SpawnUtil.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_1948 net/minecraft/world/SpawnHelper
+CLASS net/minecraft/class_1948 net/minecraft/world/SpawnUtil
 	FIELD field_24392 CHUNK_AREA I
 	FIELD field_24393 SPAWNABLE_GROUPS [Lnet/minecraft/class_1311;
 	FIELD field_9292 LOGGER Lorg/apache/logging/log4j/Logger;


### PR DESCRIPTION
Closes #1108 

This does need a little more discussion, this PR is just to get the ball rolling. Other various util classes are just named as plural nouns (`Inventories`) and sometimes just singular nouns (`ItemScatterer`). 

To me, the plural nouns and gerunds would sound the nicest, ie. (`Inventories`, `Networking`, `ItemScattering`, `TextRendering`) but this breaks down for certain utils for things such as `EnchantmentUtil` or `ModelUtil` which already have conflicting `Enchantments` and `Models` classes.

Should we have `Util` as a fallback for when a plural noun or gerund doesn't fit, or should we go through and switch all the ones that don't follow the Util pattern currently to use a Util suffix?