### PR TITLE
Map TaskExecutor and MessageListener around actor model

### DIFF
--- a/mappings/net/minecraft/client/render/chunk/ChunkBuilder.mapping
+++ b/mappings/net/minecraft/client/render/chunk/ChunkBuilder.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_846 net/minecraft/client/render/chunk/ChunkBuilder
 	FIELD field_18766 cameraPosition Lnet/minecraft/class_243;
 	FIELD field_20827 threadBuffers Ljava/util/Queue;
 	FIELD field_20828 buffers Lnet/minecraft/class_750;
-	FIELD field_20829 mailbox Lnet/minecraft/class_3846;
+	FIELD field_20829 actor Lnet/minecraft/class_3846;
 	FIELD field_20830 executor Ljava/util/concurrent/Executor;
 	FIELD field_20831 world Lnet/minecraft/class_1937;
 	FIELD field_20832 worldRenderer Lnet/minecraft/class_761;

--- a/mappings/net/minecraft/server/world/ChunkTaskPrioritySystem.mapping
+++ b/mappings/net/minecraft/server/world/ChunkTaskPrioritySystem.mapping
@@ -10,11 +10,11 @@ CLASS net/minecraft/class_3900 net/minecraft/server/world/ChunkTaskPrioritySyste
 	METHOD method_17282 execute (Lnet/minecraft/class_3906;Ljava/util/function/Function;JLjava/util/function/IntSupplier;Z)V
 		ARG 1 actor
 		ARG 5 lastLevelUpdatedToProvider
-	METHOD method_17614 createSorterExecutor (Lnet/minecraft/class_3906;)Lnet/minecraft/class_3906;
-		ARG 1 executor
+	METHOD method_17614 createPrioritizedActor (Lnet/minecraft/class_3906;)Lnet/minecraft/class_3906;
+		ARG 1 actor
 	METHOD method_17615 sort (Lnet/minecraft/class_3906;JLjava/lang/Runnable;Z)V
-	METHOD method_17622 createExecutor (Lnet/minecraft/class_3906;Z)Lnet/minecraft/class_3906;
-		ARG 1 executor
+	METHOD method_17622 createPrioritizedActor (Lnet/minecraft/class_3906;Z)Lnet/minecraft/class_3906;
+		ARG 1 actor
 	METHOD method_17626 createMessage (Ljava/lang/Runnable;JLjava/util/function/IntSupplier;)Lnet/minecraft/class_3900$class_3946;
 		ARG 0 runnable
 		ARG 1 pos

--- a/mappings/net/minecraft/server/world/ServerLightingProvider.mapping
+++ b/mappings/net/minecraft/server/world/ServerLightingProvider.mapping
@@ -3,14 +3,14 @@ CLASS net/minecraft/class_3227 net/minecraft/server/world/ServerLightingProvider
 	FIELD field_17255 processor Lnet/minecraft/class_3846;
 	FIELD field_17256 pendingTasks Lit/unimi/dsi/fastutil/objects/ObjectList;
 	FIELD field_17257 chunkStorage Lnet/minecraft/class_3898;
-	FIELD field_17259 executor Lnet/minecraft/class_3906;
+	FIELD field_17259 actor Lnet/minecraft/class_3906;
 	FIELD field_17260 taskBatchSize I
 	FIELD field_18812 ticking Ljava/util/concurrent/atomic/AtomicBoolean;
 	METHOD <init> (Lnet/minecraft/class_2823;Lnet/minecraft/class_3898;ZLnet/minecraft/class_3846;Lnet/minecraft/class_3906;)V
 		ARG 1 chunkProvider
 		ARG 2 chunkStorage
 		ARG 3 hasBlockLight
-		ARG 4 processor
+		ARG 4 actor
 		ARG 5 executor
 	METHOD method_14277 runTasks ()V
 	METHOD method_17303 tick ()V

--- a/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
+++ b/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
@@ -9,8 +9,8 @@ CLASS net/minecraft/class_3898 net/minecraft/server/world/ThreadedAnvilChunkStor
 	FIELD field_17221 unloadedChunks Lit/unimi/dsi/fastutil/longs/LongSet;
 	FIELD field_17222 chunkHolderListDirty Z
 	FIELD field_17223 chunkTaskPrioritySystem Lnet/minecraft/class_3900;
-	FIELD field_17224 worldgenExecutor Lnet/minecraft/class_3906;
-	FIELD field_17226 mainExecutor Lnet/minecraft/class_3906;
+	FIELD field_17224 worldgenActor Lnet/minecraft/class_3906;
+	FIELD field_17226 mainActor Lnet/minecraft/class_3906;
 	FIELD field_17228 ticketManager Lnet/minecraft/class_3898$class_3216;
 	FIELD field_17230 totalChunksLoadedCount Ljava/util/concurrent/atomic/AtomicInteger;
 	FIELD field_17442 worldGenerationProgressListener Lnet/minecraft/class_3949;

--- a/mappings/net/minecraft/util/thread/Actor.mapping
+++ b/mappings/net/minecraft/util/thread/Actor.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3906 net/minecraft/util/thread/MessageListener
+CLASS net/minecraft/class_3906 net/minecraft/util/thread/Actor
 	METHOD method_16898 getName ()Ljava/lang/String;
 	METHOD method_16901 send (Ljava/lang/Object;)V
 		ARG 1 message

--- a/mappings/net/minecraft/util/thread/MessageQueue.mapping
+++ b/mappings/net/minecraft/util/thread/MessageQueue.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3847 net/minecraft/util/thread/TaskQueue
+CLASS net/minecraft/class_3847 net/minecraft/util/thread/MessageQueue
 	METHOD method_16909 poll ()Ljava/lang/Object;
 	METHOD method_16910 add (Ljava/lang/Object;)Z
 		ARG 1 message

--- a/mappings/net/minecraft/util/thread/ReschedulingActor.mapping
+++ b/mappings/net/minecraft/util/thread/ReschedulingActor.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3846 net/minecraft/util/thread/TaskExecutor
+CLASS net/minecraft/class_3846 net/minecraft/util/thread/ReschedulingActor
 	FIELD field_17039 queue Lnet/minecraft/class_3847;
 	FIELD field_17040 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_17041 stateFlags Ljava/util/concurrent/atomic/AtomicInteger;
@@ -18,4 +18,4 @@ CLASS net/minecraft/class_3846 net/minecraft/util/thread/TaskExecutor
 	METHOD method_16905 hasMessages ()Z
 	METHOD method_16906 isUnpaused ()Z
 	METHOD method_16907 runNext ()Z
-	METHOD method_16908 execute ()V
+	METHOD method_16908 reschedule ()V


### PR DESCRIPTION
The systems relevant here very closely represent an actor model. This PR updates the implementations and usages of `MessageListener` (`Actor`) and `TaskExecutor` (`ReschedulingActor`) to better reflect that model.
This is already referenced once in `ChunkTaskPrioritySystem`: https://github.com/FabricMC/yarn/blob/a8502591b0c69e46676f63245b2867f39f86ba5d/mappings/net/minecraft/server/world/ChunkTaskPrioritySystem.mapping#L4

`ReschedulingActor` is an implementation that runs its tasks by rescheduling itself to a java `Executor` whenever a new task is available. It specifically only handles `T extends Runnable`, so I'm conflicted on whether it should be named rather according to that (e.g. `TaskHandlingActor` or similar)