### PR TITLE
Map missing client collision methods

### DIFF
--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -48,7 +48,7 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 	METHOD method_22119 shouldAutoJump ()Z
 	METHOD method_22120 hasMovementInput ()Z
 		COMMENT Returns whether the player has movement input.
-		COMMENT
+		COMMENT 
 		COMMENT @return True if the player has movement input, else false.
 	METHOD method_22419 showsDeathScreen ()Z
 	METHOD method_22420 setShowsDeathScreen (Z)V
@@ -56,6 +56,8 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 	METHOD method_26269 getMoodPercentage ()F
 		COMMENT Returns the percentage for the biome mood sound for the debug HUD to
 		COMMENT display.
+	METHOD method_30673 pushOutOfBlocks (DD)V
+	METHOD method_30674 wouldSuffocateAt (Lnet/minecraft/class_2338;)Z
 	METHOD method_3130 getRecipeBook ()Lnet/minecraft/class_299;
 	METHOD method_3131 hasJumpingMount ()Z
 	METHOD method_3132 openRidingInventory ()V

--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -58,6 +58,7 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 		COMMENT display.
 	METHOD method_30673 pushOutOfBlocks (DD)V
 	METHOD method_30674 wouldSuffocateAt (Lnet/minecraft/class_2338;)Z
+	METHOD method_30674 wouldCollideAt (Lnet/minecraft/class_2338;)Z
 	METHOD method_3130 getRecipeBook ()Lnet/minecraft/class_299;
 	METHOD method_3131 hasJumpingMount ()Z
 	METHOD method_3132 openRidingInventory ()V

--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -57,7 +57,6 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 		COMMENT Returns the percentage for the biome mood sound for the debug HUD to
 		COMMENT display.
 	METHOD method_30673 pushOutOfBlocks (DD)V
-	METHOD method_30674 wouldSuffocateAt (Lnet/minecraft/class_2338;)Z
 	METHOD method_30674 wouldCollideAt (Lnet/minecraft/class_2338;)Z
 	METHOD method_3130 getRecipeBook ()Lnet/minecraft/class_299;
 	METHOD method_3131 hasJumpingMount ()Z

--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -48,7 +48,7 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 	METHOD method_22119 shouldAutoJump ()Z
 	METHOD method_22120 hasMovementInput ()Z
 		COMMENT Returns whether the player has movement input.
-		COMMENT 
+		COMMENT
 		COMMENT @return True if the player has movement input, else false.
 	METHOD method_22419 showsDeathScreen ()Z
 	METHOD method_22420 setShowsDeathScreen (Z)V

--- a/mappings/net/minecraft/world/BlockCollisionSpliterator.mapping
+++ b/mappings/net/minecraft/world/BlockCollisionSpliterator.mapping
@@ -7,10 +7,13 @@ CLASS net/minecraft/class_5329 net/minecraft/world/BlockCollisionSpliterator
 	FIELD field_25173 boxShape Lnet/minecraft/class_265;
 	FIELD field_25174 world Lnet/minecraft/class_1941;
 	FIELD field_25175 checkEntity Z
+	FIELD field_25669 blockPredicate Ljava/util/function/BiPredicate;
 	METHOD <init> (Lnet/minecraft/class_1941;Lnet/minecraft/class_1297;Lnet/minecraft/class_238;)V
 		ARG 1 world
 		ARG 2 entity
 		ARG 3 box
+	METHOD <init> (Lnet/minecraft/class_1941;Lnet/minecraft/class_1297;Lnet/minecraft/class_238;Ljava/util/function/BiPredicate;)V
+		ARG 4 blockPredicate
 	METHOD method_29283 getChunk (II)Lnet/minecraft/class_1922;
 		ARG 1 x
 		ARG 2 z

--- a/mappings/net/minecraft/world/CollisionView.mapping
+++ b/mappings/net/minecraft/world/CollisionView.mapping
@@ -11,7 +11,7 @@ CLASS net/minecraft/class_1941 net/minecraft/world/CollisionView
 		ARG 1 chunkX
 		ARG 2 chunkZ
 	METHOD method_30030 getBlockCollisions (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;Ljava/util/function/BiPredicate;)Ljava/util/stream/Stream;
-	METHOD method_30635 isSpaceEmpty (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;Ljava/util/function/BiPredicate;)Z
+	METHOD method_30635 isBlockSpaceEmpty (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;Ljava/util/function/BiPredicate;)Z
 	METHOD method_8587 isSpaceEmpty (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;)Z
 		ARG 1 entity
 		ARG 2 box

--- a/mappings/net/minecraft/world/CollisionView.mapping
+++ b/mappings/net/minecraft/world/CollisionView.mapping
@@ -10,6 +10,8 @@ CLASS net/minecraft/class_1941 net/minecraft/world/CollisionView
 	METHOD method_22338 getExistingChunk (II)Lnet/minecraft/class_1922;
 		ARG 1 chunkX
 		ARG 2 chunkZ
+	METHOD method_30030 getBlockCollisions (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;Ljava/util/function/BiPredicate;)Ljava/util/stream/Stream;
+	METHOD method_30635 isSpaceEmpty (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;Ljava/util/function/BiPredicate;)Z
 	METHOD method_8587 doesNotCollide (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;)Z
 		ARG 1 entity
 		ARG 2 box

--- a/mappings/net/minecraft/world/CollisionView.mapping
+++ b/mappings/net/minecraft/world/CollisionView.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_1941 net/minecraft/world/CollisionView
-	METHOD method_17892 doesNotCollide (Lnet/minecraft/class_1297;)Z
+	METHOD method_17892 isSpaceEmpty (Lnet/minecraft/class_1297;)Z
 		ARG 1 entity
-	METHOD method_18026 doesNotCollide (Lnet/minecraft/class_238;)Z
+	METHOD method_18026 isSpaceEmpty (Lnet/minecraft/class_238;)Z
 		ARG 1 box
 	METHOD method_20743 getEntityCollisions (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;Ljava/util/function/Predicate;)Ljava/util/stream/Stream;
 	METHOD method_20812 getBlockCollisions (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;)Ljava/util/stream/Stream;
@@ -12,10 +12,10 @@ CLASS net/minecraft/class_1941 net/minecraft/world/CollisionView
 		ARG 2 chunkZ
 	METHOD method_30030 getBlockCollisions (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;Ljava/util/function/BiPredicate;)Ljava/util/stream/Stream;
 	METHOD method_30635 isSpaceEmpty (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;Ljava/util/function/BiPredicate;)Z
-	METHOD method_8587 doesNotCollide (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;)Z
+	METHOD method_8587 isSpaceEmpty (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;)Z
 		ARG 1 entity
 		ARG 2 box
-	METHOD method_8590 doesNotCollide (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;Ljava/util/function/Predicate;)Z
+	METHOD method_8590 isSpaceEmpty (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;Ljava/util/function/Predicate;)Z
 	METHOD method_8600 getCollisions (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;Ljava/util/function/Predicate;)Ljava/util/stream/Stream;
 	METHOD method_8606 intersectsEntities (Lnet/minecraft/class_1297;)Z
 		ARG 1 entity


### PR DESCRIPTION
Mojang did a small refactor on client player collision in 1.16.2, which lead to some methods not matching correctly as well as some new methods appearing.

`method_30673` -> `pushOutOfBlocks`: previously `method_5632`, same name
`method_30674` -> `wouldCollideAt`: previously `method_3150` (`cannotFitAt`). I changed this one because it causes a double negative (`!cannotFitAt`)
`method_30030` -> `getBlockCollisions`: just an overload of the existing `getBlockCollisions`, with a new predicate parameter
`method_30635` -> `isSpaceEmpty`: checks that the result of `getBlockCollisions` consists only of empty boxes