### PR TITLE
Suggest using Block#asItem instead of Item.fromBlock

### DIFF
--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -86,6 +86,7 @@ CLASS net/minecraft/class_1792 net/minecraft/item/Item
 	METHOD method_7866 getTranslationKey (Lnet/minecraft/class_1799;)Ljava/lang/String;
 		ARG 1 stack
 	METHOD method_7867 fromBlock (Lnet/minecraft/class_2248;)Lnet/minecraft/class_1792;
+		COMMENT @deprecated Please use {@link Block#asItem}
 		ARG 0 block
 	METHOD method_7869 getOrCreateTranslationKey ()Ljava/lang/String;
 	METHOD method_7870 isEnchantable (Lnet/minecraft/class_1799;)Z


### PR DESCRIPTION
`Item.fromBlock` has `@Deprecated` annotation. `Block#asItem` calls `Item.fromBlock` internally but it also caches the result to improve performance. We should use `Block#asItem` instead of `Item.fromBlock`.