### PR TITLE
Add Mapping For Valid Frame Block Predicate In AreaHelper

### DIFF
--- a/mappings/net/minecraft/world/dimension/AreaHelper.mapping
+++ b/mappings/net/minecraft/world/dimension/AreaHelper.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/class_2424 net/minecraft/world/dimension/AreaHelper
 	FIELD field_11316 lowerCorner Lnet/minecraft/class_2338;
 	FIELD field_11317 axis Lnet/minecraft/class_2350$class_2351;
 	FIELD field_11318 world Lnet/minecraft/class_1936;
+	FIELD field_25883 IS_VALID_FRAME_BLOCK Lnet/minecraft/class_4970$class_4973;
 	METHOD <init> (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350$class_2351;)V
 		ARG 1 world
 	METHOD method_10359 validStateInsidePortal (Lnet/minecraft/class_2680;)Z


### PR DESCRIPTION
I chose ``AreaHelper.IS_VALID_FRAME_BLOCK``, I though slightly verbose was better here.