### PR TITLE
Chunk generator mappings

### DIFF
--- a/mappings/net/minecraft/world/gen/CountConfig.mapping
+++ b/mappings/net/minecraft/world/gen/CountConfig.mapping
@@ -3,3 +3,6 @@ CLASS net/minecraft/class_2984 net/minecraft/world/gen/CountConfig
 	FIELD field_24878 CODEC Lcom/mojang/serialization/Codec;
 	METHOD <init> (I)V
 		ARG 1 count
+	METHOD <init> (Lnet/minecraft/class_5428;)V
+		ARG 1 distribution
+	METHOD method_30396 getCount ()Lnet/minecraft/class_5428;

--- a/mappings/net/minecraft/world/gen/carver/Carver.mapping
+++ b/mappings/net/minecraft/world/gen/carver/Carver.mapping
@@ -56,6 +56,7 @@ CLASS net/minecraft/class_2939 net/minecraft/world/gen/carver/Carver
 		ARG 8 relMinZ
 		ARG 9 relMaxZ
 	METHOD method_16580 carveRegion (Lnet/minecraft/class_2791;Ljava/util/function/Function;JIIIDDDDDLjava/util/BitSet;)Z
+		ARG 1 chunk
 		ARG 2 posToBiome
 		ARG 3 seed
 		ARG 5 seaLevel

--- a/mappings/net/minecraft/world/gen/chunk/ChunkGenerator.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/ChunkGenerator.mapping
@@ -76,6 +76,7 @@ CLASS net/minecraft/class_2794 net/minecraft/world/gen/chunk/ChunkGenerator
 		ARG 2 z
 	METHOD method_27997 withSeed (J)Lnet/minecraft/class_2794;
 		ARG 1 seed
+	METHOD method_28506 getCodec ()Lcom/mojang/serialization/Codec;
 	METHOD method_28507 isStrongholdStartingChunk (Lnet/minecraft/class_1923;)Z
 	METHOD method_28508 setStructureStart (Lnet/minecraft/class_5312;Lnet/minecraft/class_5455;Lnet/minecraft/class_5138;Lnet/minecraft/class_2791;Lnet/minecraft/class_3485;JLnet/minecraft/class_1923;Lnet/minecraft/class_1959;)V
 		ARG 6 worldSeed

--- a/mappings/net/minecraft/world/gen/chunk/ChunkGeneratorType.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/ChunkGeneratorType.mapping
@@ -23,3 +23,5 @@ CLASS net/minecraft/class_5284 net/minecraft/world/gen/chunk/ChunkGeneratorType
 	METHOD method_28005 getDefaultBlock ()Lnet/minecraft/class_2680;
 	METHOD method_28006 getDefaultFluid ()Lnet/minecraft/class_2680;
 	METHOD method_28007 getConfig ()Lnet/minecraft/class_5311;
+	METHOD method_28559 getNoiseConfig ()Lnet/minecraft/class_5309;
+	METHOD method_28561 getSeaLevel ()I

--- a/mappings/net/minecraft/world/gen/chunk/NoiseChunkGenerator.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/NoiseChunkGenerator.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3754 net/minecraft/world/gen/chunk/SurfaceChunkGenerator
+CLASS net/minecraft/class_3754 net/minecraft/world/gen/chunk/NoiseChunkGenerator
 	FIELD field_16570 horizontalNoiseResolution I
 	FIELD field_16571 surfaceDepthNoise Lnet/minecraft/class_3757;
 	FIELD field_16572 verticalNoiseResolution I
@@ -12,8 +12,14 @@ CLASS net/minecraft/class_3754 net/minecraft/world/gen/chunk/SurfaceChunkGenerat
 	FIELD field_16580 noiseSizeX I
 	FIELD field_16581 upperInterpolatedNoise Lnet/minecraft/class_3537;
 	FIELD field_16648 AIR Lnet/minecraft/class_2680;
+	FIELD field_16649 NOISE_WEIGHT_TABLE [F
 	FIELD field_24773 CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_24774 settings Ljava/util/function/Supplier;
+	FIELD field_24775 BIOME_WEIGHT_TABLE [F
+	FIELD field_24776 densityNoise Lnet/minecraft/class_3537;
+	FIELD field_24777 islandNoise Lnet/minecraft/class_3541;
 	FIELD field_24778 worldSeed J
+	FIELD field_24779 worldHeight I
 	METHOD <init> (Lnet/minecraft/class_1966;Lnet/minecraft/class_1966;JLjava/util/function/Supplier;)V
 		ARG 3 worldSeed
 	METHOD method_16405 sampleNoiseColumn ([DII)V
@@ -34,6 +40,14 @@ CLASS net/minecraft/class_3754 net/minecraft/world/gen/chunk/SurfaceChunkGenerat
 	METHOD method_16412 buildBedrock (Lnet/minecraft/class_2791;Ljava/util/Random;)V
 		ARG 1 chunk
 		ARG 2 random
+	METHOD method_16571 calculateNoiseWeight (III)D
+		ARG 0 x
+		ARG 1 y
+		ARG 2 z
+	METHOD method_16572 getNoiseWeight (III)D
+		ARG 0 x
+		ARG 1 y
+		ARG 2 z
 	METHOD method_16573 ([F)V
 		ARG 0 array
 	METHOD method_26262 getBlockState (DI)Lnet/minecraft/class_2680;
@@ -46,3 +60,6 @@ CLASS net/minecraft/class_3754 net/minecraft/world/gen/chunk/SurfaceChunkGenerat
 		ARG 4 predicate
 	METHOD method_26983 (Lnet/minecraft/class_1923;Lit/unimi/dsi/fastutil/objects/ObjectList;IILit/unimi/dsi/fastutil/objects/ObjectList;Lnet/minecraft/class_3449;)V
 		ARG 5 start
+	METHOD method_28553 getRandomDensityAt (II)D
+		ARG 1 x
+		ARG 2 z

--- a/mappings/net/minecraft/world/gen/decorator/CountMultilayerDecorator.mapping
+++ b/mappings/net/minecraft/world/gen/decorator/CountMultilayerDecorator.mapping
@@ -1,1 +1,9 @@
 CLASS net/minecraft/class_5452 net/minecraft/world/gen/decorator/CountMultilayerDecorator
+	METHOD method_30472 blocksSpawn (Lnet/minecraft/class_2680;)Z
+		ARG 0 state
+	METHOD method_30473 findPos (Lnet/minecraft/class_5444;IIII)I
+		ARG 0 context
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+		ARG 4 targetY


### PR DESCRIPTION
This PR changes `SurfaceChunkGenerator` to `NoiseChunkGenerator` to reflect it's name in the codec. It also maps some more other worldgen stuff.