### PR TITLE
Rename the WoodButtonBlock class to WoodenButtonBlock

### DIFF
--- a/mappings/net/minecraft/block/WoodButtonBlock.mapping
+++ b/mappings/net/minecraft/block/WoodButtonBlock.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_2571 net/minecraft/block/WoodButtonBlock

--- a/mappings/net/minecraft/block/WoodenButtonBlock.mapping
+++ b/mappings/net/minecraft/block/WoodenButtonBlock.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2571 net/minecraft/block/WoodenButtonBlock


### PR DESCRIPTION
This pull request renames the `WoodButtonBlock` class to `WoodenButtonBlock`, as the sound events it uses are `block.wooden_button.click_on` and `block.wooden_button.click_off`. In addition, this naming is consistent with the 'Wooden Button' name used before 1.13.