### PR TITLE
Remap LevelStorage parser method and LevelStorage$Session getter methods

### DIFF
--- a/mappings/net/minecraft/world/level/storage/LevelStorage.mapping
+++ b/mappings/net/minecraft/world/level/storage/LevelStorage.mapping
@@ -4,11 +4,12 @@ CLASS net/minecraft/class_32 net/minecraft/world/level/storage/LevelStorage
 	FIELD field_17667 backupsDirectory Ljava/nio/file/Path;
 	FIELD field_17668 dataFixer Lcom/mojang/datafixers/DataFixer;
 	FIELD field_200 TIME_FORMATTER Ljava/time/format/DateTimeFormatter;
+	FIELD field_25020 GENERATOR_OPTION_KEYS Lcom/google/common/collect/ImmutableList;
 	METHOD <init> (Ljava/nio/file/Path;Ljava/nio/file/Path;Lcom/mojang/datafixers/DataFixer;)V
 		ARG 1 savesDirectory
 		ARG 2 backupsDirectory
 		ARG 3 dataFixer
-	METHOD method_17926 readLevelProperties (Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/class_5359;)Ljava/util/function/BiFunction;
+	METHOD method_17926 createLevelDataParser (Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/class_5359;)Ljava/util/function/BiFunction;
 	METHOD method_17931 getCurrentVersion ()I
 	METHOD method_19636 getSavesDirectory ()Ljava/nio/file/Path;
 	METHOD method_230 levelExists (Ljava/lang/String;)Z
@@ -18,10 +19,16 @@ CLASS net/minecraft/class_32 net/minecraft/world/level/storage/LevelStorage
 	METHOD method_240 isLevelNameValid (Ljava/lang/String;)Z
 		ARG 1 name
 	METHOD method_26998 readLevelProperties (Ljava/io/File;Ljava/util/function/BiFunction;)Ljava/lang/Object;
+		ARG 2 levelDataParser
 	METHOD method_26999 create (Ljava/nio/file/Path;)Lnet/minecraft/class_32;
 		ARG 0 path
 	METHOD method_27002 createSession (Ljava/lang/String;)Lnet/minecraft/class_32$class_5143;
 		ARG 1 directoryName
+	METHOD method_29010 readGeneratorProperties (Lcom/mojang/serialization/Dynamic;Lcom/mojang/datafixers/DataFixer;I)Lcom/mojang/datafixers/util/Pair;
+	METHOD method_29014 createLevelDataParser (Ljava/io/File;Z)Ljava/util/function/BiFunction;
+		ARG 2 locked
+	METHOD method_29580 parseDataPackSettings (Lcom/mojang/serialization/Dynamic;)Lnet/minecraft/class_5359;
+	METHOD method_29583 readDataPackSettings (Ljava/io/File;Lcom/mojang/datafixers/DataFixer;)Lnet/minecraft/class_5359;
 	CLASS class_5143 Session
 		FIELD field_23767 lock Lnet/minecraft/class_5125;
 		FIELD field_23768 directory Ljava/nio/file/Path;
@@ -44,5 +51,10 @@ CLASS net/minecraft/class_32 net/minecraft/world/level/storage/LevelStorage
 		METHOD method_27017 checkValid ()V
 		METHOD method_27424 getWorldDirectory (Lnet/minecraft/class_5321;)Ljava/io/File;
 			ARG 1 key
+		METHOD method_27425 backupLevelDataFile (Lnet/minecraft/class_5455;Lnet/minecraft/class_5219;)V
+		METHOD method_27426 backupLevelDataFile (Lnet/minecraft/class_5455;Lnet/minecraft/class_5219;Lnet/minecraft/class_2487;)V
+		METHOD method_27427 createSaveHandler ()Lnet/minecraft/class_29;
 		METHOD method_27428 (Lnet/minecraft/class_5218;)Ljava/nio/file/Path;
 			ARG 1 path
+		METHOD method_29584 getLevelSummary ()Lnet/minecraft/class_34;
+		METHOD method_29585 getDatapackSettings ()Lnet/minecraft/class_5359;


### PR DESCRIPTION
Start with inner class `Session`, 

`method_27427` - is queried by `MinecraftServer` in the constructor that assigns the method's return value to the class property of `MinecraftServer.saveHandler`

`method_27426`, overloaded with `method_27425` - is to create a copy of `level.dat` files into `level.dat_old`

`method_29584` - performs call to the outer class method `LevelStorage.readLevelProperties`

`method_29585` - performs call to the outer class method `LevelStorage.readDataPackSettings`

---

Now onto `LevelStorage`

`readLevelProperties` --> `createLevelDataParser` - because the return type is a bifunction for reading `level.dat`, it does not perform the reading itself

`method_29014` - is a non-static method with the objective similar to `createLevelDataParser` except the parser does not consider the `Player` attribute in the `level.dat` or `level.dat_old`

`method_29580` - is to parse the datapack setting or return `DataPackSettings.SAFE_MODE` if error

`method_29583` - is to read the datapack; references `method_29580` in their map function

`field_25020` - is a static field used for getting optional world generation attribute

`method_29010` - read both generation option and lifecycle of the world and references `field_25020`

If I missed anything, feel free to notify me below
