### PR TITLE
Improve and add mappings related to soul speed

### DIFF
--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -393,7 +393,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6124 getPrimeAdversary ()Lnet/minecraft/class_1309;
 	METHOD method_6125 setMovementSpeed (F)V
 		ARG 1 movementSpeed
-	METHOD method_6126 applyFrostWalker (Lnet/minecraft/class_2338;)V
+	METHOD method_6126 applyMovementEffects (Lnet/minecraft/class_2338;)V
 		ARG 1 pos
 	METHOD method_6127 getAttributes ()Lnet/minecraft/class_5131;
 	METHOD method_6128 isFallFlying ()Z

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -405,3 +405,6 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6132 applyArmorToDamage (Lnet/minecraft/class_1282;F)F
 		ARG 1 source
 		ARG 2 amount
+	METHOD method_27303 isOnSoulSpeedBlock ()Z
+	METHOD method_25937 applySoulSpeedClientEffects ()V
+	METHOD method_25937 shouldGetSoulSpeedBoost ()Z

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -407,4 +407,4 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 2 amount
 	METHOD method_27303 isOnSoulSpeedBlock ()Z
 	METHOD method_25937 applySoulSpeedClientEffects ()V
-	METHOD method_25937 shouldGetSoulSpeedBoost ()Z
+	METHOD method_27302 shouldGetSoulSpeedBoost ()Z


### PR DESCRIPTION
This pull request maps three methods in `LivingEntity` related to soul speed, and changes the name of another method (`applyFrostWalker`) in `LivingEntity` that now has behavior based on soul speed.