### PR TITLE
Fixes mapping issues in LevelInfo

### DIFF
--- a/mappings/net/minecraft/world/level/LevelInfo.mapping
+++ b/mappings/net/minecraft/world/level/LevelInfo.mapping
@@ -2,14 +2,30 @@ CLASS net/minecraft/class_1940 net/minecraft/world/level/LevelInfo
 	FIELD field_24105 name Ljava/lang/String;
 	FIELD field_24106 difficulty Lnet/minecraft/class_1267;
 	FIELD field_24107 gameRules Lnet/minecraft/class_1928;
+	FIELD field_25403 dataPackSettings Lnet/minecraft/class_5359;
 	FIELD field_9257 gameMode Lnet/minecraft/class_1934;
-	FIELD field_9261 hardcore Z
-	FIELD field_9262 structures Z
+	FIELD field_9261 allowCommands Z
+	FIELD field_9262 hardcore Z
 	METHOD <init> (Ljava/lang/String;Lnet/minecraft/class_1934;ZLnet/minecraft/class_1267;ZLnet/minecraft/class_1928;Lnet/minecraft/class_5359;)V
 		ARG 1 name
+		ARG 2 gameMode
+		ARG 3 hardcore
+		ARG 4 difficulty
+		ARG 5 allowCommands
+		ARG 6 gameRules
+		ARG 7 dataPackSettings
 	METHOD method_27339 getLevelName ()Ljava/lang/String;
 	METHOD method_27340 getDifficulty ()Lnet/minecraft/class_1267;
 	METHOD method_27341 getGameRules ()Lnet/minecraft/class_1928;
+	METHOD method_28381 withDifficulty (Lnet/minecraft/class_1267;)Lnet/minecraft/class_1940;
+		ARG 1 difficulty
+	METHOD method_28382 withGameMode (Lnet/minecraft/class_1934;)Lnet/minecraft/class_1940;
+		ARG 1 mode
+	METHOD method_28383 fromDynamic (Lcom/mojang/serialization/Dynamic;Lnet/minecraft/class_5359;)Lnet/minecraft/class_1940;
+	METHOD method_28385 withNewGameRules ()Lnet/minecraft/class_1940;
+	METHOD method_29557 withDataPackSettings (Lnet/minecraft/class_5359;)Lnet/minecraft/class_1940;
+		ARG 1 dataPackSettings
+	METHOD method_29558 getDataPackSettings ()Lnet/minecraft/class_5359;
 	METHOD method_8574 getGameMode ()Lnet/minecraft/class_1934;
-	METHOD method_8582 isHardcore ()Z
-	METHOD method_8583 hasStructures ()Z
+	METHOD method_8582 areCommandsAllowed ()Z
+	METHOD method_8583 isHardcore ()Z

--- a/mappings/net/minecraft/world/level/LevelInfo.mapping
+++ b/mappings/net/minecraft/world/level/LevelInfo.mapping
@@ -22,7 +22,7 @@ CLASS net/minecraft/class_1940 net/minecraft/world/level/LevelInfo
 	METHOD method_28382 withGameMode (Lnet/minecraft/class_1934;)Lnet/minecraft/class_1940;
 		ARG 1 mode
 	METHOD method_28383 fromDynamic (Lcom/mojang/serialization/Dynamic;Lnet/minecraft/class_5359;)Lnet/minecraft/class_1940;
-	METHOD method_28385 withNewGameRules ()Lnet/minecraft/class_1940;
+	METHOD method_28385 withCopiedGameRules ()Lnet/minecraft/class_1940;
 	METHOD method_29557 withDataPackSettings (Lnet/minecraft/class_5359;)Lnet/minecraft/class_1940;
 		ARG 1 dataPackSettings
 	METHOD method_29558 getDataPackSettings ()Lnet/minecraft/class_5359;

--- a/mappings/net/minecraft/world/level/LevelProperties.mapping
+++ b/mappings/net/minecraft/world/level/LevelProperties.mapping
@@ -25,7 +25,9 @@ CLASS net/minecraft/class_31 net/minecraft/world/level/LevelProperties
 	FIELD field_21838 modded Z
 	FIELD field_24193 worldBorder Lnet/minecraft/class_2784$class_5200;
 	FIELD field_25029 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_25030 levelInfo Lnet/minecraft/class_1940;
 	FIELD field_25031 dragonFight Lnet/minecraft/class_2487;
+	FIELD field_25425 generatorOptions Lnet/minecraft/class_5285;
 	FIELD field_26367 spawnAngle F
 	METHOD <init> (Lcom/mojang/datafixers/DataFixer;ILnet/minecraft/class_2487;ZIIIFJJIIIZIZZZLnet/minecraft/class_2784$class_5200;IILjava/util/UUID;Ljava/util/LinkedHashSet;Lnet/minecraft/class_236;Lnet/minecraft/class_2487;Lnet/minecraft/class_2487;Lnet/minecraft/class_1940;Lnet/minecraft/class_5285;Lcom/mojang/serialization/Lifecycle;)V
 		ARG 1 dataFixer

--- a/mappings/net/minecraft/world/level/storage/LevelSummary.mapping
+++ b/mappings/net/minecraft/world/level/storage/LevelSummary.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/class_34 net/minecraft/world/level/storage/LevelSummary
 	FIELD field_209 requiresConversion Z
 	FIELD field_23772 locked Z
 	FIELD field_23773 file Ljava/io/File;
+	FIELD field_25022 levelInfo Lnet/minecraft/class_1940;
 	METHOD method_247 getGameMode ()Lnet/minecraft/class_1934;
 	METHOD method_248 getName ()Ljava/lang/String;
 	METHOD method_249 getLastPlayed ()J


### PR DESCRIPTION
This is probably a matching artifact.
The "structures" flag has moved into the generator options.

This fixes #1593