### PR TITLE
Name New Material and JD it

### DIFF
--- a/mappings/net/minecraft/block/Material.mapping
+++ b/mappings/net/minecraft/block/Material.mapping
@@ -73,7 +73,7 @@ CLASS net/minecraft/class_3614 net/minecraft/block/Material
 	FIELD field_22223 NETHER_WOOD Lnet/minecraft/class_3614;
 		COMMENT Material for blocks crafted from Nether stems and hyphae.
 	FIELD field_26708 NETHER_SHOOTS Lnet/minecraft/class_3614;
-		COMMENT Material for crimson and warped roots, as well as nether sprouts.
+		COMMENT Material for crimson and warped roots, as well as Nether sprouts.
 	METHOD <init> (Lnet/minecraft/class_3620;ZZZZZZLnet/minecraft/class_3619;)V
 		ARG 1 color
 		ARG 2 liquid

--- a/mappings/net/minecraft/block/Material.mapping
+++ b/mappings/net/minecraft/block/Material.mapping
@@ -72,6 +72,8 @@ CLASS net/minecraft/class_3614 net/minecraft/block/Material
 	FIELD field_17008 SHULKER_BOX Lnet/minecraft/class_3614;
 	FIELD field_22223 NETHER_WOOD Lnet/minecraft/class_3614;
 		COMMENT Material for blocks crafted from Nether stems and hyphae.
+	FIELD field_26708 NETHER_SHOOTS Lnet/minecraft/class_3614;
+		COMMENT Material for crimson and warped roots, as well as nether sprouts.
 	METHOD <init> (Lnet/minecraft/class_3620;ZZZZZZLnet/minecraft/class_3619;)V
 		ARG 1 color
 		ARG 2 liquid


### PR DESCRIPTION
Naming the new Material used for crimson and warped roots, as well as nether sprouts.
Named `NETHER_SHOOTS` as this is the closest available descriptor. As the visual for the block is a plant sprouting from the ground, "nether sprouts" was considered but rejected as it could be confused as being only for the nether sprouts block, so "shoots" was chosen. 
Alternatively, it could have been called "nether grass," but that is not accurate as these are not described as grass.
"Nether plant" and "nether vegetation" were rejected as the fungi and vines are not included in this Material.