### PR TITLE
Some (hopefully) uncontroversial client.font mappings

### DIFF
--- a/mappings/net/minecraft/client/font/BitmapFont.mapping
+++ b/mappings/net/minecraft/client/font/BitmapFont.mapping
@@ -4,6 +4,7 @@ CLASS net/minecraft/class_386 net/minecraft/client/font/BitmapFont
 	FIELD field_2286 LOGGER Lorg/apache/logging/log4j/Logger;
 	METHOD <init> (Lnet/minecraft/class_1011;Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;)V
 		ARG 1 image
+		ARG 2 glyphs
 	CLASS class_387 Loader
 		FIELD field_2287 ascent I
 		FIELD field_2288 height I

--- a/mappings/net/minecraft/client/font/Font.mapping
+++ b/mappings/net/minecraft/client/font/Font.mapping
@@ -1,2 +1,7 @@
 CLASS net/minecraft/class_390 net/minecraft/client/font/Font
 	METHOD method_2040 getGlyph (I)Lnet/minecraft/class_383;
+		ARG 1 codePoint
+	METHOD method_27442 getProvidedGlyphs ()Lit/unimi/dsi/fastutil/ints/IntSet;
+		COMMENT Returns the set of code points for which this font can provide glyphs.
+		COMMENT
+		COMMENT @return a set of integer code points.

--- a/mappings/net/minecraft/client/font/FontStorage.mapping
+++ b/mappings/net/minecraft/client/font/FontStorage.mapping
@@ -25,3 +25,4 @@ CLASS net/minecraft/class_377 net/minecraft/client/font/FontStorage
 		ARG 1 glyph
 	METHOD method_2014 getGlyphRenderer (I)Lnet/minecraft/class_382;
 	METHOD method_22943 getRectangleRenderer ()Lnet/minecraft/class_382;
+	METHOD method_24290 closeFonts ()V

--- a/mappings/net/minecraft/client/font/GlyphAtlasTexture.mapping
+++ b/mappings/net/minecraft/client/font/GlyphAtlasTexture.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_380 net/minecraft/client/font/GlyphAtlasTexture
+	FIELD field_21690 textLayer Lnet/minecraft/class_1921;
+	FIELD field_21691 seeThroughTextLayer Lnet/minecraft/class_1921;
 	FIELD field_2262 id Lnet/minecraft/class_2960;
 	FIELD field_2263 hasColor Z
 	FIELD field_2264 rootSlot Lnet/minecraft/class_380$class_381;

--- a/mappings/net/minecraft/client/font/GlyphRenderer.mapping
+++ b/mappings/net/minecraft/client/font/GlyphRenderer.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_382 net/minecraft/client/font/GlyphRenderer
+	FIELD field_21692 textLayer Lnet/minecraft/class_1921;
+	FIELD field_21693 seeThroughTextLayer Lnet/minecraft/class_1921;
 	FIELD field_2272 xMin F
 	FIELD field_2273 vMax F
 	FIELD field_2274 vMin F
@@ -7,6 +9,17 @@ CLASS net/minecraft/class_382 net/minecraft/client/font/GlyphRenderer
 	FIELD field_2278 yMax F
 	FIELD field_2279 yMin F
 	FIELD field_2280 xMax F
+	METHOD <init> (Lnet/minecraft/class_1921;Lnet/minecraft/class_1921;FFFFFFFF)V
+		ARG 1 textLayer
+		ARG 2 seeThroughTextLayer
+		ARG 3 uMin
+		ARG 4 uMax
+		ARG 5 vMin
+		ARG 6 vMax
+		ARG 7 xMin
+		ARG 8 xMax
+		ARG 9 yMin
+		ARG 10 yMax
 	METHOD method_2025 draw (ZFFLnet/minecraft/class_1159;Lnet/minecraft/class_4588;FFFFI)V
 		ARG 1 italic
 		ARG 2 x
@@ -23,6 +36,8 @@ CLASS net/minecraft/class_382 net/minecraft/client/font/GlyphRenderer
 		ARG 2 matrix
 		ARG 3 vertexConsumer
 		ARG 4 light
+	METHOD method_24045 getLayer (Z)Lnet/minecraft/class_1921;
+		ARG 1 seeThrough
 	CLASS class_328 Rectangle
 		FIELD field_2003 green F
 		FIELD field_2004 red F

--- a/mappings/net/minecraft/client/font/TextHandler.mapping
+++ b/mappings/net/minecraft/client/font/TextHandler.mapping
@@ -39,6 +39,13 @@ CLASS net/minecraft/class_5225 net/minecraft/client/font/TextHandler
 		ARG 1 text
 		ARG 2 width
 		ARG 3 style
+	METHOD method_27492 (Lorg/apache/commons/lang3/mutable/MutableFloat;ILnet/minecraft/class_2583;I)Z
+		ARG 2 unused
+		ARG 3 style
+		ARG 4 codePoint
+	METHOD method_27493 (Lorg/apache/commons/lang3/mutable/MutableFloat;ILorg/apache/commons/lang3/mutable/MutableInt;ILnet/minecraft/class_2583;I)Z
+		ARG 5 style
+		ARG 6 codePoint
 	METHOD method_27494 trimToWidth (Ljava/lang/String;ILnet/minecraft/class_2583;)Ljava/lang/String;
 		COMMENT Trim a string to be at most {@code maxWidth} wide.
 		COMMENT
@@ -51,6 +58,10 @@ CLASS net/minecraft/class_5225 net/minecraft/client/font/TextHandler
 			COMMENT the style of the trimmed string
 	METHOD method_27495 wrapLines (Lnet/minecraft/class_5348;ILnet/minecraft/class_2583;)Ljava/util/List;
 		ARG 2 maxWidth
+	METHOD method_27496 (Lorg/apache/commons/lang3/mutable/MutableFloat;ILnet/minecraft/class_2583;I)Z
+		ARG 2 unused
+		ARG 3 style
+		ARG 4 codePoint
 	METHOD method_27497 trimToWidthBackwards (Ljava/lang/String;ILnet/minecraft/class_2583;)Ljava/lang/String;
 		COMMENT Trim a string from right to left to be at most {@code maxWidth} wide.
 		COMMENT

--- a/mappings/net/minecraft/client/font/UnicodeTextureFont.mapping
+++ b/mappings/net/minecraft/client/font/UnicodeTextureFont.mapping
@@ -9,6 +9,7 @@ CLASS net/minecraft/class_391 net/minecraft/client/font/UnicodeTextureFont
 		ARG 2 sizes
 		ARG 3 template
 	METHOD method_2041 getImageId (I)Lnet/minecraft/class_2960;
+		ARG 1 codePoint
 	METHOD method_2042 getGlyphImage (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1011;
 		ARG 1 glyphId
 	METHOD method_2043 getStart (B)I


### PR DESCRIPTION
* `Font#method_27442` returns a set containing all the codepoints for which there are glyphs available in the Font. Alternatives: `getAvailableGlyphs`, `getContainedGlyphs`.
* `FontStorage#method_24290` just calls `close` on all fonts and then clears the list. Alternatives: `clearFonts`.
* Not sure whether `GlyphAtlasTexture#field_21691` should be `textSeeThroughLayer` (as in PR), which is consistent with `RenderLayer#getTextSeeThrough`, or `seeThroughTextLayer`.
* `GlyphRenderer` takes both of those layers in constructor so I named them the same here

The rest are mostly just parameters where the name was derived from the field they were assigned to, or obvious codepoint ints.