### PR TITLE
Added mappings for new fields in DefaultBiomeFeatures

### DIFF
--- a/mappings/net/minecraft/world/gen/feature/DefaultBiomeFeatures.mapping
+++ b/mappings/net/minecraft/world/gen/feature/DefaultBiomeFeatures.mapping
@@ -150,13 +150,37 @@ CLASS net/minecraft/class_3864 net/minecraft/world/gen/feature/DefaultBiomeFeatu
 	FIELD field_24110 VERY_RARE_BEEHIVES_CONFIG Lnet/minecraft/class_4659;
 	FIELD field_24111 REGULAR_BEEHIVES_CONFIG Lnet/minecraft/class_4659;
 	FIELD field_24112 MORE_BEEHIVES_CONFIG Lnet/minecraft/class_4659;
-	FIELD field_24682 JUNGLE_CONFIGURED_RUINED_PORTAL Lnet/minecraft/class_5312;
-	FIELD field_24683 SWAMP_CONFIGURED_RUINED_PORTAL Lnet/minecraft/class_5312;
-	FIELD field_24684 MOUNTAIN_CONFIGURED_RUINED_PORTAL Lnet/minecraft/class_5312;
-	FIELD field_24685 OCEAN_CONFIGURED_RUINED_PORTAL Lnet/minecraft/class_5312;
-	FIELD field_24686 NETHER_CONFIGURED_RUINED_PORTAL Lnet/minecraft/class_5312;
-	FIELD field_24711 STANDARD_CONFIGURED_RUINED_PORTAL Lnet/minecraft/class_5312;
-	FIELD field_24712 DESERT_CONFIGURED_RUINED_PORTAL Lnet/minecraft/class_5312;
+	FIELD field_24682 JUNGLE_RUINED_PORTAL Lnet/minecraft/class_5312;
+	FIELD field_24683 SWAMP_RUINED_PORTAL Lnet/minecraft/class_5312;
+	FIELD field_24684 MOUNTAIN_RUINED_PORTAL Lnet/minecraft/class_5312;
+	FIELD field_24685 OCEAN_RUINED_PORTAL Lnet/minecraft/class_5312;
+	FIELD field_24686 NETHER_RUINED_PORTAL Lnet/minecraft/class_5312;
+	FIELD field_24687 PILLAGER_OUTPOST Lnet/minecraft/class_5312;
+	FIELD field_24688 NORMAL_MINESHAFT Lnet/minecraft/class_5312;
+	FIELD field_24689 MESA_MINESHAFT Lnet/minecraft/class_5312;
+	FIELD field_24690 MANSION Lnet/minecraft/class_5312;
+	FIELD field_24691 JUNGLE_PYRAMID Lnet/minecraft/class_5312;
+	FIELD field_24692 DESERT_PYRAMID Lnet/minecraft/class_5312;
+	FIELD field_24693 IGLOO Lnet/minecraft/class_5312;
+	FIELD field_24694 SUNKEN_SHIPWRECK Lnet/minecraft/class_5312;
+	FIELD field_24695 BEACHED_SHIPWRECK Lnet/minecraft/class_5312;
+	FIELD field_24696 SWAMP_HUT Lnet/minecraft/class_5312;
+	FIELD field_24697 STRONGHOLD Lnet/minecraft/class_5312;
+	FIELD field_24698 MONUMENT Lnet/minecraft/class_5312;
+	FIELD field_24699 COLD_OCEAN_RUIN Lnet/minecraft/class_5312;
+	FIELD field_24700 WARM_OCEAN_RUIN Lnet/minecraft/class_5312;
+	FIELD field_24701 FORTRESS Lnet/minecraft/class_5312;
+	FIELD field_24702 NETHER_FOSSIL Lnet/minecraft/class_5312;
+	FIELD field_24703 END_CITY Lnet/minecraft/class_5312;
+	FIELD field_24704 BURIIED_TREASURE Lnet/minecraft/class_5312;
+	FIELD field_24705 BASTION_REMNANT Lnet/minecraft/class_5312;
+	FIELD field_24706 PLAINS_VILLAGE Lnet/minecraft/class_5312;
+	FIELD field_24707 DESERT_VILLAGE Lnet/minecraft/class_5312;
+	FIELD field_24708 SAVANNA_VILLAGE Lnet/minecraft/class_5312;
+	FIELD field_24709 SNOWY_VILLAGE Lnet/minecraft/class_5312;
+	FIELD field_24710 TAIGA_VILLAGE Lnet/minecraft/class_5312;
+	FIELD field_24711 STANDARD_RUINED_PORTAL Lnet/minecraft/class_5312;
+	FIELD field_24712 DESERT_RUINED_PORTAL Lnet/minecraft/class_5312;
 	METHOD method_16957 addMountainTrees (Lnet/minecraft/class_1959;)V
 		ARG 0 biome
 	METHOD method_16958 addExtraMountainTrees (Lnet/minecraft/class_1959;)V
@@ -297,9 +321,15 @@ CLASS net/minecraft/class_3864 net/minecraft/world/gen/feature/DefaultBiomeFeatu
 		ARG 0 biome
 	METHOD method_24384 addWarpedForestVegetation (Lnet/minecraft/class_1959;)V
 		ARG 0 biome
+	METHOD method_28437 (Lnet/minecraft/class_1959;)V
+		ARG 0 biome
 	METHOD method_28438 addNetherOres (Lnet/minecraft/class_1959;II)V
 		ARG 0 biome
 		ARG 1 goldCount
 		ARG 2 quartzCount
 	METHOD method_28439 addAncientDebris (Lnet/minecraft/class_1959;)V
+		ARG 0 biome
+	METHOD method_28440 (Lnet/minecraft/class_1959;)V
+		ARG 0 biome
+	METHOD method_28441 (Lnet/minecraft/class_1959;)V
 		ARG 0 biome

--- a/mappings/net/minecraft/world/gen/feature/DefaultBiomeFeatures.mapping
+++ b/mappings/net/minecraft/world/gen/feature/DefaultBiomeFeatures.mapping
@@ -172,7 +172,7 @@ CLASS net/minecraft/class_3864 net/minecraft/world/gen/feature/DefaultBiomeFeatu
 	FIELD field_24701 FORTRESS Lnet/minecraft/class_5312;
 	FIELD field_24702 NETHER_FOSSIL Lnet/minecraft/class_5312;
 	FIELD field_24703 END_CITY Lnet/minecraft/class_5312;
-	FIELD field_24704 BURIIED_TREASURE Lnet/minecraft/class_5312;
+	FIELD field_24704 BURIED_TREASURE Lnet/minecraft/class_5312;
 	FIELD field_24705 BASTION_REMNANT Lnet/minecraft/class_5312;
 	FIELD field_24706 PLAINS_VILLAGE Lnet/minecraft/class_5312;
 	FIELD field_24707 DESERT_VILLAGE Lnet/minecraft/class_5312;


### PR DESCRIPTION
The reason I removed the  `CONFIGURED` from the name is cause I accidentally made this one on an older branch where those weren't mapped yet and had decided not to add them. I, therefore, deleted those to maintain parity with my other mappings.
If you think I should add `CONFIGURED` back in, tell me.