### PR TITLE
Various entity mappings

### DIFF
--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -552,6 +552,8 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_5799 isTouchingWater ()Z
 		COMMENT Returns whether this entity's hitbox is touching water fluid.
 	METHOD method_5800 onStruckByLightning (Lnet/minecraft/class_3218;Lnet/minecraft/class_1538;)V
+		ARG 1 world
+		ARG 2 lightning
 	METHOD method_5801 playFlySound (F)F
 		ARG 1 distance
 	METHOD method_5802 getRotationClient ()Lnet/minecraft/class_241;

--- a/mappings/net/minecraft/entity/mob/DrownedEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/DrownedEntity.mapping
@@ -7,6 +7,7 @@ CLASS net/minecraft/class_1551 net/minecraft/entity/mob/DrownedEntity
 		ARG 1 pos
 	METHOD method_20673 canSpawn (Lnet/minecraft/class_1299;Lnet/minecraft/class_5425;Lnet/minecraft/class_3730;Lnet/minecraft/class_2338;Ljava/util/Random;)Z
 		ARG 0 type
+		ARG 1 world
 		ARG 2 spawnReason
 		ARG 3 pos
 		ARG 4 random

--- a/mappings/net/minecraft/entity/mob/EndermanEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/EndermanEntity.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/class_1560 net/minecraft/entity/mob/EndermanEntity
 	FIELD field_20618 PROVOKED Lnet/minecraft/class_2940;
 	FIELD field_25376 angerTime I
 	FIELD field_25377 targetUuid Ljava/util/UUID;
+	FIELD field_25378 ANGER_TIME_RANGE Lnet/minecraft/class_4801;
 	FIELD field_7252 ATTACKING_SPEED_BOOST Lnet/minecraft/class_1322;
 	FIELD field_7253 lastAngrySoundAge I
 	FIELD field_7254 ageWhenTargetSet I

--- a/mappings/net/minecraft/entity/mob/EndermiteEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/EndermiteEntity.mapping
@@ -11,3 +11,4 @@ CLASS net/minecraft/class_1559 net/minecraft/entity/mob/EndermiteEntity
 	METHOD method_7022 setPlayerSpawned (Z)V
 		ARG 1 playerSpawned
 	METHOD method_7023 isPlayerSpawned ()Z
+		COMMENT Returns whether this endermite was spawned from an enderpearl thrown by a player.

--- a/mappings/net/minecraft/entity/mob/EndermiteEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/EndermiteEntity.mapping
@@ -11,4 +11,4 @@ CLASS net/minecraft/class_1559 net/minecraft/entity/mob/EndermiteEntity
 	METHOD method_7022 setPlayerSpawned (Z)V
 		ARG 1 playerSpawned
 	METHOD method_7023 isPlayerSpawned ()Z
-		COMMENT Returns whether this endermite was spawned from an enderpearl thrown by a player.
+		COMMENT Returns whether this endermite was spawned from an ender pearl thrown by a player.

--- a/mappings/net/minecraft/entity/mob/MobEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/MobEntity.mapping
@@ -100,6 +100,7 @@ CLASS net/minecraft/class_1308 net/minecraft/entity/mob/MobEntity
 		ARG 2 penalty
 	METHOD method_5942 getNavigation ()Lnet/minecraft/class_1408;
 	METHOD method_5943 initialize (Lnet/minecraft/class_5425;Lnet/minecraft/class_1266;Lnet/minecraft/class_3730;Lnet/minecraft/class_1315;Lnet/minecraft/class_2487;)Lnet/minecraft/class_1315;
+		ARG 1 world
 		ARG 2 difficulty
 		ARG 3 spawnReason
 		ARG 4 entityData
@@ -152,7 +153,7 @@ CLASS net/minecraft/class_1308 net/minecraft/entity/mob/MobEntity
 		ARG 1 count
 	METHOD method_5970 getMinAmbientSoundDelay ()I
 	METHOD method_5971 setPersistent ()V
-	METHOD method_5972 isInDaylight ()Z
+	METHOD method_5972 isAffectedByDaylight ()Z
 	METHOD method_5974 canImmediatelyDespawn (D)Z
 		ARG 1 distanceSquared
 	METHOD method_5975 resetSoundDelay ()V

--- a/mappings/net/minecraft/entity/mob/PatrolEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/PatrolEntity.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/class_3732 net/minecraft/entity/mob/PatrolEntity
 	FIELD field_16478 patrolTarget Lnet/minecraft/class_2338;
 	FIELD field_16479 patrolLeader Z
 	METHOD method_16215 getPatrolTarget ()Lnet/minecraft/class_2338;
+		COMMENT Returns the position this patrol entity is walking to.
 	METHOD method_16216 setPatrolTarget (Lnet/minecraft/class_2338;)V
 		ARG 1 targetPos
 	METHOD method_16217 setPatrolLeader (Z)V

--- a/mappings/net/minecraft/entity/mob/PiglinBrain.mapping
+++ b/mappings/net/minecraft/entity/mob/PiglinBrain.mapping
@@ -41,8 +41,9 @@ CLASS net/minecraft/class_4838 net/minecraft/entity/mob/PiglinBrain
 	METHOD method_24732 create (Lnet/minecraft/class_4836;Lnet/minecraft/class_4095;)Lnet/minecraft/class_4095;
 		ARG 0 piglin
 		ARG 1 brain
-	METHOD method_24733 onGuardedBlockBroken (Lnet/minecraft/class_1657;Z)V
+	METHOD method_24733 onGuardedBlockInteraction (Lnet/minecraft/class_1657;Z)V
 		ARG 0 player
+		ARG 1 blockOpen
 	METHOD method_24734 (Lnet/minecraft/class_1657;Lnet/minecraft/class_4836;)V
 		ARG 1 piglin
 	METHOD method_24735 isGoldenItem (Lnet/minecraft/class_1792;)Z

--- a/mappings/net/minecraft/entity/mob/PiglinBrain.mapping
+++ b/mappings/net/minecraft/entity/mob/PiglinBrain.mapping
@@ -41,7 +41,7 @@ CLASS net/minecraft/class_4838 net/minecraft/entity/mob/PiglinBrain
 	METHOD method_24732 create (Lnet/minecraft/class_4836;Lnet/minecraft/class_4095;)Lnet/minecraft/class_4095;
 		ARG 0 piglin
 		ARG 1 brain
-	METHOD method_24733 onGuardedBlockInteraction (Lnet/minecraft/class_1657;Z)V
+	METHOD method_24733 onGuardedBlockInteracted (Lnet/minecraft/class_1657;Z)V
 		ARG 0 player
 		ARG 1 blockOpen
 	METHOD method_24734 (Lnet/minecraft/class_1657;Lnet/minecraft/class_4836;)V

--- a/mappings/net/minecraft/entity/mob/RavagerEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/RavagerEntity.mapping
@@ -6,6 +6,8 @@ CLASS net/minecraft/class_1584 net/minecraft/entity/mob/RavagerEntity
 	METHOD method_26920 createRavagerAttributes ()Lnet/minecraft/class_5132$class_5133;
 	METHOD method_7068 knockBack (Lnet/minecraft/class_1297;)V
 		ARG 1 entity
+	METHOD method_7069 (Lnet/minecraft/class_1297;)Z
+		ARG 0 entity
 	METHOD method_7070 getAttackTick ()I
 	METHOD method_7071 roar ()V
 	METHOD method_7072 getRoarTick ()I

--- a/mappings/net/minecraft/entity/mob/StrayEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/StrayEntity.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_1627 net/minecraft/entity/mob/StrayEntity
 	METHOD method_20686 canSpawn (Lnet/minecraft/class_1299;Lnet/minecraft/class_5425;Lnet/minecraft/class_3730;Lnet/minecraft/class_2338;Ljava/util/Random;)Z
 		ARG 0 type
+		ARG 1 world
 		ARG 2 spawnReason
 		ARG 3 pos
 		ARG 4 random

--- a/mappings/net/minecraft/entity/mob/ZombieEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/ZombieEntity.mapping
@@ -31,6 +31,7 @@ CLASS net/minecraft/class_1642 net/minecraft/entity/mob/ZombieEntity
 	METHOD method_7213 setTicksUntilWaterConversion (I)V
 		ARG 1 ticksUntilWaterConversion
 	METHOD method_7215 getSkull ()Lnet/minecraft/class_1799;
+		COMMENT Returns the item stack this entity will drop when killed by a charged creeper.
 	METHOD method_7216 burnsInDaylight ()Z
 	METHOD method_7218 convertInWater ()V
 	CLASS class_1643 DestroyEggGoal

--- a/mappings/net/minecraft/entity/mob/ZombifiedPiglinEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/ZombifiedPiglinEntity.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_1590 net/minecraft/entity/mob/ZombifiedPiglinEntity
+	FIELD field_25379 ANGER_TIME_RANGE Lnet/minecraft/class_4801;
 	FIELD field_25380 angerTime I
 	FIELD field_25381 targetUuid Ljava/util/UUID;
 	FIELD field_7307 ATTACKING_SPEED_BOOST Lnet/minecraft/class_1322;

--- a/mappings/net/minecraft/entity/passive/BatEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/BatEntity.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_1420 net/minecraft/entity/passive/BatEntity
 	FIELD field_18100 CLOSE_PLAYER_PREDICATE Lnet/minecraft/class_4051;
 	FIELD field_6728 BAT_FLAGS Lnet/minecraft/class_2940;
+		COMMENT Equals 0 when the bat is flying, and 1 when it's roosting.
 	FIELD field_6729 hangingPosition Lnet/minecraft/class_2338;
 	METHOD method_20661 canSpawn (Lnet/minecraft/class_1299;Lnet/minecraft/class_1936;Lnet/minecraft/class_3730;Lnet/minecraft/class_2338;Ljava/util/Random;)Z
 		ARG 0 type
@@ -12,4 +13,5 @@ CLASS net/minecraft/class_1420 net/minecraft/entity/passive/BatEntity
 	METHOD method_6449 setRoosting (Z)V
 		ARG 1 roosting
 	METHOD method_6450 isRoosting ()Z
+		COMMENT Returns whether this bat is hanging upside-down under a block.
 	METHOD method_6451 isTodayAroundHalloween ()Z

--- a/mappings/net/minecraft/entity/passive/BeeEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/BeeEntity.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_4466 net/minecraft/entity/passive/BeeEntity
-	FIELD field_20353 multipleByteTracker Lnet/minecraft/class_2940;
-	FIELD field_20354 anger Lnet/minecraft/class_2940;
+	FIELD field_20353 MULTIPLE_BYTE_TRACKER Lnet/minecraft/class_2940;
+	FIELD field_20354 ANGER Lnet/minecraft/class_2940;
 	FIELD field_20356 currentPitch F
 	FIELD field_20357 lastPitch F
 	FIELD field_20358 ticksSinceSting I
@@ -15,6 +15,7 @@ CLASS net/minecraft/class_4466 net/minecraft/entity/passive/BeeEntity
 	FIELD field_21644 ticksUntilCanPollinate I
 	FIELD field_21645 moveToHiveGoal Lnet/minecraft/class_4466$class_4472;
 	FIELD field_21646 moveToFlowerGoal Lnet/minecraft/class_4466$class_4473;
+	FIELD field_25363 ANGER_TIME_RANGE Lnet/minecraft/class_4801;
 	FIELD field_25364 targetUuid Ljava/util/UUID;
 	METHOD method_21769 addParticle (Lnet/minecraft/class_1937;DDDDDLnet/minecraft/class_2394;)V
 		ARG 1 world

--- a/mappings/net/minecraft/entity/passive/BeeEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/BeeEntity.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_4466 net/minecraft/entity/passive/BeeEntity
-	FIELD field_20353 MULTIPLE_BYTE_TRACKER Lnet/minecraft/class_2940;
+	FIELD field_20353 STATUS_TRACKER Lnet/minecraft/class_2940;
 	FIELD field_20354 ANGER Lnet/minecraft/class_2940;
 	FIELD field_20356 currentPitch F
 	FIELD field_20357 lastPitch F

--- a/mappings/net/minecraft/entity/passive/IronGolemEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/IronGolemEntity.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_1439 net/minecraft/entity/passive/IronGolemEntity
+	FIELD field_25365 ANGER_TIME_RANGE Lnet/minecraft/class_4801;
 	FIELD field_25366 angerTime I
 	FIELD field_25367 angryAt Ljava/util/UUID;
 	FIELD field_6759 lookingAtVillagerTicksLeft I

--- a/mappings/net/minecraft/entity/passive/LlamaEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/LlamaEntity.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_1501 net/minecraft/entity/passive/LlamaEntity
+	FIELD field_25375 TAMING_INGREDIENT Lnet/minecraft/class_1856;
 	FIELD field_6995 CARPET_COLOR Lnet/minecraft/class_2940;
 	FIELD field_6996 ATTR_VARIANT Lnet/minecraft/class_2940;
 	FIELD field_6997 follower Lnet/minecraft/class_1501;

--- a/mappings/net/minecraft/entity/passive/LlamaEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/LlamaEntity.mapping
@@ -1,9 +1,9 @@
 CLASS net/minecraft/class_1501 net/minecraft/entity/passive/LlamaEntity
 	FIELD field_25375 TAMING_INGREDIENT Lnet/minecraft/class_1856;
 	FIELD field_6995 CARPET_COLOR Lnet/minecraft/class_2940;
-	FIELD field_6996 ATTR_VARIANT Lnet/minecraft/class_2940;
+	FIELD field_6996 VARIANT Lnet/minecraft/class_2940;
 	FIELD field_6997 follower Lnet/minecraft/class_1501;
-	FIELD field_6998 ATTR_STRENGTH Lnet/minecraft/class_2940;
+	FIELD field_6998 STRENGTH Lnet/minecraft/class_2940;
 	FIELD field_6999 spit Z
 	FIELD field_7000 following Lnet/minecraft/class_1501;
 	METHOD method_18004 createChild ()Lnet/minecraft/class_1501;

--- a/mappings/net/minecraft/entity/passive/ParrotEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/ParrotEntity.mapping
@@ -7,7 +7,7 @@ CLASS net/minecraft/class_1453 net/minecraft/entity/passive/ParrotEntity
 	FIELD field_6823 songPlaying Z
 	FIELD field_6824 flapSpeed F
 	FIELD field_6825 TAMING_INGREDIENTS Ljava/util/Set;
-	FIELD field_6826 ATTR_VARIANT Lnet/minecraft/class_2940;
+	FIELD field_6826 VARIANT Lnet/minecraft/class_2940;
 	FIELD field_6827 prevMaxWingDeviation F
 	FIELD field_6828 COOKIE Lnet/minecraft/class_1792;
 	FIELD field_6829 prevFlapProgress F

--- a/mappings/net/minecraft/entity/passive/PassiveEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/PassiveEntity.mapping
@@ -5,6 +5,8 @@ CLASS net/minecraft/class_1296 net/minecraft/entity/passive/PassiveEntity
 	FIELD field_5950 breedingAge I
 	METHOD method_19184 isReadyToBreed ()Z
 	METHOD method_5613 createChild (Lnet/minecraft/class_3218;Lnet/minecraft/class_1296;)Lnet/minecraft/class_1296;
+		ARG 1 world
+		ARG 2 entity
 	METHOD method_5614 setBreedingAge (I)V
 		ARG 1 age
 	METHOD method_5615 growUp (I)V

--- a/mappings/net/minecraft/entity/passive/PolarBearEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/PolarBearEntity.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_1456 net/minecraft/entity/passive/PolarBearEntity
 	FIELD field_25368 targetUuid Ljava/util/UUID;
+	FIELD field_25369 ANGER_TIME_RANGE Lnet/minecraft/class_4801;
 	FIELD field_25370 angerTime I
 	FIELD field_6837 warningAnimationProgress F
 	FIELD field_6838 lastWarningAnimationProgress F

--- a/mappings/net/minecraft/entity/passive/VillagerEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/VillagerEntity.mapping
@@ -28,6 +28,9 @@ CLASS net/minecraft/class_1646 net/minecraft/entity/passive/VillagerEntity
 		ARG 1 brain
 	METHOD method_19176 releaseTicketFor (Lnet/minecraft/class_4140;)V
 	METHOD method_19177 talkWithVillager (Lnet/minecraft/class_3218;Lnet/minecraft/class_1646;J)V
+		ARG 1 world
+		ARG 2 villager
+		ARG 3 time
 	METHOD method_19179 reinitializeBrain (Lnet/minecraft/class_3218;)V
 		ARG 1 world
 	METHOD method_19182 restock ()V
@@ -37,6 +40,7 @@ CLASS net/minecraft/class_1646 net/minecraft/entity/passive/VillagerEntity
 	METHOD method_19188 canLevelUp ()Z
 	METHOD method_19189 getAvailableFood ()I
 	METHOD method_19190 spawnIronGolem (Lnet/minecraft/class_3218;)Lnet/minecraft/class_1439;
+		ARG 1 world
 	METHOD method_19191 beginTradeWith (Lnet/minecraft/class_1657;)V
 		ARG 1 customer
 	METHOD method_19192 prepareRecipesFor (Lnet/minecraft/class_1657;)V
@@ -52,6 +56,8 @@ CLASS net/minecraft/class_1646 net/minecraft/entity/passive/VillagerEntity
 	METHOD method_20687 canSummonGolem (J)Z
 		ARG 1 time
 	METHOD method_20688 summonGolem (Lnet/minecraft/class_3218;JI)V
+		ARG 1 world
+		ARG 2 time
 	METHOD method_20690 notifyDeath (Lnet/minecraft/class_1297;)V
 		ARG 1 killer
 	METHOD method_20696 decayGossip ()V
@@ -64,6 +70,7 @@ CLASS net/minecraft/class_1646 net/minecraft/entity/passive/VillagerEntity
 	METHOD method_20823 needRestock ()Z
 	METHOD method_20824 canRestock ()Z
 	METHOD method_21650 setGossipDataFromTag (Lnet/minecraft/class_2520;)V
+		ARG 1 tag
 	METHOD method_21651 getGossip ()Lnet/minecraft/class_4136;
 	METHOD method_21724 updatePricesOnDemand ()V
 	METHOD method_26955 createVillagerAttributes ()Lnet/minecraft/class_5132$class_5133;

--- a/mappings/net/minecraft/entity/vehicle/TntMinecartEntity.mapping
+++ b/mappings/net/minecraft/entity/vehicle/TntMinecartEntity.mapping
@@ -7,5 +7,6 @@ CLASS net/minecraft/class_1701 net/minecraft/entity/vehicle/TntMinecartEntity
 		ARG 6 z
 	METHOD method_7575 prime ()V
 	METHOD method_7576 explode (D)V
+		ARG 1 velocity
 	METHOD method_7577 getFuseTicks ()I
 	METHOD method_7578 isPrimed ()Z


### PR DESCRIPTION
- `isInDaylight` -> `isAffectedByDaylight` as random is implied. Closes #804 
- `onGuardedBlockBroken` -> `onGuardedBlockInteraction` as it checks for open blocks too. Closes #1662 
- Some javadocs where the getters are not obvious
- `ANGER_TIME_RANGE` fields
- Random params