### PR TITLE
Map missing Framebuffer methods

### DIFF
--- a/mappings/net/minecraft/client/gl/Framebuffer.mapping
+++ b/mappings/net/minecraft/client/gl/Framebuffer.mapping
@@ -53,4 +53,5 @@ CLASS net/minecraft/class_276 net/minecraft/client/gl/Framebuffer
 		ARG 2 height
 		ARG 3 getError
 	METHOD method_29329 copyDepthFrom (Lnet/minecraft/class_276;)V
+	METHOD method_30277 getColorAttachment ()I
 	METHOD method_30278 getDepthAttachment ()I

--- a/mappings/net/minecraft/client/gl/Framebuffer.mapping
+++ b/mappings/net/minecraft/client/gl/Framebuffer.mapping
@@ -53,3 +53,4 @@ CLASS net/minecraft/class_276 net/minecraft/client/gl/Framebuffer
 		ARG 2 height
 		ARG 3 getError
 	METHOD method_29329 copyDepthFrom (Lnet/minecraft/class_276;)V
+	METHOD method_30278 getDepthAttachment ()I


### PR DESCRIPTION
This PR names two recently added getters for framebuffer color and depth attachments
