### PR TITLE
Style.method_30938 -> withUnderline

### DIFF
--- a/mappings/net/minecraft/text/Style.mapping
+++ b/mappings/net/minecraft/text/Style.mapping
@@ -133,6 +133,10 @@ CLASS net/minecraft/class_2583 net/minecraft/text/Style
 			COMMENT the new formatting
 	METHOD method_27708 getFont ()Lnet/minecraft/class_2960;
 		COMMENT Returns the font of this style.
+	METHOD method_30938 withUnderline (Ljava/lang/Boolean;)Lnet/minecraft/class_2583;
+		COMMENT Returns a new style with the underline attribute provided and all other
+		COMMENT attributes of this style.
+		ARG 1 underline
 	CLASS class_2584 Serializer
 		COMMENT A JSON serializer for {@link Style}.
 		METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;


### PR DESCRIPTION
I've also added Javadoc in the style of all the other `with*` methods' Javadocs.