### PR TITLE
Rename villager trade select listener method to match packet name

### DIFF
--- a/mappings/net/minecraft/network/listener/ServerPlayPacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ServerPlayPacketListener.mapping
@@ -70,7 +70,7 @@ CLASS net/minecraft/class_2792 net/minecraft/network/listener/ServerPlayPacketLi
 		ARG 1 packet
 	METHOD method_12079 onConfirmTransaction (Lnet/minecraft/class_2809;)V
 		ARG 1 packet
-	METHOD method_12080 onVillagerTradeSelect (Lnet/minecraft/class_2863;)V
+	METHOD method_12080 onMerchantTradeSelect (Lnet/minecraft/class_2863;)V
 		ARG 1 packet
 	METHOD method_12081 onResourcePackStatus (Lnet/minecraft/class_2856;)V
 		ARG 1 packet


### PR DESCRIPTION
This pull request continues #1760 by changing another outdated name, as the (formerly) `onVillagerTradeSelect` method is supplied a `SelectMerchantTradeC2SPacket`, which is sent via `MerchantScreen` for both villagers and wandering traders.