### PR TITLE
Adjustments to render layers

### DIFF
--- a/mappings/net/minecraft/client/render/RenderLayers.mapping
+++ b/mappings/net/minecraft/client/render/RenderLayers.mapping
@@ -4,6 +4,7 @@ CLASS net/minecraft/class_4696 net/minecraft/client/render/RenderLayers
 	FIELD field_21472 fancyGraphicsOrBetter Z
 	METHOD method_23678 getItemLayer (Lnet/minecraft/class_1799;Z)Lnet/minecraft/class_1921;
 		ARG 0 stack
+		ARG 1 direct
 	METHOD method_23679 getBlockLayer (Lnet/minecraft/class_2680;)Lnet/minecraft/class_1921;
 		ARG 0 state
 	METHOD method_23680 getFluidLayer (Lnet/minecraft/class_3610;)Lnet/minecraft/class_1921;
@@ -12,3 +13,5 @@ CLASS net/minecraft/class_4696 net/minecraft/client/render/RenderLayers
 		ARG 0 fancyGraphicsOrBetter
 	METHOD method_23683 getEntityBlockLayer (Lnet/minecraft/class_2680;Z)Lnet/minecraft/class_1921;
 		ARG 0 state
+		ARG 1 direct
+	METHOD method_29359 getMovingBlockLayer (Lnet/minecraft/class_2680;)Lnet/minecraft/class_1921;

--- a/mappings/net/minecraft/client/render/TexturedRenderLayers.mapping
+++ b/mappings/net/minecraft/client/render/TexturedRenderLayers.mapping
@@ -18,6 +18,7 @@ CLASS net/minecraft/class_4722 net/minecraft/client/render/TexturedRenderLayers
 	FIELD field_21727 SHIELD_PATTERNS_RENDER_LAYER Lnet/minecraft/class_1921;
 	FIELD field_21728 SIGN_RENDER_LAYER Lnet/minecraft/class_1921;
 	FIELD field_21729 CHEST_RENDER_LAYER Lnet/minecraft/class_1921;
+	FIELD field_25286 ITEM_ENTITY_TRANSLUCENT_CULL Lnet/minecraft/class_1921;
 	METHOD method_24059 getBannerPatterns ()Lnet/minecraft/class_1921;
 	METHOD method_24062 getChestTexture (Lnet/minecraft/class_2586;Lnet/minecraft/class_2745;Z)Lnet/minecraft/class_4730;
 		ARG 0 blockEntity
@@ -42,3 +43,4 @@ CLASS net/minecraft/class_4722 net/minecraft/client/render/TexturedRenderLayers
 	METHOD method_24073 getEntitySolid ()Lnet/minecraft/class_1921;
 	METHOD method_24074 getEntityCutout ()Lnet/minecraft/class_1921;
 	METHOD method_24076 getEntityTranslucentCull ()Lnet/minecraft/class_1921;
+	METHOD method_29382 getItemEntityTranslucentCull ()Lnet/minecraft/class_1921;

--- a/mappings/net/minecraft/client/render/item/ItemRenderer.mapping
+++ b/mappings/net/minecraft/client/render/item/ItemRenderer.mapping
@@ -42,7 +42,7 @@ CLASS net/minecraft/class_918 net/minecraft/client/render/item/ItemRenderer
 		ARG 4 stack
 		ARG 5 light
 		ARG 6 overlay
-	METHOD method_23181 getArmorVertexConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;ZZ)Lnet/minecraft/class_4588;
+	METHOD method_23181 getGlintVertexConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;ZZ)Lnet/minecraft/class_4588;
 		ARG 0 vertexConsumers
 		ARG 1 layer
 		ARG 2 solid
@@ -62,11 +62,18 @@ CLASS net/minecraft/class_918 net/minecraft/client/render/item/ItemRenderer
 		ARG 2 stack
 		ARG 3 x
 		ARG 4 y
+	METHOD method_27952 getArmorVertexConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;ZZ)Lnet/minecraft/class_4588;
+		ARG 3 glint
 	METHOD method_27953 renderInGui (Lnet/minecraft/class_1799;II)V
 		COMMENT Renders an item in a GUI without an attached entity.
 		ARG 1 stack
 		ARG 2 x
 		ARG 3 y
+	METHOD method_29711 getDirectGlintVertexConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;ZZ)Lnet/minecraft/class_4588;
+		ARG 1 layer
+		ARG 3 glint
+	METHOD method_30114 getTransformingGlintVertexConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;Lnet/minecraft/class_4587$class_4665;)Lnet/minecraft/class_4588;
+	METHOD method_30115 getTransformingDirectGlintVertexConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;Lnet/minecraft/class_4587$class_4665;)Lnet/minecraft/class_4588;
 	METHOD method_4004 renderGuiQuad (Lnet/minecraft/class_287;IIIIIIII)V
 		ARG 1 buffer
 		ARG 2 x

--- a/mappings/net/minecraft/client/render/model/json/ModelTransformation.mapping
+++ b/mappings/net/minecraft/client/render/model/json/ModelTransformation.mapping
@@ -33,3 +33,4 @@ CLASS net/minecraft/class_809 net/minecraft/client/render/model/json/ModelTransf
 			ARG 2 json
 			ARG 3 key
 	CLASS class_811 Mode
+		METHOD method_29998 isFirstPerson ()Z


### PR DESCRIPTION
This is my first Yarn PR, so please point out any mistakes. 

This PR has adjusts some names related to render layers. I'll go through by class.

RenderLayers:
- Map the second bool parameter to numerous methods as `direct`. When true, the layer returned is the "direct" version, always rendering to the main framebuffer. When false, the newly-added off-screen framebuffers are returned when necessary.
- Name `getMovingBlockLayer`, used by moving piston and falling block renderers
- Confidence in these names: high

TexturedRenderLayers:
- map field `ITEM_ENTITY_TRANSLUCENT_CULL` and its getter according to their ID's
- Confidence: high

ModelTransformation:
- name isFirstPerson. straightforward.
- Confidence: very high

Now we have ItemRenderer:
1. Rename `method_23181` to `getGlintVertexConsumer`. The former name of `getArmorVertexConsumer` is a misnomer now as this is called any time enchantment glint is needed. Nothing to do with armor.
2. Map `method_23181`'s "direct" sibling `method_29711` to `getDirectGlintVertexConsumer`. The meaning of "direct" is as above.
3. Map `method_27952` as `getArmorVertexConsumer`, since this one is the one actually called by armor rendering
4. Map `method_30114` and its "direct" sibling `method_30115` as `getTransformingGlintVertexConsumer` (resp. `getTransformingDirectGlintVertexConsumer`). These are only used for enchanted compass rendering, but I decided to keep them general. Might be a bit long?

Confidence: high for items 1 and 2. medium-high for item 3 (only because the old name will silently change methods). medium for #4 (due to the name length).

Should apply cleanly to the snapshot but if not I'll forward port on merge.