### PR TITLE
TransformingVertexConsumer -> OverlayVertexConsumer

### DIFF
--- a/mappings/net/minecraft/client/render/OverlayVertexConsumer.mapping
+++ b/mappings/net/minecraft/client/render/OverlayVertexConsumer.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4583 net/minecraft/client/render/TransformingVertexConsumer
+CLASS net/minecraft/class_4583 net/minecraft/client/render/OverlayVertexConsumer
 	FIELD field_20866 vertexConsumer Lnet/minecraft/class_4588;
 	FIELD field_20870 x F
 	FIELD field_20871 y F

--- a/mappings/net/minecraft/client/render/item/ItemRenderer.mapping
+++ b/mappings/net/minecraft/client/render/item/ItemRenderer.mapping
@@ -72,8 +72,8 @@ CLASS net/minecraft/class_918 net/minecraft/client/render/item/ItemRenderer
 	METHOD method_29711 getDirectGlintVertexConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;ZZ)Lnet/minecraft/class_4588;
 		ARG 1 layer
 		ARG 3 glint
-	METHOD method_30114 getTransformingGlintVertexConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;Lnet/minecraft/class_4587$class_4665;)Lnet/minecraft/class_4588;
-	METHOD method_30115 getTransformingDirectGlintVertexConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;Lnet/minecraft/class_4587$class_4665;)Lnet/minecraft/class_4588;
+	METHOD method_30114 getGlintVertexConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;Lnet/minecraft/class_4587$class_4665;)Lnet/minecraft/class_4588;
+	METHOD method_30115 getDirectGlintVertexConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;Lnet/minecraft/class_4587$class_4665;)Lnet/minecraft/class_4588;
 	METHOD method_4004 renderGuiQuad (Lnet/minecraft/class_287;IIIIIIII)V
 		ARG 1 buffer
 		ARG 2 x


### PR DESCRIPTION
What is currently named TransformingVertexConsumer transforms input normals and ignores input texture coordinates. Instead, it computes texture coordinates based on the input vertex position and normal.

While it technically _is_ a transforming vertex consumer, it is not as general purpose as the name might imply. Minecraft uses its texture coordinate transformation for overlays on models such as enchantment glints and the cracks showing block breaking progress. It is not useful for much else.