### PR TITLE
Actually describe vague "checkChunk" methods.

### DIFF
--- a/mappings/net/minecraft/client/world/ClientWorld.mapping
+++ b/mappings/net/minecraft/client/world/ClientWorld.mapping
@@ -36,7 +36,7 @@ CLASS net/minecraft/class_638 net/minecraft/client/world/ClientWorld
 		ARG 1 entity
 		ARG 2 passenger
 	METHOD method_18648 checkEntityChunkPos (Lnet/minecraft/class_1297;)V
-		COMMENT Validates an entity's current position matches the it's chunk position. If the entity's chunk position and actual position don't match, then the entity will be moved to it's new chunk.
+		COMMENT Validates an entity's current position matches the its chunk position. If the entity's chunk position and actual position don't match, then the entity will be moved to its new chunk.
 		ARG 1 entity
 	METHOD method_23780 calculateColor (Lnet/minecraft/class_2338;Lnet/minecraft/world/level/ColorResolver;)I
 		ARG 1 pos

--- a/mappings/net/minecraft/client/world/ClientWorld.mapping
+++ b/mappings/net/minecraft/client/world/ClientWorld.mapping
@@ -36,7 +36,7 @@ CLASS net/minecraft/class_638 net/minecraft/client/world/ClientWorld
 		ARG 1 entity
 		ARG 2 passenger
 	METHOD method_18648 checkEntityChunkPos (Lnet/minecraft/class_1297;)V
-		COMMENT Validates an entity's current position matches the its chunk position. If the entity's chunk position and actual position don't match, then the entity will be moved to its new chunk.
+		COMMENT Validates if an entity's current position matches its chunk position. If the entity's chunk position and actual position don't match, then the entity will be moved to its new chunk.
 		ARG 1 entity
 	METHOD method_23780 calculateColor (Lnet/minecraft/class_2338;Lnet/minecraft/world/level/ColorResolver;)I
 		ARG 1 pos

--- a/mappings/net/minecraft/client/world/ClientWorld.mapping
+++ b/mappings/net/minecraft/client/world/ClientWorld.mapping
@@ -35,7 +35,8 @@ CLASS net/minecraft/class_638 net/minecraft/client/world/ClientWorld
 	METHOD method_18647 tickPassenger (Lnet/minecraft/class_1297;Lnet/minecraft/class_1297;)V
 		ARG 1 entity
 		ARG 2 passenger
-	METHOD method_18648 checkChunk (Lnet/minecraft/class_1297;)V
+	METHOD method_18648 checkEntityChunkPos (Lnet/minecraft/class_1297;)V
+		COMMENT Validates an entity's current position matches the it's chunk position. If the entity's chunk position and actual position don't match, then the entity will be moved to it's new chunk.
 		ARG 1 entity
 	METHOD method_23780 calculateColor (Lnet/minecraft/class_2338;Lnet/minecraft/world/level/ColorResolver;)I
 		ARG 1 pos

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -7,7 +7,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	FIELD field_22467 pos Lnet/minecraft/class_243;
 	FIELD field_22468 blockPos Lnet/minecraft/class_2338;
 	FIELD field_23807 inanimate Z
-	FIELD field_25154 chunkPosUpdateNeeded Z
+	FIELD field_25154 chunkPosUpdateRequested Z
 	FIELD field_5951 ridingCooldown I
 	FIELD field_5952 onGround Z
 	FIELD field_5953 firstUpdate Z

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -7,6 +7,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	FIELD field_22467 pos Lnet/minecraft/class_243;
 	FIELD field_22468 blockPos Lnet/minecraft/class_2338;
 	FIELD field_23807 inanimate Z
+	FIELD field_25154 chunkPosUpdateNeeded Z
 	FIELD field_5951 ridingCooldown I
 	FIELD field_5952 onGround Z
 	FIELD field_5953 firstUpdate Z
@@ -221,6 +222,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		ARG 1 onGround
 	METHOD method_25936 getLandingBlockState ()Lnet/minecraft/class_2680;
 	METHOD method_27298 shouldSpawnSprintingParticles ()Z
+	METHOD method_29240 chunkPosUpdateRequested ()Z
 	METHOD method_5621 getMountedHeightOffset ()D
 	METHOD method_5622 onBlockCollision (Lnet/minecraft/class_2680;)V
 		ARG 1 state

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -222,7 +222,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		ARG 1 onGround
 	METHOD method_25936 getLandingBlockState ()Lnet/minecraft/class_2680;
 	METHOD method_27298 shouldSpawnSprintingParticles ()Z
-	METHOD method_29240 chunkPosUpdateRequested ()Z
+	METHOD method_29240 isChunkPosUpdateRequested ()Z
 	METHOD method_5621 getMountedHeightOffset ()D
 	METHOD method_5622 onBlockCollision (Lnet/minecraft/class_2680;)V
 		ARG 1 state

--- a/mappings/net/minecraft/server/world/ServerWorld.mapping
+++ b/mappings/net/minecraft/server/world/ServerWorld.mapping
@@ -81,6 +81,8 @@ CLASS net/minecraft/class_3218 net/minecraft/server/world/ServerWorld
 		ARG 2 z
 		ARG 3 forced
 	METHOD method_18198 getEntities (Lnet/minecraft/class_1299;Ljava/util/function/Predicate;)Ljava/util/List;
+	METHOD method_18199 (Lnet/minecraft/class_1309;)Z
+		ARG 1 entity
 	METHOD method_18203 tickChunk (Lnet/minecraft/class_2818;I)V
 		ARG 1 chunk
 		ARG 2 randomTickSpeed
@@ -107,7 +109,9 @@ CLASS net/minecraft/class_3218 net/minecraft/server/world/ServerWorld
 		ARG 1 shouldKeepTicking
 	METHOD method_18766 getPlayers (Ljava/util/function/Predicate;)Ljava/util/List;
 		ARG 1 predicate
-	METHOD method_18767 checkChunk (Lnet/minecraft/class_1297;)V
+	METHOD method_18767 checkEntityChunkPos (Lnet/minecraft/class_1297;)V
+		COMMENT Validates an entity's current position matches the it's chunk position. If the entity's chunk position and actual position don't match, then the entity will be moved to it's new chunk.
+		ARG 1 entity
 	METHOD method_18768 tryLoadEntity (Lnet/minecraft/class_1297;)Z
 		ARG 1 entity
 	METHOD method_18769 onDimensionChanged (Lnet/minecraft/class_1297;)V
@@ -118,8 +122,12 @@ CLASS net/minecraft/class_3218 net/minecraft/server/world/ServerWorld
 		ARG 1 player
 	METHOD method_18772 unloadEntity (Lnet/minecraft/class_1297;)V
 		ARG 1 entity
+	METHOD method_18773 (Lnet/minecraft/class_3222;)V
+		ARG 0 player
 	METHOD method_18774 removeEntity (Lnet/minecraft/class_1297;)V
 		ARG 1 entity
+	METHOD method_18775 (Lnet/minecraft/class_3222;)Z
+		ARG 0 player
 	METHOD method_18776 getAliveEnderDragons ()Ljava/util/List;
 	METHOD method_18777 checkUuid (Lnet/minecraft/class_1297;)Z
 		ARG 1 entity

--- a/mappings/net/minecraft/server/world/ServerWorld.mapping
+++ b/mappings/net/minecraft/server/world/ServerWorld.mapping
@@ -110,7 +110,7 @@ CLASS net/minecraft/class_3218 net/minecraft/server/world/ServerWorld
 	METHOD method_18766 getPlayers (Ljava/util/function/Predicate;)Ljava/util/List;
 		ARG 1 predicate
 	METHOD method_18767 checkEntityChunkPos (Lnet/minecraft/class_1297;)V
-		COMMENT Validates an entity's current position matches the its chunk position. If the entity's chunk position and actual position don't match, then the entity will be moved to its new chunk.
+		COMMENT Validates if an entity's current position matches its chunk position. If the entity's chunk position and actual position don't match, then the entity will be moved to its new chunk.
 		ARG 1 entity
 	METHOD method_18768 tryLoadEntity (Lnet/minecraft/class_1297;)Z
 		ARG 1 entity

--- a/mappings/net/minecraft/server/world/ServerWorld.mapping
+++ b/mappings/net/minecraft/server/world/ServerWorld.mapping
@@ -110,7 +110,7 @@ CLASS net/minecraft/class_3218 net/minecraft/server/world/ServerWorld
 	METHOD method_18766 getPlayers (Ljava/util/function/Predicate;)Ljava/util/List;
 		ARG 1 predicate
 	METHOD method_18767 checkEntityChunkPos (Lnet/minecraft/class_1297;)V
-		COMMENT Validates an entity's current position matches the it's chunk position. If the entity's chunk position and actual position don't match, then the entity will be moved to it's new chunk.
+		COMMENT Validates an entity's current position matches the its chunk position. If the entity's chunk position and actual position don't match, then the entity will be moved to its new chunk.
 		ARG 1 entity
 	METHOD method_18768 tryLoadEntity (Lnet/minecraft/class_1297;)Z
 		ARG 1 entity


### PR DESCRIPTION
These are quite vague, and the profiler call is all we really have to go off of without looking deeper.

From looking around the codebase, these methods validate the entity's chunkX/Y/Z positions are correct. If the entity's last and current chunk pos are not the same, move the entity to it's new chunk (which also changes the chunkX/Y/Z values to the correct ones).

Oh and some synthetic method params while I was at it.