### PR TITLE
Rename interface relating to registry at world class

### DIFF
--- a/mappings/net/minecraft/RegistryProvider.mapping
+++ b/mappings/net/minecraft/RegistryProvider.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_5423 net/minecraft/RegistryProvider
+	METHOD method_30349 getRegistryManager ()Lnet/minecraft/class_5455;
+	METHOD method_31081 getBiomeRegistryKey (Lnet/minecraft/class_2338;)Ljava/util/Optional;
+		ARG 1 atPosition

--- a/mappings/net/minecraft/class_5423.mapping
+++ b/mappings/net/minecraft/class_5423.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/class_5423
-	METHOD method_30349 getRegistryManager ()Lnet/minecraft/class_5455;

--- a/mappings/net/minecraft/world/RegistryProvider.mapping
+++ b/mappings/net/minecraft/world/RegistryProvider.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_5423 net/minecraft/RegistryProvider
+CLASS net/minecraft/class_5423 net/minecraft/world/RegistryProvider
 	METHOD method_30349 getRegistryManager ()Lnet/minecraft/class_5455;
 	METHOD method_31081 getBiomeRegistryKey (Lnet/minecraft/class_2338;)Ljava/util/Optional;
 		ARG 1 atPosition


### PR DESCRIPTION
I use the name `RegistryProvider` for one of its methods to provide `DynamicRegistryManager` instance. However, most of the usage is to access `Registry.BIOME_KEY` and biome feature-related operation. Considering `DynamicRegistryManager` can be used for accessing other registry keys, I stick with `RegistryProvider` rather than `BiomeRegistryProvider` or so. 

~However, there are three redundant overrides to the extended interface method that has no relationship with registry. I have no idea why are they there and speculate that these methods may be properly overriden in the future.~ (It's hard to explain this part, pardon.) The overrides are to default them to the defaulted method of the right parent. e.g. Interface A and Interface B are exclusive but have the same method signature, but Interface A has it as a defaulted method, so an Interface C that extends A and B would like to use the defaulted method of Interface A. 

To add context, `class_5423` extends world-related interfaces: `EntityView`, `WorldView`, and `ModifiableTestableWorld` interfaces. All in all, I think this makes `class_5423` a world-specific interface.

The other change is made for the method_31081. It is pretty clear that the method is used to get the biome registry key from the given block position.

Also, I am new to contributing. I have read through contribution.md and pretty sure these mappings arent MCP/Mojang mapping. Do let me know what other stuffs that I am missing. Thanks.