### PR TITLE
Move raid classes to village package

### DIFF
--- a/mappings/net/minecraft/village/raid/Raid.mapping
+++ b/mappings/net/minecraft/village/raid/Raid.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3765 net/minecraft/entity/raid/Raid
+CLASS net/minecraft/class_3765 net/minecraft/village/raid/Raid
 	FIELD field_16605 ticksActive J
 	FIELD field_16606 active Z
 	FIELD field_16607 bar Lnet/minecraft/class_3213;
@@ -85,6 +85,8 @@ CLASS net/minecraft/class_3765 net/minecraft/entity/raid/Raid
 	METHOD method_16832 isFinished ()Z
 	METHOD method_16833 shouldSpawnMoreGroups ()Z
 	METHOD method_16834 removeObsoleteRaiders ()V
+	METHOD method_19208 (Lnet/minecraft/class_3222;)Z
+		ARG 1 player
 	METHOD method_20012 hasSpawnedFinalWave ()Z
 	METHOD method_20013 hasExtraWave ()Z
 	METHOD method_20014 hasSpawnedExtraWave ()Z
@@ -113,6 +115,7 @@ CLASS net/minecraft/class_3765 net/minecraft/entity/raid/Raid
 		ARG 1 proximity
 	METHOD method_20509 setCenter (Lnet/minecraft/class_2338;)V
 		ARG 1 center
+	METHOD method_20511 moveRaidCenter ()V
 	CLASS class_3766 Member
 		FIELD field_16628 countInWave [I
 		FIELD field_16629 type Lnet/minecraft/class_1299;

--- a/mappings/net/minecraft/village/raid/RaidManager.mapping
+++ b/mappings/net/minecraft/village/raid/RaidManager.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3767 net/minecraft/entity/raid/RaidManager
+CLASS net/minecraft/class_3767 net/minecraft/village/raid/RaidManager
 	FIELD field_16637 currentTime I
 	FIELD field_16638 nextAvailableId I
 	FIELD field_16639 raids Ljava/util/Map;


### PR DESCRIPTION
Detached this from original entity packages PR.

Rationale is that a village is always the subject of a raid.