### PR TITLE
Map HandledScreen label coordinates

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/ingame/HandledScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/HandledScreen.mapping
@@ -1,5 +1,9 @@
 CLASS net/minecraft/class_465 net/minecraft/client/gui/screen/ingame/HandledScreen
 	FIELD field_17410 playerInventory Lnet/minecraft/class_1661;
+	FIELD field_25267 titleX I
+	FIELD field_25268 titleY I
+	FIELD field_25269 playerInventoryTitleX I
+	FIELD field_25270 playerInventoryTitleY I
 	FIELD field_2776 x I
 	FIELD field_2777 touchDragSlotStart Lnet/minecraft/class_1735;
 	FIELD field_2778 heldButtonCode I


### PR DESCRIPTION
The player inventory title is now drawn by `HandledScreen` instead of subclasses, and Mojang has also split the title coordinates to their own fields.