### PR TITLE
Add mappings for client (options and some screens/widgets).

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/GraphicsConfirmationScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/GraphicsConfirmationScreen.mapping
@@ -1,11 +1,11 @@
 CLASS net/minecraft/class_5405 net/minecraft/client/gui/screen/GraphicsConfirmationScreen
 	FIELD field_25675 message Lnet/minecraft/class_5348;
 	FIELD field_25676 choiceButtons Lcom/google/common/collect/ImmutableList;
-	FIELD field_25677 messages Ljava/util/List;
+	FIELD field_25677 lines Ljava/util/List;
 	METHOD <init> (Lnet/minecraft/class_2561;Ljava/util/List;Lcom/google/common/collect/ImmutableList;)V
 		ARG 1 title
-		ARG 2 message
-		ARG 3 buttons
+		ARG 2 messageParts
+		ARG 3 choiceButtons
 	CLASS class_5406 ChoiceButton
 		FIELD field_25680 message Lnet/minecraft/class_2561;
 		FIELD field_25681 pressAction Lnet/minecraft/class_4185$class_4241;

--- a/mappings/net/minecraft/client/gui/screen/GraphicsConfirmationScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/GraphicsConfirmationScreen.mapping
@@ -1,0 +1,14 @@
+CLASS net/minecraft/class_5405 net/minecraft/client/gui/screen/GraphicsConfirmationScreen
+	FIELD field_25675 message Lnet/minecraft/class_5348;
+	FIELD field_25676 choiceButtons Lcom/google/common/collect/ImmutableList;
+	FIELD field_25677 messages Ljava/util/List;
+	METHOD <init> (Lnet/minecraft/class_2561;Ljava/util/List;Lcom/google/common/collect/ImmutableList;)V
+		ARG 1 title
+		ARG 2 message
+		ARG 3 buttons
+	CLASS class_5406 ChoiceButton
+		FIELD field_25680 message Lnet/minecraft/class_2561;
+		FIELD field_25681 pressAction Lnet/minecraft/class_4185$class_4241;
+		METHOD <init> (Lnet/minecraft/class_2561;Lnet/minecraft/class_4185$class_4241;)V
+			ARG 1 message
+			ARG 2 pressAction

--- a/mappings/net/minecraft/client/gui/screen/VideoOptionsScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/VideoOptionsScreen.mapping
@@ -1,8 +1,21 @@
 CLASS net/minecraft/class_446 net/minecraft/client/gui/screen/VideoOptionsScreen
 	FIELD field_19186 mipmapLevels I
+	FIELD field_25453 tooltip Ljava/util/List;
+	FIELD field_25682 GRAPHICS_FABULOUS_TEXT Lnet/minecraft/class_2561;
+	FIELD field_25683 GRAPHICS_WARNING_MESSAGE_TEXT Lnet/minecraft/class_2561;
+	FIELD field_25684 GRAPHICS_WARNING_TITLE_TEXT Lnet/minecraft/class_2561;
+	FIELD field_25685 GRAPHICS_WARNING_ACCEPT_TEXT Lnet/minecraft/class_2561;
+	FIELD field_25686 GRAPHICS_WARNING_CANCEL_TEXT Lnet/minecraft/class_2561;
+	FIELD field_25687 NEWLINE_TEXT Lnet/minecraft/class_2561;
 	FIELD field_2639 list Lnet/minecraft/class_353;
 	FIELD field_2640 OPTIONS [Lnet/minecraft/class_316;
 	METHOD <init> (Lnet/minecraft/class_437;Lnet/minecraft/class_315;)V
 		ARG 1 parent
 	METHOD method_19865 (Lnet/minecraft/class_4185;)V
 		ARG 1 button
+	METHOD method_30052 (Lnet/minecraft/class_4185;)V
+		ARG 1 button
+	METHOD method_30053 (Lnet/minecraft/class_4185;)V
+		ARG 1 button
+	METHOD method_30054 (Ljava/util/List;)V
+		ARG 1 tooltip

--- a/mappings/net/minecraft/client/gui/widget/ButtonListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ButtonListWidget.mapping
@@ -6,10 +6,15 @@ CLASS net/minecraft/class_353 net/minecraft/client/gui/widget/ButtonListWidget
 		ARG 2 secondOption
 	METHOD method_20408 addAll ([Lnet/minecraft/class_316;)V
 		ARG 1 options
+	METHOD method_29624 getHoveredButton (DD)Ljava/util/Optional;
+		ARG 1 mouseX
+		ARG 3 mouseY
 	CLASS class_354 ButtonEntry
 		FIELD field_18214 buttons Ljava/util/List;
 		METHOD <init> (Ljava/util/List;)V
 			ARG 1 buttons
+		METHOD method_18622 (ILnet/minecraft/class_4587;IIFLnet/minecraft/class_339;)V
+			ARG 5 button
 		METHOD method_20409 create (Lnet/minecraft/class_315;ILnet/minecraft/class_316;)Lnet/minecraft/class_353$class_354;
 			ARG 0 options
 			ARG 1 width

--- a/mappings/net/minecraft/client/gui/widget/EntryListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/EntryListWidget.mapping
@@ -34,7 +34,8 @@ CLASS net/minecraft/class_350 net/minecraft/client/gui/widget/EntryListWidget
 		ARG 2 y
 	METHOD method_25311 renderList (Lnet/minecraft/class_4587;IIIIF)V
 		ARG 1 matrices
-		ARG 2 rowLeft
+		ARG 2 x
+		ARG 3 y
 		ARG 4 mouseX
 		ARG 5 mouseY
 		ARG 6 delta
@@ -96,6 +97,9 @@ CLASS net/minecraft/class_350 net/minecraft/client/gui/widget/EntryListWidget
 	METHOD method_29344 setRenderSelection (Z)V
 		ARG 1 renderSelection
 	METHOD method_30013 moveSelectionIf (Lnet/minecraft/class_350$class_5403;Ljava/util/function/Predicate;)V
+		COMMENT Moves the selection in the specified direction until the predicate returns true.
+		COMMENT
+		COMMENT @param direction The direction to move the selection.
 		ARG 1 direction
 	METHOD method_30014 (Lnet/minecraft/class_350$class_351;)Z
 		ARG 0 entry
@@ -125,5 +129,6 @@ CLASS net/minecraft/class_350 net/minecraft/client/gui/widget/EntryListWidget
 			ARG 1 index
 			ARG 2 entry
 	CLASS class_5403 MoveDirection
+		COMMENT Represents the direction in which the selection is moved.
 		FIELD field_25661 UP Lnet/minecraft/class_350$class_5403;
 		FIELD field_25662 DOWN Lnet/minecraft/class_350$class_5403;

--- a/mappings/net/minecraft/client/gui/widget/EntryListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/EntryListWidget.mapping
@@ -33,6 +33,11 @@ CLASS net/minecraft/class_350 net/minecraft/client/gui/widget/EntryListWidget
 		ARG 1 x
 		ARG 2 y
 	METHOD method_25311 renderList (Lnet/minecraft/class_4587;IIIIF)V
+		ARG 1 matrices
+		ARG 2 rowLeft
+		ARG 4 mouseX
+		ARG 5 mouseY
+		ARG 6 delta
 	METHOD method_25312 renderHeader (Lnet/minecraft/class_4587;IILnet/minecraft/class_289;)V
 		ARG 1 matrices
 		ARG 2 x
@@ -79,6 +84,7 @@ CLASS net/minecraft/class_350 net/minecraft/client/gui/widget/EntryListWidget
 		ARG 1 left
 	METHOD method_25334 getSelected ()Lnet/minecraft/class_350$class_351;
 	METHOD method_25335 moveSelection (Lnet/minecraft/class_350$class_5403;)V
+		ARG 1 direction
 	METHOD method_25337 getRowTop (I)I
 		ARG 1 index
 	METHOD method_25338 remove (I)Lnet/minecraft/class_350$class_351;
@@ -87,6 +93,12 @@ CLASS net/minecraft/class_350 net/minecraft/client/gui/widget/EntryListWidget
 	METHOD method_25340 getItemCount ()I
 	METHOD method_25341 getScrollAmount ()D
 	METHOD method_25342 getRowLeft ()I
+	METHOD method_29344 setRenderSelection (Z)V
+		ARG 1 renderSelection
+	METHOD method_30013 moveSelectionIf (Lnet/minecraft/class_350$class_5403;Ljava/util/function/Predicate;)V
+		ARG 1 direction
+	METHOD method_30014 (Lnet/minecraft/class_350$class_351;)Z
+		ARG 0 entry
 	CLASS class_351 Entry
 		FIELD field_22752 list Lnet/minecraft/class_350;
 		METHOD method_25343 render (Lnet/minecraft/class_4587;IIIIIIIZF)V
@@ -112,3 +124,6 @@ CLASS net/minecraft/class_350 net/minecraft/client/gui/widget/EntryListWidget
 		METHOD set (ILjava/lang/Object;)Ljava/lang/Object;
 			ARG 1 index
 			ARG 2 entry
+	CLASS class_5403 MoveDirection
+		FIELD field_25661 UP Lnet/minecraft/class_350$class_5403;
+		FIELD field_25662 DOWN Lnet/minecraft/class_350$class_5403;

--- a/mappings/net/minecraft/client/gui/widget/EntryListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/EntryListWidget.mapping
@@ -98,9 +98,8 @@ CLASS net/minecraft/class_350 net/minecraft/client/gui/widget/EntryListWidget
 		ARG 1 renderSelection
 	METHOD method_30013 moveSelectionIf (Lnet/minecraft/class_350$class_5403;Ljava/util/function/Predicate;)V
 		COMMENT Moves the selection in the specified direction until the predicate returns true.
-		COMMENT
-		COMMENT @param direction The direction to move the selection.
 		ARG 1 direction
+			COMMENT The direction to move the selection.
 	METHOD method_30014 (Lnet/minecraft/class_350$class_351;)Z
 		ARG 0 entry
 	CLASS class_351 Entry

--- a/mappings/net/minecraft/client/gui/widget/OptionButtonWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/OptionButtonWidget.mapping
@@ -7,3 +7,4 @@ CLASS net/minecraft/class_349 net/minecraft/client/gui/widget/OptionButtonWidget
 		ARG 4 height
 		ARG 5 option
 		ARG 7 pressAction
+	METHOD method_29623 getOption ()Lnet/minecraft/class_316;

--- a/mappings/net/minecraft/client/options/BooleanOption.mapping
+++ b/mappings/net/minecraft/client/options/BooleanOption.mapping
@@ -17,3 +17,5 @@ CLASS net/minecraft/class_4062 net/minecraft/client/options/BooleanOption
 		ARG 1 options
 	METHOD method_18495 getDisplayString (Lnet/minecraft/class_315;)Lnet/minecraft/class_2561;
 		ARG 1 options
+	METHOD method_19786 (Lnet/minecraft/class_315;Lnet/minecraft/class_4185;)V
+		ARG 2 button

--- a/mappings/net/minecraft/client/options/CyclingOption.mapping
+++ b/mappings/net/minecraft/client/options/CyclingOption.mapping
@@ -10,3 +10,5 @@ CLASS net/minecraft/class_4064 net/minecraft/client/options/CyclingOption
 		ARG 2 amount
 	METHOD method_18501 getMessage (Lnet/minecraft/class_315;)Lnet/minecraft/class_2561;
 		ARG 1 options
+	METHOD method_19787 (Lnet/minecraft/class_315;Lnet/minecraft/class_4185;)V
+		ARG 2 button

--- a/mappings/net/minecraft/client/options/Option.mapping
+++ b/mappings/net/minecraft/client/options/Option.mapping
@@ -48,9 +48,9 @@ CLASS net/minecraft/class_316 net/minecraft/client/options/Option
 	FIELD field_23931 CHAT_DELAY_INSTANT Lnet/minecraft/class_4067;
 	FIELD field_24213 ENTITY_DISTANCE_SCALING Lnet/minecraft/class_4067;
 	FIELD field_25442 tooltip Ljava/util/Optional;
-	FIELD field_25672 GRAPHICS_FAST_TOOLTIP Lnet/minecraft/class_2561;
-	FIELD field_25673 GRAPHICS_FABULOUS_TOOLTIP Lnet/minecraft/class_2561;
-	FIELD field_25674 GRAPHICS_FANCY_TOOLTIP Lnet/minecraft/class_2561;
+	FIELD field_25672 FAST_GRAPHICS_TOOLTIP Lnet/minecraft/class_2561;
+	FIELD field_25673 FABULOUS_GRAPHICS_TOOLTIP Lnet/minecraft/class_2561;
+	FIELD field_25674 FANCY_GRAPHICS_TOOLTIP Lnet/minecraft/class_2561;
 	METHOD <init> (Ljava/lang/String;)V
 		ARG 1 key
 	METHOD method_18518 getDisplayPrefix ()Lnet/minecraft/class_5250;

--- a/mappings/net/minecraft/client/options/Option.mapping
+++ b/mappings/net/minecraft/client/options/Option.mapping
@@ -47,6 +47,10 @@ CLASS net/minecraft/class_316 net/minecraft/client/options/Option
 	FIELD field_23930 CHAT_LINE_SPACING Lnet/minecraft/class_4067;
 	FIELD field_23931 CHAT_DELAY_INSTANT Lnet/minecraft/class_4067;
 	FIELD field_24213 ENTITY_DISTANCE_SCALING Lnet/minecraft/class_4067;
+	FIELD field_25442 tooltip Ljava/util/Optional;
+	FIELD field_25672 GRAPHICS_FAST_TOOLTIP Lnet/minecraft/class_2561;
+	FIELD field_25673 GRAPHICS_FABULOUS_TOOLTIP Lnet/minecraft/class_2561;
+	FIELD field_25674 GRAPHICS_FANCY_TOOLTIP Lnet/minecraft/class_2561;
 	METHOD <init> (Ljava/lang/String;)V
 		ARG 1 key
 	METHOD method_18518 getDisplayPrefix ()Lnet/minecraft/class_5250;
@@ -60,3 +64,6 @@ CLASS net/minecraft/class_316 net/minecraft/client/options/Option
 	METHOD method_18554 (Lnet/minecraft/class_315;Ljava/lang/Integer;)V
 		ARG 0 options
 		ARG 1 count
+	METHOD method_29618 setTooltip (Ljava/util/List;)V
+		ARG 1 tooltip
+	METHOD method_29619 getTooltip ()Ljava/util/Optional;


### PR DESCRIPTION
Changelog (mainly new mappings, no rename):
 - Map `class_5405` to `GraphicsConfirmationScreen` as it is called when one wants to use the Fabulous graphics option when they don't have the required computer.
 - `VideoOptionsScreen` changes:
   - `field_25453` -> `tooltip` : the current tooltip to draw on screen.
   - `field_25682` -> `GRAPHICS_FABULOUS_TEXT`
   - `field_25683` -> `GRAPHICS_WARNING_MESSAGE_TEXT`
   - `field_25684` -> `GRAPHICS_WARNING_TITLE_TEXT`
   - `field_25685` -> `GRAPHICS_WARNING_ACCEPT_TEXT`
   - `field_25686` -> `GRAPHICS_WARNING_CANCEL_TEXT`
   - `field_25687` -> `NEWLINE_TEXT` : it's literally a `LiteralText` with `\n`
 - `ButtonListWidget` changes:
   - `method_29624` -> `getHoveredButton`
 - `EntryListWidget` changes:
   - `method_29344` -> `setRenderSelection` : as it is a setter of a variable of the same name (without the set).
   - `method_30013` -> `moveSelectionIf` : as it is called by `moveSelection` but has a Predicate to check if the next selection is valid from the predicate.
   - `class_5403` -> `MoveDirection` : it's the enum in `moveSelection` and determines the direction.
     - `field_2566` -> `UP`
     - `field_25662` -> `DOWN`
 - `OptionButtonWidget` changes:
   - `method_29623` -> `getOption`
 - `Option` changes:
   - `field_25442` -> `tooltip`
   - `field_25672` -> `GRAPHICS_FAST_TOOLTIP`
   - `field_25673` -> `GRAPHICS_FABULOUS_TOOLTIP`
   - `field_25674` -> `GRAPHICS_FANCY_TOOLTIP`
   - `method_29618` -> `setTooltip`
   - `method_29619` -> `getTooltip`

And that's all!