### PR TITLE
New Ingredient.ofStacks (single method)

### DIFF
--- a/mappings/net/minecraft/recipe/Ingredient.mapping
+++ b/mappings/net/minecraft/recipe/Ingredient.mapping
@@ -5,6 +5,8 @@ CLASS net/minecraft/class_1856 net/minecraft/recipe/Ingredient
 	FIELD field_9019 entries [Lnet/minecraft/class_1856$class_1859;
 	METHOD <init> (Ljava/util/stream/Stream;)V
 		ARG 1 entries
+	METHOD method_26964 ofStacks (Ljava/util/stream/Stream;)Lnet/minecraft/class_1856;
+		ARG 0 stacks
 	METHOD method_8086 fromPacket (Lnet/minecraft/class_2540;)Lnet/minecraft/class_1856;
 		ARG 0 buf
 	METHOD method_8088 write (Lnet/minecraft/class_2540;)V


### PR DESCRIPTION
The old one apparently became client-side only, but the new one is unmapped.