### PR TITLE
Remap misc world classes

### DIFF
--- a/mappings/net/minecraft/class_5459.mapping
+++ b/mappings/net/minecraft/class_5459.mapping
@@ -1,7 +1,0 @@
-CLASS net/minecraft/class_5459
-	CLASS class_5461 IntBounds
-		FIELD field_25939 min I
-		FIELD field_25940 max I
-		METHOD <init> (II)V
-			ARG 1 min
-			ARG 2 max

--- a/mappings/net/minecraft/entity/ai/pathing/NavigationHelper.mapping
+++ b/mappings/net/minecraft/entity/ai/pathing/NavigationHelper.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_5493 net/minecraft/entity/ai/pathing/NavigationHelper
+	METHOD method_30955 hasMobNavigation (Lnet/minecraft/class_1308;)Z
+		ARG 0 mob

--- a/mappings/net/minecraft/world/BlockHelper.mapping
+++ b/mappings/net/minecraft/world/BlockHelper.mapping
@@ -1,0 +1,17 @@
+CLASS net/minecraft/class_5459 net/minecraft/world/BlockHelper
+	METHOD method_30574 findContainingBox (Lnet/minecraft/class_2338;Lnet/minecraft/class_2350$class_2351;ILnet/minecraft/class_2350$class_2351;ILjava/util/function/Predicate;)Lnet/minecraft/class_5459$class_5460;
+	METHOD method_30575 getMaxDistance (Ljava/util/function/Predicate;Lnet/minecraft/class_2338$class_2339;Lnet/minecraft/class_2350;I)I
+	CLASS class_5460 BoxResult
+		FIELD field_25936 corner Lnet/minecraft/class_2338;
+		FIELD field_25937 xSize I
+		FIELD field_25938 zSize I
+		METHOD <init> (Lnet/minecraft/class_2338;II)V
+			ARG 1 corner
+			ARG 2 xSize
+			ARG 3 zSize
+	CLASS class_5461 IntBounds
+		FIELD field_25939 min I
+		FIELD field_25940 max I
+		METHOD <init> (II)V
+			ARG 1 min
+			ARG 2 max

--- a/mappings/net/minecraft/world/GeneralWorldAccess.mapping
+++ b/mappings/net/minecraft/world/GeneralWorldAccess.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_5423 net/minecraft/world/GeneralWorldAccess

--- a/mappings/net/minecraft/world/TimeAccess.mapping
+++ b/mappings/net/minecraft/world/TimeAccess.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_5424 net/minecraft/world/TimeAccess
+	METHOD method_30271 getDayTime ()J


### PR DESCRIPTION
Mojang is starting a habit of making small classes with a few helper methods which makes it difficult to give them meaningful names.