### PR TITLE
Mapped method to retrieve recipe list

### DIFF
--- a/mappings/net/minecraft/recipe/RecipeManager.mapping
+++ b/mappings/net/minecraft/recipe/RecipeManager.mapping
@@ -14,6 +14,9 @@ CLASS net/minecraft/class_1863 net/minecraft/recipe/RecipeManager
 		ARG 3 world
 	METHOD method_20702 setRecipes (Ljava/lang/Iterable;)V
 		ARG 1 recipes
+	METHOD method_30027 listAllOfType (Lnet/minecraft/class_3956;)Ljava/util/List;
+		COMMENT Creates a list of all recipes of the given type.
+		COMMENT Modifications to the returned list do not affect the manager.
 	METHOD method_8126 values ()Ljava/util/Collection;
 	METHOD method_8127 keys ()Ljava/util/stream/Stream;
 	METHOD method_8128 getRemainingStacks (Lnet/minecraft/class_3956;Lnet/minecraft/class_1263;Lnet/minecraft/class_1937;)Lnet/minecraft/class_2371;


### PR DESCRIPTION
There's a public method to retrieve all recipes of a given type, in addition to the existing (private) method that returned a modifiable map, this one returns a copy (bad for performance, better for encapsulation I guess).

p.s.: `getAllOfTypeAsList` sucks, but `getAllOfType` is taken by the map-returning version.

I was also thinking of maybe making the warning about it returning a new copy **every time** a bit more explicit. It's a performance problem if called too often I think.