### PR TITLE
Minor nbt stuff

### DIFF
--- a/mappings/net/minecraft/nbt/AbstractListTag.mapping
+++ b/mappings/net/minecraft/nbt/AbstractListTag.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_2483 net/minecraft/nbt/AbstractListTag
 	METHOD add (ILjava/lang/Object;)V
-		ARG 1 value
+		ARG 1 index
+		ARG 2 value
 	METHOD method_10533 addTag (ILnet/minecraft/class_2520;)Z
 		ARG 1 index
 		ARG 2 tag
@@ -12,3 +13,4 @@ CLASS net/minecraft/class_2483 net/minecraft/nbt/AbstractListTag
 		ARG 1 index
 	METHOD set (ILjava/lang/Object;)Ljava/lang/Object;
 		ARG 1 index
+		ARG 2 value

--- a/mappings/net/minecraft/nbt/CompoundTag.mapping
+++ b/mappings/net/minecraft/nbt/CompoundTag.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/class_2487 net/minecraft/nbt/CompoundTag
 	FIELD field_11515 tags Ljava/util/Map;
 	FIELD field_11516 PATTERN Ljava/util/regex/Pattern;
 	FIELD field_21029 READER Lnet/minecraft/class_4614;
+	FIELD field_25128 CODEC Lcom/mojang/serialization/Codec;
 	METHOD <init> (Ljava/util/Map;)V
 		ARG 1 tags
 	METHOD equals (Ljava/lang/Object;)Z
@@ -124,3 +125,4 @@ CLASS net/minecraft/class_2487 net/minecraft/nbt/CompoundTag
 		COMMENT Returns {@code true} if this {@code CompoundTag} contains a valid UUID representation associated with the given key.
 		COMMENT A valid UUID is represented by an int array of length 4.
 		ARG 1 key
+	METHOD method_29143 toMap ()Ljava/util/Map;

--- a/mappings/net/minecraft/nbt/NbtIo.mapping
+++ b/mappings/net/minecraft/nbt/NbtIo.mapping
@@ -7,6 +7,7 @@ CLASS net/minecraft/class_2507 net/minecraft/nbt/NbtIo
 		ARG 1 depth
 		ARG 2 tracker
 	METHOD method_10627 read (Ljava/io/DataInput;)Lnet/minecraft/class_2487;
+		ARG 0 input
 	METHOD method_10628 write (Lnet/minecraft/class_2487;Ljava/io/DataOutput;)V
 		ARG 0 tag
 		ARG 1 output
@@ -23,3 +24,8 @@ CLASS net/minecraft/class_2507 net/minecraft/nbt/NbtIo
 	METHOD method_10634 writeCompressed (Lnet/minecraft/class_2487;Ljava/io/OutputStream;)V
 		ARG 0 tag
 		ARG 1 stream
+	METHOD method_30613 readCompressed (Ljava/io/File;)Lnet/minecraft/class_2487;
+		ARG 0 file
+	METHOD method_30614 writeCompressed (Lnet/minecraft/class_2487;Ljava/io/File;)V
+		ARG 0 tag
+		ARG 1 file


### PR DESCRIPTION
See #1649 for that `toMap` (only usage, protected, copies the content of this compound tag to an immutable map and return the map)
Signed-off-by: liach <liach@users.noreply.github.com>