### PR TITLE
Replace generic trader naming with merchant

### DIFF
--- a/mappings/net/minecraft/entity/passive/MerchantEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/MerchantEntity.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3988 net/minecraft/entity/passive/AbstractTraderEntity
+CLASS net/minecraft/class_3988 net/minecraft/entity/passive/MerchantEntity
 	FIELD field_17721 offers Lnet/minecraft/class_1916;
 	FIELD field_17722 customer Lnet/minecraft/class_1657;
 	FIELD field_17723 inventory Lnet/minecraft/class_1277;

--- a/mappings/net/minecraft/village/Merchant.mapping
+++ b/mappings/net/minecraft/village/Merchant.mapping
@@ -1,8 +1,8 @@
-CLASS net/minecraft/class_1915 net/minecraft/village/Trader
+CLASS net/minecraft/class_1915 net/minecraft/village/Merchant
 	METHOD method_17449 sendOffers (Lnet/minecraft/class_1657;Lnet/minecraft/class_2561;I)V
 	METHOD method_18010 getYesSound ()Lnet/minecraft/class_3414;
 	METHOD method_19269 getExperience ()I
-	METHOD method_19270 isLeveledTrader ()Z
+	METHOD method_19270 isLeveledMerchant ()Z
 	METHOD method_19271 setExperienceFromServer (I)V
 		ARG 1 experience
 	METHOD method_20708 canRefreshTrades ()Z
@@ -11,7 +11,7 @@ CLASS net/minecraft/class_1915 net/minecraft/village/Trader
 		ARG 1 stack
 	METHOD method_8259 setCurrentCustomer (Lnet/minecraft/class_1657;)V
 		ARG 1 customer
-	METHOD method_8260 getTraderWorld ()Lnet/minecraft/class_1937;
+	METHOD method_8260 getMerchantWorld ()Lnet/minecraft/class_1937;
 	METHOD method_8261 setOffersFromServer (Lnet/minecraft/class_1916;)V
 		ARG 1 offers
 	METHOD method_8262 trade (Lnet/minecraft/class_1914;)V

--- a/mappings/net/minecraft/village/MerchantInventory.mapping
+++ b/mappings/net/minecraft/village/MerchantInventory.mapping
@@ -1,8 +1,8 @@
-CLASS net/minecraft/class_1725 net/minecraft/village/TraderInventory
+CLASS net/minecraft/class_1725 net/minecraft/village/MerchantInventory
 	FIELD field_18668 traderRewardedExperience I
 	FIELD field_7842 recipeIndex I
-	FIELD field_7843 traderRecipe Lnet/minecraft/class_1914;
-	FIELD field_7844 trader Lnet/minecraft/class_1915;
+	FIELD field_7843 tradeOffer Lnet/minecraft/class_1914;
+	FIELD field_7844 merchant Lnet/minecraft/class_1915;
 	FIELD field_7845 inventory Lnet/minecraft/class_2371;
 	METHOD method_19252 getTraderRewardedExperience ()I
 	METHOD method_7642 getTradeOffer ()Lnet/minecraft/class_1914;

--- a/mappings/net/minecraft/village/SimpleMerchant.mapping
+++ b/mappings/net/minecraft/village/SimpleMerchant.mapping
@@ -1,5 +1,5 @@
-CLASS net/minecraft/class_1645 net/minecraft/village/SimpleTrader
+CLASS net/minecraft/class_1645 net/minecraft/village/SimpleMerchant
 	FIELD field_18525 experience I
 	FIELD field_7441 player Lnet/minecraft/class_1657;
 	FIELD field_7442 recipeList Lnet/minecraft/class_1916;
-	FIELD field_7443 traderInventory Lnet/minecraft/class_1725;
+	FIELD field_7443 merchantInventory Lnet/minecraft/class_1725;

--- a/mappings/net/minecraft/village/TradeOfferList.mapping
+++ b/mappings/net/minecraft/village/TradeOfferList.mapping
@@ -1,7 +1,7 @@
-CLASS net/minecraft/class_1916 net/minecraft/village/TraderOfferList
+CLASS net/minecraft/class_1916 net/minecraft/village/TradeOfferList
 	METHOD method_8265 fromPacket (Lnet/minecraft/class_2540;)Lnet/minecraft/class_1916;
 		ARG 0 byteBuf
-	METHOD method_8267 getValidRecipe (Lnet/minecraft/class_1799;Lnet/minecraft/class_1799;I)Lnet/minecraft/class_1914;
+	METHOD method_8267 getValidOffer (Lnet/minecraft/class_1799;Lnet/minecraft/class_1799;I)Lnet/minecraft/class_1914;
 		ARG 1 firstBuyItem
 		ARG 2 secondBuyItem
 		ARG 3 index


### PR DESCRIPTION
This pull request changes the generic trader naming to merchant, as trader is already used for shortening wandering trader (such as `minecraft:trader_llama` and `doTraderSpawning`).