### PR TITLE
Miscellaneous Text and TranslatableText mappings

### DIFF
--- a/mappings/net/minecraft/text/Text.mapping
+++ b/mappings/net/minecraft/text/Text.mapping
@@ -42,6 +42,10 @@ CLASS net/minecraft/class_2561 net/minecraft/text/Text
 		COMMENT <p>A shallow copy is made for the siblings.</p>
 	METHOD method_27662 copy ()Lnet/minecraft/class_5250;
 		COMMENT Copies the text itself, excluding the styles or siblings.
+	METHOD method_30163 fromString (Ljava/lang/String;)Lnet/minecraft/class_2561;
+		COMMENT Creates a {@link Text} instance from a nullable string.
+		COMMENT @return the {@link Text} instance created from {@code string}
+		COMMENT @param string a nullable string.
 	CLASS class_2562 Serializer
 		COMMENT A JSON serializer for {@link Text}.
 		FIELD field_11752 JSON_READER_LINE_START Ljava/lang/reflect/Field;

--- a/mappings/net/minecraft/text/Text.mapping
+++ b/mappings/net/minecraft/text/Text.mapping
@@ -42,10 +42,9 @@ CLASS net/minecraft/class_2561 net/minecraft/text/Text
 		COMMENT <p>A shallow copy is made for the siblings.</p>
 	METHOD method_27662 copy ()Lnet/minecraft/class_5250;
 		COMMENT Copies the text itself, excluding the styles or siblings.
-	METHOD method_30163 fromString (Ljava/lang/String;)Lnet/minecraft/class_2561;
-		COMMENT Creates a {@link Text} instance from a nullable string.
-		COMMENT @return the {@link Text} instance created from {@code string}
-		COMMENT @param string a nullable string.
+	METHOD method_30163 of (Ljava/lang/String;)Lnet/minecraft/class_2561;
+		COMMENT Creates a literal text with the given string as content.
+		ARG 0 string
 	CLASS class_2562 Serializer
 		COMMENT A JSON serializer for {@link Text}.
 		FIELD field_11752 JSON_READER_LINE_START Ljava/lang/reflect/Field;

--- a/mappings/net/minecraft/text/TranslatableText.mapping
+++ b/mappings/net/minecraft/text/TranslatableText.mapping
@@ -17,3 +17,5 @@ CLASS net/minecraft/class_2588 net/minecraft/text/TranslatableText
 	METHOD method_11024 setTranslation (Ljava/lang/String;)V
 		ARG 1 translation
 	METHOD method_11025 updateTranslations ()V
+	METHOD method_29434 getArg (I)Lnet/minecraft/class_5348;
+		ARG 1 index


### PR DESCRIPTION
* `Text.fromString(String)` returns a `LiteralText` instance constructed from the passed string (or the `EMPTY` constant in case of null). Alternatives: `asText`, `asLiteralText`. No known overrides.
* `TranslatableText.getArg(int)` returns an integer-indexed element of the `args` field (see: `#getArgs`), throwing an exception on out-of-bounds access with following message: `Invalid index %d requested for %s`.

This PR conflicts with #1635 , though we're mapping two different methods.