### PR TITLE
Fix Material.SUPPORTED -> Material.DECORATION

### DIFF
--- a/mappings/net/minecraft/block/Material.mapping
+++ b/mappings/net/minecraft/block/Material.mapping
@@ -15,8 +15,8 @@ CLASS net/minecraft/class_3614 net/minecraft/block/Material
 		COMMENT Not in use, but has foliage color.
 	FIELD field_15922 LAVA Lnet/minecraft/class_3614;
 	FIELD field_15923 LEAVES Lnet/minecraft/class_3614;
-	FIELD field_15924 SUPPORTED Lnet/minecraft/class_3614;
-		COMMENT Material for blocks that require a supporting block such as redstone components, torches, flower pots, and skulls.
+	FIELD field_15924 DECORATION Lnet/minecraft/class_3614;
+		COMMENT Material for decoration blocks such as redstone components, torches, flower pots, rails, buttons, and skulls.
 	FIELD field_15925 CACTUS Lnet/minecraft/class_3614;
 	FIELD field_15926 REPLACEABLE_UNDERWATER_PLANT Lnet/minecraft/class_3614;
 	FIELD field_15927 STRUCTURE_VOID Lnet/minecraft/class_3614;


### PR DESCRIPTION
This is the material for rails, torches, redstone wire, ladders, levers, redstone torches, buttons, repeaters, tripwire hooks, potted plants, skulls, the dragon head, end rods, & scaffolding. This is quite a diverse group, but I think `DECORATION` is a good name because most of these blocks fall under the `Decoration Blocks` tab in the Creative menu.

Closes #1467