### PR TITLE
Mapped missing arg in Input.mapping.

### DIFF
--- a/mappings/net/minecraft/client/input/Input.mapping
+++ b/mappings/net/minecraft/client/input/Input.mapping
@@ -10,3 +10,4 @@ CLASS net/minecraft/class_744 net/minecraft/client/input/Input
 	METHOD method_20622 hasForwardMovement ()Z
 	METHOD method_3128 getMovementInput ()Lnet/minecraft/class_241;
 	METHOD method_3129 tick (Z)V
+		ARG 1 isHoldingSneakKey


### PR DESCRIPTION
In ClientPlayerEntity it says this.input.tick(this.isHoldingSneakKey()); so that's how I got the name.