### PR TITLE
remove an invalid mapping

### DIFF
--- a/mappings/net/minecraft/block/RedstoneWireBlock.mapping
+++ b/mappings/net/minecraft/block/RedstoneWireBlock.mapping
@@ -10,11 +10,6 @@ CLASS net/minecraft/class_2457 net/minecraft/block/RedstoneWireBlock
 	FIELD field_11440 WIRE_CONNECTION_NORTH Lnet/minecraft/class_2754;
 	METHOD <init> (Lnet/minecraft/class_2248$class_2251;)V
 		ARG 1 settings
-	METHOD b (Lnet/minecraft/class_2680;Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;I)V
-		ARG 1 state
-		ARG 2 world
-		ARG 3 pos
-		ARG 4 flags
 	METHOD method_10477 getRenderConnectionType (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Lnet/minecraft/class_2773;
 		ARG 1 view
 		ARG 2 pos


### PR DESCRIPTION
There's a mapping for a non-existent method `b` in `RedstoneWireBlock`. This happens to match up with an obfuscated name, and has been causing problems for me when I try to remap things from srg to intermediary and yarn.

This removes this 🅱️ad mapping.