### PR TITLE
Map system toast and file dragging handler in Screen, rename misnamed Screen

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/DialogScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/DialogScreen.mapping
@@ -1,7 +1,9 @@
-CLASS net/minecraft/class_5405 net/minecraft/client/gui/screen/GraphicsConfirmationScreen
+CLASS net/minecraft/class_5405 net/minecraft/client/gui/screen/DialogScreen
 	FIELD field_25675 message Lnet/minecraft/class_5348;
 	FIELD field_25676 choiceButtons Lcom/google/common/collect/ImmutableList;
 	FIELD field_25677 lines Ljava/util/List;
+	FIELD field_25678 linesY I
+	FIELD field_25679 buttonWidth I
 	METHOD <init> (Lnet/minecraft/class_2561;Ljava/util/List;Lcom/google/common/collect/ImmutableList;)V
 		ARG 1 title
 		ARG 2 messageParts

--- a/mappings/net/minecraft/client/gui/screen/Screen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/Screen.mapping
@@ -61,6 +61,7 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 		ARG 3 height
 	METHOD method_25424 renderTooltip (Lnet/minecraft/class_4587;Lnet/minecraft/class_5348;II)V
 		ARG 1 matrices
+		ARG 2 text
 		ARG 3 x
 		ARG 4 y
 	METHOD method_25425 sendMessage (Ljava/lang/String;Z)V
@@ -100,3 +101,5 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 	METHOD method_25441 hasControlDown ()Z
 	METHOD method_25442 hasShiftDown ()Z
 	METHOD method_25443 hasAltDown ()Z
+	METHOD method_29638 filesDragged (Ljava/util/List;)V
+		ARG 1 paths

--- a/mappings/net/minecraft/client/toast/SystemToast.mapping
+++ b/mappings/net/minecraft/client/toast/SystemToast.mapping
@@ -40,7 +40,7 @@ CLASS net/minecraft/class_370 net/minecraft/client/toast/SystemToast
 		ARG 4 textureV
 		ARG 5 y
 		ARG 6 height
-	METHOD method_29047 newSystemToast (Lnet/minecraft/class_310;Lnet/minecraft/class_370$class_371;Lnet/minecraft/class_2561;Lnet/minecraft/class_2561;)Lnet/minecraft/class_370;
+	METHOD method_29047 create (Lnet/minecraft/class_310;Lnet/minecraft/class_370$class_371;Lnet/minecraft/class_2561;Lnet/minecraft/class_2561;)Lnet/minecraft/class_370;
 		ARG 0 client
 		ARG 1 type
 		ARG 2 title

--- a/mappings/net/minecraft/client/toast/SystemToast.mapping
+++ b/mappings/net/minecraft/client/toast/SystemToast.mapping
@@ -3,6 +3,17 @@ CLASS net/minecraft/class_370 net/minecraft/client/toast/SystemToast
 	FIELD field_2214 justUpdated Z
 	FIELD field_2215 title Lnet/minecraft/class_5348;
 	FIELD field_2216 startTime J
+	FIELD field_25037 lines Ljava/util/List;
+	FIELD field_25038 width I
+	METHOD <init> (Lnet/minecraft/class_370$class_371;Lnet/minecraft/class_2561;Ljava/util/List;I)V
+		ARG 1 type
+		ARG 2 title
+		ARG 3 lines
+		ARG 4 width
+	METHOD <init> (Lnet/minecraft/class_370$class_371;Lnet/minecraft/class_2561;Lnet/minecraft/class_2561;)V
+		ARG 1 type
+		ARG 2 title
+		ARG 3 description
 	METHOD method_1990 show (Lnet/minecraft/class_374;Lnet/minecraft/class_370$class_371;Lnet/minecraft/class_2561;Lnet/minecraft/class_2561;)V
 		ARG 0 manager
 		ARG 1 type
@@ -22,4 +33,21 @@ CLASS net/minecraft/class_370 net/minecraft/client/toast/SystemToast
 	METHOD method_27025 addWorldDeleteFailureToast (Lnet/minecraft/class_310;Ljava/lang/String;)V
 		ARG 0 client
 		ARG 1 worldName
+	METHOD method_29046 drawPart (Lnet/minecraft/class_4587;Lnet/minecraft/class_374;IIII)V
+		ARG 1 matrices
+		ARG 2 manager
+		ARG 3 width
+		ARG 4 textureV
+		ARG 5 y
+		ARG 6 height
+	METHOD method_29047 newSystemToast (Lnet/minecraft/class_310;Lnet/minecraft/class_370$class_371;Lnet/minecraft/class_2561;Lnet/minecraft/class_2561;)Lnet/minecraft/class_370;
+		ARG 0 client
+		ARG 1 type
+		ARG 2 title
+		ARG 3 description
+	METHOD method_29626 getTextAsList (Lnet/minecraft/class_2561;)Lcom/google/common/collect/ImmutableList;
+		ARG 0 text
+	METHOD method_29627 addPackCopyFailure (Lnet/minecraft/class_310;Ljava/lang/String;)V
+		ARG 0 client
+		ARG 1 directory
 	CLASS class_371 Type

--- a/mappings/net/minecraft/client/toast/Toast.mapping
+++ b/mappings/net/minecraft/client/toast/Toast.mapping
@@ -6,6 +6,8 @@ CLASS net/minecraft/class_368 net/minecraft/client/toast/Toast
 		ARG 2 manager
 		ARG 3 startTime
 	METHOD method_1987 getType ()Ljava/lang/Object;
+	METHOD method_29049 getWidth ()I
+	METHOD method_29050 getHeight ()I
 	CLASS class_369 Visibility
 		FIELD field_2211 sound Lnet/minecraft/class_3414;
 		METHOD <init> (Ljava/lang/String;ILnet/minecraft/class_3414;)V


### PR DESCRIPTION
Changelog:
- `GraphicsConfirmationScreen` -> `DialogScreen`
  - I believe to have misnamed this screen as its purpose seems more wide even if only used for graphics. Could be used for other stuff in theory.
  - `field_25678` -> `linesY`
  - `field_25679` -> `buttonWidth`
- Screen: `method_29638` -> `filesDragged`
  - I followed the same naming scheme as `keyReleased`, `keyPressed`, `mouseClicked`, etc.
- `SystemToast` maps:
  - `field_25037` -> `lines`
  - `field_25038` -> `width`
  - `method_29046` -> `drawPart` I'm not too sure about that name, open to suggestions
  - `method_29047` -> `create`
  - `method_29627` -> `addPackCopyFailure`
- `Toast` maps:
  - `method_29049` -> `getWidth`
  - `method_29050` -> `getHeight`