### PR TITLE
Improve ChunkTaskPrioritySystem mappings

### DIFF
--- a/mappings/net/minecraft/server/world/ChunkTaskPrioritySystem.mapping
+++ b/mappings/net/minecraft/server/world/ChunkTaskPrioritySystem.mapping
@@ -1,46 +1,72 @@
 CLASS net/minecraft/class_3900 net/minecraft/server/world/ChunkTaskPrioritySystem
 	FIELD field_17248 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_17249 queues Ljava/util/Map;
-	FIELD field_17250 actors Ljava/util/Set;
-	FIELD field_17251 sorter Lnet/minecraft/class_3846;
+	FIELD field_17250 idleActors Ljava/util/Set;
+	FIELD field_17251 controlActor Lnet/minecraft/class_3846;
 	METHOD <init> (Ljava/util/List;Ljava/util/concurrent/Executor;I)V
 		ARG 1 actors
 		ARG 2 executor
 		ARG 3 maxQueues
-	METHOD method_17282 execute (Lnet/minecraft/class_3906;Ljava/util/function/Function;JLjava/util/function/IntSupplier;Z)V
+	METHOD method_17280 (ILnet/minecraft/class_1923;ILnet/minecraft/class_3899;)V
+		ARG 3 queue
+	METHOD method_17282 enqueueChunk (Lnet/minecraft/class_3906;Ljava/util/function/Function;JLjava/util/function/IntSupplier;Z)V
 		ARG 1 actor
+		ARG 2 task
+		ARG 3 chunkPos
 		ARG 5 lastLevelUpdatedToProvider
-	METHOD method_17614 createSorterExecutor (Lnet/minecraft/class_3906;)Lnet/minecraft/class_3906;
+		ARG 6 addBlocker
+	METHOD method_17613 (ILnet/minecraft/class_3906;)Lnet/minecraft/class_3899;
+		ARG 1 actor
+	METHOD method_17614 createUnblockingExecutor (Lnet/minecraft/class_3906;)Lnet/minecraft/class_3906;
 		ARG 1 executor
-	METHOD method_17615 sort (Lnet/minecraft/class_3906;JLjava/lang/Runnable;Z)V
+	METHOD method_17615 removeChunk (Lnet/minecraft/class_3906;JLjava/lang/Runnable;Z)V
+		ARG 1 actor
+		ARG 2 chunkPos
+		ARG 4 callback
+		ARG 5 clearTask
+	METHOD method_17617 (Lnet/minecraft/class_3906;Lnet/minecraft/class_3906;)Lnet/minecraft/class_3847$class_3907;
+		ARG 2 yield
+	METHOD method_17619 (Lnet/minecraft/class_3906;Lcom/mojang/datafixers/util/Either;)Ljava/util/concurrent/CompletableFuture;
+		ARG 1 executeOrAddBlocking
 	METHOD method_17622 createExecutor (Lnet/minecraft/class_3906;Z)Lnet/minecraft/class_3906;
 		ARG 1 executor
+		ARG 2 addBlocker
+	METHOD method_17623 (Lnet/minecraft/class_3906;ZLnet/minecraft/class_3906;)Lnet/minecraft/class_3847$class_3907;
+		ARG 3 yield
+	METHOD method_17625 (Ljava/lang/Runnable;)Ljava/util/concurrent/CompletableFuture;
+		ARG 0 addBlocking
 	METHOD method_17626 createMessage (Ljava/lang/Runnable;JLjava/util/function/IntSupplier;)Lnet/minecraft/class_3900$class_3946;
-		ARG 0 runnable
+		ARG 0 task
 		ARG 1 pos
 		ARG 3 lastLevelUpdatedToProvider
-	METHOD method_17627 createSorterMessage (Ljava/lang/Runnable;JZ)Lnet/minecraft/class_3900$class_3947;
-		ARG 0 runnable
+	METHOD method_17627 createUnblockingMessage (Ljava/lang/Runnable;JZ)Lnet/minecraft/class_3900$class_3947;
+		ARG 0 task
 		ARG 1 pos
+		ARG 3 removeTask
+	METHOD method_17628 (Ljava/lang/Runnable;Lnet/minecraft/class_3906;)Ljava/lang/Runnable;
+		ARG 1 yield
 	METHOD method_17629 createMessage (Lnet/minecraft/class_3193;Ljava/lang/Runnable;)Lnet/minecraft/class_3900$class_3946;
 		ARG 0 holder
-		ARG 1 runnable
-	METHOD method_17630 (Lnet/minecraft/class_3899;Lnet/minecraft/class_3906;)V
+		ARG 1 task
+	METHOD method_17630 enqueueExecution (Lnet/minecraft/class_3899;Lnet/minecraft/class_3906;)V
+		ARG 1 queue
 		ARG 2 actor
 	METHOD method_17632 getQueue (Lnet/minecraft/class_3906;)Lnet/minecraft/class_3899;
 		ARG 1 actor
 	METHOD method_21680 getDebugString ()Ljava/lang/String;
 	CLASS class_3946 Task
-		FIELD field_17446 function Ljava/util/function/Function;
+		FIELD field_17446 taskFunction Ljava/util/function/Function;
 		FIELD field_17447 pos J
 		FIELD field_17448 lastLevelUpdatedToProvider Ljava/util/function/IntSupplier;
 		METHOD <init> (Ljava/util/function/Function;JLjava/util/function/IntSupplier;)V
 			ARG 1 function
 			ARG 2 pos
 			ARG 4 lastLevelUpdatedToProvider
-	CLASS class_3947 SorterMessage
-		FIELD field_17449 runnable Ljava/lang/Runnable;
+	CLASS class_3947 UnblockingMessage
+		FIELD field_17449 callback Ljava/lang/Runnable;
 		FIELD field_17450 pos J
+		FIELD field_17451 removeTask Z
 		METHOD <init> (Ljava/lang/Runnable;JZ)V
-			ARG 1 runnable
+			ARG 1 callback
 			ARG 2 pos
+			ARG 4 removeTask

--- a/mappings/net/minecraft/server/world/ChunkTicketManager.mapping
+++ b/mappings/net/minecraft/server/world/ChunkTicketManager.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_3204 net/minecraft/server/world/ChunkTicketManager
 	FIELD field_17455 nearbyChunkTicketUpdater Lnet/minecraft/class_3204$class_3948;
 	FIELD field_17456 levelUpdateListener Lnet/minecraft/class_3900;
 	FIELD field_17457 playerTicketThrottler Lnet/minecraft/class_3906;
-	FIELD field_17458 playerTicketThrottlerSorter Lnet/minecraft/class_3906;
+	FIELD field_17458 playerTicketThrottlerUnblocker Lnet/minecraft/class_3906;
 	FIELD field_17459 chunkPositions Lit/unimi/dsi/fastutil/longs/LongSet;
 	FIELD field_17460 mainThreadExecutor Ljava/util/concurrent/Executor;
 	FIELD field_18252 distanceFromTicketTracker Lnet/minecraft/class_3204$class_4077;

--- a/mappings/net/minecraft/server/world/LevelPrioritizedQueue.mapping
+++ b/mappings/net/minecraft/server/world/LevelPrioritizedQueue.mapping
@@ -3,8 +3,8 @@ CLASS net/minecraft/class_3899 net/minecraft/server/world/LevelPrioritizedQueue
 	FIELD field_17243 levelToPosToElements Ljava/util/List;
 	FIELD field_17244 firstNonEmptyLevel I
 	FIELD field_17247 name Ljava/lang/String;
-	FIELD field_17444 chunkPositions Lit/unimi/dsi/fastutil/longs/LongSet;
-	FIELD field_17445 maxSize I
+	FIELD field_17444 blockingChunks Lit/unimi/dsi/fastutil/longs/LongSet;
+	FIELD field_17445 maxBlocking I
 	METHOD <init> (Ljava/lang/String;I)V
 		ARG 1 name
 		ARG 2 maxSize
@@ -17,8 +17,9 @@ CLASS net/minecraft/class_3899 net/minecraft/server/world/LevelPrioritizedQueue
 		ARG 2 pos
 		ARG 4 level
 	METHOD method_17606 poll ()Ljava/util/stream/Stream;
-	METHOD method_17607 createPositionAdder (J)Ljava/lang/Runnable;
+	METHOD method_17607 createBlockingAdder (J)Ljava/lang/Runnable;
 		ARG 1 pos
-	METHOD method_17609 clearPosition (JZ)V
+	METHOD method_17609 remove (JZ)V
 		ARG 1 pos
-		ARG 3 includePresent
+		ARG 3 removeElement
+	METHOD method_21679 getBlockingChunks ()Lit/unimi/dsi/fastutil/longs/LongSet;


### PR DESCRIPTION
Currently, the mapping in `ChunkTaskPrioritySystem` is fairly misleading. The main example of this is with the current "sorter" executor. Unlike implied by the name, it is rather responsible for clearing "blocking" elements from the queue. 

These blocking elements essentially prevent the normal executor from progressing beyond the current priority level until they are removed through the unblocking executor. I'm not hugely confident with the name based around "blocking", so any alternative ideas greatly appreciated. :)