### PR TITLE
Give the NeFos and RUPO structure piece types actual names

### DIFF
--- a/mappings/net/minecraft/structure/StructurePieceType.mapping
+++ b/mappings/net/minecraft/structure/StructurePieceType.mapping
@@ -54,6 +54,8 @@ CLASS net/minecraft/class_3773 net/minecraft/structure/StructurePieceType
 	FIELD field_16968 MINESHAFT_STAIRS Lnet/minecraft/class_3773;
 	FIELD field_16969 MINESHAFT_CORRIDOR Lnet/minecraft/class_3773;
 	FIELD field_16970 OCEAN_MONUMENT_DOUBLE_Y_Z_ROOM Lnet/minecraft/class_3773;
+	FIELD field_22195 NETHER_FOSSIL Lnet/minecraft/class_3773;
+	FIELD field_24010 RUINED_PORTAL Lnet/minecraft/class_3773;
 	METHOD load (Lnet/minecraft/class_3485;Lnet/minecraft/class_2487;)Lnet/minecraft/class_3443;
 		ARG 1 structureManager
 		ARG 2 tag


### PR DESCRIPTION
Their names are automapped, but they are based on the short IDs (`NeFos` and `RUPO`) which don't make any sense.