### PR TITLE
Amend prohibited mapping sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To obtain a deobfuscated Minecraft jar, [`./gradlew mapNamedJar`](#mapNamedJar) 
 
 ## Contributing
 
-Please remember that copying and pasting mappings from alternate projects under more restrictive licenses (such as MCP or Mojang's obfuscation maps)
+Please remember that copying and pasting mappings from alternate projects under more restrictive licenses (such as MCP, Spigot's or Mojang's obfuscation maps)
 is **completely forbidden** without explicit permission from the owners of said mappings to distribute the names under the CC0 license.
 This includes using the names from those mappings for inspiration. Discussing the naming approaches used in said projects
 is also not welcome - you have been warned. However, it is a good idea to consult name changes with other people - use pull requests or our community spaces to ask questions!


### PR DESCRIPTION
All of spigot's files related to their mappings have the following in their header: `(c) 2014-2020 SpigotMC Pty. Ltd.` This file header is effectively `All Rights Reserved` due to no legal language on the file or repository specifying any other licensing. 

Per the file header of spigot's mappings (albeit minimal mappings) is incompatible with yarn's license and as such cannot be used.

Further discussion about Paper, which uses the same mappings as spigot in their patches for the root of their project should be discussed. Paper's `OBFHELPER` commented method renames are pseudo dual licensed (LGPL or MIT) depending on the author of the patch (as specified by their license file: https://github.com/PaperMC/Paper/blob/master/LICENSE.md). Though, these may not be compatable with yarn's licensing with the LGPL or MIT licensed patches, or because they have been lifted from other projects (MCP, Spigot, or Mojang's mappings) that are incompatible with yarn's licensing.