### PR TITLE
Rename Box fields to use min/max

### DIFF
--- a/mappings/net/minecraft/util/math/Box.mapping
+++ b/mappings/net/minecraft/util/math/Box.mapping
@@ -1,10 +1,10 @@
 CLASS net/minecraft/class_238 net/minecraft/util/math/Box
-	FIELD field_1320 x2 D
-	FIELD field_1321 z1 D
-	FIELD field_1322 y1 D
-	FIELD field_1323 x1 D
-	FIELD field_1324 z2 D
-	FIELD field_1325 y2 D
+	FIELD field_1320 maxX D
+	FIELD field_1321 minZ D
+	FIELD field_1322 minY D
+	FIELD field_1323 minX D
+	FIELD field_1324 maxZ D
+	FIELD field_1325 maxY D
 	METHOD <init> (DDDDDD)V
 		ARG 1 x1
 		ARG 3 y1


### PR DESCRIPTION
This makes them consistent with `BlockBox` and clarifies that `x/y/z1` and `x/y/z2` have an order.