### PR TITLE
Rename the IS_PUMPKIN_PREDICATE field to IS_GOLEM_HEAD_PREDICATE

### DIFF
--- a/mappings/net/minecraft/block/CarvedPumpkinBlock.mapping
+++ b/mappings/net/minecraft/block/CarvedPumpkinBlock.mapping
@@ -2,10 +2,12 @@ CLASS net/minecraft/class_2276 net/minecraft/block/CarvedPumpkinBlock
 	FIELD field_10748 FACING Lnet/minecraft/class_2753;
 	FIELD field_10749 snowGolemDispenserPattern Lnet/minecraft/class_2700;
 	FIELD field_10750 snowGolemPattern Lnet/minecraft/class_2700;
-	FIELD field_10751 IS_PUMPKIN_PREDICATE Ljava/util/function/Predicate;
+	FIELD field_10751 IS_GOLEM_HEAD_PREDICATE Ljava/util/function/Predicate;
 	FIELD field_10752 ironGolemDispenserPattern Lnet/minecraft/class_2700;
 	FIELD field_10753 ironGolemPattern Lnet/minecraft/class_2700;
 	METHOD method_9727 getIronGolemDispenserPattern ()Lnet/minecraft/class_2700;
+	METHOD method_9728 (Lnet/minecraft/class_2680;)Z
+		ARG 0 state
 	METHOD method_9729 getSnowGolemPattern ()Lnet/minecraft/class_2700;
 	METHOD method_9730 getIronGolemPattern ()Lnet/minecraft/class_2700;
 	METHOD method_9731 trySpawnEntity (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)V


### PR DESCRIPTION
This predicate is used to match carved pumpkins and jack o' lanterns for iron and snow golem heads.