### PR TITLE
Map more 1.16 additions to default biome features

### DIFF
--- a/mappings/net/minecraft/world/biome/DefaultBiomeFeatures.mapping
+++ b/mappings/net/minecraft/world/biome/DefaultBiomeFeatures.mapping
@@ -139,6 +139,14 @@ CLASS net/minecraft/class_3864 net/minecraft/world/biome/DefaultBiomeFeatures
 	FIELD field_22064 SOUL_SOIL Lnet/minecraft/class_2680;
 	FIELD field_22065 CRIMSON_ROOTS Lnet/minecraft/class_2680;
 	FIELD field_23076 NETHER_GOLD_ORE Lnet/minecraft/class_2680;
+	FIELD field_23851 MIXED_NETHER_SPRING_CONFIG Lnet/minecraft/class_4642;
+	FIELD field_23852 SOUL_SAND_SPRING_CONFIG Lnet/minecraft/class_4642;
+	FIELD field_23853 ENCLOSED_SOUL_SAND_SPRING_CONFIG Lnet/minecraft/class_4642;
+	FIELD field_23854 BASALT_COLUMN_CONFIG Lnet/minecraft/class_5156;
+	FIELD field_23855 TALL_BASALT_COLUMN_CONFIG Lnet/minecraft/class_5156;
+	FIELD field_23856 BASALT_BLOB_CONFIG Lnet/minecraft/class_5160;
+	FIELD field_23857 BLACKSTONE_BLOB_CONFIG Lnet/minecraft/class_5160;
+	FIELD field_23858 DELTA_CONFIG Lnet/minecraft/class_5158;
 	FIELD field_24110 VERY_RARE_BEEHIVES_CONFIG Lnet/minecraft/class_4659;
 	FIELD field_24111 REGULAR_BEEHIVES_CONFIG Lnet/minecraft/class_4659;
 	FIELD field_24112 MORE_BEEHIVES_CONFIG Lnet/minecraft/class_4659;

--- a/mappings/net/minecraft/world/biome/DefaultBiomeFeatures.mapping
+++ b/mappings/net/minecraft/world/biome/DefaultBiomeFeatures.mapping
@@ -150,6 +150,13 @@ CLASS net/minecraft/class_3864 net/minecraft/world/biome/DefaultBiomeFeatures
 	FIELD field_24110 VERY_RARE_BEEHIVES_CONFIG Lnet/minecraft/class_4659;
 	FIELD field_24111 REGULAR_BEEHIVES_CONFIG Lnet/minecraft/class_4659;
 	FIELD field_24112 MORE_BEEHIVES_CONFIG Lnet/minecraft/class_4659;
+	FIELD field_24682 JUNGLE_CONFIGURED_RUINED_PORTAL Lnet/minecraft/class_5312;
+	FIELD field_24683 SWAMP_CONFIGURED_RUINED_PORTAL Lnet/minecraft/class_5312;
+	FIELD field_24684 MOUNTAIN_CONFIGURED_RUINED_PORTAL Lnet/minecraft/class_5312;
+	FIELD field_24685 OCEAN_CONFIGURED_RUINED_PORTAL Lnet/minecraft/class_5312;
+	FIELD field_24686 NETHER_CONFIGURED_RUINED_PORTAL Lnet/minecraft/class_5312;
+	FIELD field_24711 STANDARD_CONFIGURED_RUINED_PORTAL Lnet/minecraft/class_5312;
+	FIELD field_24712 DESERT_CONFIGURED_RUINED_PORTAL Lnet/minecraft/class_5312;
 	METHOD method_16957 addMountainTrees (Lnet/minecraft/class_1959;)V
 		ARG 0 biome
 	METHOD method_16958 addExtraMountainTrees (Lnet/minecraft/class_1959;)V

--- a/mappings/net/minecraft/world/gen/feature/DefaultBiomeFeatures.mapping
+++ b/mappings/net/minecraft/world/gen/feature/DefaultBiomeFeatures.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3864 net/minecraft/world/biome/DefaultBiomeFeatures
+CLASS net/minecraft/class_3864 net/minecraft/world/gen/feature/DefaultBiomeFeatures
 	FIELD field_21088 PLAINS_FLOWER_CONFIG Lnet/minecraft/class_4638;
 	FIELD field_21089 FOREST_FLOWER_CONFIG Lnet/minecraft/class_4638;
 	FIELD field_21090 DEAD_BUSH_CONFIG Lnet/minecraft/class_4638;


### PR DESCRIPTION
This pull request maps the following 1.16 additions to `DefaultBiomeFeatures`:

- Miscellaneous Nether feature configs such as basalt/blackstone blobs, deltas, basalt columns, and springs
- Configured ruined portal features