### PR TITLE
Map optional tag entries

### DIFF
--- a/mappings/net/minecraft/tag/Tag.mapping
+++ b/mappings/net/minecraft/tag/Tag.mapping
@@ -18,6 +18,8 @@ CLASS net/minecraft/class_3494 net/minecraft/tag/Tag
 		ARG 0 values
 	METHOD method_28134 codec (Ljava/util/function/Supplier;)Lcom/mojang/serialization/Codec;
 		ARG 0 groupGetter
+	METHOD method_28136 (Ljava/util/function/Supplier;Lnet/minecraft/class_2960;)Lcom/mojang/serialization/DataResult;
+		ARG 1 id
 	CLASS class_3495 Builder
 		COMMENT A builder class to ease the creation of tags. It can also be used as a
 		COMMENT mutable form of a tag.
@@ -29,6 +31,8 @@ CLASS net/minecraft/class_3494 net/minecraft/tag/Tag
 		METHOD method_26782 build (Ljava/util/function/Function;Ljava/util/function/Function;)Ljava/util/Optional;
 			ARG 1 tagGetter
 			ARG 2 objectGetter
+		METHOD method_26783 (Ljava/util/function/Function;Ljava/util/function/Function;Lnet/minecraft/class_3494$class_5145;)Z
+			ARG 2 trackedEntry
 		METHOD method_26784 add (Lnet/minecraft/class_2960;Ljava/lang/String;)Lnet/minecraft/class_3494$class_3495;
 			ARG 1 id
 			ARG 2 source
@@ -45,6 +49,10 @@ CLASS net/minecraft/class_3494 net/minecraft/tag/Tag
 		METHOD method_27065 add (Lnet/minecraft/class_3494$class_3496;Ljava/lang/String;)Lnet/minecraft/class_3494$class_3495;
 			ARG 1 entry
 			ARG 2 source
+		METHOD method_27066 (Ljava/lang/String;Lnet/minecraft/class_3494$class_3496;)V
+			ARG 2 entry
+		METHOD method_30740 resolveEntry (Lcom/google/gson/JsonElement;)Lnet/minecraft/class_3494$class_3496;
+			ARG 0 json
 	CLASS class_3496 Entry
 		METHOD method_26789 addToJson (Lcom/google/gson/JsonArray;)V
 			ARG 1 json
@@ -69,3 +77,11 @@ CLASS net/minecraft/class_3494 net/minecraft/tag/Tag
 			ARG 1 entry
 			ARG 2 source
 		METHOD method_27067 getEntry ()Lnet/minecraft/class_3494$class_3496;
+	CLASS class_5479 OptionalObjectEntry
+		FIELD field_26383 id Lnet/minecraft/class_2960;
+		METHOD <init> (Lnet/minecraft/class_2960;)V
+			ARG 1 id
+	CLASS class_5480 OptionalTagEntry
+		FIELD field_26384 id Lnet/minecraft/class_2960;
+		METHOD <init> (Lnet/minecraft/class_2960;)V
+			ARG 1 id


### PR DESCRIPTION
This pull request maps the `Tag.OptionalTagEntry` and `Tag.OptionalObjectEntry` inner classes used to represent tag entries such as the following:

```json5
{
	"values": [
		{
			"id": "#missing:tag",
			"required": false // Tag.OptionalTagEntry
		},
		{
			"id": "missing:block",
			"required": false // Tag.OptionalObjectEntry
		}
	]
}
```