### PR TITLE
Improve state mappings for 20w21a

### DIFF
--- a/mappings/net/minecraft/block/RedstoneWireBlock.mapping
+++ b/mappings/net/minecraft/block/RedstoneWireBlock.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/class_2457 net/minecraft/block/RedstoneWireBlock
 	FIELD field_11438 wiresGivePower Z
 	FIELD field_11439 WIRE_CONNECTION_WEST Lnet/minecraft/class_2754;
 	FIELD field_11440 WIRE_CONNECTION_NORTH Lnet/minecraft/class_2754;
+	FIELD field_24733 dotShape Lnet/minecraft/class_2680;
 	METHOD method_10477 getRenderConnectionType (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Lnet/minecraft/class_2773;
 	METHOD method_10479 updateNeighbors (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)V
 		ARG 1 world
@@ -23,3 +24,15 @@ CLASS net/minecraft/class_2457 net/minecraft/block/RedstoneWireBlock
 		ARG 1 state
 	METHOD method_10487 getWireColor (I)I
 		ARG 0 powerLevel
+	METHOD method_27840 (Lnet/minecraft/class_1922;Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;)Lnet/minecraft/class_2680;
+		ARG 1 world
+		ARG 2 state
+		ARG 3 pos
+	METHOD method_27846 isFullyConnected (Lnet/minecraft/class_2680;)Z
+		ARG 0 state
+	METHOD method_27937 canRunOnTop (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)Z
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 floor
+	METHOD method_28483 isNotConnected (Lnet/minecraft/class_2680;)Z
+		ARG 0 state

--- a/mappings/net/minecraft/state/State.mapping
+++ b/mappings/net/minecraft/state/State.mapping
@@ -1,10 +1,32 @@
 CLASS net/minecraft/class_2688 net/minecraft/state/State
+	FIELD field_24737 PROPERTY_MAP_PRINTER Ljava/util/function/Function;
+	FIELD field_24738 entries Lcom/google/common/collect/ImmutableMap;
+	FIELD field_24739 owner Ljava/lang/Object;
+	FIELD field_24741 withTable Lcom/google/common/collect/Table;
+	METHOD <init> (Ljava/lang/Object;Lcom/google/common/collect/ImmutableMap;Lcom/mojang/serialization/MapCodec;)V
+		ARG 1 owner
+		ARG 2 entries
 	METHOD method_11654 get (Lnet/minecraft/class_2769;)Ljava/lang/Comparable;
 		ARG 1 property
 	METHOD method_11656 getEntries ()Lcom/google/common/collect/ImmutableMap;
 	METHOD method_11657 with (Lnet/minecraft/class_2769;Ljava/lang/Comparable;)Ljava/lang/Object;
 		ARG 1 property
 		ARG 2 value
+	METHOD method_28493 cycle (Lnet/minecraft/class_2769;)Ljava/lang/Object;
+		ARG 1 property
+	METHOD method_28495 getNext (Ljava/util/Collection;Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 0 values
+		ARG 1 value
+	METHOD method_28496 createWithTable (Ljava/util/Map;)V
+		ARG 1 states
+	METHOD method_28498 contains (Lnet/minecraft/class_2769;)Z
+		ARG 1 property
+	METHOD method_28499 toMapWith (Lnet/minecraft/class_2769;Ljava/lang/Comparable;)Ljava/util/Map;
+		ARG 1 property
+		ARG 2 value
+	METHOD method_28500 (Lnet/minecraft/class_2769;)Ljava/util/Optional;
+		ARG 1 property
+	METHOD method_28501 getProperties ()Ljava/util/Collection;
 	CLASS 1
 		METHOD method_11575 nameValue (Lnet/minecraft/class_2769;Ljava/lang/Comparable;)Ljava/lang/String;
 			ARG 1 property

--- a/mappings/net/minecraft/state/property/Properties.mapping
+++ b/mappings/net/minecraft/state/property/Properties.mapping
@@ -197,6 +197,7 @@ CLASS net/minecraft/class_2741 net/minecraft/state/property/Properties
 		COMMENT A property that specifies how a wall extends from the center post to the south.‌
 	FIELD field_22177 WEST_WALL_SHAPE Lnet/minecraft/class_2754;
 		COMMENT A property that specifies how a wall extends from the center post to the west.‌
+	FIELD field_23084 VINE_END Lnet/minecraft/class_2746;
 	FIELD field_23187 CHARGES Lnet/minecraft/class_2758;
 		COMMENT A property that specifies the amount of charges a respawn anchor has.
 	FIELD field_23333 ORIENTATION Lnet/minecraft/class_2754;


### PR DESCRIPTION
This pull request maps the following state changes:

* Moves mappings that were in the former `AbstractState` class to `State`.
* Adds mappings for the new redstone wire dot-cross toggle functionality.
* Maps the unused `vine_end` boolean blockstate.