### PR TITLE
ItemUsageContext -> BlockUsageContext + related names

### DIFF
--- a/mappings/net/minecraft/block/AutomaticBlockPlacementContext.mapping
+++ b/mappings/net/minecraft/block/AutomaticBlockPlacementContext.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2968 net/minecraft/item/AutomaticItemPlacementContext
+CLASS net/minecraft/class_2968 net/minecraft/block/AutomaticBlockPlacementContext
 	FIELD field_13362 facing Lnet/minecraft/class_2350;
 	METHOD <init> (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;Lnet/minecraft/class_1799;Lnet/minecraft/class_2350;)V
 		ARG 1 world

--- a/mappings/net/minecraft/block/BlockPlacementContext.mapping
+++ b/mappings/net/minecraft/block/BlockPlacementContext.mapping
@@ -1,6 +1,11 @@
-CLASS net/minecraft/class_1750 net/minecraft/item/ItemPlacementContext
+CLASS net/minecraft/class_1750 net/minecraft/block/BlockPlacementContext
 	FIELD field_7903 placementPos Lnet/minecraft/class_2338;
 	FIELD field_7904 canReplaceExisting Z
+	METHOD <init> (Lnet/minecraft/class_1657;Lnet/minecraft/class_1268;Lnet/minecraft/class_1799;Lnet/minecraft/class_3965;)V
+		ARG 1 player
+		ARG 2 hand
+		ARG 3 stack
+		ARG 4 hit
 	METHOD <init> (Lnet/minecraft/class_1838;)V
 		ARG 1 context
 	METHOD method_16355 offset (Lnet/minecraft/class_1750;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Lnet/minecraft/class_1750;

--- a/mappings/net/minecraft/block/BlockUsageContext.mapping
+++ b/mappings/net/minecraft/block/BlockUsageContext.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_1838 net/minecraft/item/ItemUsageContext
+CLASS net/minecraft/class_1838 net/minecraft/block/BlockUsageContext
 	FIELD field_17543 hit Lnet/minecraft/class_3965;
 	FIELD field_19176 hand Lnet/minecraft/class_1268;
 	FIELD field_8941 stack Lnet/minecraft/class_1799;
@@ -14,7 +14,7 @@ CLASS net/minecraft/class_1838 net/minecraft/item/ItemUsageContext
 		ARG 3 hand
 		ARG 4 stack
 		ARG 5 hit
-	METHOD method_17698 getHitPos ()Lnet/minecraft/class_243;
+	METHOD method_17698 getPos ()Lnet/minecraft/class_243;
 	METHOD method_17699 hitsInsideBlock ()Z
 	METHOD method_20287 getHand ()Lnet/minecraft/class_1268;
 	METHOD method_8036 getPlayer ()Lnet/minecraft/class_1657;


### PR DESCRIPTION
Closes #1508.

The context is for using *blocks*, not items; it's only used when blocks are placed or blocks are used with items. It also doesn't make much sense to "place items" in Minecraft.

As this is a large rename, also specifically requesting a review from @modmuss50.