### PR TITLE
Improve AdvancementFrame mappings

### DIFF
--- a/mappings/net/minecraft/advancement/AdvancementFrame.mapping
+++ b/mappings/net/minecraft/advancement/AdvancementFrame.mapping
@@ -2,10 +2,12 @@ CLASS net/minecraft/class_189 net/minecraft/advancement/AdvancementFrame
 	FIELD field_1251 id Ljava/lang/String;
 	FIELD field_1252 texV I
 	FIELD field_1255 titleFormat Lnet/minecraft/class_124;
+	FIELD field_26386 toastText Lnet/minecraft/class_2561;
 	METHOD <init> (Ljava/lang/String;ILjava/lang/String;ILnet/minecraft/class_124;)V
 		ARG 3 id
 		ARG 4 texV
 		ARG 5 titleFormat
+	METHOD method_30756 getToastText ()Lnet/minecraft/class_2561;
 	METHOD method_830 getTitleFormat ()Lnet/minecraft/class_124;
 	METHOD method_831 getId ()Ljava/lang/String;
 	METHOD method_832 texV ()I

--- a/mappings/net/minecraft/advancement/AdvancementFrame.mapping
+++ b/mappings/net/minecraft/advancement/AdvancementFrame.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_189 net/minecraft/advancement/AdvancementFrame
 	FIELD field_1251 id Ljava/lang/String;
-	FIELD field_1252 texV I
+	FIELD field_1252 textureV I
 	FIELD field_1255 titleFormat Lnet/minecraft/class_124;
 	FIELD field_26386 toastText Lnet/minecraft/class_2561;
 	METHOD <init> (Ljava/lang/String;ILjava/lang/String;ILnet/minecraft/class_124;)V
@@ -10,6 +10,6 @@ CLASS net/minecraft/class_189 net/minecraft/advancement/AdvancementFrame
 	METHOD method_30756 getToastText ()Lnet/minecraft/class_2561;
 	METHOD method_830 getTitleFormat ()Lnet/minecraft/class_124;
 	METHOD method_831 getId ()Ljava/lang/String;
-	METHOD method_832 texV ()I
+	METHOD method_832 getTextureV ()I
 	METHOD method_833 forName (Ljava/lang/String;)Lnet/minecraft/class_189;
 		ARG 0 name


### PR DESCRIPTION
This pull request modifies the `texV` field and its getter method, which haven't changed for [over 3 years](https://github.com/FabricMC/yarn/blame/781eb35cc9c87cefcc638f245b6f3e11daeeceec/mappings/net/minecraft/advancement/AdvancementFrame.mapping), to fit modern Yarn conventions. In addition, it maps the `toastText` field and its getter method, which are used to show the 'Advancement Made!' and similar text in advancement toasts.