### PR TITLE
Fix naming of blockState in ChunkDeltaUpdate packet

### DIFF
--- a/mappings/net/minecraft/network/packet/s2c/play/ChunkDeltaUpdateS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/ChunkDeltaUpdateS2CPacket.mapping
@@ -1,16 +1,15 @@
 CLASS net/minecraft/class_2637 net/minecraft/network/packet/s2c/play/ChunkDeltaUpdateS2CPacket
 	FIELD field_26345 sectionPos Lnet/minecraft/class_4076;
-	FIELD field_26346 packedLocalPos [S
-		COMMENT The packed local positions {@see ChunkSectionPos#getPackedLocalPos} for
-		COMMENT each entry in {@see #blockState}.
-	FIELD field_26347 blockState [Lnet/minecraft/class_2680;
+	FIELD field_26346 positions [S
+		COMMENT The packed local positions {@see ChunkSectionPos#getPackedLocalPos} for each entry in {@see #blockStates}.
+	FIELD field_26347 blockStates [Lnet/minecraft/class_2680;
 	METHOD <init> (Lnet/minecraft/class_4076;Lit/unimi/dsi/fastutil/shorts/ShortSet;Lnet/minecraft/class_2826;)V
 		ARG 1 sectionPos
 			COMMENT the position of the given chunk section that will be sent to the client
-		ARG 2 updatedLocalPosSet
+		ARG 2 updatedPositions
 			COMMENT the set of packed local positions within the given chunk section that should be included in the packet
 		ARG 3 section
 	METHOD method_30620 allocateBuffers (I)V
-		ARG 1 posCount
+		ARG 1 positionCount
 	METHOD method_30621 visitUpdates (Ljava/util/function/BiConsumer;)V
 		COMMENT Calls the given consumer for each pair of block position and block state contained in this packet.


### PR DESCRIPTION
It was pointed out to me that naming an array of BlockStates "blockState" is bad, so here's the fix for that and for added consistency, renamed "packedLocalPos" (I couldn't find a good plural) to "positions"