### PR TITLE
Map the remaining VoxelShape fields

### DIFF
--- a/mappings/net/minecraft/block/AbstractFireBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractFireBlock.mapping
@@ -1,5 +1,11 @@
 CLASS net/minecraft/class_4770 net/minecraft/block/AbstractFireBlock
 	FIELD field_22088 damage F
+	FIELD field_22497 UP_SHAPE Lnet/minecraft/class_265;
+	FIELD field_22498 BASE_SHAPE Lnet/minecraft/class_265;
+	FIELD field_22499 WEST_SHAPE Lnet/minecraft/class_265;
+	FIELD field_22500 EAST_SHAPE Lnet/minecraft/class_265;
+	FIELD field_22501 NORTH_SHAPE Lnet/minecraft/class_265;
+	FIELD field_22502 SOUTH_SHAPE Lnet/minecraft/class_265;
 	METHOD <init> (Lnet/minecraft/class_4970$class_2251;F)V
 		ARG 1 settings
 		ARG 2 damage

--- a/mappings/net/minecraft/block/RedstoneWireBlock.mapping
+++ b/mappings/net/minecraft/block/RedstoneWireBlock.mapping
@@ -6,7 +6,8 @@ CLASS net/minecraft/class_2457 net/minecraft/block/RedstoneWireBlock
 	FIELD field_11438 wiresGivePower Z
 	FIELD field_11439 WIRE_CONNECTION_WEST Lnet/minecraft/class_2754;
 	FIELD field_11440 WIRE_CONNECTION_NORTH Lnet/minecraft/class_2754;
-	FIELD field_24733 dotShape Lnet/minecraft/class_2680;
+	FIELD field_24413 DOT_SHAPE Lnet/minecraft/class_265;
+	FIELD field_24733 dotState Lnet/minecraft/class_2680;
 	METHOD method_10477 getRenderConnectionType (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Lnet/minecraft/class_2773;
 	METHOD method_10479 updateNeighbors (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)V
 		ARG 1 world

--- a/mappings/net/minecraft/block/TwistingVinesPlantBlock.mapping
+++ b/mappings/net/minecraft/block/TwistingVinesPlantBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_4950 net/minecraft/block/TwistingVinesPlantBlock
+	FIELD field_23325 SHAPE Lnet/minecraft/class_265;

--- a/mappings/net/minecraft/block/WallBlock.mapping
+++ b/mappings/net/minecraft/block/WallBlock.mapping
@@ -7,6 +7,11 @@ CLASS net/minecraft/class_2544 net/minecraft/block/WallBlock
 	FIELD field_22160 WATERLOGGED Lnet/minecraft/class_2746;
 	FIELD field_22161 shapeMap Ljava/util/Map;
 	FIELD field_22162 collisionShapeMap Ljava/util/Map;
+	FIELD field_22163 TALL_POST_SHAPE Lnet/minecraft/class_265;
+	FIELD field_22164 TALL_NORTH_SHAPE Lnet/minecraft/class_265;
+	FIELD field_22165 TALL_SOUTH_SHAPE Lnet/minecraft/class_265;
+	FIELD field_22166 TALL_WEST_SHAPE Lnet/minecraft/class_265;
+	FIELD field_22167 TALL_EAST_SHAPE Lnet/minecraft/class_265;
 	METHOD method_16704 shouldConnectTo (Lnet/minecraft/class_2680;ZLnet/minecraft/class_2350;)Z
 		ARG 1 state
 		ARG 2 faceFullSquare

--- a/mappings/net/minecraft/block/WeepingVinesPlantBlock.mapping
+++ b/mappings/net/minecraft/block/WeepingVinesPlantBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_4951 net/minecraft/block/WeepingVinesPlantBlock
+	FIELD field_23326 SHAPE Lnet/minecraft/class_265;


### PR DESCRIPTION
This pull request maps the remaining unmapped `VoxelShape` fields in `AbstractFireBlock`, `WallBlock`, `RedstoneWireBlock`, `WeepingVinesPlantBlock`, and `TwistingVinesPlantBlock`.