### PR TITLE
Fix wrong param name in worldChanged

### DIFF
--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -114,7 +114,7 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	METHOD method_17668 setCameraPosition (Lnet/minecraft/class_4076;)V
 		ARG 1 cameraPosition
 	METHOD method_18783 worldChanged (Lnet/minecraft/class_3218;)V
-		ARG 1 targetWorld
+		ARG 1 origin
 	METHOD method_26280 getSpawnPointPosition ()Lnet/minecraft/class_2338;
 	METHOD method_26281 getSpawnPointDimension ()Lnet/minecraft/class_5321;
 	METHOD method_26282 isSpawnPointSet ()Z


### PR DESCRIPTION
The parameter is the original world the player was in, not the destination world.