### PR TITLE
Add javadoc for the class Element 

### DIFF
--- a/mappings/net/minecraft/client/gui/Element.mapping
+++ b/mappings/net/minecraft/client/gui/Element.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 	COMMENT Mouse coordinate is bounded by the size of the window in
 	COMMENT pixels.
 	METHOD method_16014 mouseMoved (DD)V
-		COMMENT Callback for when a mouse moved event has been captured.
+		COMMENT Callback for when a mouse move event has been captured.
 		COMMENT
 		COMMENT @param mouseX the X coordinate of the mouse
 		COMMENT @param mouseY the Y coordinate of the mouse
@@ -16,9 +16,9 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 		COMMENT Callback for when a key up event has been captured.
 		COMMENT
 		COMMENT The key code is identified by the constants in
-		COMMENT {@link org.lwjgl.glfw.GLFW GLFW class}.
+		COMMENT {@link org.lwjgl.glfw.GLFW GLFW} class.
 		COMMENT
-		COMMENT See the difference of a key code, scan code, and a
+		COMMENT See the difference of a key code, a scan code, and a
 		COMMENT modifier in {@link org.lwjgl.glfw.GLFWKeyCallbackI#invoke(long, int, int, int, int) GLFWKeyCallbackI}
 		COMMENT
 		COMMENT @param keyCode the key code of the event
@@ -35,7 +35,7 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 		COMMENT Callback for when a character input has been captured.
 		COMMENT
 		COMMENT The key code is identified by the constants in
-		COMMENT {@link org.lwjgl.glfw.GLFW GLFW class}.
+		COMMENT {@link org.lwjgl.glfw.GLFW GLFW} class.
 		COMMENT
 		COMMENT @param chr the character
 		COMMENT @param keyCode the key code of the event
@@ -53,7 +53,7 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 		COMMENT @param mouseY the Y coordinate of the mouse
 		COMMENT @param amount value is {@code > 1} if scrolled down, {@code < 1} if scrolled up
 		COMMENT @return {@code true} to indicate that the event handling is successful/valid
-		COMMENT @see net.minecraft.client.Mouse#onMouseScroll
+		COMMENT @see net.minecraft.client.Mouse#onMouseScroll(long, double, double)
 		ARG 1 mouseX
 		ARG 3 mouseY
 		ARG 5 amount
@@ -62,13 +62,13 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 		COMMENT has been captured.
 		COMMENT
 		COMMENT The button number is identified by the constants in
-		COMMENT {@link org.lwjgl.glfw.GLFW GLFW class}.
+		COMMENT {@link org.lwjgl.glfw.GLFW GLFW} class.
 		COMMENT
 		COMMENT @param mouseX the X coordinate of the mouse
 		COMMENT @param mouseY the Y coordinate of the mouse
 		COMMENT @param button the mouse button number
 		COMMENT @return {@code true} to indicate that the event handling is successful/valid
-		COMMENT @see net.minecraft.client.Mouse#onMouseButton(long, double, double)
+		COMMENT @see net.minecraft.client.Mouse#onMouseButton(long, int, int, int)
 		COMMENT @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		ARG 1 mouseX
 		ARG 3 mouseY
@@ -78,7 +78,7 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 		COMMENT has been captured.
 		COMMENT
 		COMMENT The button number is identified by the constants in
-		COMMENT {@link org.lwjgl.glfw.GLFW GLFW class}
+		COMMENT {@link org.lwjgl.glfw.GLFW GLFW} class.
 		COMMENT
 		COMMENT @param mouseX the current X coordinate of the mouse
 		COMMENT @param mouseY the current Y coordinate of the mouse
@@ -86,7 +86,7 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 		COMMENT @param deltaX the difference of the current X with the previous X coordinate
 		COMMENT @param deltaY the difference of the current Y with the previous X coordinate
 		COMMENT @return {@code true} to indicate that the event handling is successful/valid
-		COMMENT @see net.minecraft.client.Mouse#onCursorPos
+		COMMENT @see net.minecraft.client.Mouse#onCursorPos(long, double, double)
 		COMMENT @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		ARG 1 mouseX
 		ARG 3 mouseY
@@ -97,9 +97,9 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 		COMMENT Callback for when a key down event has been captured.
 		COMMENT
 		COMMENT The key code is identified by the constants in
-		COMMENT {@link org.lwjgl.glfw.GLFW GLFW class}.
+		COMMENT {@link org.lwjgl.glfw.GLFW GLFW} class.
 		COMMENT
-		COMMENT See the difference of a key code, scan code, and a
+		COMMENT See the difference of a key code, a scan code, and a
 		COMMENT modifier in {@link org.lwjgl.glfw.GLFWKeyCallbackI#invoke(long, int, int, int, int) GLFWKeyCallbackI}
 		COMMENT
 		COMMENT @param keyCode the key code of the event
@@ -126,13 +126,13 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 		COMMENT has been captured.
 		COMMENT
 		COMMENT The button number is identified by the constants in
-		COMMENT {@link org.lwjgl.glfw.GLFW GLFW class}
+		COMMENT {@link org.lwjgl.glfw.GLFW GLFW} class.
 		COMMENT
 		COMMENT @param mouseX the X coordinate of the mouse
 		COMMENT @param mouseY the Y coordinate of the mouse
 		COMMENT @param button the mouse button number
 		COMMENT @return {@code true} to indicate that the event handling is successful/valid
-		COMMENT @see net.minecraft.client.Mouse#onMouseButton
+		COMMENT @see net.minecraft.client.Mouse#onMouseButton(long, int, int, int)
 		COMMENT @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		ARG 1 mouseX
 		ARG 3 mouseY
@@ -140,7 +140,7 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 	METHOD method_25407 changeFocus (Z)Z
 		COMMENT Changes the focusing element by cycling to the next/previous element.
 		COMMENT
-		COMMENT This action is done typically when user has pressed the 'Tab' or 'Ctrl+Tab'
+		COMMENT This action is done typically when the user has pressed the 'Tab' or 'Ctrl+Tab'
 		COMMENT key.
 		COMMENT
 		COMMENT @param lookForwards {@code true} if to cycle forward, otherwise cycle backwards

--- a/mappings/net/minecraft/client/gui/Element.mapping
+++ b/mappings/net/minecraft/client/gui/Element.mapping
@@ -27,7 +27,7 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 		ARG 2 scanCode
 			COMMENT the unique/platform-specific scan code of the keyboard input
 		ARG 3 modifiers
-			COMMENT a GLFW bitfield describing the modifier keys that are held down; See {@linkplain https://www.glfw.org/docs/3.3/group__mods.html GLFW Modifier key flags}
+			COMMENT a GLFW bitfield describing the modifier keys that are held down (see {@linkplain https://www.glfw.org/docs/3.3/group__mods.html GLFW Modifier key flags})
 	METHOD method_25400 charTyped (CI)Z
 		COMMENT Callback for when a character input has been captured.
 		COMMENT

--- a/mappings/net/minecraft/client/gui/Element.mapping
+++ b/mappings/net/minecraft/client/gui/Element.mapping
@@ -105,7 +105,7 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 		ARG 2 scanCode
 			COMMENT the unique/platform-specific scan code of the keyboard input
 		ARG 3 modifiers
-			COMMENT a GLFW bitfield describing the modifier keys that are held down; See {@linkplain https://www.glfw.org/docs/3.3/group__mods.html GLFW Modifier key flags}
+			COMMENT a GLFW bitfield describing the modifier keys that are held down (see {@linkplain https://www.glfw.org/docs/3.3/group__mods.html GLFW Modifier key flags})
 	METHOD method_25405 isMouseOver (DD)Z
 		COMMENT Checks if the mouse position is within the bound
 		COMMENT of the element.

--- a/mappings/net/minecraft/client/gui/Element.mapping
+++ b/mappings/net/minecraft/client/gui/Element.mapping
@@ -1,38 +1,148 @@
 CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
+	COMMENT Base GUI interface for handling callbacks related to
+	COMMENT keyboard or mouse actions.
+	COMMENT
+	COMMENT Mouse coordinate is bounded by the size of the window in
+	COMMENT pixels.
 	METHOD method_16014 mouseMoved (DD)V
+		COMMENT Callback for when a mouse moved event has been captured.
+		COMMENT
+		COMMENT @param mouseX the X coordinate of the mouse
+		COMMENT @param mouseY the Y coordinate of the mouse
+		COMMENT @see net.minecraft.client.Mouse#onCursorPos
 		ARG 1 mouseX
 		ARG 3 mouseY
 	METHOD method_16803 keyReleased (III)Z
+		COMMENT Callback for when a key up event has been captured.
+		COMMENT
+		COMMENT The key code is identified by the constants in
+		COMMENT {@link org.lwjgl.glfw.GLFW GLFW class}.
+		COMMENT
+		COMMENT See the difference of a key code, scan code, and a
+		COMMENT modifier in {@link org.lwjgl.glfw.GLFWKeyCallbackI#invoke(long, int, int, int, int) GLFWKeyCallbackI}
+		COMMENT
+		COMMENT @param keyCode the key code of the event
+		COMMENT @param scanCode the scan code of the event
+		COMMENT @param modifiers a bitfield/flag describing the which modifier keys are held down
+		COMMENT @return {@code true} to indicate that the event handling is successful/valid
+		COMMENT @see net.minecraft.client.Keyboard#onKey(long, int, int, int, int)
+		COMMENT @see org.lwjgl.glfw.GLFW#GLFW_KEY_Q
+		COMMENT @see org.lwjgl.glfw.GLFWKeyCallbackI#invoke(long, int, int, int, int)
 		ARG 1 keyCode
 		ARG 2 scanCode
 		ARG 3 modifiers
 	METHOD method_25400 charTyped (CI)Z
+		COMMENT Callback for when a character input has been captured.
+		COMMENT
+		COMMENT The key code is identified by the constants in
+		COMMENT {@link org.lwjgl.glfw.GLFW GLFW class}.
+		COMMENT
+		COMMENT @param chr the character
+		COMMENT @param keyCode the key code of the event
+		COMMENT @return {@code true} to indicate that the event handling is successful/valid
+		COMMENT @see net.minecraft.client.Keyboard#onChar(long, int, int)
+		COMMENT @see org.lwjgl.glfw.GLFW#GLFW_KEY_Q
+		COMMENT @see org.lwjgl.glfw.GLFWKeyCallbackI#invoke(long, int, int, int, int)
 		ARG 1 chr
 		ARG 2 keyCode
 	METHOD method_25401 mouseScrolled (DDD)Z
+		COMMENT Callback for when a mouse button scroll event
+		COMMENT has been captured.
+		COMMENT
+		COMMENT @param mouseX the X coordinate of the mouse
+		COMMENT @param mouseY the Y coordinate of the mouse
+		COMMENT @param amount value is {@code > 1} if scrolled down, {@code < 1} if scrolled up
+		COMMENT @return {@code true} to indicate that the event handling is successful/valid
+		COMMENT @see net.minecraft.client.Mouse#onMouseScroll
 		ARG 1 mouseX
 		ARG 3 mouseY
 		ARG 5 amount
 	METHOD method_25402 mouseClicked (DDI)Z
+		COMMENT Callback for when a mouse button down event
+		COMMENT has been captured.
+		COMMENT
+		COMMENT The button number is identified by the constants in
+		COMMENT {@link org.lwjgl.glfw.GLFW GLFW class}.
+		COMMENT
+		COMMENT @param mouseX the X coordinate of the mouse
+		COMMENT @param mouseY the Y coordinate of the mouse
+		COMMENT @param button the mouse button number
+		COMMENT @return {@code true} to indicate that the event handling is successful/valid
+		COMMENT @see net.minecraft.client.Mouse#onMouseButton(long, double, double)
+		COMMENT @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		ARG 1 mouseX
 		ARG 3 mouseY
 		ARG 5 button
 	METHOD method_25403 mouseDragged (DDIDD)Z
+		COMMENT Callback for when a mouse button drag event
+		COMMENT has been captured.
+		COMMENT
+		COMMENT The button number is identified by the constants in
+		COMMENT {@link org.lwjgl.glfw.GLFW GLFW class}
+		COMMENT
+		COMMENT @param mouseX the current X coordinate of the mouse
+		COMMENT @param mouseY the current Y coordinate of the mouse
+		COMMENT @param button the mouse button number
+		COMMENT @param deltaX the difference of the current X with the previous X coordinate
+		COMMENT @param deltaY the difference of the current Y with the previous X coordinate
+		COMMENT @return {@code true} to indicate that the event handling is successful/valid
+		COMMENT @see net.minecraft.client.Mouse#onCursorPos
+		COMMENT @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		ARG 1 mouseX
 		ARG 3 mouseY
 		ARG 5 button
 		ARG 6 deltaX
 		ARG 8 deltaY
 	METHOD method_25404 keyPressed (III)Z
+		COMMENT Callback for when a key down event has been captured.
+		COMMENT
+		COMMENT The key code is identified by the constants in
+		COMMENT {@link org.lwjgl.glfw.GLFW GLFW class}.
+		COMMENT
+		COMMENT See the difference of a key code, scan code, and a
+		COMMENT modifier in {@link org.lwjgl.glfw.GLFWKeyCallbackI#invoke(long, int, int, int, int) GLFWKeyCallbackI}
+		COMMENT
+		COMMENT @param keyCode the key code of the event
+		COMMENT @param scanCode the scan code of the event
+		COMMENT @param modifiers a bitfield/flag describing the which modifier keys are held down
+		COMMENT @return {@code true} to indicate that the event handling is successful/valid
+		COMMENT @see net.minecraft.client.Keyboard#onKey(long, int, int, int, int)
+		COMMENT @see org.lwjgl.glfw.GLFW#GLFW_KEY_Q
+		COMMENT @see org.lwjgl.glfw.GLFWKeyCallbackI#invoke(long, int, int, int, int)
 		ARG 1 keyCode
 		ARG 2 scanCode
 		ARG 3 modifiers
 	METHOD method_25405 isMouseOver (DD)Z
+		COMMENT Checks of the mouse position is within the bound
+		COMMENT of the element.
+		COMMENT
+		COMMENT @param mouseX the X coordinate of the mouse
+		COMMENT @param mouseY the Y coordinate of the mouse
+		COMMENT @return {@code true} if the mouse is within the bound of the element, otherwise {@code false}
 		ARG 1 mouseX
 		ARG 3 mouseY
 	METHOD method_25406 mouseReleased (DDI)Z
+		COMMENT Callback for when a mouse button release event
+		COMMENT has been captured.
+		COMMENT
+		COMMENT The button number is identified by the constants in
+		COMMENT {@link org.lwjgl.glfw.GLFW GLFW class}
+		COMMENT
+		COMMENT @param mouseX the X coordinate of the mouse
+		COMMENT @param mouseY the Y coordinate of the mouse
+		COMMENT @param button the mouse button number
+		COMMENT @return {@code true} to indicate that the event handling is successful/valid
+		COMMENT @see net.minecraft.client.Mouse#onMouseButton
+		COMMENT @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		ARG 1 mouseX
 		ARG 3 mouseY
 		ARG 5 button
 	METHOD method_25407 changeFocus (Z)Z
+		COMMENT Changes the focusing element by cycling to the next/previous element.
+		COMMENT
+		COMMENT This action is done typically when user has pressed the 'Tab' or 'Ctrl+Tab'
+		COMMENT key.
+		COMMENT
+		COMMENT @param lookForwards {@code true} if to cycle forward, otherwise cycle backwards
+		COMMENT @return {@code true} to indicate that the event handling is successful/valid
 		ARG 1 lookForwards

--- a/mappings/net/minecraft/client/gui/Element.mapping
+++ b/mappings/net/minecraft/client/gui/Element.mapping
@@ -139,4 +139,4 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 		COMMENT
 		COMMENT @return {@code true} to indicate that the event handling is successful/valid
 		ARG 1 lookForwards
-			COMMENT {@code true} if to cycle forward, otherwise cycle backwards
+			COMMENT {@code true} to cycle forwards, otherwise cycle backwards

--- a/mappings/net/minecraft/client/gui/Element.mapping
+++ b/mappings/net/minecraft/client/gui/Element.mapping
@@ -7,56 +7,53 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 	METHOD method_16014 mouseMoved (DD)V
 		COMMENT Callback for when a mouse move event has been captured.
 		COMMENT
-		COMMENT @param mouseX the X coordinate of the mouse
-		COMMENT @param mouseY the Y coordinate of the mouse
 		COMMENT @see net.minecraft.client.Mouse#onCursorPos
 		ARG 1 mouseX
+			COMMENT the X coordinate of the mouse
 		ARG 3 mouseY
+			COMMENT mouseY the Y coordinate of the mouse
 	METHOD method_16803 keyReleased (III)Z
-		COMMENT Callback for when a key up event has been captured.
+		COMMENT Callback for when a key down event has been captured.
 		COMMENT
 		COMMENT The key code is identified by the constants in
 		COMMENT {@link org.lwjgl.glfw.GLFW GLFW} class.
 		COMMENT
-		COMMENT See the difference of a key code, a scan code, and a
-		COMMENT modifier in {@link org.lwjgl.glfw.GLFWKeyCallbackI#invoke(long, int, int, int, int) GLFWKeyCallbackI}
-		COMMENT
-		COMMENT @param keyCode the key code of the event
-		COMMENT @param scanCode the scan code of the event
-		COMMENT @param modifiers a bitfield/flag describing the which modifier keys are held down
 		COMMENT @return {@code true} to indicate that the event handling is successful/valid
 		COMMENT @see net.minecraft.client.Keyboard#onKey(long, int, int, int, int)
 		COMMENT @see org.lwjgl.glfw.GLFW#GLFW_KEY_Q
 		COMMENT @see org.lwjgl.glfw.GLFWKeyCallbackI#invoke(long, int, int, int, int)
 		ARG 1 keyCode
+			COMMENT the named key code of the event as described in the {@link org.lwjgl.glfw.GLFW GLFW} class
 		ARG 2 scanCode
+			COMMENT the unique/platform-specific scan code of the keyboard input
 		ARG 3 modifiers
+			COMMENT a GLFW bitfield describing the modifier keys that are held down; See {@linkplain https://www.glfw.org/docs/3.3/group__mods.html GLFW Modifier key flags}
 	METHOD method_25400 charTyped (CI)Z
 		COMMENT Callback for when a character input has been captured.
 		COMMENT
 		COMMENT The key code is identified by the constants in
 		COMMENT {@link org.lwjgl.glfw.GLFW GLFW} class.
 		COMMENT
-		COMMENT @param chr the character
-		COMMENT @param keyCode the key code of the event
 		COMMENT @return {@code true} to indicate that the event handling is successful/valid
 		COMMENT @see net.minecraft.client.Keyboard#onChar(long, int, int)
 		COMMENT @see org.lwjgl.glfw.GLFW#GLFW_KEY_Q
 		COMMENT @see org.lwjgl.glfw.GLFWKeyCallbackI#invoke(long, int, int, int, int)
 		ARG 1 chr
+			COMMENT the captured character
 		ARG 2 keyCode
+			COMMENT the associated key code
 	METHOD method_25401 mouseScrolled (DDD)Z
 		COMMENT Callback for when a mouse button scroll event
 		COMMENT has been captured.
 		COMMENT
-		COMMENT @param mouseX the X coordinate of the mouse
-		COMMENT @param mouseY the Y coordinate of the mouse
-		COMMENT @param amount value is {@code > 1} if scrolled down, {@code < 1} if scrolled up
 		COMMENT @return {@code true} to indicate that the event handling is successful/valid
 		COMMENT @see net.minecraft.client.Mouse#onMouseScroll(long, double, double)
 		ARG 1 mouseX
+			COMMENT the X coordinate of the mouse
 		ARG 3 mouseY
+			COMMENT the Y coordinate of the mouse
 		ARG 5 amount
+			COMMENT value is {@code > 1} if scrolled down, {@code < 1} if scrolled up
 	METHOD method_25402 mouseClicked (DDI)Z
 		COMMENT Callback for when a mouse button down event
 		COMMENT has been captured.
@@ -64,15 +61,15 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 		COMMENT The button number is identified by the constants in
 		COMMENT {@link org.lwjgl.glfw.GLFW GLFW} class.
 		COMMENT
-		COMMENT @param mouseX the X coordinate of the mouse
-		COMMENT @param mouseY the Y coordinate of the mouse
-		COMMENT @param button the mouse button number
 		COMMENT @return {@code true} to indicate that the event handling is successful/valid
 		COMMENT @see net.minecraft.client.Mouse#onMouseButton(long, int, int, int)
 		COMMENT @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		ARG 1 mouseX
+			COMMENT the X coordinate of the mouse
 		ARG 3 mouseY
+			COMMENT the Y coordinate of the mouse
 		ARG 5 button
+			COMMENT the mouse button number
 	METHOD method_25403 mouseDragged (DDIDD)Z
 		COMMENT Callback for when a mouse button drag event
 		COMMENT has been captured.
@@ -80,47 +77,44 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 		COMMENT The button number is identified by the constants in
 		COMMENT {@link org.lwjgl.glfw.GLFW GLFW} class.
 		COMMENT
-		COMMENT @param mouseX the current X coordinate of the mouse
-		COMMENT @param mouseY the current Y coordinate of the mouse
-		COMMENT @param button the mouse button number
-		COMMENT @param deltaX the difference of the current X with the previous X coordinate
-		COMMENT @param deltaY the difference of the current Y with the previous X coordinate
 		COMMENT @return {@code true} to indicate that the event handling is successful/valid
 		COMMENT @see net.minecraft.client.Mouse#onCursorPos(long, double, double)
 		COMMENT @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		ARG 1 mouseX
+			COMMENT the current X coordinate of the mouse
 		ARG 3 mouseY
+			COMMENT the current Y coordinate of the mouse
 		ARG 5 button
+			COMMENT the mouse button number
 		ARG 6 deltaX
+			COMMENT the difference of the current X with the previous X coordinate
 		ARG 8 deltaY
+			COMMENT the difference of the current Y with the previous Y coordinate
 	METHOD method_25404 keyPressed (III)Z
 		COMMENT Callback for when a key down event has been captured.
 		COMMENT
 		COMMENT The key code is identified by the constants in
 		COMMENT {@link org.lwjgl.glfw.GLFW GLFW} class.
 		COMMENT
-		COMMENT See the difference of a key code, a scan code, and a
-		COMMENT modifier in {@link org.lwjgl.glfw.GLFWKeyCallbackI#invoke(long, int, int, int, int) GLFWKeyCallbackI}
-		COMMENT
-		COMMENT @param keyCode the key code of the event
-		COMMENT @param scanCode the scan code of the event
-		COMMENT @param modifiers a bitfield/flag describing the which modifier keys are held down
 		COMMENT @return {@code true} to indicate that the event handling is successful/valid
 		COMMENT @see net.minecraft.client.Keyboard#onKey(long, int, int, int, int)
 		COMMENT @see org.lwjgl.glfw.GLFW#GLFW_KEY_Q
 		COMMENT @see org.lwjgl.glfw.GLFWKeyCallbackI#invoke(long, int, int, int, int)
 		ARG 1 keyCode
+			COMMENT the named key code of the event as described in the {@link org.lwjgl.glfw.GLFW GLFW} class
 		ARG 2 scanCode
+			COMMENT the unique/platform-specific scan code of the keyboard input
 		ARG 3 modifiers
+			COMMENT a GLFW bitfield describing the modifier keys that are held down; See {@linkplain https://www.glfw.org/docs/3.3/group__mods.html GLFW Modifier key flags}
 	METHOD method_25405 isMouseOver (DD)Z
 		COMMENT Checks of the mouse position is within the bound
 		COMMENT of the element.
 		COMMENT
-		COMMENT @param mouseX the X coordinate of the mouse
-		COMMENT @param mouseY the Y coordinate of the mouse
 		COMMENT @return {@code true} if the mouse is within the bound of the element, otherwise {@code false}
 		ARG 1 mouseX
+			COMMENT the X coordinate of the mouse
 		ARG 3 mouseY
+			COMMENT the Y coordinate of the mouse
 	METHOD method_25406 mouseReleased (DDI)Z
 		COMMENT Callback for when a mouse button release event
 		COMMENT has been captured.
@@ -128,21 +122,21 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 		COMMENT The button number is identified by the constants in
 		COMMENT {@link org.lwjgl.glfw.GLFW GLFW} class.
 		COMMENT
-		COMMENT @param mouseX the X coordinate of the mouse
-		COMMENT @param mouseY the Y coordinate of the mouse
-		COMMENT @param button the mouse button number
 		COMMENT @return {@code true} to indicate that the event handling is successful/valid
 		COMMENT @see net.minecraft.client.Mouse#onMouseButton(long, int, int, int)
 		COMMENT @see org.lwjgl.glfw.GLFW#GLFW_MOUSE_BUTTON_1
 		ARG 1 mouseX
+			COMMENT the X coordinate of the mouse
 		ARG 3 mouseY
+			COMMENT the Y coordinate of the mouse
 		ARG 5 button
+			COMMENT the mouse button number
 	METHOD method_25407 changeFocus (Z)Z
 		COMMENT Changes the focusing element by cycling to the next/previous element.
 		COMMENT
 		COMMENT This action is done typically when the user has pressed the 'Tab' or 'Ctrl+Tab'
 		COMMENT key.
 		COMMENT
-		COMMENT @param lookForwards {@code true} if to cycle forward, otherwise cycle backwards
 		COMMENT @return {@code true} to indicate that the event handling is successful/valid
 		ARG 1 lookForwards
+			COMMENT {@code true} if to cycle forward, otherwise cycle backwards

--- a/mappings/net/minecraft/client/gui/Element.mapping
+++ b/mappings/net/minecraft/client/gui/Element.mapping
@@ -107,7 +107,7 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 		ARG 3 modifiers
 			COMMENT a GLFW bitfield describing the modifier keys that are held down; See {@linkplain https://www.glfw.org/docs/3.3/group__mods.html GLFW Modifier key flags}
 	METHOD method_25405 isMouseOver (DD)Z
-		COMMENT Checks of the mouse position is within the bound
+		COMMENT Checks if the mouse position is within the bound
 		COMMENT of the element.
 		COMMENT
 		COMMENT @return {@code true} if the mouse is within the bound of the element, otherwise {@code false}

--- a/mappings/net/minecraft/client/gui/Element.mapping
+++ b/mappings/net/minecraft/client/gui/Element.mapping
@@ -11,7 +11,7 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 		ARG 1 mouseX
 			COMMENT the X coordinate of the mouse
 		ARG 3 mouseY
-			COMMENT mouseY the Y coordinate of the mouse
+			COMMENT the Y coordinate of the mouse
 	METHOD method_16803 keyReleased (III)Z
 		COMMENT Callback for when a key down event has been captured.
 		COMMENT


### PR DESCRIPTION
This PR fulfills the request by the issue #1753 especially on referencing the `GLFW` constants in key codes and mouse buttons.

Feel free inform if there is any critical correction required.