### PR TITLE
Standardize attribute modifier mappings

### DIFF
--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_18073 SLEEPING_POSITION Lnet/minecraft/class_2940;
 	FIELD field_18321 brain Lnet/minecraft/class_4095;
 	FIELD field_20348 STINGER_COUNT Lnet/minecraft/class_2940;
-	FIELD field_23128 SOUL_SPEED_BOOST_ATTRIBUTE_MODIFIER_ID Ljava/util/UUID;
+	FIELD field_23128 SOUL_SPEED_BOOST_ID Ljava/util/UUID;
 	FIELD field_6210 bodyTrackingIncrements I
 	FIELD field_6211 lastLimbDistance F
 	FIELD field_6212 sidewaysSpeed F

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -23,13 +23,13 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6228 jumpingCooldown I
 	FIELD field_6229 lastHandSwingProgress F
 	FIELD field_6230 lastAttackedTime I
-	FIELD field_6231 ATTR_SPRINTING_SPEED_BOOST Lnet/minecraft/class_1322;
+	FIELD field_6231 SPRINTING_SPEED_BOOST Lnet/minecraft/class_1322;
 	FIELD field_6232 scoreAmount I
 	FIELD field_6233 stepBobbingAmount F
 	FIELD field_6234 equippedHand Lnet/minecraft/class_2371;
 	FIELD field_6235 hurtTime I
 	FIELD field_6236 attacking Lnet/minecraft/class_1309;
-	FIELD field_6237 ATTR_SPRINTING_SPEED_BOOST_ID Ljava/util/UUID;
+	FIELD field_6237 SPRINTING_SPEED_BOOST_ID Ljava/util/UUID;
 	FIELD field_6238 playerHitTimer I
 	FIELD field_6239 roll I
 	FIELD field_6240 POTION_SWIRLS_COLOR Lnet/minecraft/class_2940;

--- a/mappings/net/minecraft/entity/mob/EndermanEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/EndermanEntity.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/class_1560 net/minecraft/entity/mob/EndermanEntity
 	FIELD field_7253 lastAngrySoundAge I
 	FIELD field_7254 ageWhenTargetSet I
 	FIELD field_7255 ANGRY Lnet/minecraft/class_2940;
-	FIELD field_7256 ATTACKING_SPEED_BOOST_UUID Ljava/util/UUID;
+	FIELD field_7256 ATTACKING_SPEED_BOOST_ID Ljava/util/UUID;
 	FIELD field_7257 CARRIED_BLOCK Lnet/minecraft/class_2940;
 	METHOD method_22330 isProvoked ()Z
 	METHOD method_22331 setProvoked ()V

--- a/mappings/net/minecraft/entity/mob/PiglinEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/PiglinEntity.mapping
@@ -4,8 +4,8 @@ CLASS net/minecraft/class_4836 net/minecraft/entity/mob/PiglinEntity
 	FIELD field_22376 SENSOR_TYPES Lcom/google/common/collect/ImmutableList;
 	FIELD field_22377 BABY Lnet/minecraft/class_2940;
 	FIELD field_22378 CHARGING Lnet/minecraft/class_2940;
-	FIELD field_22379 BABY_SPEED_BOOST_MODIFIER_ID Ljava/util/UUID;
-	FIELD field_22380 BABY_SPEED_BOOST_MODIFIER Lnet/minecraft/class_1322;
+	FIELD field_22379 BABY_SPEED_BOOST_ID Ljava/util/UUID;
+	FIELD field_22380 BABY_SPEED_BOOST Lnet/minecraft/class_1322;
 	FIELD field_22381 MEMORY_MODULE_TYPES Lcom/google/common/collect/ImmutableList;
 	FIELD field_22419 IMMUNE_TO_ZOMBIFICATION Lnet/minecraft/class_2940;
 	FIELD field_23738 cannotHunt Z

--- a/mappings/net/minecraft/entity/mob/ShulkerEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/ShulkerEntity.mapping
@@ -3,8 +3,8 @@ CLASS net/minecraft/class_1606 net/minecraft/entity/mob/ShulkerEntity
 	FIELD field_7338 ATTACHED_BLOCK Lnet/minecraft/class_2940;
 	FIELD field_7339 prevOpenProgress F
 	FIELD field_7340 teleportLerpTimer I
-	FIELD field_7341 ATTR_COVERED_ARMOR_BONUS_ID Ljava/util/UUID;
-	FIELD field_7342 ATTR_COVERED_ARMOR_BONUS Lnet/minecraft/class_1322;
+	FIELD field_7341 COVERED_ARMOR_BONUS_ID Ljava/util/UUID;
+	FIELD field_7342 COVERED_ARMOR_BONUS Lnet/minecraft/class_1322;
 	FIELD field_7343 COLOR Lnet/minecraft/class_2940;
 	FIELD field_7344 ATTACHED_FACE Lnet/minecraft/class_2940;
 	FIELD field_7345 prevAttachedBlock Lnet/minecraft/class_2338;

--- a/mappings/net/minecraft/entity/mob/ShulkerEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/ShulkerEntity.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_1606 net/minecraft/entity/mob/ShulkerEntity
 	FIELD field_7338 ATTACHED_BLOCK Lnet/minecraft/class_2940;
 	FIELD field_7339 prevOpenProgress F
 	FIELD field_7340 teleportLerpTimer I
-	FIELD field_7341 ATTR_COVERED_ARMOR_BONUS_UUID Ljava/util/UUID;
+	FIELD field_7341 ATTR_COVERED_ARMOR_BONUS_ID Ljava/util/UUID;
 	FIELD field_7342 ATTR_COVERED_ARMOR_BONUS Lnet/minecraft/class_1322;
 	FIELD field_7343 COLOR Lnet/minecraft/class_2940;
 	FIELD field_7344 ATTACHED_FACE Lnet/minecraft/class_2940;

--- a/mappings/net/minecraft/entity/mob/ZombifiedPiglinEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/ZombifiedPiglinEntity.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_1590 net/minecraft/entity/mob/ZombifiedPiglinEntity
 	FIELD field_7308 angrySoundDelay I
 	FIELD field_7309 anger I
 	FIELD field_7310 angerTarget Ljava/util/UUID;
-	FIELD field_7311 ATTACKING_SPEED_BOOST_UUID Ljava/util/UUID;
+	FIELD field_7311 ATTACKING_SPEED_BOOST_ID Ljava/util/UUID;
 	METHOD method_20682 canSpawn (Lnet/minecraft/class_1299;Lnet/minecraft/class_1936;Lnet/minecraft/class_3730;Lnet/minecraft/class_2338;Ljava/util/Random;)Z
 		ARG 0 type
 		ARG 1 world

--- a/mappings/net/minecraft/entity/passive/HorseEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/HorseEntity.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_1498 net/minecraft/entity/passive/HorseEntity
-	FIELD field_6985 HORSE_ARMOR_BONUS_UUID Ljava/util/UUID;
+	FIELD field_6985 HORSE_ARMOR_BONUS_ID Ljava/util/UUID;
 	FIELD field_6990 VARIANT Lnet/minecraft/class_2940;
 	METHOD method_18445 equipArmor (Lnet/minecraft/class_1799;)V
 		ARG 1 stack

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -1,11 +1,11 @@
 CLASS net/minecraft/class_1792 net/minecraft/item/Item
 	FIELD field_18672 foodComponent Lnet/minecraft/class_4174;
 	FIELD field_21979 fireproof Z
-	FIELD field_8001 ATTACK_SPEED_MODIFIER_UUID Ljava/util/UUID;
+	FIELD field_8001 ATTACK_SPEED_MODIFIER_ID Ljava/util/UUID;
 	FIELD field_8003 BLOCK_ITEMS Ljava/util/Map;
 	FIELD field_8004 group Lnet/minecraft/class_1761;
 	FIELD field_8005 RANDOM Ljava/util/Random;
-	FIELD field_8006 ATTACK_DAMAGE_MODIFIER_UUID Ljava/util/UUID;
+	FIELD field_8006 ATTACK_DAMAGE_MODIFIER_ID Ljava/util/UUID;
 	FIELD field_8008 recipeRemainder Lnet/minecraft/class_1792;
 	FIELD field_8009 rarity Lnet/minecraft/class_1814;
 	FIELD field_8012 maxDamage I


### PR DESCRIPTION
This pull request standardizes attribute modifier fields:

- IDs: `[MODIFIER]_ID`
- Modifiers: `[MODIFIER]`

In addition, if an attribute modifier is considered a boost, it is suffixed with `_BOOST`.