### PR TITLE
Improvements to lighting engine mappings

### DIFF
--- a/mappings/net/minecraft/util/math/ChunkSectionPos.mapping
+++ b/mappings/net/minecraft/util/math/ChunkSectionPos.mapping
@@ -37,13 +37,13 @@ CLASS net/minecraft/class_4076 net/minecraft/util/math/ChunkSectionPos
 	METHOD method_18686 getX (J)I
 		ARG 0 packed
 	METHOD method_18687 getSectionZ ()I
-	METHOD method_18688 getWorldCoord (I)I
+	METHOD method_18688 getBlockCoord (I)I
 		ARG 0 sectionCoord
 	METHOD method_18689 getY (J)I
 		ARG 0 packed
 	METHOD method_18690 getZ (J)I
 		ARG 0 packed
-	METHOD method_18691 fromWorldPos (J)J
+	METHOD method_18691 fromBlockPos (J)J
 		ARG 0 blockPos
 	METHOD method_18692 toChunkPos ()Lnet/minecraft/class_1923;
 	METHOD method_18693 withZeroZ (J)J

--- a/mappings/net/minecraft/util/math/ChunkSectionPos.mapping
+++ b/mappings/net/minecraft/util/math/ChunkSectionPos.mapping
@@ -38,13 +38,13 @@ CLASS net/minecraft/class_4076 net/minecraft/util/math/ChunkSectionPos
 		ARG 0 packed
 	METHOD method_18687 getSectionZ ()I
 	METHOD method_18688 getWorldCoord (I)I
-		ARG 0 chunkCoord
+		ARG 0 sectionCoord
 	METHOD method_18689 getY (J)I
 		ARG 0 packed
 	METHOD method_18690 getZ (J)I
 		ARG 0 packed
-	METHOD method_18691 fromGlobalPos (J)J
-		ARG 0 globalLong
+	METHOD method_18691 fromWorldPos (J)J
+		ARG 0 blockPos
 	METHOD method_18692 toChunkPos ()Lnet/minecraft/class_1923;
 	METHOD method_18693 withZeroZ (J)J
 		ARG 0 pos

--- a/mappings/net/minecraft/world/chunk/light/ChunkLightProvider.mapping
+++ b/mappings/net/minecraft/world/chunk/light/ChunkLightProvider.mapping
@@ -10,15 +10,15 @@ CLASS net/minecraft/class_3558 net/minecraft/world/chunk/light/ChunkLightProvide
 		ARG 1 chunkProvider
 		ARG 2 type
 		ARG 3 lightStorage
-	METHOD method_15512 setLightEnabled (Lnet/minecraft/class_1923;Z)V
+	METHOD method_15512 setColumnEnabled (Lnet/minecraft/class_1923;Z)V
 		ARG 1 pos
-		ARG 2 lightEnabled
+		ARG 2 enabled
 	METHOD method_15513 checkBlock (Lnet/minecraft/class_2338;)V
 		ARG 1 pos
 	METHOD method_15514 addLightSource (Lnet/minecraft/class_2338;I)V
 		ARG 1 pos
 		ARG 2 level
-	METHOD method_15515 setLightArray (JLnet/minecraft/class_2804;Z)V
+	METHOD method_15515 enqueueSectionData (JLnet/minecraft/class_2804;Z)V
 		ARG 1 pos
 		ARG 3 lightArray
 	METHOD method_15516 doLightUpdates (IZZ)I
@@ -43,10 +43,12 @@ CLASS net/minecraft/class_3558 net/minecraft/world/chunk/light/ChunkLightProvide
 		ARG 6 opacity2
 	METHOD method_20479 getStateForLighting (JLorg/apache/commons/lang3/mutable/MutableInt;)Lnet/minecraft/class_2680;
 		ARG 1 pos
-	METHOD method_20599 setRetainData (Lnet/minecraft/class_1923;Z)V
+	METHOD method_20599 setRetainColumn (Lnet/minecraft/class_1923;Z)V
 		ARG 1 pos
 		ARG 2 retainData
 	METHOD method_20710 getOpaqueShape (Lnet/minecraft/class_2680;JLnet/minecraft/class_2350;)Lnet/minecraft/class_265;
 		ARG 1 world
 		ARG 2 pos
 		ARG 4 facing
+	METHOD method_22875 displaySectionLevel (J)Ljava/lang/String;
+		ARG 1 sectionPos

--- a/mappings/net/minecraft/world/chunk/light/ChunkLightProvider.mapping
+++ b/mappings/net/minecraft/world/chunk/light/ChunkLightProvider.mapping
@@ -48,7 +48,7 @@ CLASS net/minecraft/class_3558 net/minecraft/world/chunk/light/ChunkLightProvide
 		ARG 2 retainData
 	METHOD method_20710 getOpaqueShape (Lnet/minecraft/class_2680;JLnet/minecraft/class_2350;)Lnet/minecraft/class_265;
 		ARG 1 world
-		ARG 2 blockPos
+		ARG 2 pos
 		ARG 4 facing
 	METHOD method_22875 displaySectionLevel (J)Ljava/lang/String;
 		ARG 1 sectionPos

--- a/mappings/net/minecraft/world/chunk/light/ChunkLightProvider.mapping
+++ b/mappings/net/minecraft/world/chunk/light/ChunkLightProvider.mapping
@@ -19,14 +19,14 @@ CLASS net/minecraft/class_3558 net/minecraft/world/chunk/light/ChunkLightProvide
 		ARG 1 pos
 		ARG 2 level
 	METHOD method_15515 enqueueSectionData (JLnet/minecraft/class_2804;Z)V
-		ARG 1 pos
+		ARG 1 sectionPos
 		ARG 3 lightArray
 	METHOD method_15516 doLightUpdates (IZZ)I
 		ARG 1 maxSteps
 		ARG 2 doSkylight
 		ARG 3 skipEdgeLightPropagation
-	METHOD method_15517 getCurrentLevelFromArray (Lnet/minecraft/class_2804;J)I
-		ARG 1 array
+	METHOD method_15517 getCurrentLevelFromSection (Lnet/minecraft/class_2804;J)I
+		ARG 1 section
 		ARG 2 blockPos
 	METHOD method_15518 hasUpdates ()Z
 	METHOD method_17529 getChunk (II)Lnet/minecraft/class_1922;
@@ -42,13 +42,13 @@ CLASS net/minecraft/class_3558 net/minecraft/world/chunk/light/ChunkLightProvide
 		ARG 5 direction
 		ARG 6 opacity2
 	METHOD method_20479 getStateForLighting (JLorg/apache/commons/lang3/mutable/MutableInt;)Lnet/minecraft/class_2680;
-		ARG 1 pos
+		ARG 1 blockPos
 	METHOD method_20599 setRetainColumn (Lnet/minecraft/class_1923;Z)V
 		ARG 1 pos
 		ARG 2 retainData
 	METHOD method_20710 getOpaqueShape (Lnet/minecraft/class_2680;JLnet/minecraft/class_2350;)Lnet/minecraft/class_265;
 		ARG 1 world
-		ARG 2 pos
+		ARG 2 blockPos
 		ARG 4 facing
 	METHOD method_22875 displaySectionLevel (J)Ljava/lang/String;
 		ARG 1 sectionPos

--- a/mappings/net/minecraft/world/chunk/light/ChunkLightProvider.mapping
+++ b/mappings/net/minecraft/world/chunk/light/ChunkLightProvider.mapping
@@ -42,7 +42,7 @@ CLASS net/minecraft/class_3558 net/minecraft/world/chunk/light/ChunkLightProvide
 		ARG 5 direction
 		ARG 6 opacity2
 	METHOD method_20479 getStateForLighting (JLorg/apache/commons/lang3/mutable/MutableInt;)Lnet/minecraft/class_2680;
-		ARG 1 blockPos
+		ARG 1 pos
 	METHOD method_20599 setRetainColumn (Lnet/minecraft/class_1923;Z)V
 		ARG 1 pos
 		ARG 2 retainData

--- a/mappings/net/minecraft/world/chunk/light/ChunkLightingView.mapping
+++ b/mappings/net/minecraft/world/chunk/light/ChunkLightingView.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_3562 net/minecraft/world/chunk/light/ChunkLightingView
 	METHOD method_15543 getLightLevel (Lnet/minecraft/class_2338;)I
-	METHOD method_15544 getLightArray (Lnet/minecraft/class_4076;)Lnet/minecraft/class_2804;
+	METHOD method_15544 getLightSection (Lnet/minecraft/class_4076;)Lnet/minecraft/class_2804;
 		ARG 1 pos
 	CLASS class_3563 Empty

--- a/mappings/net/minecraft/world/chunk/light/LevelPropagator.mapping
+++ b/mappings/net/minecraft/world/chunk/light/LevelPropagator.mapping
@@ -65,6 +65,9 @@ CLASS net/minecraft/class_3554 net/minecraft/world/chunk/light/LevelPropagator
 		ARG 5 removeFully
 	METHOD method_15494 isMarker (J)Z
 		ARG 1 id
+	METHOD method_24206 removePendingUpdateIf (Ljava/util/function/LongPredicate;)V
+		ARG 1 predicate
+	METHOD method_24208 getPendingUpdateCount ()I
 	CLASS 1
 		METHOD rehash (I)V
 			ARG 1 newN

--- a/mappings/net/minecraft/world/chunk/light/LightStorage.mapping
+++ b/mappings/net/minecraft/world/chunk/light/LightStorage.mapping
@@ -1,4 +1,15 @@
 CLASS net/minecraft/class_3560 net/minecraft/world/chunk/light/LightStorage
+	COMMENT LightStorage handles the access, storage and propagation of a specific kind of light within the world.
+	COMMENT For example, separate instances will be used to store block light as opposed to sky light.
+	COMMENT
+	COMMENT The smallest unit within LightStorage is the section. Sections represent a cube of 16x16x16 blocks and their lighting data.
+	COMMENT In turn, 16 sections stacked on top of each other form a column, which are analogous to the standard 16x256x16 world chunks.
+	COMMENT
+	COMMENT To avoid allocations, LightStorage packs all the coordinate arguments into single long values. Extra care should be taken
+	COMMENT to ensure that the relevant types are being used where appropriate.
+	COMMENT
+	COMMENT @see SkyLightStorage
+	COMMENT @see BlockLightStorage
 	FIELD field_15796 storage Lnet/minecraft/class_3556;
 	FIELD field_15797 markedNotReadySections Lit/unimi/dsi/fastutil/longs/LongSet;
 	FIELD field_15798 sectionsToRemove Lit/unimi/dsi/fastutil/longs/LongSet;

--- a/mappings/net/minecraft/world/chunk/light/LightStorage.mapping
+++ b/mappings/net/minecraft/world/chunk/light/LightStorage.mapping
@@ -1,55 +1,69 @@
 CLASS net/minecraft/class_3560 net/minecraft/world/chunk/light/LightStorage
-	FIELD field_15796 lightArrays Lnet/minecraft/class_3556;
-	FIELD field_15798 lightArraysToRemove Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD field_15796 storage Lnet/minecraft/class_3556;
+	FIELD field_15797 markedNotReadySections Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD field_15798 sectionsToRemove Lit/unimi/dsi/fastutil/longs/LongSet;
 	FIELD field_15799 DIRECTIONS [Lnet/minecraft/class_2350;
 	FIELD field_15800 hasLightUpdates Z
 	FIELD field_15801 EMPTY Lnet/minecraft/class_2804;
+	FIELD field_15802 dirtySections Lit/unimi/dsi/fastutil/longs/LongSet;
 	FIELD field_15803 chunkProvider Lnet/minecraft/class_2823;
+	FIELD field_15804 markedReadySections Lit/unimi/dsi/fastutil/longs/LongSet;
 	FIELD field_15805 lightType Lnet/minecraft/class_1944;
-	FIELD field_15806 uncachedLightArrays Lnet/minecraft/class_3556;
-	FIELD field_15807 lightArraysToAdd Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;
-	FIELD field_15808 nonEmptySections Lit/unimi/dsi/fastutil/longs/LongSet;
-	FIELD field_16448 dirtySections Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD field_15806 uncachedStorage Lnet/minecraft/class_3556;
+	FIELD field_15807 queuedSections Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;
+	FIELD field_15808 readySections Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD field_16448 notifySections Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD field_19342 columnsToRetain Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD field_25621 queuedEdgeSections Lit/unimi/dsi/fastutil/longs/LongSet;
 	METHOD <init> (Lnet/minecraft/class_1944;Lnet/minecraft/class_2823;Lnet/minecraft/class_3556;)V
 		ARG 1 lightType
 		ARG 2 chunkProvider
 		ARG 3 lightData
-	METHOD method_15522 getLightArray (JZ)Lnet/minecraft/class_2804;
+	METHOD method_15522 getLightSection (JZ)Lnet/minecraft/class_2804;
 		ARG 1 sectionPos
 		ARG 3 cached
-	METHOD method_15523 onLightArrayCreated (J)V
-		ARG 1 blockPos
-	METHOD method_15524 hasLight (J)Z
+	METHOD method_15523 onLoadSection (J)V
+		ARG 1 sectionPos
+	METHOD method_15524 hasSection (J)Z
 		ARG 1 sectionPos
 	METHOD method_15525 set (JI)V
 		ARG 1 blockPos
 		ARG 3 value
-	METHOD method_15526 updateSectionStatus (JZ)V
-		ARG 1 pos
-		ARG 3 empty
-	METHOD method_15527 updateLightArrays (Lnet/minecraft/class_3558;ZZ)V
+	METHOD method_15526 setSectionStatus (JZ)V
+		ARG 1 sectionPos
+		ARG 3 notReady
+	METHOD method_15527 updateLight (Lnet/minecraft/class_3558;ZZ)V
+		ARG 1 lightProvider
 		ARG 2 doSkylight
 		ARG 3 skipEdgeLightPropagation
 	METHOD method_15528 hasLightUpdates ()Z
-	METHOD method_15529 createLightArray (J)Lnet/minecraft/class_2804;
-		ARG 1 pos
-	METHOD method_15530 notifyChunkProvider ()V
-	METHOD method_15532 setLightArray (JLnet/minecraft/class_2804;Z)V
-		ARG 1 pos
+	METHOD method_15529 createSection (J)Lnet/minecraft/class_2804;
+		ARG 1 sectionPos
+	METHOD method_15530 notifyChanges ()V
+	METHOD method_15532 enqueueSectionData (JLnet/minecraft/class_2804;Z)V
+		ARG 1 sectionPos
 		ARG 3 array
-	METHOD method_15533 getLightArray (Lnet/minecraft/class_3556;J)Lnet/minecraft/class_2804;
+	METHOD method_15533 getLightSection (Lnet/minecraft/class_3556;J)Lnet/minecraft/class_2804;
 		ARG 1 storage
 		ARG 2 sectionPos
-	METHOD method_15534 onChunkRemoved (J)V
-	METHOD method_15535 setLightEnabled (JZ)V
-	METHOD method_15536 removeChunkData (Lnet/minecraft/class_3558;J)V
+	METHOD method_15534 onUnloadSection (J)V
+		ARG 1 sectionPos
+	METHOD method_15535 setColumnEnabled (JZ)V
+		ARG 1 columnPos
+		ARG 3 enabled
+	METHOD method_15536 removeSection (Lnet/minecraft/class_3558;J)V
 		ARG 1 storage
-		ARG 2 blockChunkPos
+		ARG 2 sectionPos
 	METHOD method_15537 get (J)I
 		ARG 1 blockPos
 	METHOD method_15538 getLight (J)I
 		ARG 1 blockPos
 	METHOD method_15539 updateAll ()V
-	METHOD method_20533 getLightArray (J)Lnet/minecraft/class_2804;
+	METHOD method_20533 getLightSection (J)Lnet/minecraft/class_2804;
 		ARG 1 sectionPos
-	METHOD method_20600 setRetainData (JZ)V
+	METHOD method_20600 setRetainColumn (JZ)V
+		ARG 1 sectionPos
+		ARG 3 retain
+	METHOD method_29967 updateSection (Lnet/minecraft/class_3558;J)V
+		ARG 1 lightProvider
+		ARG 2 sectionPos

--- a/mappings/net/minecraft/world/chunk/light/LightStorage.mapping
+++ b/mappings/net/minecraft/world/chunk/light/LightStorage.mapping
@@ -2,10 +2,10 @@ CLASS net/minecraft/class_3560 net/minecraft/world/chunk/light/LightStorage
 	COMMENT LightStorage handles the access, storage and propagation of a specific kind of light within the world.
 	COMMENT For example, separate instances will be used to store block light as opposed to sky light.
 	COMMENT
-	COMMENT The smallest unit within LightStorage is the section. Sections represent a cube of 16x16x16 blocks and their lighting data.
+	COMMENT <p>The smallest unit within LightStorage is the section. Sections represent a cube of 16x16x16 blocks and their lighting data.
 	COMMENT In turn, 16 sections stacked on top of each other form a column, which are analogous to the standard 16x256x16 world chunks.
 	COMMENT
-	COMMENT To avoid allocations, LightStorage packs all the coordinate arguments into single long values. Extra care should be taken
+	COMMENT <p>To avoid allocations, LightStorage packs all the coordinate arguments into single long values. Extra care should be taken
 	COMMENT to ensure that the relevant types are being used where appropriate.
 	COMMENT
 	COMMENT @see SkyLightStorage

--- a/mappings/net/minecraft/world/chunk/light/LightingProvider.mapping
+++ b/mappings/net/minecraft/world/chunk/light/LightingProvider.mapping
@@ -5,10 +5,10 @@ CLASS net/minecraft/class_3568 net/minecraft/world/chunk/light/LightingProvider
 		ARG 1 chunkProvider
 		ARG 2 hasBlockLight
 		ARG 3 hasSkyLight
-	METHOD method_15557 setLightEnabled (Lnet/minecraft/class_1923;Z)V
+	METHOD method_15557 setColumnEnabled (Lnet/minecraft/class_1923;Z)V
 		ARG 1 pos
 		ARG 2 lightEnabled
-	METHOD method_15558 queueData (Lnet/minecraft/class_1944;Lnet/minecraft/class_4076;Lnet/minecraft/class_2804;Z)V
+	METHOD method_15558 enqueueSectionData (Lnet/minecraft/class_1944;Lnet/minecraft/class_4076;Lnet/minecraft/class_2804;Z)V
 		ARG 1 lightType
 		ARG 2 pos
 		ARG 3 nibbles
@@ -30,3 +30,4 @@ CLASS net/minecraft/class_3568 net/minecraft/world/chunk/light/LightingProvider
 	METHOD method_22363 getLight (Lnet/minecraft/class_2338;I)I
 		ARG 1 pos
 		ARG 2 ambientDarkness
+	METHOD method_22876 displaySectionLevel (Lnet/minecraft/class_1944;Lnet/minecraft/class_4076;)Ljava/lang/String;

--- a/mappings/net/minecraft/world/chunk/light/LightingView.mapping
+++ b/mappings/net/minecraft/world/chunk/light/LightingView.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_3565 net/minecraft/world/chunk/light/LightingView
-	METHOD method_15551 updateSectionStatus (Lnet/minecraft/class_4076;Z)V
+	METHOD method_15551 setSectionStatus (Lnet/minecraft/class_4076;Z)V
 		ARG 1 pos
-		ARG 2 status
-	METHOD method_15552 updateSectionStatus (Lnet/minecraft/class_2338;Z)V
+		ARG 2 notReady
+	METHOD method_15552 setSectionStatus (Lnet/minecraft/class_2338;Z)V
 		ARG 1 pos
-		ARG 2 status
+		ARG 2 notReady

--- a/mappings/net/minecraft/world/chunk/light/SkyLightStorage.mapping
+++ b/mappings/net/minecraft/world/chunk/light/SkyLightStorage.mapping
@@ -1,17 +1,28 @@
 CLASS net/minecraft/class_3569 net/minecraft/world/chunk/light/SkyLightStorage
-	FIELD field_15815 pendingSkylightUpdates Lit/unimi/dsi/fastutil/longs/LongSet;
-	FIELD field_15817 lightEnabled Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD field_15815 skyLightSectionsToUpdate Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD field_15816 skyLightSectionsToRemove Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD field_15817 enabledColumns Lit/unimi/dsi/fastutil/longs/LongSet;
 	FIELD field_15818 LIGHT_REDUCTION_DIRECTIONS [Lnet/minecraft/class_2350;
 	FIELD field_15819 hasSkyLightUpdates Z
 	METHOD <init> (Lnet/minecraft/class_2823;)V
 		ARG 1 chunkProvider
-	METHOD method_15566 isLightEnabled (J)Z
+	METHOD method_15565 isTopmostBlock (J)Z
+		ARG 1 blockPos
+	METHOD method_15566 isSectionEnabled (J)Z
 		ARG 1 sectionPos
 	METHOD method_15567 isAboveMinHeight (I)Z
-		ARG 1 blockY
-	METHOD method_15568 isAboveTopmostLightArray (J)Z
+		ARG 1 sectionY
+	METHOD method_15568 isAtOrAboveTopmostSection (J)Z
 		ARG 1 pos
 	METHOD method_15569 checkForUpdates ()V
+	METHOD method_20809 enqueueRemoveSection (J)V
+		ARG 1 sectionPos
+	METHOD method_20810 enqueueAddSection (J)V
+		ARG 1 sectionPos
 	CLASS class_3570 Data
-		FIELD field_15821 topArraySectionY Lit/unimi/dsi/fastutil/longs/Long2IntOpenHashMap;
-		FIELD field_15822 defaultTopArraySectionY I
+		FIELD field_15821 columnToTopSection Lit/unimi/dsi/fastutil/longs/Long2IntOpenHashMap;
+		FIELD field_15822 minSectionY I
+		METHOD <init> (Lit/unimi/dsi/fastutil/longs/Long2ObjectOpenHashMap;Lit/unimi/dsi/fastutil/longs/Long2IntOpenHashMap;I)V
+			ARG 1 arrays
+			ARG 2 columnToTopSection
+			ARG 3 minSectionY

--- a/mappings/net/minecraft/world/chunk/light/SkyLightStorage.mapping
+++ b/mappings/net/minecraft/world/chunk/light/SkyLightStorage.mapping
@@ -1,9 +1,9 @@
 CLASS net/minecraft/class_3569 net/minecraft/world/chunk/light/SkyLightStorage
-	FIELD field_15815 skyLightSectionsToUpdate Lit/unimi/dsi/fastutil/longs/LongSet;
-	FIELD field_15816 skyLightSectionsToRemove Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD field_15815 sectionsToUpdate Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD field_15816 sectionsToRemove Lit/unimi/dsi/fastutil/longs/LongSet;
 	FIELD field_15817 enabledColumns Lit/unimi/dsi/fastutil/longs/LongSet;
 	FIELD field_15818 LIGHT_REDUCTION_DIRECTIONS [Lnet/minecraft/class_2350;
-	FIELD field_15819 hasSkyLightUpdates Z
+	FIELD field_15819 hasUpdates Z
 	METHOD <init> (Lnet/minecraft/class_2823;)V
 		ARG 1 chunkProvider
 	METHOD method_15565 isTopmostBlock (J)Z

--- a/mappings/net/minecraft/world/chunk/light/SkyLightStorage.mapping
+++ b/mappings/net/minecraft/world/chunk/light/SkyLightStorage.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/class_3569 net/minecraft/world/chunk/light/SkyLightStorage
 	METHOD method_15567 isAboveMinHeight (I)Z
 		ARG 1 sectionY
 	METHOD method_15568 isAtOrAboveTopmostSection (J)Z
-		ARG 1 pos
+		ARG 1 sectionPos
 	METHOD method_15569 checkForUpdates ()V
 	METHOD method_20809 enqueueRemoveSection (J)V
 		ARG 1 sectionPos


### PR DESCRIPTION
This PR focuses on improving the consistency of mappings within the lighting engine, as well as adding a few more new names. The main confusion arises from the packed `long` parameters which represent different things, but are often not described within the method or argument name.