### PR TITLE
AbstractButtonWidget -> AbstractClickableWidget

### DIFF
--- a/mappings/net/minecraft/client/gui/widget/AbstractClickableWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/AbstractClickableWidget.mapping
@@ -1,8 +1,9 @@
-CLASS net/minecraft/class_339 net/minecraft/client/gui/widget/AbstractButtonWidget
+CLASS net/minecraft/class_339 net/minecraft/client/gui/widget/AbstractClickableWidget
+	COMMENT A specialized widget which is clickable and may optionally display a message.
 	FIELD field_22754 message Lnet/minecraft/class_2561;
 	FIELD field_22755 wasHovered Z
 	FIELD field_22756 focused Z
-	FIELD field_22757 WIDGETS_LOCATION Lnet/minecraft/class_2960;
+	FIELD field_22757 WIDGETS_TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_22758 width I
 	FIELD field_22759 height I
 	FIELD field_22760 x I
@@ -34,7 +35,7 @@ CLASS net/minecraft/class_339 net/minecraft/client/gui/widget/AbstractButtonWidg
 		ARG 1 matrices
 		ARG 2 mouseX
 		ARG 3 mouseY
-	METHOD method_25353 renderBg (Lnet/minecraft/class_4587;Lnet/minecraft/class_310;II)V
+	METHOD method_25353 renderBackground (Lnet/minecraft/class_4587;Lnet/minecraft/class_310;II)V
 		ARG 1 matrices
 		ARG 2 client
 		ARG 3 mouseX
@@ -42,6 +43,7 @@ CLASS net/minecraft/class_339 net/minecraft/client/gui/widget/AbstractButtonWidg
 	METHOD method_25354 playDownSound (Lnet/minecraft/class_1144;)V
 		ARG 1 soundManager
 	METHOD method_25355 setMessage (Lnet/minecraft/class_2561;)V
+		ARG 1 text
 	METHOD method_25356 getYImage (Z)I
 		ARG 1 hovered
 	METHOD method_25357 onRelease (DD)V

--- a/mappings/net/minecraft/client/gui/widget/AbstractPressableButtonWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/AbstractPressableButtonWidget.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/class_4264 net/minecraft/client/gui/widget/AbstractPressableButtonWidget
+	COMMENT A simple widget which handles a clicking action and plays a click sound.
 	METHOD method_25306 onPress ()V

--- a/mappings/net/minecraft/client/gui/widget/ButtonWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ButtonWidget.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_4185 net/minecraft/client/gui/widget/ButtonWidget
+	COMMENT A simple button widget which allows specification of a press action and tooltip popups.
 	FIELD field_22767 onPress Lnet/minecraft/class_4185$class_4241;
 	FIELD field_25035 EMPTY Lnet/minecraft/class_4185$class_5316;
 	FIELD field_25036 tooltipSupplier Lnet/minecraft/class_4185$class_5316;
@@ -24,9 +25,13 @@ CLASS net/minecraft/class_4185 net/minecraft/client/gui/widget/ButtonWidget
 		ARG 3 mouseY
 	CLASS class_4241 PressAction
 		METHOD onPress (Lnet/minecraft/class_4185;)V
+			COMMENT Callback for when the button is pressed.
 			ARG 1 button
+				COMMENT the button being pressed
 	CLASS class_5316 TooltipSupplier
 		METHOD onTooltip (Lnet/minecraft/class_4185;Lnet/minecraft/class_4587;II)V
+			COMMENT Callback for rendering a tooltip.
+			COMMENT The tooltip is rendered when the mouse cursor is within the bounds of the button.
 			ARG 1 button
 			ARG 2 matrices
 			ARG 3 mouseX

--- a/mappings/net/minecraft/client/gui/widget/TexturedButtonWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/TexturedButtonWidget.mapping
@@ -29,6 +29,7 @@ CLASS net/minecraft/class_344 net/minecraft/client/gui/widget/TexturedButtonWidg
 		ARG 9 textureWidth
 		ARG 10 textureHeight
 		ARG 11 pressAction
+		ARG 12 text
 	METHOD <init> (IIIIIIILnet/minecraft/class_2960;Lnet/minecraft/class_4185$class_4241;)V
 		ARG 1 x
 		ARG 2 y


### PR DESCRIPTION
Fixes #1752

Why?
`AbstractButtonWidget` is not used exclusively by buttons. This class is used by the text field and slider widgets. Whats common between those two widget types and button widgets is that you "click" the widget.

Also `renderBg` -> `renderBackground`