### PR TITLE
Glint layer mappings

### DIFF
--- a/mappings/net/minecraft/client/render/RenderLayer.mapping
+++ b/mappings/net/minecraft/client/render/RenderLayer.mapping
@@ -115,8 +115,8 @@ CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 		ARG 0 texture
 	METHOD method_29380 getTranslucentMovingBlock ()Lnet/minecraft/class_1921;
 	METHOD method_29381 getItemPhaseData ()Lnet/minecraft/class_1921$class_4688;
-	METHOD method_29706 getGlintDirect ()Lnet/minecraft/class_1921;
-	METHOD method_29707 getEntityGlintDirect ()Lnet/minecraft/class_1921;
+	METHOD method_29706 getDirectGlint ()Lnet/minecraft/class_1921;
+	METHOD method_29707 getDirectEntityGlint ()Lnet/minecraft/class_1921;
 	METHOD method_29996 getTripwirePhaseData ()Lnet/minecraft/class_1921$class_4688;
 	METHOD method_29997 getTripwire ()Lnet/minecraft/class_1921;
 	CLASS class_4687 MultiPhase

--- a/mappings/net/minecraft/client/render/RenderLayer.mapping
+++ b/mappings/net/minecraft/client/render/RenderLayer.mapping
@@ -5,6 +5,8 @@ CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 	FIELD field_20975 hasCrumbling Z
 	FIELD field_21402 translucent Z
 	FIELD field_21850 optionalThis Ljava/util/Optional;
+	FIELD field_25487 DIRECT_GLINT Lnet/minecraft/class_1921;
+	FIELD field_25488 DIRECT_ENTITY_GLINT Lnet/minecraft/class_1921;
 	METHOD <init> (Ljava/lang/String;Lnet/minecraft/class_293;IIZZLjava/lang/Runnable;Ljava/lang/Runnable;)V
 		ARG 1 name
 		ARG 2 vertexFormat

--- a/mappings/net/minecraft/client/render/item/ItemRenderer.mapping
+++ b/mappings/net/minecraft/client/render/item/ItemRenderer.mapping
@@ -42,7 +42,7 @@ CLASS net/minecraft/class_918 net/minecraft/client/render/item/ItemRenderer
 		ARG 4 stack
 		ARG 5 light
 		ARG 6 overlay
-	METHOD method_23181 getGlintVertexConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;ZZ)Lnet/minecraft/class_4588;
+	METHOD method_23181 getItemGlintConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;ZZ)Lnet/minecraft/class_4588;
 		ARG 0 vertexConsumers
 		ARG 1 layer
 		ARG 2 solid
@@ -62,8 +62,8 @@ CLASS net/minecraft/class_918 net/minecraft/client/render/item/ItemRenderer
 		ARG 2 stack
 		ARG 3 x
 		ARG 4 y
-	METHOD method_27952 getArmorVertexConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;ZZ)Lnet/minecraft/class_4588;
-		ARG 0 vertexConsumers
+	METHOD method_27952 getArmorGlintConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;ZZ)Lnet/minecraft/class_4588;
+		ARG 0 provider
 		ARG 1 layer
 		ARG 2 solid
 		ARG 3 glint
@@ -72,11 +72,19 @@ CLASS net/minecraft/class_918 net/minecraft/client/render/item/ItemRenderer
 		ARG 1 stack
 		ARG 2 x
 		ARG 3 y
-	METHOD method_29711 getDirectGlintVertexConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;ZZ)Lnet/minecraft/class_4588;
+	METHOD method_29711 getDirectItemGlintConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;ZZ)Lnet/minecraft/class_4588;
+		ARG 0 provider
 		ARG 1 layer
+		ARG 2 solid
 		ARG 3 glint
-	METHOD method_30114 getGlintVertexConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;Lnet/minecraft/class_4587$class_4665;)Lnet/minecraft/class_4588;
-	METHOD method_30115 getDirectGlintVertexConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;Lnet/minecraft/class_4587$class_4665;)Lnet/minecraft/class_4588;
+	METHOD method_30114 getCompassGlintConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;Lnet/minecraft/class_4587$class_4665;)Lnet/minecraft/class_4588;
+		ARG 0 provider
+		ARG 1 layer
+		ARG 2 entry
+	METHOD method_30115 getDirectCompassGlintConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;Lnet/minecraft/class_4587$class_4665;)Lnet/minecraft/class_4588;
+		ARG 0 provider
+		ARG 1 layer
+		ARG 2 entry
 	METHOD method_4004 renderGuiQuad (Lnet/minecraft/class_287;IIIIIIII)V
 		ARG 1 buffer
 		ARG 2 x


### PR DESCRIPTION
Mapped all the new vertex consumer methods Mojang added to ItemRenderer (most likely in the process of fixing enchantment glints)