### PR TITLE
desync -> dsync

### DIFF
--- a/mappings/net/minecraft/world/storage/RegionBasedStorage.mapping
+++ b/mappings/net/minecraft/world/storage/RegionBasedStorage.mapping
@@ -1,10 +1,10 @@
 CLASS net/minecraft/class_2867 net/minecraft/world/storage/RegionBasedStorage
 	FIELD field_17657 cachedRegionFiles Lit/unimi/dsi/fastutil/longs/Long2ObjectLinkedOpenHashMap;
 	FIELD field_18690 directory Ljava/io/File;
-	FIELD field_23748 desync Z
+	FIELD field_23748 dsync Z
 	METHOD <init> (Ljava/io/File;Z)V
 		ARG 1 directory
-		ARG 2 desync
+		ARG 2 dsync
 	METHOD method_12440 getRegionFile (Lnet/minecraft/class_1923;)Lnet/minecraft/class_2861;
 		ARG 1 pos
 	METHOD method_17911 getTagAt (Lnet/minecraft/class_1923;)Lnet/minecraft/class_2487;

--- a/mappings/net/minecraft/world/storage/RegionFile.mapping
+++ b/mappings/net/minecraft/world/storage/RegionFile.mapping
@@ -11,12 +11,12 @@ CLASS net/minecraft/class_2861 net/minecraft/world/storage/RegionFile
 	METHOD <init> (Ljava/io/File;Ljava/io/File;Z)V
 		ARG 1 file
 		ARG 2 directory
-		ARG 3 desync
+		ARG 3 dsync
 	METHOD <init> (Ljava/nio/file/Path;Ljava/nio/file/Path;Lnet/minecraft/class_4486;Z)V
 		ARG 1 file
 		ARG 2 directory
 		ARG 3 outputChunkStreamVersion
-		ARG 4 desync
+		ARG 4 dsync
 	METHOD method_12419 getSectorData (Lnet/minecraft/class_1923;)I
 		ARG 1 pos
 	METHOD method_12423 hasChunk (Lnet/minecraft/class_1923;)Z


### PR DESCRIPTION
In #1506, I mistakenly assumed that "dsync" as a typo of "desync". This PR reverts that mistaken correction.