### PR TITLE
Map class and methods in NarratorOptionsScreen

### DIFF
--- a/mappings/net/minecraft/NarratorOptionsScreen.mapping
+++ b/mappings/net/minecraft/NarratorOptionsScreen.mapping
@@ -1,0 +1,10 @@
+CLASS net/minecraft/class_5500 net/minecraft/NarratorOptionsScreen
+	FIELD field_26679 options [Lnet/minecraft/class_316;
+	FIELD field_26680 narratorButton Lnet/minecraft/class_339;
+	FIELD field_26681 buttonList Lnet/minecraft/class_353;
+	METHOD <init> (Lnet/minecraft/class_437;Lnet/minecraft/class_315;Lnet/minecraft/class_2561;[Lnet/minecraft/class_316;)V
+		ARG 1 screen
+		ARG 2 gameOptions
+		ARG 3 title
+		ARG 4 options
+	METHOD method_31050 updateNarratorButtonText ()V

--- a/mappings/net/minecraft/client/gui/screen/options/GameOptionsScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/options/GameOptionsScreen.mapping
@@ -5,3 +5,6 @@ CLASS net/minecraft/class_4667 net/minecraft/client/gui/screen/options/GameOptio
 		ARG 1 parent
 		ARG 2 gameOptions
 		ARG 3 title
+	METHOD method_31048 getHoveredButtonTooltip (Lnet/minecraft/class_353;II)Ljava/util/List;
+		ARG 1 mouseX
+		ARG 2 mouseY

--- a/mappings/net/minecraft/client/gui/screen/options/NarratorOptionsScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/options/NarratorOptionsScreen.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_5500 net/minecraft/NarratorOptionsScreen
+CLASS net/minecraft/class_5500 net/minecraft/client/gui/screen/options/NarratorOptionsScreen
 	FIELD field_26679 options [Lnet/minecraft/class_316;
 	FIELD field_26680 narratorButton Lnet/minecraft/class_339;
 	FIELD field_26681 buttonList Lnet/minecraft/class_353;

--- a/mappings/net/minecraft/client/gui/screen/options/NarratorOptionsScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/options/NarratorOptionsScreen.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_5500 net/minecraft/client/gui/screen/options/NarratorO
 	FIELD field_26680 narratorButton Lnet/minecraft/class_339;
 	FIELD field_26681 buttonList Lnet/minecraft/class_353;
 	METHOD <init> (Lnet/minecraft/class_437;Lnet/minecraft/class_315;Lnet/minecraft/class_2561;[Lnet/minecraft/class_316;)V
-		ARG 1 screen
+		ARG 1 parent
 		ARG 2 gameOptions
 		ARG 3 title
 		ARG 4 options

--- a/mappings/net/minecraft/client/gui/widget/ButtonListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ButtonListWidget.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_353 net/minecraft/client/gui/widget/ButtonListWidget
 	METHOD method_29624 getHoveredButton (DD)Ljava/util/Optional;
 		ARG 1 mouseX
 		ARG 3 mouseY
-	METHOD method_31046 findOptionButton (Lnet/minecraft/class_316;)Lnet/minecraft/class_339;
+	METHOD method_31046 getButtonFor (Lnet/minecraft/class_316;)Lnet/minecraft/class_339;
 	CLASS class_354 ButtonEntry
 		FIELD field_18214 buttons Ljava/util/List;
 		METHOD <init> (Ljava/util/List;)V

--- a/mappings/net/minecraft/client/gui/widget/ButtonListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ButtonListWidget.mapping
@@ -9,6 +9,7 @@ CLASS net/minecraft/class_353 net/minecraft/client/gui/widget/ButtonListWidget
 	METHOD method_29624 getHoveredButton (DD)Ljava/util/Optional;
 		ARG 1 mouseX
 		ARG 3 mouseY
+	METHOD method_31046 findOptionButton (Lnet/minecraft/class_316;)Lnet/minecraft/class_339;
 	CLASS class_354 ButtonEntry
 		FIELD field_18214 buttons Ljava/util/List;
 		METHOD <init> (Ljava/util/List;)V


### PR DESCRIPTION
# Map class and methods in NarratorOptionsScreen
This PR maps the class `class_5500`, which is the base of `AccessibilityOptionsScreen` and `ChatOptionsScreen`.
The class simply contains code to handle updating the narrator button text when the mode is changed via the
keyboard shortcut.
It also maps two related functions in `GameOptionsScreen` and `ButtonListWidget`.