### PR TITLE
(Controversial) Rename client.font.TextureFont -> BitmapFont

### DIFF
--- a/mappings/net/minecraft/client/font/BitmapFont.mapping
+++ b/mappings/net/minecraft/client/font/BitmapFont.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_386 net/minecraft/client/font/TextureFont
+CLASS net/minecraft/class_386 net/minecraft/client/font/BitmapFont
 	FIELD field_2284 glyphs Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
 	FIELD field_2285 image Lnet/minecraft/class_1011;
 	FIELD field_2286 LOGGER Lorg/apache/logging/log4j/Logger;
@@ -22,7 +22,7 @@ CLASS net/minecraft/class_386 net/minecraft/client/font/TextureFont
 			ARG 3 characterHeight
 			ARG 4 charPosX
 			ARG 5 charPosY
-	CLASS class_388 TextureFontGlyph
+	CLASS class_388 BitmapFontGlyph
 		FIELD field_2291 ascent I
 		FIELD field_2292 advance I
 		FIELD field_2293 height I


### PR DESCRIPTION
Two reasons for this:
1) There are no textures involved in this class,
   only CPU-side `NativeImage`s.
2) This name is consistent with the enum value in `FontType`.

Of course, naming it `ImageFont` or `NativeImageFont` would be the ultimate yarn-move, but in this case, the unobfuscated enum value is making this a clear-cut case in my view.

Edit: It has been pointed out to me that "bitmap font" is in fact an established term for exactly this type of font: https://en.wikipedia.org/wiki/Computer_font#Bitmap_fonts