### PR TITLE
Fix lots of spelling errors throughout yarn

### DIFF
--- a/mappings/net/minecraft/block/AbstractRailBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractRailBlock.mapping
@@ -15,7 +15,7 @@ CLASS net/minecraft/class_2241 net/minecraft/block/AbstractRailBlock
 		COMMENT
 		COMMENT <p>This method will return true if:
 		COMMENT <ul><li>The rail block is ascending.</li>
-		COMMENT <li>The block in the direction of ascension does not have a top rim.</li></ul>
+		COMMENT <li>The block in the direction of ascent does not have a top rim.</li></ul>
 		ARG 0 pos
 		ARG 1 world
 		ARG 2 shape

--- a/mappings/net/minecraft/block/entity/BeehiveBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BeehiveBlockEntity.mapping
@@ -36,7 +36,7 @@ CLASS net/minecraft/class_4482 net/minecraft/block/entity/BeehiveBlockEntity
 	CLASS class_4483 Bee
 		FIELD field_20425 entityData Lnet/minecraft/class_2487;
 		FIELD field_20426 ticksInHive I
-		FIELD field_20427 minOccupationTIcks I
+		FIELD field_20427 minOccupationTicks I
 		METHOD <init> (Lnet/minecraft/class_2487;II)V
 			ARG 1 entityData
 			ARG 2 ticksInHive

--- a/mappings/net/minecraft/client/MinecraftClient.mapping
+++ b/mappings/net/minecraft/client/MinecraftClient.mapping
@@ -91,7 +91,7 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 	FIELD field_18174 resourceReloadFuture Ljava/util/concurrent/CompletableFuture;
 	FIELD field_18175 overlay Lnet/minecraft/class_4071;
 	FIELD field_20907 debugChunkInfo Z
-	FIELD field_20908 debugChunkOcculsion Z
+	FIELD field_20908 debugChunkOcclusion Z
 	FIELD field_20909 bufferBuilders Lnet/minecraft/class_4599;
 	FIELD field_22224 trackingTick I
 	FIELD field_22225 tickTimeTracker Lnet/minecraft/class_4757;
@@ -226,9 +226,9 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 	METHOD method_24038 createResourcePackProfile (Ljava/lang/String;ZLjava/util/function/Supplier;Lnet/minecraft/class_3262;Lnet/minecraft/class_3272;Lnet/minecraft/class_3288$class_3289;Lnet/minecraft/class_5352;)Lnet/minecraft/class_1075;
 	METHOD method_24041 resetMipmapLevels (I)V
 		ARG 1 mipmapLevels
-	METHOD method_24042 createV3ResoucePackFactory (Ljava/util/function/Supplier;)Ljava/util/function/Supplier;
+	METHOD method_24042 createV3ResourcePackFactory (Ljava/util/function/Supplier;)Ljava/util/function/Supplier;
 	METHOD method_24043 createV4ResourcePackFactory (Ljava/util/function/Supplier;)Ljava/util/function/Supplier;
-	METHOD method_24226 handleResourceReloadExecption (Ljava/lang/Throwable;)V
+	METHOD method_24226 handleResourceReloadException (Ljava/lang/Throwable;)V
 		ARG 1 throwable
 	METHOD method_24287 getWindowTitle ()Ljava/lang/String;
 	METHOD method_24288 updateWindowTitle ()V
@@ -275,7 +275,7 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 	METHOD method_29610 startIntegratedServer (Ljava/lang/String;Lnet/minecraft/class_5318$class_5319;Ljava/util/function/Function;Lcom/mojang/datafixers/util/Function4;ZLnet/minecraft/class_310$class_5366;)V
 		ARG 1 worldName
 		ARG 2 registryTracker
-		ARG 5 safemode
+		ARG 5 safeMode
 	METHOD method_29611 isFabulousGraphicsOrBetter ()Z
 	CLASS class_5366 WorldLoadAction
 	CLASS class_5367 IntegratedResourceManager

--- a/mappings/net/minecraft/client/font/GlyphRenderer.mapping
+++ b/mappings/net/minecraft/client/font/GlyphRenderer.mapping
@@ -38,7 +38,7 @@ CLASS net/minecraft/class_382 net/minecraft/client/font/GlyphRenderer
 			ARG 2 yMin
 			ARG 3 xMax
 			ARG 4 yMax
-			ARG 5 zndex
+			ARG 5 zIndex
 			ARG 6 red
 			ARG 7 green
 			ARG 8 blue

--- a/mappings/net/minecraft/client/gui/screen/ingame/EnchantmentScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/EnchantmentScreen.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_486 net/minecraft/client/gui/screen/ingame/EnchantmentScreen
-	FIELD field_2901 BOOK_TEXURE Lnet/minecraft/class_2960;
+	FIELD field_2901 BOOK_TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_2904 pageTurningSpeed F
 	FIELD field_2905 nextPageTurningSpeed F
 	FIELD field_2906 pageRotationSpeed F

--- a/mappings/net/minecraft/client/render/RenderPhase.mapping
+++ b/mappings/net/minecraft/client/render/RenderPhase.mapping
@@ -14,7 +14,7 @@ CLASS net/minecraft/class_4668 net/minecraft/client/render/RenderPhase
 	FIELD field_21357 BLACK_FOG Lnet/minecraft/class_4668$class_4674;
 	FIELD field_21358 MAIN_TARGET Lnet/minecraft/class_4668$class_4678;
 	FIELD field_21359 OUTLINE_TARGET Lnet/minecraft/class_4668$class_4678;
-	FIELD field_21360 FULL_LINEWIDTH Lnet/minecraft/class_4668$class_4677;
+	FIELD field_21360 FULL_LINE_WIDTH Lnet/minecraft/class_4668$class_4677;
 	FIELD field_21361 beginAction Ljava/lang/Runnable;
 	FIELD field_21362 endAction Ljava/lang/Runnable;
 	FIELD field_21363 name Ljava/lang/String;

--- a/mappings/net/minecraft/client/render/VertexFormatElement.mapping
+++ b/mappings/net/minecraft/client/render/VertexFormatElement.mapping
@@ -35,7 +35,7 @@ CLASS net/minecraft/class_296 net/minecraft/client/render/VertexFormatElement
 		METHOD method_1391 getSize ()I
 	CLASS class_298 Type
 		FIELD field_1630 name Ljava/lang/String;
-		FIELD field_20783 stater Lnet/minecraft/class_296$class_298$class_4575;
+		FIELD field_20783 starter Lnet/minecraft/class_296$class_298$class_4575;
 		FIELD field_20784 finisher Ljava/util/function/IntConsumer;
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;Lnet/minecraft/class_296$class_298$class_4575;Ljava/util/function/IntConsumer;)V
 			ARG 3 name

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -21,7 +21,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	FIELD field_4061 END_SKY Lnet/minecraft/class_2960;
 	FIELD field_4062 renderDistance I
 	FIELD field_4064 lastCameraYaw D
-	FIELD field_4065 capturedFrustrumOrientation [Lnet/minecraft/class_1162;
+	FIELD field_4065 capturedFrustumOrientation [Lnet/minecraft/class_1162;
 	FIELD field_4069 lastCameraX D
 	FIELD field_4070 lastCameraChunkUpdateZ D
 	FIELD field_4071 FORCEFIELD Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/render/entity/EnderDragonEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EnderDragonEntityRenderer.mapping
@@ -57,4 +57,4 @@ CLASS net/minecraft/class_895 net/minecraft/client/render/entity/EnderDragonEnti
 			ARG 2 vertices
 			ARG 3 light
 			ARG 4 overlay
-			ARG 5 offse
+			ARG 5 offset

--- a/mappings/net/minecraft/client/render/model/ModelLoader.mapping
+++ b/mappings/net/minecraft/client/render/model/ModelLoader.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_1088 net/minecraft/client/render/model/ModelLoader
 	FIELD field_17907 spriteAtlasData Ljava/util/Map;
-	FIELD field_20272 colorationManager Lnet/minecraft/class_324;
+	FIELD field_20272 blockColors Lnet/minecraft/class_324;
 	FIELD field_20273 nextStateId I
 	FIELD field_20274 stateLookup Lit/unimi/dsi/fastutil/objects/Object2IntMap;
 	FIELD field_20847 BANNER_BASE Lnet/minecraft/class_4730;

--- a/mappings/net/minecraft/client/render/model/json/Transformation.mapping
+++ b/mappings/net/minecraft/client/render/model/json/Transformation.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/class_804 net/minecraft/client/render/model/json/Transformat
 		ARG 1 leftHanded
 		ARG 2 matrices
 	CLASS class_805 Deserializer
-		FIELD field_4288 DEFAULT_ROATATION Lnet/minecraft/class_1160;
+		FIELD field_4288 DEFAULT_ROTATION Lnet/minecraft/class_1160;
 		FIELD field_4289 DEFAULT_SCALE Lnet/minecraft/class_1160;
 		FIELD field_4290 DEFAULT_TRANSLATION Lnet/minecraft/class_1160;
 		METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;

--- a/mappings/net/minecraft/client/resource/ClientBuiltinResourcePackProvider.mapping
+++ b/mappings/net/minecraft/client/resource/ClientBuiltinResourcePackProvider.mapping
@@ -19,6 +19,6 @@ CLASS net/minecraft/class_1066 net/minecraft/client/resource/ClientBuiltinResour
 	METHOD method_4640 download (Ljava/lang/String;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
 	METHOD method_4641 verifyFile (Ljava/lang/String;Ljava/io/File;)Z
 		ARG 1 expectedSha1
-		ARG 2 rfile
+		ARG 2 file
 	METHOD method_4642 clear ()V
 	METHOD method_4643 deleteOldServerPack ()V

--- a/mappings/net/minecraft/client/texture/Sprite.mapping
+++ b/mappings/net/minecraft/client/texture/Sprite.mapping
@@ -69,7 +69,7 @@ CLASS net/minecraft/class_1058 net/minecraft/client/texture/Sprite
 		METHOD <init> (Lnet/minecraft/class_1058;Lnet/minecraft/class_1058$class_4727;I)V
 			ARG 3 mipmap
 		METHOD method_24128 apply ()V
-			COMMENT Linearly interpolate between the current and next frame on all miplevels
+			COMMENT Linearly interpolate between the current and next frame on all mip levels
 			COMMENT based on the tick position within the current frame,
 			COMMENT and upload the results to the currently bound texture to the frame slot at position (0,0).
 		METHOD method_24129 lerp (DII)I

--- a/mappings/net/minecraft/client/texture/TextureUtil.mapping
+++ b/mappings/net/minecraft/client/texture/TextureUtil.mapping
@@ -19,7 +19,7 @@ CLASS net/minecraft/class_4536 net/minecraft/client/texture/TextureUtil
 		ARG 3 height
 	METHOD method_24961 allocate (Lnet/minecraft/class_1011$class_1013;IIII)V
 		COMMENT Allocate uninitialized backing memory for {@code maxLevel+1}
-		COMMENT miplevels to texture {@code id}.
+		COMMENT mip levels to texture {@code id}.
 		ARG 0 internalFormat
 		ARG 1 id
 		ARG 2 maxLevel

--- a/mappings/net/minecraft/client/toast/ToastManager.mapping
+++ b/mappings/net/minecraft/client/toast/ToastManager.mapping
@@ -24,5 +24,5 @@ CLASS net/minecraft/class_374 net/minecraft/client/toast/ToastManager
 			ARG 1 x
 			ARG 2 y
 			ARG 3 matrices
-		METHOD method_2003 getDissapearProgress (J)F
+		METHOD method_2003 getDisappearProgress (J)F
 			ARG 1 time

--- a/mappings/net/minecraft/client/util/math/AffineTransformations.mapping
+++ b/mappings/net/minecraft/client/util/math/AffineTransformations.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_4609 net/minecraft/client/util/math/AffineTransformations
 	FIELD field_21021 DIRECTION_ROTATIONS Ljava/util/EnumMap;
-	FIELD field_21022 INVERSED_DIRECTION_ROTATIONS Ljava/util/EnumMap;
+	FIELD field_21022 INVERTED_DIRECTION_ROTATIONS Ljava/util/EnumMap;
 	FIELD field_21023 LOGGER Lorg/apache/logging/log4j/Logger;
 	METHOD method_23220 setupUvLock (Lnet/minecraft/class_4590;)Lnet/minecraft/class_4590;
 	METHOD method_23221 uvLock (Lnet/minecraft/class_4590;Lnet/minecraft/class_2350;Ljava/util/function/Supplier;)Lnet/minecraft/class_4590;

--- a/mappings/net/minecraft/command/arguments/ScoreboardSlotArgumentType.mapping
+++ b/mappings/net/minecraft/command/arguments/ScoreboardSlotArgumentType.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_2239 net/minecraft/command/arguments/ScoreboardSlotArg
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 context
 		ARG 2 builder
-	METHOD method_9465 getScorebordSlot (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)I
+	METHOD method_9465 getScoreboardSlot (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)I
 		ARG 0 context
 		ARG 1 name
 	METHOD method_9468 scoreboardSlot ()Lnet/minecraft/class_2239;

--- a/mappings/net/minecraft/data/client/model/BlockStateModelGenerator.mapping
+++ b/mappings/net/minecraft/data/client/model/BlockStateModelGenerator.mapping
@@ -340,7 +340,7 @@ CLASS net/minecraft/class_4910 net/minecraft/data/client/model/BlockStateModelGe
 	METHOD method_25695 registerComparator ()V
 	METHOD method_25696 registerFurnaceLikeOrientable (Lnet/minecraft/class_2248;)V
 		ARG 1 block
-	METHOD method_25697 registorSmoothStone ()V
+	METHOD method_25697 registerSmoothStone ()V
 	METHOD method_25698 registerNetherrackBottomCustomTop (Lnet/minecraft/class_2248;)V
 		ARG 1 block
 	METHOD method_25699 registerBrewingStand ()V

--- a/mappings/net/minecraft/data/client/model/TexturedModel.mapping
+++ b/mappings/net/minecraft/data/client/model/TexturedModel.mapping
@@ -19,7 +19,7 @@ CLASS net/minecraft/class_4946 net/minecraft/data/client/model/TexturedModel
 	FIELD field_23054 TEMPLATE_SEAGRASS Lnet/minecraft/class_4946$class_4947;
 	FIELD field_23055 END_FOR_TOP_CUBE_COLUMN Lnet/minecraft/class_4946$class_4947;
 	FIELD field_23056 END_FOR_TOP_CUBE_COLUMN_HORIZONTAL Lnet/minecraft/class_4946$class_4947;
-	FIELD field_23057 WALL_CUBE_BUTTOM_TOP Lnet/minecraft/class_4946$class_4947;
+	FIELD field_23057 WALL_CUBE_BOTTOM_TOP Lnet/minecraft/class_4946$class_4947;
 	FIELD field_23058 texture Lnet/minecraft/class_4944;
 	FIELD field_23059 model Lnet/minecraft/class_4942;
 	METHOD <init> (Lnet/minecraft/class_4944;Lnet/minecraft/class_4942;)V

--- a/mappings/net/minecraft/datafixer/fix/ChunkPalettedStorageFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/ChunkPalettedStorageFix.mapping
@@ -11,7 +11,7 @@ CLASS net/minecraft/class_3582 net/minecraft/datafixer/fix/ChunkPalettedStorageF
 	FIELD field_15843 air Lcom/mojang/serialization/Dynamic;
 	FIELD field_15844 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_15845 fernUpper Lcom/mojang/serialization/Dynamic;
-	FIELD field_15846 noteblock Ljava/util/Map;
+	FIELD field_15846 noteBlock Ljava/util/Map;
 	FIELD field_15847 peonyUpper Lcom/mojang/serialization/Dynamic;
 	FIELD field_15848 lilacUpper Lcom/mojang/serialization/Dynamic;
 	FIELD field_15849 bed Ljava/util/Map;

--- a/mappings/net/minecraft/datafixer/fix/EntityPufferfishRenameFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/EntityPufferfishRenameFix.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_3608 net/minecraft/datafixer/fix/EntityPufferfishRenameFix
-	FIELD field_15899 RENAMED_FISHES Ljava/util/Map;
+	FIELD field_15899 RENAMED_FISH Ljava/util/Map;
 	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V
 		ARG 1 outputSchema
 		ARG 2 changesType

--- a/mappings/net/minecraft/datafixer/fix/ItemInstanceTheFlatteningFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/ItemInstanceTheFlatteningFix.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_1188 net/minecraft/datafixer/fix/ItemInstanceTheFlatteningFix
-	FIELD field_5682 DAMAGABLE_ITEMS Ljava/util/Set;
+	FIELD field_5682 DAMAGEABLE_ITEMS Ljava/util/Set;
 	FIELD field_5683 ORIGINAL_ITEM_NAMES Ljava/util/Set;
 	FIELD field_5684 FLATTENING_MAP Ljava/util/Map;
 	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;Z)V

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -206,7 +206,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		ARG 5 z
 	METHOD method_24201 updatePassengerPosition (Lnet/minecraft/class_1297;Lnet/minecraft/class_1297$class_4738;)V
 		ARG 1 passenger
-	METHOD method_24203 positAfterTeleport (DDD)V
+	METHOD method_24203 refreshPositionAfterTeleport (DDD)V
 		ARG 1 x
 		ARG 3 y
 		ARG 5 z

--- a/mappings/net/minecraft/entity/LightningEntity.mapping
+++ b/mappings/net/minecraft/entity/LightningEntity.mapping
@@ -1,10 +1,10 @@
 CLASS net/minecraft/class_1538 net/minecraft/entity/LightningEntity
-	FIELD field_7182 channeller Lnet/minecraft/class_3222;
+	FIELD field_7182 channeler Lnet/minecraft/class_3222;
 	FIELD field_7183 remainingActions I
 	FIELD field_7184 cosmetic Z
 	FIELD field_7185 ambientTick I
 	FIELD field_7186 seed J
 	METHOD method_6960 spawnFire (I)V
 		ARG 1 spreadAttempts
-	METHOD method_6961 setChanneller (Lnet/minecraft/class_3222;)V
-		ARG 1 channeller
+	METHOD method_6961 setChanneler (Lnet/minecraft/class_3222;)V
+		ARG 1 channeler

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -158,7 +158,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_23733 onKilledBy (Lnet/minecraft/class_1309;)V
 		COMMENT Performs secondary effects after this mob has been killed.
 		COMMENT
-		COMMENT <p> The default behaviour spawns a wither rose if {@code adversary} is a {@code WitherEntity}.
+		COMMENT <p> The default behavior spawns a wither rose if {@code adversary} is a {@code WitherEntity}.
 		ARG 1 adversary
 			COMMENT the main adversary responsible for this entity's death
 	METHOD method_23883 dropXp ()V

--- a/mappings/net/minecraft/entity/ai/brain/task/HoldTradeOffersTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/HoldTradeOffersTask.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/class_4130 net/minecraft/entity/ai/brain/task/HoldTradeOffer
 	FIELD field_18395 offerIndex I
 	FIELD field_18396 ticksLeft I
 	METHOD <init> (II)V
-		ARG 1 rminRunTime
+		ARG 1 minRunTime
 		ARG 2 maxRunTime
 	METHOD method_19026 refreshShownOffer (Lnet/minecraft/class_1646;)V
 		ARG 1 villager
@@ -18,5 +18,5 @@ CLASS net/minecraft/class_4130 net/minecraft/entity/ai/brain/task/HoldTradeOffer
 		ARG 1 villager
 	METHOD method_19601 loadPossibleOffers (Lnet/minecraft/class_1646;)V
 		ARG 1 villager
-	METHOD method_19603 findPotentialCuatomer (Lnet/minecraft/class_1646;)Lnet/minecraft/class_1309;
+	METHOD method_19603 findPotentialCustomer (Lnet/minecraft/class_1646;)Lnet/minecraft/class_1309;
 		ARG 1 villager

--- a/mappings/net/minecraft/entity/ai/goal/PounceAtTargetGoal.mapping
+++ b/mappings/net/minecraft/entity/ai/goal/PounceAtTargetGoal.mapping
@@ -3,5 +3,5 @@ CLASS net/minecraft/class_1359 net/minecraft/entity/ai/goal/PounceAtTargetGoal
 	FIELD field_6476 mob Lnet/minecraft/class_1308;
 	FIELD field_6477 target Lnet/minecraft/class_1309;
 	METHOD <init> (Lnet/minecraft/class_1308;F)V
-		ARG 1 rmob
+		ARG 1 mob
 		ARG 2 velocity

--- a/mappings/net/minecraft/entity/ai/goal/RaidGoal.mapping
+++ b/mappings/net/minecraft/entity/ai/goal/RaidGoal.mapping
@@ -4,6 +4,6 @@ CLASS net/minecraft/class_3909 net/minecraft/entity/ai/goal/RaidGoal
 		ARG 1 raider
 		ARG 2 targetEntityClass
 		ARG 3 checkVisibility
-		ARG 4 tragetPredicate
+		ARG 4 targetPredicate
 	METHOD method_17352 getCooldown ()I
 	METHOD method_17353 decreaseCooldown ()V

--- a/mappings/net/minecraft/entity/ai/goal/TemptGoal.mapping
+++ b/mappings/net/minecraft/entity/ai/goal/TemptGoal.mapping
@@ -23,6 +23,6 @@ CLASS net/minecraft/class_1391 net/minecraft/entity/ai/goal/TemptGoal
 		ARG 4 canBeScared
 		ARG 5 food
 	METHOD method_16081 canBeScared ()Z
-	METHOD method_6312 isTempedBy (Lnet/minecraft/class_1799;)Z
+	METHOD method_6312 isTemptedBy (Lnet/minecraft/class_1799;)Z
 		ARG 1 stack
 	METHOD method_6313 isActive ()Z

--- a/mappings/net/minecraft/entity/ai/goal/WanderAroundFarGoal.mapping
+++ b/mappings/net/minecraft/entity/ai/goal/WanderAroundFarGoal.mapping
@@ -3,4 +3,4 @@ CLASS net/minecraft/class_1394 net/minecraft/entity/ai/goal/WanderAroundFarGoal
 	METHOD <init> (Lnet/minecraft/class_1314;DF)V
 		ARG 1 mob
 		ARG 2 speed
-		ARG 4 probabiliity
+		ARG 4 probability

--- a/mappings/net/minecraft/entity/boss/BossBarManager.mapping
+++ b/mappings/net/minecraft/entity/boss/BossBarManager.mapping
@@ -14,5 +14,5 @@ CLASS net/minecraft/class_3004 net/minecraft/entity/boss/BossBarManager
 	METHOD method_12974 toTag ()Lnet/minecraft/class_2487;
 	METHOD method_12975 onPlayerConnect (Lnet/minecraft/class_3222;)V
 		ARG 1 player
-	METHOD method_12976 onPlayerDisconnenct (Lnet/minecraft/class_3222;)V
+	METHOD method_12976 onPlayerDisconnect (Lnet/minecraft/class_3222;)V
 		ARG 1 player

--- a/mappings/net/minecraft/entity/passive/CatEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/CatEntity.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_1451 net/minecraft/entity/passive/CatEntity
 	FIELD field_16284 SLEEPING_WITH_OWNER Lnet/minecraft/class_2940;
 	FIELD field_16285 COLLAR_COLOR Lnet/minecraft/class_2940;
 	FIELD field_16286 headDownAnimation F
-	FIELD field_16287 prevHeadDownAniamtion F
+	FIELD field_16287 prevHeadDownAnimation F
 	FIELD field_16288 tailCurlAnimation F
 	FIELD field_16289 prevTailCurlAnimation F
 	FIELD field_16290 sleepAnimation F

--- a/mappings/net/minecraft/entity/passive/FoxEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/FoxEntity.mapping
@@ -91,7 +91,7 @@ CLASS net/minecraft/class_4019 net/minecraft/entity/passive/FoxEntity
 		FIELD field_17974 timer I
 		METHOD <init> (Lnet/minecraft/class_4019;DII)V
 			ARG 2 speed
-			ARG 4 rannge
+			ARG 4 range
 			ARG 5 maxYDifference
 		METHOD method_18307 eatSweetBerry ()V
 	CLASS class_4026 FoxSwimGoal
@@ -110,7 +110,7 @@ CLASS net/minecraft/class_4019 net/minecraft/entity/passive/FoxEntity
 			ARG 2 unused
 			ARG 3 searchRange
 		METHOD method_18308 canGoToVillage ()Z
-	CLASS class_4032 EscapeWhenNotAggresiveGoal
+	CLASS class_4032 EscapeWhenNotAggressiveGoal
 		METHOD <init> (Lnet/minecraft/class_4019;D)V
 			ARG 2 speed
 	CLASS class_4033 JumpChasingGoal

--- a/mappings/net/minecraft/entity/passive/VillagerEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/VillagerEntity.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_1646 net/minecraft/entity/passive/VillagerEntity
 	FIELD field_18526 ITEM_FOOD_VALUES Ljava/util/Map;
 	FIELD field_18527 GATHERABLE_ITEMS Ljava/util/Set;
 	FIELD field_18528 levelUpTimer I
-	FIELD field_18529 levellingUp Z
+	FIELD field_18529 levelingUp Z
 	FIELD field_18530 lastCustomer Lnet/minecraft/class_1657;
 	FIELD field_18533 foodLevel B
 	FIELD field_18534 gossip Lnet/minecraft/class_4136;

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -177,7 +177,6 @@ CLASS net/minecraft/class_1657 net/minecraft/entity/player/PlayerEntity
 		ARG 1 stack
 		ARG 2 retainOwnership
 	METHOD method_7329 dropItem (Lnet/minecraft/class_1799;ZZ)Lnet/minecraft/class_1542;
-		COMMENT
 		ARG 1 stack
 		ARG 2 throwRandomly
 			COMMENT If true, the item will be thrown in a random direction from the entity regardless of which direction the entity is facing

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -177,9 +177,10 @@ CLASS net/minecraft/class_1657 net/minecraft/entity/player/PlayerEntity
 		ARG 1 stack
 		ARG 2 retainOwnership
 	METHOD method_7329 dropItem (Lnet/minecraft/class_1799;ZZ)Lnet/minecraft/class_1542;
+		COMMENT
 		ARG 1 stack
 		ARG 2 throwRandomly
-			COMMENT If true, the item will be thrown in a random direction from the entity regardless of which direction the tntity is facing
+			COMMENT If true, the item will be thrown in a random direction from the entity regardless of which direction the entity is facing
 		ARG 3 retainOwnership
 	METHOD method_7330 updateTurtleHelmet ()V
 	METHOD method_7331 requestRespawn ()V

--- a/mappings/net/minecraft/item/ShovelItem.mapping
+++ b/mappings/net/minecraft/item/ShovelItem.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_1821 net/minecraft/item/ShovelItem
-	FIELD field_8912 PATH_BLOCKSTATES Ljava/util/Map;
+	FIELD field_8912 PATH_STATES Ljava/util/Map;
 	FIELD field_8913 EFFECTIVE_BLOCKS Ljava/util/Set;
 	METHOD <init> (Lnet/minecraft/class_1832;FFLnet/minecraft/class_1792$class_1793;)V
 		ARG 1 material

--- a/mappings/net/minecraft/item/ToolMaterials.mapping
+++ b/mappings/net/minecraft/item/ToolMaterials.mapping
@@ -10,5 +10,5 @@ CLASS net/minecraft/class_1834 net/minecraft/item/ToolMaterials
 		ARG 4 itemDurability
 		ARG 5 miningSpeed
 		ARG 6 attackDamage
-		ARG 7 enchantibility
+		ARG 7 enchantability
 		ARG 8 repairIngredient

--- a/mappings/net/minecraft/loot/function/CopyNbtLootFunction.mapping
+++ b/mappings/net/minecraft/loot/function/CopyNbtLootFunction.mapping
@@ -61,7 +61,7 @@ CLASS net/minecraft/class_3837 net/minecraft/loot/function/CopyNbtLootFunction
 			ARG 3 name
 		METHOD method_16864 merge (Lnet/minecraft/class_2520;Lnet/minecraft/class_2203$class_2209;Ljava/util/List;)V
 			ARG 1 itemTag
-			ARG 2 tragetPath
+			ARG 2 targetPath
 			ARG 3 sourceTags
 		METHOD method_16865 get (Ljava/lang/String;)Lnet/minecraft/class_3837$class_3841;
 			ARG 0 name

--- a/mappings/net/minecraft/nbt/NbtIo.mapping
+++ b/mappings/net/minecraft/nbt/NbtIo.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_2507 net/minecraft/nbt/NbtIo
 	METHOD method_10625 read (Ljava/io/DataInput;Lnet/minecraft/class_2505;)Lnet/minecraft/class_2487;
 		ARG 0 input
-		ARG 1 trakcer
+		ARG 1 tracker
 	METHOD method_10626 read (Ljava/io/DataInput;ILnet/minecraft/class_2505;)Lnet/minecraft/class_2520;
 		ARG 0 input
 		ARG 1 depth

--- a/mappings/net/minecraft/network/ServerAddress.mapping
+++ b/mappings/net/minecraft/network/ServerAddress.mapping
@@ -9,6 +9,6 @@ CLASS net/minecraft/class_639 net/minecraft/network/ServerAddress
 		ARG 0 port
 		ARG 1 def
 	METHOD method_2952 getAddress ()Ljava/lang/String;
-	METHOD method_2953 resolveSrv (Ljava/lang/String;)Lcom/mojang/datafixers/util/Pair;
+	METHOD method_2953 resolveServer (Ljava/lang/String;)Lcom/mojang/datafixers/util/Pair;
 		ARG 0 address
 	METHOD method_2954 getPort ()I

--- a/mappings/net/minecraft/predicate/StatePredicate.mapping
+++ b/mappings/net/minecraft/predicate/StatePredicate.mapping
@@ -22,7 +22,7 @@ CLASS net/minecraft/class_4559 net/minecraft/predicate/StatePredicate
 	METHOD method_22522 asNullableString (Lcom/google/gson/JsonElement;)Ljava/lang/String;
 		ARG 0 json
 	CLASS class_4560 Builder
-		FIELD field_20738 conditons Ljava/util/List;
+		FIELD field_20738 conditions Ljava/util/List;
 		METHOD method_22523 create ()Lnet/minecraft/class_4559$class_4560;
 		METHOD method_22524 exactMatch (Lnet/minecraft/class_2769;I)Lnet/minecraft/class_4559$class_4560;
 			ARG 1 property

--- a/mappings/net/minecraft/recipe/BrewingRecipeRegistry.mapping
+++ b/mappings/net/minecraft/recipe/BrewingRecipeRegistry.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_1845 net/minecraft/recipe/BrewingRecipeRegistry
 		ARG 0 stack
 	METHOD method_8070 hasItemRecipe (Lnet/minecraft/class_1799;Lnet/minecraft/class_1799;)Z
 		ARG 0 input
-		ARG 1 ingredien
+		ARG 1 ingredient
 	METHOD method_8071 registerItemRecipe (Lnet/minecraft/class_1792;Lnet/minecraft/class_1792;Lnet/minecraft/class_1792;)V
 		ARG 0 input
 		ARG 1 ingredient

--- a/mappings/net/minecraft/resource/AbstractFileResourcePack.mapping
+++ b/mappings/net/minecraft/resource/AbstractFileResourcePack.mapping
@@ -10,7 +10,7 @@ CLASS net/minecraft/class_3255 net/minecraft/resource/AbstractFileResourcePack
 		ARG 1 inputStream
 	METHOD method_14393 containsFile (Ljava/lang/String;)Z
 		ARG 1 name
-	METHOD method_14394 warnNonLowercaseNamespace (Ljava/lang/String;)V
+	METHOD method_14394 warnNonLowerCaseNamespace (Ljava/lang/String;)V
 		ARG 1 namespace
 	METHOD method_14395 getFilename (Lnet/minecraft/class_3264;Lnet/minecraft/class_2960;)Ljava/lang/String;
 		ARG 0 type

--- a/mappings/net/minecraft/resource/ResourcePackProfile.mapping
+++ b/mappings/net/minecraft/resource/ResourcePackProfile.mapping
@@ -53,7 +53,7 @@ CLASS net/minecraft/class_3288 net/minecraft/resource/ResourcePackProfile
 			ARG 1 items
 			ARG 2 item
 			ARG 3 profileGetter
-			ARG 4 listInversed
+			ARG 4 listInverted
 	CLASS class_5351 Factory
 		METHOD create (Ljava/lang/String;ZLjava/util/function/Supplier;Lnet/minecraft/class_3262;Lnet/minecraft/class_3272;Lnet/minecraft/class_3288$class_3289;Lnet/minecraft/class_5352;)Lnet/minecraft/class_3288;
 			ARG 1 name

--- a/mappings/net/minecraft/screen/MerchantScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/MerchantScreenHandler.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_1728 net/minecraft/screen/MerchantScreenHandler
 	FIELD field_18669 levelProgress I
-	FIELD field_18670 levelled Z
+	FIELD field_18670 leveled Z
 	FIELD field_19358 canRefreshTrades Z
 	FIELD field_7861 traderInventory Lnet/minecraft/class_1725;
 	FIELD field_7863 trader Lnet/minecraft/class_1915;
@@ -21,9 +21,9 @@ CLASS net/minecraft/class_1728 net/minecraft/screen/MerchantScreenHandler
 		ARG 1 experience
 	METHOD method_19256 getTraderRewardedExperience ()I
 	METHOD method_19257 setLevelProgress (I)V
-		ARG 1 porgress
+		ARG 1 progress
 	METHOD method_19258 getLevelProgress ()I
-	METHOD method_19259 isLevelled ()Z
+	METHOD method_19259 isLeveled ()Z
 	METHOD method_20213 equals (Lnet/minecraft/class_1799;Lnet/minecraft/class_1799;)Z
 		ARG 1 itemStack
 		ARG 2 otherItemStack

--- a/mappings/net/minecraft/screen/ScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/ScreenHandler.mapping
@@ -18,14 +18,14 @@ CLASS net/minecraft/class_1703 net/minecraft/screen/ScreenHandler
 	METHOD method_17359 checkSize (Lnet/minecraft/class_1263;I)V
 		COMMENT Checks that the size of the provided inventory is at least as large as the {@code expectedSize}.
 		COMMENT
-		COMMENT @throws IllegalArgumentException if the inventory size is smaller than {@code exceptedSize}
+		COMMENT @throws IllegalArgumentException if the inventory size is smaller than {@code expectedSize}
 		ARG 0 inventory
 		ARG 1 expectedSize
 	METHOD method_17360 addProperties (Lnet/minecraft/class_3913;)V
 	METHOD method_17361 checkDataCount (Lnet/minecraft/class_3913;I)V
-		COMMENT Checks that the size of the {@code data} is at least as large as the {@code exceptedCount}.
+		COMMENT Checks that the size of the {@code data} is at least as large as the {@code expectedCount}.
 		COMMENT
-		COMMENT @throws IllegalArgumentException if the {@code data} has a smaller size than {@code exceptedCount}
+		COMMENT @throws IllegalArgumentException if the {@code data} has a smaller size than {@code expectedCount}
 		ARG 0 data
 		ARG 1 expectedCount
 	METHOD method_17362 addProperty (Lnet/minecraft/class_3915;)Lnet/minecraft/class_3915;
@@ -101,7 +101,7 @@ CLASS net/minecraft/class_1703 net/minecraft/screen/ScreenHandler
 		ARG 4 fromLast
 	METHOD method_7617 calculateStackSize (Ljava/util/Set;ILnet/minecraft/class_1799;I)V
 		ARG 0 slots
-		ARG 1 rmode
+		ARG 1 mode
 		ARG 2 stack
 		ARG 3 stackSize
 	METHOD method_7618 calculateComparatorOutput (Lnet/minecraft/class_1263;)I

--- a/mappings/net/minecraft/server/MinecraftServer.mapping
+++ b/mappings/net/minecraft/server/MinecraftServer.mapping
@@ -105,7 +105,7 @@ CLASS net/minecraft/server/MinecraftServer
 	METHOD method_29439 reloadResources (Ljava/util/Collection;)Ljava/util/concurrent/CompletableFuture;
 	METHOD method_29736 loadDataPacks (Lnet/minecraft/class_3283;Lnet/minecraft/class_5359;Z)Lnet/minecraft/class_5359;
 		ARG 0 resourcePackManager
-		ARG 2 safemode
+		ARG 2 safeMode
 	METHOD method_29740 startServer (Ljava/util/function/Function;)Lnet/minecraft/server/MinecraftServer;
 		ARG 0 serverFactory
 	METHOD method_30002 getOverworld ()Lnet/minecraft/class_3218;

--- a/mappings/net/minecraft/server/command/CommandSource.mapping
+++ b/mappings/net/minecraft/server/command/CommandSource.mapping
@@ -16,7 +16,7 @@ CLASS net/minecraft/class_2172 net/minecraft/server/command/CommandSource
 	METHOD method_9257 suggestIdentifiers (Ljava/util/stream/Stream;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 builder
 	METHOD method_9258 suggestIdentifiers (Ljava/lang/Iterable;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
-		ARG 0 candiates
+		ARG 0 candidates
 		ARG 1 builder
 	METHOD method_9259 hasPermissionLevel (I)Z
 		ARG 1 level

--- a/mappings/net/minecraft/server/command/DebugCommand.mapping
+++ b/mappings/net/minecraft/server/command/DebugCommand.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_3032 net/minecraft/server/command/DebugCommand
 	FIELD field_13596 ALREADY_RUNNING_EXCEPTION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
-	FIELD field_13597 NOT_RUNNING_EXCPETION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
+	FIELD field_13597 NOT_RUNNING_EXCEPTION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
 	FIELD field_20283 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_20310 FILE_SYSTEM_PROVIDER Ljava/nio/file/spi/FileSystemProvider;
 	METHOD method_13156 register (Lcom/mojang/brigadier/CommandDispatcher;)V

--- a/mappings/net/minecraft/server/dedicated/gui/PlayerStatsGui.mapping
+++ b/mappings/net/minecraft/server/dedicated/gui/PlayerStatsGui.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_3186 net/minecraft/server/dedicated/gui/PlayerStatsGui
 	FIELD field_13845 memoryUsePercentage [I
 	FIELD field_13846 AVG_TICK_FORMAT Ljava/text/DecimalFormat;
 	FIELD field_13847 lines [Ljava/lang/String;
-	FIELD field_13848 memoryusePctPos I
+	FIELD field_13848 memoryUsePercentagePos I
 	FIELD field_13849 server Lnet/minecraft/server/MinecraftServer;
 	FIELD field_16858 timer Ljavax/swing/Timer;
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;)V

--- a/mappings/net/minecraft/server/function/CommandFunctionManager.mapping
+++ b/mappings/net/minecraft/server/function/CommandFunctionManager.mapping
@@ -21,7 +21,7 @@ CLASS net/minecraft/class_2991 net/minecraft/server/function/CommandFunctionMana
 		FIELD field_13424 source Lnet/minecraft/class_2168;
 		FIELD field_13425 element Lnet/minecraft/class_2158$class_2161;
 		METHOD <init> (Lnet/minecraft/class_2991;Lnet/minecraft/class_2168;Lnet/minecraft/class_2158$class_2161;)V
-			ARG 1 manger
+			ARG 1 manager
 			ARG 2 source
 			ARG 3 element
 		METHOD method_12914 execute (Ljava/util/ArrayDeque;I)V

--- a/mappings/net/minecraft/server/rcon/RconCommandOutput.mapping
+++ b/mappings/net/minecraft/server/rcon/RconCommandOutput.mapping
@@ -4,6 +4,6 @@ CLASS net/minecraft/class_3350 net/minecraft/server/rcon/RconCommandOutput
 	FIELD field_25146 RCON_NAME Lnet/minecraft/class_2585;
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;)V
 		ARG 1 server
-	METHOD method_14700 createReconCommandSource ()Lnet/minecraft/class_2168;
+	METHOD method_14700 createRconCommandSource ()Lnet/minecraft/class_2168;
 	METHOD method_14701 asString ()Ljava/lang/String;
 	METHOD method_14702 clear ()V

--- a/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
+++ b/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_3898 net/minecraft/server/world/ThreadedAnvilChunkStor
 	FIELD field_17221 unloadedChunks Lit/unimi/dsi/fastutil/longs/LongSet;
 	FIELD field_17222 chunkHolderListDirty Z
 	FIELD field_17223 chunkTaskPrioritySystem Lnet/minecraft/class_3900;
-	FIELD field_17224 worldgenExecutor Lnet/minecraft/class_3906;
+	FIELD field_17224 worldGenExecutor Lnet/minecraft/class_3906;
 	FIELD field_17226 mainExecutor Lnet/minecraft/class_3906;
 	FIELD field_17228 ticketManager Lnet/minecraft/class_3898$class_3216;
 	FIELD field_17230 totalChunksLoadedCount Ljava/util/concurrent/atomic/AtomicInteger;

--- a/mappings/net/minecraft/structure/StrongholdGenerator.mapping
+++ b/mappings/net/minecraft/structure/StrongholdGenerator.mapping
@@ -34,7 +34,7 @@ CLASS net/minecraft/class_3421 net/minecraft/structure/StrongholdGenerator
 		FIELD field_15281 isStructureStart Z
 	CLASS class_3434 Start
 	CLASS class_3435 Corridor
-		FIELD field_15285 rightExitExixts Z
+		FIELD field_15285 rightExitExists Z
 		FIELD field_15286 leftExitExists Z
 	CLASS class_3436 Stairs
 	CLASS class_3437 Piece

--- a/mappings/net/minecraft/structure/StructurePiece.mapping
+++ b/mappings/net/minecraft/structure/StructurePiece.mapping
@@ -66,14 +66,14 @@ CLASS net/minecraft/class_3443 net/minecraft/structure/StructurePiece
 		ARG 5 y
 		ARG 6 z
 		ARG 7 facing
-		ARG 8 lootTbaleId
+		ARG 8 lootTableId
 	METHOD method_14931 generate (Lnet/minecraft/class_5281;Lnet/minecraft/class_5138;Lnet/minecraft/class_2794;Ljava/util/Random;Lnet/minecraft/class_3341;Lnet/minecraft/class_1923;Lnet/minecraft/class_2338;)Z
 		ARG 2 structureAccessor
 		ARG 3 chunkGenerator
 		ARG 4 random
 		ARG 5 boundingBox
 	METHOD method_14932 getOverlappingPiece (Ljava/util/List;Lnet/minecraft/class_3341;)Lnet/minecraft/class_3443;
-	METHOD method_14933 fillWithOutlineUnderSealevel (Lnet/minecraft/class_1936;Lnet/minecraft/class_3341;Ljava/util/Random;FIIIIIILnet/minecraft/class_2680;Lnet/minecraft/class_2680;ZZ)V
+	METHOD method_14933 fillWithOutlineUnderSeaLevel (Lnet/minecraft/class_1936;Lnet/minecraft/class_3341;Ljava/util/Random;FIIIIIILnet/minecraft/class_2680;Lnet/minecraft/class_2680;ZZ)V
 		ARG 3 random
 	METHOD method_14934 getFacing ()Lnet/minecraft/class_2350;
 	METHOD method_14935 getBoundingBox ()Lnet/minecraft/class_3341;

--- a/mappings/net/minecraft/village/Trader.mapping
+++ b/mappings/net/minecraft/village/Trader.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_1915 net/minecraft/village/Trader
 	METHOD method_17449 sendOffers (Lnet/minecraft/class_1657;Lnet/minecraft/class_2561;I)V
 	METHOD method_18010 getYesSound ()Lnet/minecraft/class_3414;
 	METHOD method_19269 getExperience ()I
-	METHOD method_19270 isLevelledTrader ()Z
+	METHOD method_19270 isLeveledTrader ()Z
 	METHOD method_19271 setExperienceFromServer (I)V
 		ARG 1 experience
 	METHOD method_20708 canRefreshTrades ()Z

--- a/mappings/net/minecraft/world/BlockCollisionSpliterator.mapping
+++ b/mappings/net/minecraft/world/BlockCollisionSpliterator.mapping
@@ -17,5 +17,5 @@ CLASS net/minecraft/class_5329 net/minecraft/world/BlockCollisionSpliterator
 	METHOD method_29284 isInWorldBorder (Lnet/minecraft/class_2784;Lnet/minecraft/class_238;)Z
 		ARG 0 border
 		ARG 1 box
-	METHOD method_29285 offerEntitylessShape (Ljava/util/function/Consumer;)Z
+	METHOD method_29285 offerBlockShape (Ljava/util/function/Consumer;)Z
 	METHOD method_29286 offerEntityShape (Ljava/util/function/Consumer;)Z

--- a/mappings/net/minecraft/world/BlockView.mapping
+++ b/mappings/net/minecraft/world/BlockView.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_1922 net/minecraft/world/BlockView
 		ARG 1 context
 	METHOD method_17744 rayTrace (Lnet/minecraft/class_3959;Ljava/util/function/BiFunction;Ljava/util/function/Function;)Ljava/lang/Object;
 		ARG 1 context
-		ARG 2 blockRaytracer
+		ARG 2 blockRayTracer
 	METHOD method_17745 rayTraceBlock (Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_2338;Lnet/minecraft/class_265;Lnet/minecraft/class_2680;)Lnet/minecraft/class_3965;
 		ARG 1 start
 		ARG 2 end

--- a/mappings/net/minecraft/world/EntityView.mapping
+++ b/mappings/net/minecraft/world/EntityView.mapping
@@ -35,7 +35,7 @@ CLASS net/minecraft/class_1924 net/minecraft/world/EntityView
 	METHOD method_18466 getTargets (Ljava/lang/Class;Lnet/minecraft/class_4051;Lnet/minecraft/class_1309;Lnet/minecraft/class_238;)Ljava/util/List;
 		ARG 1 entityClass
 		ARG 2 targetPredicate
-		ARG 3 targettingEntity
+		ARG 3 targetingEntity
 		ARG 4 box
 	METHOD method_18467 getNonSpectatingEntities (Ljava/lang/Class;Lnet/minecraft/class_238;)Ljava/util/List;
 		ARG 1 entityClass

--- a/mappings/net/minecraft/world/GameMode.mapping
+++ b/mappings/net/minecraft/world/GameMode.mapping
@@ -12,7 +12,7 @@ CLASS net/minecraft/class_1934 net/minecraft/world/GameMode
 		ARG 0 id
 		ARG 1 defaultMode
 	METHOD method_8381 getName ()Ljava/lang/String;
-	METHOD method_8382 setAbilitites (Lnet/minecraft/class_1656;)V
+	METHOD method_8382 setAbilities (Lnet/minecraft/class_1656;)V
 		ARG 1 abilities
 	METHOD method_8383 getTranslatableName ()Lnet/minecraft/class_2561;
 	METHOD method_8384 byId (I)Lnet/minecraft/class_1934;

--- a/mappings/net/minecraft/world/ModifiableWorld.mapping
+++ b/mappings/net/minecraft/world/ModifiableWorld.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_1945 net/minecraft/world/ModifiableWorld
-	COMMENT Represents a modifable world where block states can be changed and entities spawned.
+	COMMENT Represents a modifiable world where block states can be changed and entities spawned.
 	METHOD method_22352 breakBlock (Lnet/minecraft/class_2338;Z)Z
 		ARG 1 pos
 		ARG 2 drop

--- a/mappings/net/minecraft/world/WanderingTraderManager.mapping
+++ b/mappings/net/minecraft/world/WanderingTraderManager.mapping
@@ -7,4 +7,4 @@ CLASS net/minecraft/class_3990 net/minecraft/world/WanderingTraderManager
 		ARG 1 wanderingTrader
 		ARG 2 range
 	METHOD method_18017 getNearbySpawnPos (Lnet/minecraft/class_4538;Lnet/minecraft/class_2338;I)Lnet/minecraft/class_2338;
-	METHOD method_23279 wontSuffocateAt (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z
+	METHOD method_23279 doesNotSuffocateAt (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z

--- a/mappings/net/minecraft/world/biome/BiomeEffects.mapping
+++ b/mappings/net/minecraft/world/biome/BiomeEffects.mapping
@@ -11,7 +11,7 @@ CLASS net/minecraft/class_4763 net/minecraft/world/biome/BiomeEffects
 	METHOD <init> (IIILjava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V
 		ARG 1 fogColor
 		ARG 2 waterColor
-		ARG 3 waterFogCOlor
+		ARG 3 waterFogColor
 		ARG 4 particleConfig
 		ARG 5 loopSound
 		ARG 6 moodSound

--- a/mappings/net/minecraft/world/gen/ChunkRandom.mapping
+++ b/mappings/net/minecraft/world/gen/ChunkRandom.mapping
@@ -40,7 +40,7 @@ CLASS net/minecraft/class_2919 net/minecraft/world/gen/ChunkRandom
 		ARG 4 scrambler
 	METHOD method_12663 setCarverSeed (JII)J
 		COMMENT Seeds the randomizer to generate larger features such as caves, ravines, mineshafts
-		COMMENT and strongholds. It is also used to initiate structure start behaviour such as rotation.
+		COMMENT and strongholds. It is also used to initiate structure start behavior such as rotation.
 		COMMENT
 		COMMENT <p>Similar to the population seed, only the 48 lowest bits of the world seed affect the
 		COMMENT output since it the upper 16 bits are truncated in the setSeed() call.</p>

--- a/mappings/net/minecraft/world/gen/feature/EndSpikeFeatureConfig.mapping
+++ b/mappings/net/minecraft/world/gen/feature/EndSpikeFeatureConfig.mapping
@@ -7,6 +7,6 @@ CLASS net/minecraft/class_3666 net/minecraft/world/gen/feature/EndSpikeFeatureCo
 		ARG 1 crystalInvulnerable
 		ARG 2 spikes
 		ARG 3 crystalBeamTarget
-	METHOD method_15883 isCrystalInvulerable ()Z
+	METHOD method_15883 isCrystalInvulnerable ()Z
 	METHOD method_15884 getPos ()Lnet/minecraft/class_2338;
 	METHOD method_15885 getSpikes ()Ljava/util/List;

--- a/mappings/net/minecraft/world/gen/surfacebuilder/BadlandsSurfaceBuilder.mapping
+++ b/mappings/net/minecraft/world/gen/surfacebuilder/BadlandsSurfaceBuilder.mapping
@@ -1,15 +1,15 @@
 CLASS net/minecraft/class_3506 net/minecraft/world/gen/surfacebuilder/BadlandsSurfaceBuilder
-	FIELD field_15616 BROWN_TERACOTTA Lnet/minecraft/class_2680;
-	FIELD field_15617 LIGHT_GRAY_TERACOTTA Lnet/minecraft/class_2680;
+	FIELD field_15616 BROWN_TERRACOTTA Lnet/minecraft/class_2680;
+	FIELD field_15617 LIGHT_GRAY_TERRACOTTA Lnet/minecraft/class_2680;
 	FIELD field_15618 heightNoise Lnet/minecraft/class_3543;
 	FIELD field_15619 layerNoise Lnet/minecraft/class_3543;
 	FIELD field_15620 ORANGE_TERRACOTTA Lnet/minecraft/class_2680;
-	FIELD field_15621 RED_TERACOTTA Lnet/minecraft/class_2680;
+	FIELD field_15621 RED_TERRACOTTA Lnet/minecraft/class_2680;
 	FIELD field_15622 seed J
 	FIELD field_15623 heightCutoffNoise Lnet/minecraft/class_3543;
-	FIELD field_15624 WHITE_TERACOTTA Lnet/minecraft/class_2680;
-	FIELD field_15625 TERACOTTA Lnet/minecraft/class_2680;
-	FIELD field_15626 YELLOW_TERACOTTA Lnet/minecraft/class_2680;
+	FIELD field_15624 WHITE_TERRACOTTA Lnet/minecraft/class_2680;
+	FIELD field_15625 TERRACOTTA Lnet/minecraft/class_2680;
+	FIELD field_15626 YELLOW_TERRACOTTA Lnet/minecraft/class_2680;
 	FIELD field_15627 layerBlocks [Lnet/minecraft/class_2680;
 	METHOD method_15207 calculateLayerBlockState (III)Lnet/minecraft/class_2680;
 		ARG 1 x

--- a/mappings/net/minecraft/world/gen/surfacebuilder/ErodedBadlandsSurfaceBuilder.mapping
+++ b/mappings/net/minecraft/world/gen/surfacebuilder/ErodedBadlandsSurfaceBuilder.mapping
@@ -1,4 +1,4 @@
 CLASS net/minecraft/class_3507 net/minecraft/world/gen/surfacebuilder/ErodedBadlandsSurfaceBuilder
 	FIELD field_15628 ORANGE_TERRACOTTA Lnet/minecraft/class_2680;
 	FIELD field_15629 WHITE_TERRACOTTA Lnet/minecraft/class_2680;
-	FIELD field_15630 TERACOTTA Lnet/minecraft/class_2680;
+	FIELD field_15630 TERRACOTTA Lnet/minecraft/class_2680;

--- a/mappings/net/minecraft/world/storage/RegionBasedStorage.mapping
+++ b/mappings/net/minecraft/world/storage/RegionBasedStorage.mapping
@@ -1,10 +1,10 @@
 CLASS net/minecraft/class_2867 net/minecraft/world/storage/RegionBasedStorage
 	FIELD field_17657 cachedRegionFiles Lit/unimi/dsi/fastutil/longs/Long2ObjectLinkedOpenHashMap;
 	FIELD field_18690 directory Ljava/io/File;
-	FIELD field_23748 dsync Z
+	FIELD field_23748 desync Z
 	METHOD <init> (Ljava/io/File;Z)V
 		ARG 1 directory
-		ARG 2 dsync
+		ARG 2 desync
 	METHOD method_12440 getRegionFile (Lnet/minecraft/class_1923;)Lnet/minecraft/class_2861;
 		ARG 1 pos
 	METHOD method_17911 getTagAt (Lnet/minecraft/class_1923;)Lnet/minecraft/class_2487;

--- a/mappings/net/minecraft/world/storage/RegionFile.mapping
+++ b/mappings/net/minecraft/world/storage/RegionFile.mapping
@@ -11,12 +11,12 @@ CLASS net/minecraft/class_2861 net/minecraft/world/storage/RegionFile
 	METHOD <init> (Ljava/io/File;Ljava/io/File;Z)V
 		ARG 1 file
 		ARG 2 directory
-		ARG 3 dsync
+		ARG 3 desync
 	METHOD <init> (Ljava/nio/file/Path;Ljava/nio/file/Path;Lnet/minecraft/class_4486;Z)V
 		ARG 1 file
 		ARG 2 directory
 		ARG 3 outputChunkStreamVersion
-		ARG 4 dsync
+		ARG 4 desync
 	METHOD method_12419 getSectorData (Lnet/minecraft/class_1923;)I
 		ARG 1 pos
 	METHOD method_12423 hasChunk (Lnet/minecraft/class_1923;)Z


### PR DESCRIPTION
I ran yarn through a spellchecker.
Note that this doesn't fix anything in the realms package, as some of those spelling errors are due to odd Mojang conventions that should really be left to another PR to fix.