### PR TITLE
Fix wrong method name in ItemGroup.

### DIFF
--- a/mappings/net/minecraft/item/ItemGroup.mapping
+++ b/mappings/net/minecraft/item/ItemGroup.mapping
@@ -48,6 +48,6 @@ CLASS net/minecraft/class_1761 net/minecraft/item/ItemGroup
 	METHOD method_7753 setTexture (Ljava/lang/String;)Lnet/minecraft/class_1761;
 		ARG 1 texture
 	METHOD method_7754 shouldRenderName ()Z
-		COMMENT Checks if this item group should render it's name.
+		COMMENT Checks if this item group should render its name.
 	METHOD method_7755 isTopRow ()Z
 	METHOD method_7756 hasScrollbar ()Z

--- a/mappings/net/minecraft/item/ItemGroup.mapping
+++ b/mappings/net/minecraft/item/ItemGroup.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_1761 net/minecraft/item/ItemGroup
 	FIELD field_7914 REDSTONE Lnet/minecraft/class_1761;
 	FIELD field_7915 SEARCH Lnet/minecraft/class_1761;
 	FIELD field_7916 COMBAT Lnet/minecraft/class_1761;
-	FIELD field_7917 renderTitle Z
+	FIELD field_7917 renderName Z
 	FIELD field_7918 INVENTORY Lnet/minecraft/class_1761;
 	FIELD field_7919 texture Ljava/lang/String;
 	FIELD field_7920 scrollbar Z

--- a/mappings/net/minecraft/item/ItemGroup.mapping
+++ b/mappings/net/minecraft/item/ItemGroup.mapping
@@ -39,7 +39,7 @@ CLASS net/minecraft/class_1761 net/minecraft/item/ItemGroup
 	METHOD method_7745 setEnchantments ([Lnet/minecraft/class_1886;)Lnet/minecraft/class_1761;
 		ARG 1 targets
 	METHOD method_7747 getIcon ()Lnet/minecraft/class_1799;
-	METHOD method_7748 dontRenderName ()Lnet/minecraft/class_1761;
+	METHOD method_7748 hideName ()Lnet/minecraft/class_1761;
 		COMMENT Specifies that when this item group is selected, the name of the item group should not be rendered.
 	METHOD method_7749 setNoScrollbar ()Lnet/minecraft/class_1761;
 	METHOD method_7750 createIcon ()Lnet/minecraft/class_1799;

--- a/mappings/net/minecraft/item/ItemGroup.mapping
+++ b/mappings/net/minecraft/item/ItemGroup.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_1761 net/minecraft/item/ItemGroup
 	FIELD field_7914 REDSTONE Lnet/minecraft/class_1761;
 	FIELD field_7915 SEARCH Lnet/minecraft/class_1761;
 	FIELD field_7916 COMBAT Lnet/minecraft/class_1761;
-	FIELD field_7917 tooltip Z
+	FIELD field_7917 renderTitle Z
 	FIELD field_7918 INVENTORY Lnet/minecraft/class_1761;
 	FIELD field_7919 texture Ljava/lang/String;
 	FIELD field_7920 scrollbar Z
@@ -39,13 +39,15 @@ CLASS net/minecraft/class_1761 net/minecraft/item/ItemGroup
 	METHOD method_7745 setEnchantments ([Lnet/minecraft/class_1886;)Lnet/minecraft/class_1761;
 		ARG 1 targets
 	METHOD method_7747 getIcon ()Lnet/minecraft/class_1799;
-	METHOD method_7748 setNoTooltip ()Lnet/minecraft/class_1761;
+	METHOD method_7748 dontRenderName ()Lnet/minecraft/class_1761;
+		COMMENT Specifies that when this item group is selected, the name of the item group should not be rendered.
 	METHOD method_7749 setNoScrollbar ()Lnet/minecraft/class_1761;
 	METHOD method_7750 createIcon ()Lnet/minecraft/class_1799;
 	METHOD method_7751 getName ()Ljava/lang/String;
 	METHOD method_7752 isSpecial ()Z
 	METHOD method_7753 setTexture (Ljava/lang/String;)Lnet/minecraft/class_1761;
 		ARG 1 texture
-	METHOD method_7754 hasTooltip ()Z
+	METHOD method_7754 shouldRenderName ()Z
+		COMMENT Checks if this item group should render it's name.
 	METHOD method_7755 isTopRow ()Z
 	METHOD method_7756 hasScrollbar ()Z

--- a/mappings/net/minecraft/item/ItemGroup.mapping
+++ b/mappings/net/minecraft/item/ItemGroup.mapping
@@ -49,5 +49,7 @@ CLASS net/minecraft/class_1761 net/minecraft/item/ItemGroup
 		ARG 1 texture
 	METHOD method_7754 shouldRenderName ()Z
 		COMMENT Checks if this item group should render its name.
+		COMMENT
+		COMMENT <p>The name is rendered below the top row of item groups and above the inventory.
 	METHOD method_7755 isTopRow ()Z
 	METHOD method_7756 hasScrollbar ()Z


### PR DESCRIPTION
`hasTooltip` does not control whether an item group tooltip renders, but rather if the group's name should render in the inventory