### PR TITLE
Rename logger print streams to not use prefix naming

### DIFF
--- a/mappings/net/minecraft/util/logging/DebugLoggerPrintStream.mapping
+++ b/mappings/net/minecraft/util/logging/DebugLoggerPrintStream.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2980 net/minecraft/util/logging/DebugLoggerPrintStream

--- a/mappings/net/minecraft/util/logging/DebugPrintStreamLogger.mapping
+++ b/mappings/net/minecraft/util/logging/DebugPrintStreamLogger.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_2980 net/minecraft/util/logging/DebugPrintStreamLogger

--- a/mappings/net/minecraft/util/logging/LoggerPrintStream.mapping
+++ b/mappings/net/minecraft/util/logging/LoggerPrintStream.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2983 net/minecraft/util/logging/PrintStreamLogger
+CLASS net/minecraft/class_2983 net/minecraft/util/logging/LoggerPrintStream
 	FIELD field_13383 name Ljava/lang/String;
 	FIELD field_13384 LOGGER Lorg/apache/logging/log4j/Logger;
 	METHOD <init> (Ljava/lang/String;Ljava/io/OutputStream;)V


### PR DESCRIPTION
It's a logger-backed `PrintStream`, not a `PrintStream`-related logger.