### PR TITLE
Map transparency shader fields and methods

### DIFF
--- a/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
+++ b/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
@@ -474,6 +474,7 @@ CLASS net/minecraft/class_4493 com/mojang/blaze3d/platform/GlStateManager
 	METHOD method_24221 setupGuiFlatDiffuseLighting (Lnet/minecraft/class_1160;Lnet/minecraft/class_1160;)V
 	METHOD method_24222 setupGui3dDiffuseLighting (Lnet/minecraft/class_1160;Lnet/minecraft/class_1160;)V
 	METHOD method_29330 supportsGl30 ()Z
+	METHOD method_29331 copyTexSubImage2D (IIIIIIII)V
 	METHOD method_29332 blitFramebuffer (IIIIIIIIII)V
 	METHOD method_29333 getFramebufferAttachmentParameter ()I
 	METHOD method_29334 getActiveBoundTexture ()I

--- a/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
+++ b/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
@@ -476,7 +476,7 @@ CLASS net/minecraft/class_4493 com/mojang/blaze3d/platform/GlStateManager
 	METHOD method_29330 supportsGl30 ()Z
 	METHOD method_29331 copyTexSubImage2D (IIIIIIII)V
 	METHOD method_29332 blitFramebuffer (IIIIIIIIII)V
-	METHOD method_29333 getFramebufferAttachmentParameter ()I
+	METHOD method_29333 getFramebufferDepthAttachment ()I
 	METHOD method_29334 getActiveBoundTexture ()I
 	CLASS class_1010 FBOMode
 	CLASS class_1016 AlphaTestState

--- a/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
+++ b/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
@@ -474,6 +474,7 @@ CLASS net/minecraft/class_4493 com/mojang/blaze3d/platform/GlStateManager
 	METHOD method_24221 setupGuiFlatDiffuseLighting (Lnet/minecraft/class_1160;Lnet/minecraft/class_1160;)V
 	METHOD method_24222 setupGui3dDiffuseLighting (Lnet/minecraft/class_1160;Lnet/minecraft/class_1160;)V
 	METHOD method_29330 supportsGl30 ()Z
+	METHOD method_29332 blitFramebuffer (IIIIIIIIII)V
 	CLASS class_1010 FBOMode
 	CLASS class_1016 AlphaTestState
 		FIELD field_5042 capState Lnet/minecraft/class_4493$class_1018;

--- a/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
+++ b/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
@@ -474,7 +474,7 @@ CLASS net/minecraft/class_4493 com/mojang/blaze3d/platform/GlStateManager
 	METHOD method_24221 setupGuiFlatDiffuseLighting (Lnet/minecraft/class_1160;Lnet/minecraft/class_1160;)V
 	METHOD method_24222 setupGui3dDiffuseLighting (Lnet/minecraft/class_1160;Lnet/minecraft/class_1160;)V
 	METHOD method_29330 supportsGl30 ()Z
-	METHOD method_29331 copyTexSubImage2D (IIIIIIII)V
+	METHOD method_29331 copyTexSubImage2d (IIIIIIII)V
 	METHOD method_29332 blitFramebuffer (IIIIIIIIII)V
 	METHOD method_29333 getFramebufferDepthAttachment ()I
 	METHOD method_29334 getActiveBoundTexture ()I

--- a/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
+++ b/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
@@ -176,7 +176,7 @@ CLASS net/minecraft/class_4493 com/mojang/blaze3d/platform/GlStateManager
 	METHOD method_21973 initFramebufferSupport (Lorg/lwjgl/opengl/GLCapabilities;)Ljava/lang/String;
 		COMMENT Configures the frame buffer and populates {@link FramebufferInfo} with the appropriate constants
 		COMMENT for the current GLCapabilities.
-		COMMENT 
+		COMMENT
 		COMMENT @return human-readable string representing the selected frame buffer technology
 		COMMENT @throws IllegalStateException if no known frame buffer technology is supported
 		ARG 0 capabilities

--- a/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
+++ b/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
@@ -475,6 +475,7 @@ CLASS net/minecraft/class_4493 com/mojang/blaze3d/platform/GlStateManager
 	METHOD method_24222 setupGui3dDiffuseLighting (Lnet/minecraft/class_1160;Lnet/minecraft/class_1160;)V
 	METHOD method_29330 supportsGl30 ()Z
 	METHOD method_29332 blitFramebuffer (IIIIIIIIII)V
+	METHOD method_29333 getFramebufferAttachmentParameter ()I
 	CLASS class_1010 FBOMode
 	CLASS class_1016 AlphaTestState
 		FIELD field_5042 capState Lnet/minecraft/class_4493$class_1018;

--- a/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
+++ b/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
@@ -176,7 +176,7 @@ CLASS net/minecraft/class_4493 com/mojang/blaze3d/platform/GlStateManager
 	METHOD method_21973 initFramebufferSupport (Lorg/lwjgl/opengl/GLCapabilities;)Ljava/lang/String;
 		COMMENT Configures the frame buffer and populates {@link FramebufferInfo} with the appropriate constants
 		COMMENT for the current GLCapabilities.
-		COMMENT
+		COMMENT 
 		COMMENT @return human-readable string representing the selected frame buffer technology
 		COMMENT @throws IllegalStateException if no known frame buffer technology is supported
 		ARG 0 capabilities
@@ -473,6 +473,7 @@ CLASS net/minecraft/class_4493 com/mojang/blaze3d/platform/GlStateManager
 	METHOD method_23283 teardownOutline ()V
 	METHOD method_24221 setupGuiFlatDiffuseLighting (Lnet/minecraft/class_1160;Lnet/minecraft/class_1160;)V
 	METHOD method_24222 setupGui3dDiffuseLighting (Lnet/minecraft/class_1160;Lnet/minecraft/class_1160;)V
+	METHOD method_29330 supportsGl30 ()Z
 	CLASS class_1010 FBOMode
 	CLASS class_1016 AlphaTestState
 		FIELD field_5042 capState Lnet/minecraft/class_4493$class_1018;

--- a/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
+++ b/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
@@ -476,6 +476,7 @@ CLASS net/minecraft/class_4493 com/mojang/blaze3d/platform/GlStateManager
 	METHOD method_29330 supportsGl30 ()Z
 	METHOD method_29332 blitFramebuffer (IIIIIIIIII)V
 	METHOD method_29333 getFramebufferAttachmentParameter ()I
+	METHOD method_29334 getActiveBoundTexture ()I
 	CLASS class_1010 FBOMode
 	CLASS class_1016 AlphaTestState
 		FIELD field_5042 capState Lnet/minecraft/class_4493$class_1018;

--- a/mappings/net/minecraft/client/gl/Framebuffer.mapping
+++ b/mappings/net/minecraft/client/gl/Framebuffer.mapping
@@ -52,4 +52,4 @@ CLASS net/minecraft/class_276 net/minecraft/client/gl/Framebuffer
 		ARG 1 width
 		ARG 2 height
 		ARG 3 getError
-	METHOD method_29329 copyFrom (Lnet/minecraft/class_276;)V
+	METHOD method_29329 copyDepthFrom (Lnet/minecraft/class_276;)V

--- a/mappings/net/minecraft/client/gl/Framebuffer.mapping
+++ b/mappings/net/minecraft/client/gl/Framebuffer.mapping
@@ -52,3 +52,4 @@ CLASS net/minecraft/class_276 net/minecraft/client/gl/Framebuffer
 		ARG 1 width
 		ARG 2 height
 		ARG 3 getError
+	METHOD method_29329 copyFrom (Lnet/minecraft/class_276;)V

--- a/mappings/net/minecraft/client/render/RenderPhase.mapping
+++ b/mappings/net/minecraft/client/render/RenderPhase.mapping
@@ -67,6 +67,7 @@ CLASS net/minecraft/class_4668 net/minecraft/client/render/RenderPhase
 			ARG 1 culling
 	CLASS class_4672 DepthTest
 		FIELD field_21391 func I
+		FIELD field_22242 depthFunction Ljava/lang/String;
 	CLASS class_4673 DiffuseLighting
 		METHOD <init> (Z)V
 			ARG 1 guiLighting

--- a/mappings/net/minecraft/client/render/RenderPhase.mapping
+++ b/mappings/net/minecraft/client/render/RenderPhase.mapping
@@ -43,6 +43,7 @@ CLASS net/minecraft/class_4668 net/minecraft/client/render/RenderPhase
 	FIELD field_21387 ENABLE_DIFFUSE_LIGHTING Lnet/minecraft/class_4668$class_4673;
 	FIELD field_21388 DISABLE_DIFFUSE_LIGHTING Lnet/minecraft/class_4668$class_4673;
 	FIELD field_22241 VIEW_OFFSET_Z_LAYERING Lnet/minecraft/class_4668$class_4675;
+	FIELD field_25280 TRANSLUCENT_TARGET Lnet/minecraft/class_4668$class_4678;
 	FIELD field_25281 PARTICLES_TARGET Lnet/minecraft/class_4668$class_4678;
 	METHOD <init> (Ljava/lang/String;Ljava/lang/Runnable;Ljava/lang/Runnable;)V
 		ARG 1 name

--- a/mappings/net/minecraft/client/render/RenderPhase.mapping
+++ b/mappings/net/minecraft/client/render/RenderPhase.mapping
@@ -47,6 +47,7 @@ CLASS net/minecraft/class_4668 net/minecraft/client/render/RenderPhase
 	FIELD field_25281 PARTICLES_TARGET Lnet/minecraft/class_4668$class_4678;
 	FIELD field_25282 WEATHER_TARGET Lnet/minecraft/class_4668$class_4678;
 	FIELD field_25283 CLOUDS_TARGET Lnet/minecraft/class_4668$class_4678;
+	FIELD field_25284 ITEM_TRANSPARENCY Lnet/minecraft/class_4668$class_4685;
 	METHOD <init> (Ljava/lang/String;Ljava/lang/Runnable;Ljava/lang/Runnable;)V
 		ARG 1 name
 		ARG 2 beginAction

--- a/mappings/net/minecraft/client/render/RenderPhase.mapping
+++ b/mappings/net/minecraft/client/render/RenderPhase.mapping
@@ -43,6 +43,7 @@ CLASS net/minecraft/class_4668 net/minecraft/client/render/RenderPhase
 	FIELD field_21387 ENABLE_DIFFUSE_LIGHTING Lnet/minecraft/class_4668$class_4673;
 	FIELD field_21388 DISABLE_DIFFUSE_LIGHTING Lnet/minecraft/class_4668$class_4673;
 	FIELD field_22241 VIEW_OFFSET_Z_LAYERING Lnet/minecraft/class_4668$class_4675;
+	FIELD field_25281 PARTICLES_TARGET Lnet/minecraft/class_4668$class_4678;
 	METHOD <init> (Ljava/lang/String;Ljava/lang/Runnable;Ljava/lang/Runnable;)V
 		ARG 1 name
 		ARG 2 beginAction

--- a/mappings/net/minecraft/client/render/RenderPhase.mapping
+++ b/mappings/net/minecraft/client/render/RenderPhase.mapping
@@ -46,6 +46,7 @@ CLASS net/minecraft/class_4668 net/minecraft/client/render/RenderPhase
 	FIELD field_25280 TRANSLUCENT_TARGET Lnet/minecraft/class_4668$class_4678;
 	FIELD field_25281 PARTICLES_TARGET Lnet/minecraft/class_4668$class_4678;
 	FIELD field_25282 WEATHER_TARGET Lnet/minecraft/class_4668$class_4678;
+	FIELD field_25283 CLOUDS_TARGET Lnet/minecraft/class_4668$class_4678;
 	METHOD <init> (Ljava/lang/String;Ljava/lang/Runnable;Ljava/lang/Runnable;)V
 		ARG 1 name
 		ARG 2 beginAction

--- a/mappings/net/minecraft/client/render/RenderPhase.mapping
+++ b/mappings/net/minecraft/client/render/RenderPhase.mapping
@@ -68,6 +68,8 @@ CLASS net/minecraft/class_4668 net/minecraft/client/render/RenderPhase
 	CLASS class_4672 DepthTest
 		FIELD field_21391 func I
 		FIELD field_22242 depthFunction Ljava/lang/String;
+			COMMENT A string representation of the comparison function used by this {@code DepthTest} phase.
+			COMMENT @see org.lwjgl.opengl.GL11#glDepthFunc(int) 
 	CLASS class_4673 DiffuseLighting
 		METHOD <init> (Z)V
 			ARG 1 guiLighting

--- a/mappings/net/minecraft/client/render/RenderPhase.mapping
+++ b/mappings/net/minecraft/client/render/RenderPhase.mapping
@@ -45,6 +45,7 @@ CLASS net/minecraft/class_4668 net/minecraft/client/render/RenderPhase
 	FIELD field_22241 VIEW_OFFSET_Z_LAYERING Lnet/minecraft/class_4668$class_4675;
 	FIELD field_25280 TRANSLUCENT_TARGET Lnet/minecraft/class_4668$class_4678;
 	FIELD field_25281 PARTICLES_TARGET Lnet/minecraft/class_4668$class_4678;
+	FIELD field_25282 WEATHER_TARGET Lnet/minecraft/class_4668$class_4678;
 	METHOD <init> (Ljava/lang/String;Ljava/lang/Runnable;Ljava/lang/Runnable;)V
 		ARG 1 name
 		ARG 2 beginAction

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -9,6 +9,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	FIELD field_25274 translucentFramebuffer Lnet/minecraft/class_276;
 	FIELD field_25275 entityFramebuffer Lnet/minecraft/class_276;
 	FIELD field_25276 particlesFramebuffer Lnet/minecraft/class_276;
+	FIELD field_25277 weatherFramebuffer Lnet/minecraft/class_276;
 	FIELD field_25278 cloudsFramebuffer Lnet/minecraft/class_276;
 	FIELD field_4055 noCullingBlockEntities Ljava/util/Set;
 	FIELD field_4056 capturedFrustum Lnet/minecraft/class_4604;

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	FIELD field_20950 blockBreakingProgressions Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;
 	FIELD field_20951 bufferBuilders Lnet/minecraft/class_4599;
 	FIELD field_21799 chunkUpdateSmoother Lnet/minecraft/class_4740;
+	FIELD field_25275 entityFramebuffer Lnet/minecraft/class_276;
 	FIELD field_4055 noCullingBlockEntities Ljava/util/Set;
 	FIELD field_4056 capturedFrustum Lnet/minecraft/class_4604;
 	FIELD field_4057 textureManager Lnet/minecraft/class_1060;

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -8,7 +8,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	FIELD field_21799 chunkUpdateSmoother Lnet/minecraft/class_4740;
 	FIELD field_25274 translucentFramebuffer Lnet/minecraft/class_276;
 	FIELD field_25275 entityFramebuffer Lnet/minecraft/class_276;
-	FIELD field_25276 particleFramebuffer Lnet/minecraft/class_276;
+	FIELD field_25276 particlesFramebuffer Lnet/minecraft/class_276;
 	FIELD field_4055 noCullingBlockEntities Ljava/util/Set;
 	FIELD field_4056 capturedFrustum Lnet/minecraft/class_4604;
 	FIELD field_4057 textureManager Lnet/minecraft/class_1060;

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	FIELD field_20950 blockBreakingProgressions Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;
 	FIELD field_20951 bufferBuilders Lnet/minecraft/class_4599;
 	FIELD field_21799 chunkUpdateSmoother Lnet/minecraft/class_4740;
+	FIELD field_25274 translucentFramebuffer Lnet/minecraft/class_276;
 	FIELD field_25275 entityFramebuffer Lnet/minecraft/class_276;
 	FIELD field_25276 particleFramebuffer Lnet/minecraft/class_276;
 	FIELD field_4055 noCullingBlockEntities Ljava/util/Set;

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -11,6 +11,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	FIELD field_25276 particlesFramebuffer Lnet/minecraft/class_276;
 	FIELD field_25277 weatherFramebuffer Lnet/minecraft/class_276;
 	FIELD field_25278 cloudsFramebuffer Lnet/minecraft/class_276;
+	FIELD field_25279 transparencyShader Lnet/minecraft/class_279;
 	FIELD field_4055 noCullingBlockEntities Ljava/util/Set;
 	FIELD field_4056 capturedFrustum Lnet/minecraft/class_4604;
 	FIELD field_4057 textureManager Lnet/minecraft/class_1060;

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -133,6 +133,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	METHOD method_23794 getLightmapCoordinates (Lnet/minecraft/class_1920;Lnet/minecraft/class_2338;)I
 		ARG 0 world
 		ARG 1 pos
+	METHOD method_29362 getParticlesFramebuffer ()Lnet/minecraft/class_276;
 	METHOD method_3239 renderClouds (Lnet/minecraft/class_287;DDDLnet/minecraft/class_243;)V
 		ARG 1 builder
 		ARG 2 x

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -137,6 +137,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 		ARG 0 world
 		ARG 1 pos
 	METHOD method_29362 getParticlesFramebuffer ()Lnet/minecraft/class_276;
+	METHOD method_29365 loadTransparencyShader ()V
 	METHOD method_3239 renderClouds (Lnet/minecraft/class_287;DDDLnet/minecraft/class_243;)V
 		ARG 1 builder
 		ARG 2 x

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -9,6 +9,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	FIELD field_25274 translucentFramebuffer Lnet/minecraft/class_276;
 	FIELD field_25275 entityFramebuffer Lnet/minecraft/class_276;
 	FIELD field_25276 particlesFramebuffer Lnet/minecraft/class_276;
+	FIELD field_25278 cloudsFramebuffer Lnet/minecraft/class_276;
 	FIELD field_4055 noCullingBlockEntities Ljava/util/Set;
 	FIELD field_4056 capturedFrustum Lnet/minecraft/class_4604;
 	FIELD field_4057 textureManager Lnet/minecraft/class_1060;

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -7,6 +7,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	FIELD field_20951 bufferBuilders Lnet/minecraft/class_4599;
 	FIELD field_21799 chunkUpdateSmoother Lnet/minecraft/class_4740;
 	FIELD field_25275 entityFramebuffer Lnet/minecraft/class_276;
+	FIELD field_25276 particleFramebuffer Lnet/minecraft/class_276;
 	FIELD field_4055 noCullingBlockEntities Ljava/util/Set;
 	FIELD field_4056 capturedFrustum Lnet/minecraft/class_4604;
 	FIELD field_4057 textureManager Lnet/minecraft/class_1060;

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -254,7 +254,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		ARG 1 yaw
 	METHOD method_5637 isWet ()Z
 		COMMENT Returns whether this entity is touching water, or is being rained on, or is inside a bubble column...
-		COMMENT 
+		COMMENT
 		COMMENT @see net.minecraft.entity.Entity#isTouchingWater()
 		COMMENT @see net.minecraft.entity.Entity#isBeingRainedOn()
 		COMMENT @see net.minecraft.entity.Entity#isInsideBubbleColumn()
@@ -554,7 +554,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		ARG 1 silent
 	METHOD method_5804 startRiding (Lnet/minecraft/class_1297;)Z
 		ARG 1 entity
-	METHOD method_5805 isValid ()Z
+	METHOD method_5805 isAlive ()Z
 	METHOD method_5806 getDefaultNetherPortalCooldown ()I
 	METHOD method_5807 isCustomNameVisible ()Z
 	METHOD method_5808 refreshPositionAndAngles (DDDFF)V

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -254,7 +254,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		ARG 1 yaw
 	METHOD method_5637 isWet ()Z
 		COMMENT Returns whether this entity is touching water, or is being rained on, or is inside a bubble column...
-		COMMENT
+		COMMENT 
 		COMMENT @see net.minecraft.entity.Entity#isTouchingWater()
 		COMMENT @see net.minecraft.entity.Entity#isBeingRainedOn()
 		COMMENT @see net.minecraft.entity.Entity#isInsideBubbleColumn()
@@ -554,7 +554,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		ARG 1 silent
 	METHOD method_5804 startRiding (Lnet/minecraft/class_1297;)Z
 		ARG 1 entity
-	METHOD method_5805 isAlive ()Z
+	METHOD method_5805 isValid ()Z
 	METHOD method_5806 getDefaultNetherPortalCooldown ()I
 	METHOD method_5807 isCustomNameVisible ()Z
 	METHOD method_5808 refreshPositionAndAngles (DDDFF)V


### PR DESCRIPTION
This PR adds mappings related to the new transparency shader, notably in the `Framebuffer`, `RenderLayer`, and `WorldRenderer` classes.
