### PR TITLE
rayTrace -> raycast

### DIFF
--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -154,7 +154,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD method_9584 getRayCastShape (Lnet/minecraft/class_2680;Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Lnet/minecraft/class_265;
+	METHOD method_9584 getRaycastShape (Lnet/minecraft/class_2680;Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Lnet/minecraft/class_265;
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
@@ -534,7 +534,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 			ARG 1 world
 			ARG 2 pos
 		METHOD method_26223 getPistonBehavior ()Lnet/minecraft/class_3619;
-		METHOD method_26224 getRayCastShape (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Lnet/minecraft/class_265;
+		METHOD method_26224 getRaycastShape (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Lnet/minecraft/class_265;
 			ARG 1 world
 			ARG 2 pos
 		METHOD method_26225 isOpaque ()Z

--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -154,7 +154,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-	METHOD method_9584 getRayTraceShape (Lnet/minecraft/class_2680;Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Lnet/minecraft/class_265;
+	METHOD method_9584 getRayCastShape (Lnet/minecraft/class_2680;Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Lnet/minecraft/class_265;
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
@@ -534,7 +534,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 			ARG 1 world
 			ARG 2 pos
 		METHOD method_26223 getPistonBehavior ()Lnet/minecraft/class_3619;
-		METHOD method_26224 getRayTraceShape (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Lnet/minecraft/class_265;
+		METHOD method_26224 getRayCastShape (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Lnet/minecraft/class_265;
 			ARG 1 world
 			ARG 2 pos
 		METHOD method_26225 isOpaque ()Z

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -454,7 +454,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_5742 onStoppedTrackingBy (Lnet/minecraft/class_3222;)V
 		ARG 1 player
 	METHOD method_5743 getItemsEquipped ()Ljava/lang/Iterable;
-	METHOD method_5745 rayTrace (DFZ)Lnet/minecraft/class_239;
+	METHOD method_5745 rayCast (DFZ)Lnet/minecraft/class_239;
 		ARG 1 maxDistance
 		ARG 3 tickDelta
 		ARG 4 includeFluids

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -454,7 +454,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_5742 onStoppedTrackingBy (Lnet/minecraft/class_3222;)V
 		ARG 1 player
 	METHOD method_5743 getItemsEquipped ()Ljava/lang/Iterable;
-	METHOD method_5745 rayCast (DFZ)Lnet/minecraft/class_239;
+	METHOD method_5745 raycast (DFZ)Lnet/minecraft/class_239;
 		ARG 1 maxDistance
 		ARG 3 tickDelta
 		ARG 4 includeFluids

--- a/mappings/net/minecraft/entity/projectile/ProjectileUtil.mapping
+++ b/mappings/net/minecraft/entity/projectile/ProjectileUtil.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_1675 net/minecraft/entity/projectile/ProjectileUtil
 	METHOD method_18074 getCollision (Lnet/minecraft/class_1297;Ljava/util/function/Predicate;)Lnet/minecraft/class_239;
-	METHOD method_18075 rayTrace (Lnet/minecraft/class_1297;Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_238;Ljava/util/function/Predicate;D)Lnet/minecraft/class_3966;
+	METHOD method_18075 rayCast (Lnet/minecraft/class_1297;Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_238;Ljava/util/function/Predicate;D)Lnet/minecraft/class_3966;
 	METHOD method_18077 getEntityCollision (Lnet/minecraft/class_1937;Lnet/minecraft/class_1297;Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_238;Ljava/util/function/Predicate;)Lnet/minecraft/class_3966;
 	METHOD method_18812 getHandPossiblyHolding (Lnet/minecraft/class_1309;Lnet/minecraft/class_1792;)Lnet/minecraft/class_1268;
 		ARG 0 entity

--- a/mappings/net/minecraft/entity/projectile/ProjectileUtil.mapping
+++ b/mappings/net/minecraft/entity/projectile/ProjectileUtil.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_1675 net/minecraft/entity/projectile/ProjectileUtil
 	METHOD method_18074 getCollision (Lnet/minecraft/class_1297;Ljava/util/function/Predicate;)Lnet/minecraft/class_239;
-	METHOD method_18075 rayCast (Lnet/minecraft/class_1297;Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_238;Ljava/util/function/Predicate;D)Lnet/minecraft/class_3966;
+	METHOD method_18075 raycast (Lnet/minecraft/class_1297;Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_238;Ljava/util/function/Predicate;D)Lnet/minecraft/class_3966;
 	METHOD method_18077 getEntityCollision (Lnet/minecraft/class_1937;Lnet/minecraft/class_1297;Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_238;Ljava/util/function/Predicate;)Lnet/minecraft/class_3966;
 	METHOD method_18812 getHandPossiblyHolding (Lnet/minecraft/class_1309;Lnet/minecraft/class_1792;)Lnet/minecraft/class_1268;
 		ARG 0 entity

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -90,7 +90,7 @@ CLASS net/minecraft/class_1792 net/minecraft/item/Item
 	METHOD method_7869 getOrCreateTranslationKey ()Ljava/lang/String;
 	METHOD method_7870 isEnchantable (Lnet/minecraft/class_1799;)Z
 		ARG 1 stack
-	METHOD method_7872 rayTrace (Lnet/minecraft/class_1937;Lnet/minecraft/class_1657;Lnet/minecraft/class_3959$class_242;)Lnet/minecraft/class_3965;
+	METHOD method_7872 rayCast (Lnet/minecraft/class_1937;Lnet/minecraft/class_1657;Lnet/minecraft/class_3959$class_242;)Lnet/minecraft/class_3965;
 		ARG 0 world
 		ARG 1 player
 		ARG 2 fluidHandling

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -90,7 +90,7 @@ CLASS net/minecraft/class_1792 net/minecraft/item/Item
 	METHOD method_7869 getOrCreateTranslationKey ()Ljava/lang/String;
 	METHOD method_7870 isEnchantable (Lnet/minecraft/class_1799;)Z
 		ARG 1 stack
-	METHOD method_7872 rayCast (Lnet/minecraft/class_1937;Lnet/minecraft/class_1657;Lnet/minecraft/class_3959$class_242;)Lnet/minecraft/class_3965;
+	METHOD method_7872 raycast (Lnet/minecraft/class_1937;Lnet/minecraft/class_1657;Lnet/minecraft/class_3959$class_242;)Lnet/minecraft/class_3965;
 		ARG 0 world
 		ARG 1 player
 		ARG 2 fluidHandling

--- a/mappings/net/minecraft/util/math/Box.mapping
+++ b/mappings/net/minecraft/util/math/Box.mapping
@@ -54,7 +54,7 @@ CLASS net/minecraft/class_238 net/minecraft/util/math/Box
 		ARG 1 x
 		ARG 3 y
 		ARG 5 z
-	METHOD method_1010 rayCast (Ljava/lang/Iterable;Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_2338;)Lnet/minecraft/class_3965;
+	METHOD method_1010 raycast (Ljava/lang/Iterable;Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_2338;)Lnet/minecraft/class_3965;
 		ARG 0 boxes
 		ARG 1 from
 		ARG 2 to
@@ -83,7 +83,7 @@ CLASS net/minecraft/class_238 net/minecraft/util/math/Box
 		ARG 1 axis
 	METHOD method_991 union (Lnet/minecraft/class_238;)Lnet/minecraft/class_238;
 		ARG 1 box
-	METHOD method_992 rayCast (Lnet/minecraft/class_243;Lnet/minecraft/class_243;)Ljava/util/Optional;
+	METHOD method_992 raycast (Lnet/minecraft/class_243;Lnet/minecraft/class_243;)Ljava/util/Optional;
 		ARG 1 min
 		ARG 2 max
 	METHOD method_993 intersects (Lnet/minecraft/class_243;Lnet/minecraft/class_243;)Z

--- a/mappings/net/minecraft/util/math/Box.mapping
+++ b/mappings/net/minecraft/util/math/Box.mapping
@@ -54,7 +54,7 @@ CLASS net/minecraft/class_238 net/minecraft/util/math/Box
 		ARG 1 x
 		ARG 3 y
 		ARG 5 z
-	METHOD method_1010 rayTrace (Ljava/lang/Iterable;Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_2338;)Lnet/minecraft/class_3965;
+	METHOD method_1010 rayCast (Ljava/lang/Iterable;Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_2338;)Lnet/minecraft/class_3965;
 		ARG 0 boxes
 		ARG 1 from
 		ARG 2 to
@@ -83,7 +83,7 @@ CLASS net/minecraft/class_238 net/minecraft/util/math/Box
 		ARG 1 axis
 	METHOD method_991 union (Lnet/minecraft/class_238;)Lnet/minecraft/class_238;
 		ARG 1 box
-	METHOD method_992 rayTrace (Lnet/minecraft/class_243;Lnet/minecraft/class_243;)Ljava/util/Optional;
+	METHOD method_992 rayCast (Lnet/minecraft/class_243;Lnet/minecraft/class_243;)Ljava/util/Optional;
 		ARG 1 min
 		ARG 2 max
 	METHOD method_993 intersects (Lnet/minecraft/class_243;Lnet/minecraft/class_243;)Z

--- a/mappings/net/minecraft/util/shape/VoxelShape.mapping
+++ b/mappings/net/minecraft/util/shape/VoxelShape.mapping
@@ -7,7 +7,7 @@ CLASS net/minecraft/class_265 net/minecraft/util/shape/VoxelShape
 	METHOD method_1090 getBoundingBoxes ()Ljava/util/List;
 	METHOD method_1091 getMin (Lnet/minecraft/class_2350$class_2351;)D
 		ARG 1 axis
-	METHOD method_1092 rayCast (Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_2338;)Lnet/minecraft/class_3965;
+	METHOD method_1092 raycast (Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_2338;)Lnet/minecraft/class_3965;
 		ARG 1 start
 		ARG 2 end
 		ARG 3 pos

--- a/mappings/net/minecraft/util/shape/VoxelShape.mapping
+++ b/mappings/net/minecraft/util/shape/VoxelShape.mapping
@@ -7,7 +7,7 @@ CLASS net/minecraft/class_265 net/minecraft/util/shape/VoxelShape
 	METHOD method_1090 getBoundingBoxes ()Ljava/util/List;
 	METHOD method_1091 getMin (Lnet/minecraft/class_2350$class_2351;)D
 		ARG 1 axis
-	METHOD method_1092 rayTrace (Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_2338;)Lnet/minecraft/class_3965;
+	METHOD method_1092 rayCast (Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_2338;)Lnet/minecraft/class_3965;
 		ARG 1 start
 		ARG 2 end
 		ARG 3 pos

--- a/mappings/net/minecraft/world/BlockView.mapping
+++ b/mappings/net/minecraft/world/BlockView.mapping
@@ -1,11 +1,11 @@
 CLASS net/minecraft/class_1922 net/minecraft/world/BlockView
 	COMMENT Represents a scoped, read-only view of block states, fluid states and block entities.
-	METHOD method_17742 rayCast (Lnet/minecraft/class_3959;)Lnet/minecraft/class_3965;
+	METHOD method_17742 raycast (Lnet/minecraft/class_3959;)Lnet/minecraft/class_3965;
 		ARG 1 context
-	METHOD method_17744 rayCast (Lnet/minecraft/class_3959;Ljava/util/function/BiFunction;Ljava/util/function/Function;)Ljava/lang/Object;
+	METHOD method_17744 raycast (Lnet/minecraft/class_3959;Ljava/util/function/BiFunction;Ljava/util/function/Function;)Ljava/lang/Object;
 		ARG 1 context
-		ARG 2 blockRayCaster
-	METHOD method_17745 rayCastBlock (Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_2338;Lnet/minecraft/class_265;Lnet/minecraft/class_2680;)Lnet/minecraft/class_3965;
+		ARG 2 blockRaycaster
+	METHOD method_17745 raycastBlock (Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_2338;Lnet/minecraft/class_265;Lnet/minecraft/class_2680;)Lnet/minecraft/class_3965;
 		ARG 1 start
 		ARG 2 end
 		ARG 3 pos

--- a/mappings/net/minecraft/world/BlockView.mapping
+++ b/mappings/net/minecraft/world/BlockView.mapping
@@ -1,11 +1,11 @@
 CLASS net/minecraft/class_1922 net/minecraft/world/BlockView
 	COMMENT Represents a scoped, read-only view of block states, fluid states and block entities.
-	METHOD method_17742 rayTrace (Lnet/minecraft/class_3959;)Lnet/minecraft/class_3965;
+	METHOD method_17742 rayCast (Lnet/minecraft/class_3959;)Lnet/minecraft/class_3965;
 		ARG 1 context
-	METHOD method_17744 rayTrace (Lnet/minecraft/class_3959;Ljava/util/function/BiFunction;Ljava/util/function/Function;)Ljava/lang/Object;
+	METHOD method_17744 rayCast (Lnet/minecraft/class_3959;Ljava/util/function/BiFunction;Ljava/util/function/Function;)Ljava/lang/Object;
 		ARG 1 context
-		ARG 2 blockRayTracer
-	METHOD method_17745 rayTraceBlock (Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_2338;Lnet/minecraft/class_265;Lnet/minecraft/class_2680;)Lnet/minecraft/class_3965;
+		ARG 2 blockRayCaster
+	METHOD method_17745 rayCastBlock (Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_2338;Lnet/minecraft/class_265;Lnet/minecraft/class_2680;)Lnet/minecraft/class_3965;
 		ARG 1 start
 		ARG 2 end
 		ARG 3 pos

--- a/mappings/net/minecraft/world/RayCastContext.mapping
+++ b/mappings/net/minecraft/world/RayCastContext.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3959 net/minecraft/world/RayTraceContext
+CLASS net/minecraft/class_3959 net/minecraft/world/RayCastContext
 	FIELD field_17553 start Lnet/minecraft/class_243;
 	FIELD field_17554 end Lnet/minecraft/class_243;
 	FIELD field_17555 shapeType Lnet/minecraft/class_3959$class_3960;

--- a/mappings/net/minecraft/world/RaycastContext.mapping
+++ b/mappings/net/minecraft/world/RaycastContext.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3959 net/minecraft/world/RayCastContext
+CLASS net/minecraft/class_3959 net/minecraft/world/RaycastContext
 	FIELD field_17553 start Lnet/minecraft/class_243;
 	FIELD field_17554 end Lnet/minecraft/class_243;
 	FIELD field_17555 shapeType Lnet/minecraft/class_3959$class_3960;


### PR DESCRIPTION
Quoting from wikipedia,
> In 3D computer graphics, ray tracing is a rendering technique for generating an image by tracing the path of light as pixels in an image plane and simulating the effects of its encounters with virtual objects.

https://en.wikipedia.org/wiki/Ray_tracing_(graphics)
> Ray casting can refer to [...] a non-recursive ray tracing rendering algorithm that only casts primary rays

https://en.wikipedia.org/wiki/Ray_casting

For example, ProjectileUtil#rayCast is used by GameRenderer#updateTargetedEntity to get the first entity within reach distance. The ray is never bounced off walls.

Another example, Item#rayCast is used by LilyPadItem to find the water source to place the lilypad on.

There aren't any rayTraces left, because there's nothing that actually follows a ray bouncing on a surface.
