### PR TITLE
NativeImage#Format.ABGR not NativeImage#Format.AGBR

### DIFF
--- a/mappings/net/minecraft/client/texture/NativeImage.mapping
+++ b/mappings/net/minecraft/client/texture/NativeImage.mapping
@@ -109,7 +109,7 @@ CLASS net/minecraft/class_1011 net/minecraft/client/texture/NativeImage
 		COMMENT Gets the color of a pixel on this native image.
 		COMMENT The color returned by this method will be in a ABGR format.
 		COMMENT
-		COMMENT <p>This is only supported when this native image's format is {@link NativeImage#Format#AGBR ABGR}.
+		COMMENT <p>This is only supported when this native image's format is {@link NativeImage#Format#ABGR ABGR}.
 		ARG 1 x
 		ARG 2 y
 	METHOD method_4316 makeGlyphBitmapSubpixel (Lorg/lwjgl/stb/STBTTFontinfo;IIIFFFFII)V


### PR DESCRIPTION
Fixed a typo in the docs for NativeImage.