### PR TITLE
Simplify some Inventory names and Javadocs

### DIFF
--- a/mappings/net/minecraft/block/entity/ChestBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/ChestBlockEntity.mapping
@@ -10,7 +10,7 @@ CLASS net/minecraft/class_2595 net/minecraft/block/entity/ChestBlockEntity
 	METHOD method_11048 getPlayersLookingInChestCount (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)I
 		ARG 0 world
 		ARG 1 pos
-	METHOD method_11049 onInvOpenOrClose ()V
+	METHOD method_11049 onOpenOrClose ()V
 	METHOD method_11050 playSound (Lnet/minecraft/class_3414;)V
 	METHOD method_17765 countViewers (Lnet/minecraft/class_1937;Lnet/minecraft/class_2624;III)I
 		ARG 0 world

--- a/mappings/net/minecraft/block/entity/ContainerBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/ContainerBlockEntity.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2624 net/minecraft/block/entity/LockableContainerBlockEntity
+CLASS net/minecraft/class_2624 net/minecraft/block/entity/ContainerBlockEntity
 	FIELD field_12045 lock Lnet/minecraft/class_1273;
 	FIELD field_17376 customName Lnet/minecraft/class_2561;
 	METHOD method_17487 checkUnlocked (Lnet/minecraft/class_1657;Lnet/minecraft/class_1273;Lnet/minecraft/class_2561;)Z
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_2624 net/minecraft/block/entity/LockableContainerBlock
 		ARG 1 customName
 	METHOD method_17489 checkUnlocked (Lnet/minecraft/class_1657;)Z
 		ARG 1 player
-	METHOD method_17823 getContainerName ()Lnet/minecraft/class_2561;
+	METHOD method_17823 getDefaultName ()Lnet/minecraft/class_2561;
 	METHOD method_5465 createScreenHandler (ILnet/minecraft/class_1661;)Lnet/minecraft/class_1703;
 		ARG 1 syncId
 		ARG 2 playerInventory

--- a/mappings/net/minecraft/block/entity/EnderChestBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/EnderChestBlockEntity.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/class_2611 net/minecraft/block/entity/EnderChestBlockEntity
 	FIELD field_12005 ticks I
 	FIELD field_12006 viewerCount I
 	FIELD field_12007 animationProgress F
-	METHOD method_11218 canPlayerUse (Lnet/minecraft/class_1657;)Z
+	METHOD method_11218 canPlayerAccess (Lnet/minecraft/class_1657;)Z
+		ARG 1 player
 	METHOD method_11219 onOpen ()V
 	METHOD method_11220 onClose ()V

--- a/mappings/net/minecraft/block/entity/LootableBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/LootableBlockEntity.mapping
@@ -1,9 +1,9 @@
-CLASS net/minecraft/class_2621 net/minecraft/block/entity/LootableContainerBlockEntity
+CLASS net/minecraft/class_2621 net/minecraft/block/entity/LootableBlockEntity
 	FIELD field_12036 lootTableSeed J
 	FIELD field_12037 lootTableId Lnet/minecraft/class_2960;
-	METHOD method_11281 setInvStackList (Lnet/minecraft/class_2371;)V
+	METHOD method_11281 setStacks (Lnet/minecraft/class_2371;)V
 		ARG 1 list
-	METHOD method_11282 getInvStackList ()Lnet/minecraft/class_2371;
+	METHOD method_11282 getStacks ()Lnet/minecraft/class_2371;
 	METHOD method_11283 deserializeLootTable (Lnet/minecraft/class_2487;)Z
 	METHOD method_11285 setLootTable (Lnet/minecraft/class_2960;J)V
 		ARG 1 id

--- a/mappings/net/minecraft/block/entity/LootableContainerBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/LootableContainerBlockEntity.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2621 net/minecraft/block/entity/LootableBlockEntity
+CLASS net/minecraft/class_2621 net/minecraft/block/entity/LootableContainerBlockEntity
 	FIELD field_12036 lootTableSeed J
 	FIELD field_12037 lootTableId Lnet/minecraft/class_2960;
 	METHOD method_11281 setStacks (Lnet/minecraft/class_2371;)V

--- a/mappings/net/minecraft/inventory/Inventory.mapping
+++ b/mappings/net/minecraft/inventory/Inventory.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/class_1263 net/minecraft/inventory/Inventory
 		COMMENT @return whether or not this inventory contains any of the specified items
 		ARG 1 items
 	METHOD method_5431 markDirty ()V
-	METHOD method_5432 onFinishAccess (Lnet/minecraft/class_1657;)V
+	METHOD method_5432 onClose (Lnet/minecraft/class_1657;)V
 		ARG 1 player
 	METHOD method_5434 removeStack (II)Lnet/minecraft/class_1799;
 		COMMENT Removes a specific number of items in the given slot.
@@ -14,7 +14,7 @@ CLASS net/minecraft/class_1263 net/minecraft/inventory/Inventory
 		COMMENT @return the removed items as a stack
 		ARG 1 slot
 		ARG 2 amount
-	METHOD method_5435 onStartAccess (Lnet/minecraft/class_1657;)V
+	METHOD method_5435 onOpen (Lnet/minecraft/class_1657;)V
 		ARG 1 player
 	METHOD method_5437 canInsert (ILnet/minecraft/class_1799;)Z
 		COMMENT @return whether or not the stack can be inserted into the specified slot
@@ -33,7 +33,7 @@ CLASS net/minecraft/class_1263 net/minecraft/inventory/Inventory
 		COMMENT @return the stack previously stored at the indicated index
 		ARG 1 slot
 	METHOD method_5442 isEmpty ()Z
-	METHOD method_5443 canAccess (Lnet/minecraft/class_1657;)Z
+	METHOD method_5443 canPlayerAccess (Lnet/minecraft/class_1657;)Z
 		ARG 1 player
 	METHOD method_5444 getMaxCountPerStack ()I
 		COMMENT Returns the maximum number of items a stack can contain when placed inside this inventory.

--- a/mappings/net/minecraft/inventory/Inventory.mapping
+++ b/mappings/net/minecraft/inventory/Inventory.mapping
@@ -1,42 +1,44 @@
 CLASS net/minecraft/class_1263 net/minecraft/inventory/Inventory
 	METHOD method_18861 count (Lnet/minecraft/class_1792;)I
-		COMMENT Returns the number of times the specified item occurs in this inventory across all stored stacks.
+		COMMENT @return the total count of the item across all stacks
 		ARG 1 item
 	METHOD method_18862 containsAny (Ljava/util/Set;)Z
-		COMMENT Determines whether this inventory contains any of the given candidate items.
+		COMMENT @return whether or not this inventory contains any of the specified items
 		ARG 1 items
 	METHOD method_5431 markDirty ()V
-	METHOD method_5432 onClose (Lnet/minecraft/class_1657;)V
+	METHOD method_5432 onFinishAccess (Lnet/minecraft/class_1657;)V
 		ARG 1 player
 	METHOD method_5434 removeStack (II)Lnet/minecraft/class_1799;
-		COMMENT Removes a specific number of items from the given slot.
+		COMMENT Removes a specific number of items in the given slot.
 		COMMENT
 		COMMENT @return the removed items as a stack
 		ARG 1 slot
 		ARG 2 amount
-	METHOD method_5435 onOpen (Lnet/minecraft/class_1657;)V
+	METHOD method_5435 onStartAccess (Lnet/minecraft/class_1657;)V
 		ARG 1 player
-	METHOD method_5437 isValid (ILnet/minecraft/class_1799;)Z
-		COMMENT Returns whether the given stack is a valid for the indicated slot position.
+	METHOD method_5437 canInsert (ILnet/minecraft/class_1799;)Z
+		COMMENT @return whether or not the stack can be inserted into the specified slot
 		ARG 1 slot
 		ARG 2 stack
 	METHOD method_5438 getStack (I)Lnet/minecraft/class_1799;
-		COMMENT Fetches the stack currently stored at the given slot. If the slot is empty,
-		COMMENT or is outside the bounds of this inventory, returns see {@link ItemStack#EMPTY}.
+		COMMENT Fetches the stack currently stored in the given slot. If the stack in the slot
+		COMMENT is empty or the index is outside the bounds of this inventory, returns {@link ItemStack#EMPTY}.
+		COMMENT
+		COMMENT @return the stack in the given slot
 		ARG 1 slot
 	METHOD method_5439 size ()I
 	METHOD method_5441 removeStack (I)Lnet/minecraft/class_1799;
-		COMMENT Removes the stack currently stored at the indicated slot.
+		COMMENT Removes the stack currently stored at the indicated index.
 		COMMENT
-		COMMENT @return the stack previously stored at the indicated slot.
+		COMMENT @return the stack previously stored at the indicated index
 		ARG 1 slot
 	METHOD method_5442 isEmpty ()Z
-	METHOD method_5443 canPlayerUse (Lnet/minecraft/class_1657;)Z
+	METHOD method_5443 canAccess (Lnet/minecraft/class_1657;)Z
 		ARG 1 player
 	METHOD method_5444 getMaxCountPerStack ()I
 		COMMENT Returns the maximum number of items a stack can contain when placed inside this inventory.
-		COMMENT No slots may have more than this number of items. It is effectively the
-		COMMENT stacking limit for this inventory's slots.
+		COMMENT No slot may have a stack with a count greater than this. It is effectively the
+		COMMENT stacking limit for each stack in the inventory.
 		COMMENT
 		COMMENT @return the max {@link ItemStack#getCount() count} of item stacks in this inventory
 	METHOD method_5447 setStack (ILnet/minecraft/class_1799;)V

--- a/mappings/net/minecraft/inventory/SidedInventory.mapping
+++ b/mappings/net/minecraft/inventory/SidedInventory.mapping
@@ -1,15 +1,15 @@
 CLASS net/minecraft/class_1278 net/minecraft/inventory/SidedInventory
 	COMMENT A special inventory interface for inventories that expose different slots for different sides, such as hoppers.
 	METHOD method_5492 canInsert (ILnet/minecraft/class_1799;Lnet/minecraft/class_2350;)Z
-		COMMENT Determines whether the given stack can be inserted into this inventory at the specified slot position from the given direction.
+		COMMENT Determines whether or not a specific stack can be inserted into a specific slot in this inventory from a specific direction.
 		ARG 1 slot
 		ARG 2 stack
-		ARG 3 dir
+		ARG 3 direction
 	METHOD method_5493 canExtract (ILnet/minecraft/class_1799;Lnet/minecraft/class_2350;)Z
-		COMMENT Determines whether the given stack can be removed from this inventory at the specified slot position from the given direction.
+		COMMENT Determines whether or not a specific stack can be removed from a specific slot in this inventory from a specific direction.
 		ARG 1 slot
 		ARG 2 stack
-		ARG 3 dir
+		ARG 3 direction
 	METHOD method_5494 getAvailableSlots (Lnet/minecraft/class_2350;)[I
-		COMMENT Gets the available slot positions that are reachable from a given side.
-		ARG 1 side
+		COMMENT @return an array of the slots exposed to a specific direction
+		ARG 1 direction

--- a/mappings/net/minecraft/util/Lock.mapping
+++ b/mappings/net/minecraft/util/Lock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_1273 net/minecraft/inventory/ContainerLock
+CLASS net/minecraft/class_1273 net/minecraft/util/Lock
 	FIELD field_5817 EMPTY Lnet/minecraft/class_1273;
 		COMMENT An empty container lock that can always be opened.
 	FIELD field_5818 key Ljava/lang/String;


### PR DESCRIPTION
Notes on a few changes:
- `ContainerLock` is not specific to containers or even inventories. It's just a `Lock`.
- Removed some redundant `Inv` prefixes
- Fixed some awkward wording in some of the javadocs
- Simplified the name `LockableContainerBlockEntity` to `ContainerBlockEntity` - this is the base class for all BlockEntity containers
- `canPlayerUse` -> `canPlayerAccess` - just a general improvement. Do you use a villager's inventory? Not really, but you can access it.