### PR TITLE
Shorten inner class names on GameRules

### DIFF
--- a/mappings/net/minecraft/world/GameRules.mapping
+++ b/mappings/net/minecraft/world/GameRules.mapping
@@ -97,7 +97,7 @@ CLASS net/minecraft/class_1928 net/minecraft/world/GameRules
 		METHOD method_27332 validate (Ljava/lang/String;)Z
 			COMMENT Validates that an input is valid for this rule.
 			ARG 1 input
-	CLASS class_4313 RuleKey
+	CLASS class_4313 Key
 		FIELD field_19413 name Ljava/lang/String;
 		FIELD field_24103 category Lnet/minecraft/class_1928$class_5198;
 		METHOD <init> (Ljava/lang/String;Lnet/minecraft/class_1928$class_5198;)V
@@ -108,7 +108,7 @@ CLASS net/minecraft/class_1928 net/minecraft/world/GameRules
 		METHOD method_20771 getName ()Ljava/lang/String;
 		METHOD method_27334 getTranslationKey ()Ljava/lang/String;
 		METHOD method_27335 getCategory ()Lnet/minecraft/class_1928$class_5198;
-	CLASS class_4314 RuleType
+	CLASS class_4314 Type
 		FIELD field_19414 argumentType Ljava/util/function/Supplier;
 		FIELD field_19415 ruleFactory Ljava/util/function/Function;
 		FIELD field_19416 changeCallback Ljava/util/function/BiConsumer;
@@ -148,7 +148,7 @@ CLASS net/minecraft/class_1928 net/minecraft/world/GameRules
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
 			ARG 3 category
 		METHOD method_27328 getCategory ()Ljava/lang/String;
-	CLASS class_5199 RuleAcceptor
+	CLASS class_5199 Acceptor
 		METHOD call (Lnet/minecraft/class_1928$class_4311;Lnet/minecraft/class_1928$class_4313;Lnet/minecraft/class_1928$class_4314;)V
 			ARG 1 consumer
 			ARG 2 key

--- a/mappings/net/minecraft/world/GameRules.mapping
+++ b/mappings/net/minecraft/world/GameRules.mapping
@@ -66,7 +66,7 @@ CLASS net/minecraft/class_1928 net/minecraft/world/GameRules
 		METHOD method_20760 create (ZLjava/util/function/BiConsumer;)Lnet/minecraft/class_1928$class_4314;
 			ARG 0 initialValue
 			ARG 1 changeCallback
-	CLASS class_4311 RuleTypeConsumer
+	CLASS class_4311 TypeConsumer
 		METHOD method_20762 accept (Lnet/minecraft/class_1928$class_4313;Lnet/minecraft/class_1928$class_4314;)V
 			ARG 1 key
 			ARG 2 type
@@ -143,7 +143,7 @@ CLASS net/minecraft/class_1928 net/minecraft/world/GameRules
 			ARG 1 rule
 			ARG 2 server
 		METHOD method_27338 copy ()Lnet/minecraft/class_1928$class_4315;
-	CLASS class_5198 RuleCategory
+	CLASS class_5198 Category
 		FIELD field_24101 category Ljava/lang/String;
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
 			ARG 3 category


### PR DESCRIPTION
Since the Key, Type and Acceptor are inner classes on `GameRules`, the `Rule` prefix is redundant imo.

So:
`GameRules.RuleType` -> `GameRules.Type`
`GameRules.RuleKey` -> `GameRules.Key`
`GameRules.RuleAcceptor` -> `GameRules.Acceptor`
`GameRules.RuleTypeConsumer` -> `GameRules.TypeConsumer`
`GameRules.RuleCategory` -> `GameRules.Category`

`GameRules.Rule`, `GameRules.IntRule` and `GameRules.BooleanRule` are unchanged due to not being redundantly named.