### PR TITLE
Map unmapped fields that have getter methods

### DIFF
--- a/mappings/net/minecraft/client/gui/hud/spectator/TeleportToSpecificPlayerSpectatorCommand.mapping
+++ b/mappings/net/minecraft/client/gui/hud/spectator/TeleportToSpecificPlayerSpectatorCommand.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_530 net/minecraft/client/gui/hud/spectator/TeleportToSpecificPlayerSpectatorCommand
+	FIELD field_26611 name Lnet/minecraft/class_2585;
 	FIELD field_3252 skinId Lnet/minecraft/class_2960;
 	FIELD field_3253 gameProfile Lcom/mojang/authlib/GameProfile;
 	METHOD <init> (Lcom/mojang/authlib/GameProfile;)V

--- a/mappings/net/minecraft/client/recipebook/ClientRecipeBook.mapping
+++ b/mappings/net/minecraft/client/recipebook/ClientRecipeBook.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_299 net/minecraft/client/recipebook/ClientRecipeBook
 	FIELD field_1638 resultsByGroup Ljava/util/Map;
+	FIELD field_25778 orderedResults Ljava/util/List;
 	METHOD method_1393 getOrderedResults ()Ljava/util/List;
 	METHOD method_1396 getResultsForGroup (Lnet/minecraft/class_314;)Ljava/util/List;
 		ARG 1 category

--- a/mappings/net/minecraft/client/render/entity/model/GhastEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/GhastEntityModel.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_567 net/minecraft/client/render/entity/model/GhastEntityModel
+	FIELD field_20929 getParts Lcom/google/common/collect/ImmutableList;

--- a/mappings/net/minecraft/client/render/entity/model/GhastEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/GhastEntityModel.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_567 net/minecraft/client/render/entity/model/GhastEntityModel
-	FIELD field_20929 getParts Lcom/google/common/collect/ImmutableList;
+	FIELD field_20929 parts Lcom/google/common/collect/ImmutableList;

--- a/mappings/net/minecraft/client/render/entity/model/MagmaCubeEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/MagmaCubeEntityModel.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/class_576 net/minecraft/client/render/entity/model/MagmaCubeEntityModel
+	FIELD field_20934 parts Lcom/google/common/collect/ImmutableList;
 	FIELD field_3428 innerCube Lnet/minecraft/class_630;

--- a/mappings/net/minecraft/client/render/entity/model/SilverfishEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SilverfishEntityModel.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_604 net/minecraft/client/render/entity/model/SilverfishEntityModel
+	FIELD field_20941 parts Lcom/google/common/collect/ImmutableList;

--- a/mappings/net/minecraft/client/render/entity/model/SquidEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SquidEntityModel.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/class_610 net/minecraft/client/render/entity/model/SquidEntityModel
+	FIELD field_20942 parts Lcom/google/common/collect/ImmutableList;
 	FIELD field_3575 head Lnet/minecraft/class_630;

--- a/mappings/net/minecraft/client/render/entity/model/WitherEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/WitherEntityModel.mapping
@@ -1,3 +1,4 @@
 CLASS net/minecraft/class_621 net/minecraft/client/render/entity/model/WitherEntityModel
+	FIELD field_20943 parts Lcom/google/common/collect/ImmutableList;
 	METHOD <init> (F)V
 		ARG 1 scale

--- a/mappings/net/minecraft/client/render/model/BuiltinBakedModel.mapping
+++ b/mappings/net/minecraft/client/render/model/BuiltinBakedModel.mapping
@@ -1,8 +1,10 @@
 CLASS net/minecraft/class_1090 net/minecraft/client/render/model/BuiltinBakedModel
 	FIELD field_16594 sprite Lnet/minecraft/class_1058;
+	FIELD field_21862 sideLit Z
 	FIELD field_5404 transformation Lnet/minecraft/class_809;
 	FIELD field_5405 itemPropertyOverrides Lnet/minecraft/class_806;
 	METHOD <init> (Lnet/minecraft/class_809;Lnet/minecraft/class_806;Lnet/minecraft/class_1058;Z)V
 		ARG 1 transformation
 		ARG 2 itemPropertyOverrides
 		ARG 3 sprite
+		ARG 4 sideLit

--- a/mappings/net/minecraft/client/render/model/MultipartBakedModel.mapping
+++ b/mappings/net/minecraft/client/render/model/MultipartBakedModel.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_1095 net/minecraft/client/render/model/MultipartBakedModel
+	FIELD field_21863 sideLit Z
 	FIELD field_5425 sprite Lnet/minecraft/class_1058;
 	FIELD field_5426 transformations Lnet/minecraft/class_809;
 	FIELD field_5427 components Ljava/util/List;

--- a/mappings/net/minecraft/client/resource/language/LanguageManager.mapping
+++ b/mappings/net/minecraft/client/resource/language/LanguageManager.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_1076 net/minecraft/client/resource/language/LanguageManager
+	FIELD field_25292 language Lnet/minecraft/class_1077;
 	FIELD field_5323 currentLanguageCode Ljava/lang/String;
 	FIELD field_5324 languageDefs Ljava/util/Map;
 	FIELD field_5325 LOGGER Lorg/apache/logging/log4j/Logger;

--- a/mappings/net/minecraft/client/world/ClientWorld.mapping
+++ b/mappings/net/minecraft/client/world/ClientWorld.mapping
@@ -113,6 +113,7 @@ CLASS net/minecraft/class_638 net/minecraft/client/world/ClientWorld
 		FIELD field_24441 difficulty Lnet/minecraft/class_1267;
 		FIELD field_24442 difficultyLocked Z
 		FIELD field_24607 flatWorld Z
+		FIELD field_26372 spawnAngle F
 		METHOD <init> (Lnet/minecraft/class_1267;ZZ)V
 			ARG 1 difficulty
 			ARG 2 hardcore

--- a/mappings/net/minecraft/entity/ai/brain/Activity.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/Activity.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_4168 net/minecraft/entity/ai/brain/Activity
 	FIELD field_18600 id Ljava/lang/String;
+	FIELD field_23827 hashCode I
 	METHOD <init> (Ljava/lang/String;)V
 		ARG 1 id
 	METHOD method_19210 register (Ljava/lang/String;)Lnet/minecraft/class_4168;

--- a/mappings/net/minecraft/entity/ai/brain/MemoryModuleType.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/MemoryModuleType.mapping
@@ -1,9 +1,9 @@
 CLASS net/minecraft/class_4140 net/minecraft/entity/ai/brain/MemoryModuleType
-	FIELD field_24668 factory Ljava/util/Optional;
+	FIELD field_24668 codec Ljava/util/Optional;
 	METHOD <init> (Ljava/util/Optional;)V
 		ARG 1 factory
 	METHOD method_19092 register (Ljava/lang/String;Lcom/mojang/serialization/Codec;)Lnet/minecraft/class_4140;
 		ARG 0 id
-	METHOD method_19093 getFactory ()Ljava/util/Optional;
+	METHOD method_19093 getCodec ()Ljava/util/Optional;
 	METHOD method_20738 register (Ljava/lang/String;)Lnet/minecraft/class_4140;
 		ARG 0 id

--- a/mappings/net/minecraft/entity/ai/brain/MemoryModuleType.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/MemoryModuleType.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_4140 net/minecraft/entity/ai/brain/MemoryModuleType
+	FIELD field_24668 factory Ljava/util/Optional;
 	METHOD <init> (Ljava/util/Optional;)V
 		ARG 1 factory
 	METHOD method_19092 register (Ljava/lang/String;Lcom/mojang/serialization/Codec;)Lnet/minecraft/class_4140;

--- a/mappings/net/minecraft/entity/passive/IronGolemEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/IronGolemEntity.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_1439 net/minecraft/entity/passive/IronGolemEntity
+	FIELD field_25366 angerTime I
+	FIELD field_25367 angryAt Ljava/util/UUID;
 	FIELD field_6759 lookingAtVillagerTicksLeft I
 	FIELD field_6762 attackTicksLeft I
 	FIELD field_6763 IRON_GOLEM_FLAGS Lnet/minecraft/class_2940;

--- a/mappings/net/minecraft/network/packet/s2c/play/UnlockRecipesS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/UnlockRecipesS2CPacket.mapping
@@ -2,9 +2,11 @@ CLASS net/minecraft/class_2713 net/minecraft/network/packet/s2c/play/UnlockRecip
 	FIELD field_12408 action Lnet/minecraft/class_2713$class_2714;
 	FIELD field_12409 recipeIdsToInit Ljava/util/List;
 	FIELD field_12414 recipeIdsToChange Ljava/util/List;
-	FIELD field_25797 furnaceFilteringCraftable Lnet/minecraft/class_5411;
+	FIELD field_25797 options Lnet/minecraft/class_5411;
+	METHOD <init> (Lnet/minecraft/class_2713$class_2714;Ljava/util/Collection;Ljava/util/Collection;Lnet/minecraft/class_5411;)V
+		ARG 4 options
 	METHOD method_11750 getRecipeIdsToChange ()Ljava/util/List;
 	METHOD method_11751 getAction ()Lnet/minecraft/class_2713$class_2714;
-	METHOD method_11756 isFurnaceFilteringCraftable ()Lnet/minecraft/class_5411;
+	METHOD method_11756 getOptions ()Lnet/minecraft/class_5411;
 	METHOD method_11757 getRecipeIdsToInit ()Ljava/util/List;
 	CLASS class_2714 Action

--- a/mappings/net/minecraft/network/packet/s2c/play/UnlockRecipesS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/UnlockRecipesS2CPacket.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/class_2713 net/minecraft/network/packet/s2c/play/UnlockRecip
 	FIELD field_12408 action Lnet/minecraft/class_2713$class_2714;
 	FIELD field_12409 recipeIdsToInit Ljava/util/List;
 	FIELD field_12414 recipeIdsToChange Ljava/util/List;
+	FIELD field_25797 furnaceFilteringCraftable Lnet/minecraft/class_5411;
 	METHOD method_11750 getRecipeIdsToChange ()Ljava/util/List;
 	METHOD method_11751 getAction ()Lnet/minecraft/class_2713$class_2714;
 	METHOD method_11756 isFurnaceFilteringCraftable ()Lnet/minecraft/class_5411;

--- a/mappings/net/minecraft/screen/AbstractFurnaceScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/AbstractFurnaceScreenHandler.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_1720 net/minecraft/screen/AbstractFurnaceScreenHandler
 	FIELD field_17286 propertyDelegate Lnet/minecraft/class_3913;
 	FIELD field_17494 recipeType Lnet/minecraft/class_3956;
+	FIELD field_25762 category Lnet/minecraft/class_5421;
 	FIELD field_7822 world Lnet/minecraft/class_1937;
 	FIELD field_7824 inventory Lnet/minecraft/class_1263;
 	METHOD <init> (Lnet/minecraft/class_3917;Lnet/minecraft/class_3956;Lnet/minecraft/class_5421;ILnet/minecraft/class_1661;)V

--- a/mappings/net/minecraft/server/function/FunctionLoader.mapping
+++ b/mappings/net/minecraft/server/function/FunctionLoader.mapping
@@ -3,9 +3,10 @@ CLASS net/minecraft/class_5349 net/minecraft/server/function/FunctionLoader
 	FIELD field_25327 PATH_PREFIX_LENGTH I
 	FIELD field_25328 PATH_SUFFIX_LENGTH I
 	FIELD field_25329 functions Ljava/util/Map;
-	FIELD field_25330 tags Lnet/minecraft/class_3503;
+	FIELD field_25330 tagLoader Lnet/minecraft/class_3503;
 	FIELD field_25331 level I
 	FIELD field_25332 commandDispatcher Lcom/mojang/brigadier/CommandDispatcher;
+	FIELD field_25801 tags Lnet/minecraft/class_5414;
 	METHOD <init> (ILcom/mojang/brigadier/CommandDispatcher;)V
 		ARG 1 level
 		ARG 2 commandDispatcher

--- a/mappings/net/minecraft/world/biome/BiomeParticleConfig.mapping
+++ b/mappings/net/minecraft/world/biome/BiomeParticleConfig.mapping
@@ -1,8 +1,8 @@
 CLASS net/minecraft/class_4761 net/minecraft/world/biome/BiomeParticleConfig
 	FIELD field_22035 chance F
 	FIELD field_24675 CODEC Lcom/mojang/serialization/Codec;
-	FIELD field_24676 particleType Lnet/minecraft/class_2394;
+	FIELD field_24676 particle Lnet/minecraft/class_2394;
 	METHOD <init> (Lnet/minecraft/class_2394;F)V
-		ARG 1 particleType
-	METHOD method_24369 getParticleType ()Lnet/minecraft/class_2394;
+		ARG 1 particle
+	METHOD method_24369 getParticle ()Lnet/minecraft/class_2394;
 	METHOD method_24370 shouldAddParticle (Ljava/util/Random;)Z

--- a/mappings/net/minecraft/world/biome/BiomeParticleConfig.mapping
+++ b/mappings/net/minecraft/world/biome/BiomeParticleConfig.mapping
@@ -1,5 +1,8 @@
 CLASS net/minecraft/class_4761 net/minecraft/world/biome/BiomeParticleConfig
 	FIELD field_22035 chance F
 	FIELD field_24675 CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_24676 particleType Lnet/minecraft/class_2394;
+	METHOD <init> (Lnet/minecraft/class_2394;F)V
+		ARG 1 particleType
 	METHOD method_24369 getParticleType ()Lnet/minecraft/class_2394;
 	METHOD method_24370 shouldAddParticle (Ljava/util/Random;)Z

--- a/mappings/net/minecraft/world/gen/chunk/ChunkGeneratorType.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/ChunkGeneratorType.mapping
@@ -2,16 +2,22 @@ CLASS net/minecraft/class_5284 net/minecraft/world/gen/chunk/ChunkGeneratorType
 	FIELD field_24514 defaultBlock Lnet/minecraft/class_2680;
 	FIELD field_24515 defaultFluid Lnet/minecraft/class_2680;
 	FIELD field_24516 config Lnet/minecraft/class_5311;
+	FIELD field_24782 noiseConfig Lnet/minecraft/class_5309;
 	FIELD field_24783 bedrockCeilingY I
 	FIELD field_24784 bedrockFloorY I
+	FIELD field_24785 seaLevel I
 	METHOD <init> (Lnet/minecraft/class_5311;Lnet/minecraft/class_5309;Lnet/minecraft/class_2680;Lnet/minecraft/class_2680;IIIZ)V
 		ARG 1 config
+		ARG 2 noiseConfig
 		ARG 3 defaultBlock
 		ARG 4 defaultFluid
+		ARG 7 seaLevel
 	METHOD <init> (Lnet/minecraft/class_5311;Lnet/minecraft/class_5309;Lnet/minecraft/class_2680;Lnet/minecraft/class_2680;IIIZLjava/util/Optional;)V
 		ARG 1 config
+		ARG 2 noiseConfig
 		ARG 3 defaultBlock
 		ARG 4 defaultFluid
+		ARG 7 seaLevel
 	METHOD method_16400 getBedrockCeilingY ()I
 		COMMENT Returns the Y level of the bedrock ceiling.
 		COMMENT


### PR DESCRIPTION
This pull request maps most unmapped fields that have getter methods. In addition, it maps the constructor arguments used to set these fields if applicable.

`ChunkGenerator.field_24747`, despite being returned by the `ChunkGenerator.getBiomeSource` method, was not mapped as there is an existing `ChunkGenerator.biomeSource` already.