### PR TITLE
Map disable multiplayer and chat command line options

### DIFF
--- a/mappings/net/minecraft/client/MinecraftClient.mapping
+++ b/mappings/net/minecraft/client/MinecraftClient.mapping
@@ -97,6 +97,8 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 	FIELD field_22225 tickTimeTracker Lnet/minecraft/class_4757;
 	FIELD field_22226 tickProfilerResult Lnet/minecraft/class_3696;
 	FIELD field_24211 UNICODE_FONT_ID Lnet/minecraft/class_2960;
+	FIELD field_25033 multiplayerEnabled Z
+	FIELD field_25034 onlineChatEnabled Z
 	METHOD <init> (Lnet/minecraft/class_542;)V
 		ARG 1 args
 	METHOD method_1476 checkIs64Bit ()Z
@@ -242,3 +244,5 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 		ARG 2 monitor
 	METHOD method_27466 initFont (Z)V
 		ARG 1 forcesUnicode
+	METHOD method_29043 isMultiplayerEnabled ()Z
+	METHOD method_29044 isOnlineChatEnabled ()Z

--- a/mappings/net/minecraft/client/RunArgs.mapping
+++ b/mappings/net/minecraft/client/RunArgs.mapping
@@ -22,6 +22,8 @@ CLASS net/minecraft/class_542 net/minecraft/client/RunArgs
 			ARG 4 assetIndex
 		METHOD method_2788 getResourceIndex ()Lnet/minecraft/class_1064;
 	CLASS class_545 Game
+		FIELD field_25061 multiplayerDisabled Z
+		FIELD field_25062 onlineChatDisabled Z
 		FIELD field_3291 versionType Ljava/lang/String;
 		FIELD field_3292 demo Z
 		FIELD field_3293 version Ljava/lang/String;
@@ -29,6 +31,8 @@ CLASS net/minecraft/class_542 net/minecraft/client/RunArgs
 			ARG 1 demo
 			ARG 2 version
 			ARG 3 versionType
+			ARG 4 multiplayerDisabled
+			ARG 5 onlineChatDisabled
 	CLASS class_546 AutoConnect
 		FIELD field_3294 serverAddress Ljava/lang/String;
 		FIELD field_3295 serverPort I


### PR DESCRIPTION
This pull request maps the new `disableMultiplayer` and `disableChat` command line options that were added in snapshot 20w21a.