### PR TITLE
Replace remaining references to generic trader naming with merchant

### DIFF
--- a/mappings/net/minecraft/advancement/criterion/VillagerTradeCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/VillagerTradeCriterion.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_2140 net/minecraft/advancement/criterion/VillagerTrade
 	FIELD field_9762 ID Lnet/minecraft/class_2960;
 	METHOD method_9146 handle (Lnet/minecraft/class_3222;Lnet/minecraft/class_3988;Lnet/minecraft/class_1799;)V
 		ARG 1 player
-		ARG 2 trader
+		ARG 2 merchant
 		ARG 3 stack
 	CLASS class_2142 Conditions
 		FIELD field_9766 item Lnet/minecraft/class_2073;
@@ -13,5 +13,5 @@ CLASS net/minecraft/class_2140 net/minecraft/advancement/criterion/VillagerTrade
 			ARG 3 item
 		METHOD method_9153 any ()Lnet/minecraft/class_2140$class_2142;
 		METHOD method_9154 matches (Lnet/minecraft/class_47;Lnet/minecraft/class_1799;)Z
-			ARG 1 traderContext
+			ARG 1 merchantContext
 			ARG 2 stack

--- a/mappings/net/minecraft/entity/ai/goal/LookAtCustomerGoal.mapping
+++ b/mappings/net/minecraft/entity/ai/goal/LookAtCustomerGoal.mapping
@@ -1,4 +1,4 @@
 CLASS net/minecraft/class_1364 net/minecraft/entity/ai/goal/LookAtCustomerGoal
-	FIELD field_6495 trader Lnet/minecraft/class_3988;
+	FIELD field_6495 merchant Lnet/minecraft/class_3988;
 	METHOD <init> (Lnet/minecraft/class_3988;)V
-		ARG 1 trader
+		ARG 1 merchant

--- a/mappings/net/minecraft/entity/ai/goal/StopFollowingCustomerGoal.mapping
+++ b/mappings/net/minecraft/entity/ai/goal/StopFollowingCustomerGoal.mapping
@@ -1,4 +1,4 @@
 CLASS net/minecraft/class_1390 net/minecraft/entity/ai/goal/StopFollowingCustomerGoal
-	FIELD field_6610 trader Lnet/minecraft/class_3988;
+	FIELD field_6610 merchant Lnet/minecraft/class_3988;
 	METHOD <init> (Lnet/minecraft/class_3988;)V
-		ARG 1 trader
+		ARG 1 merchant

--- a/mappings/net/minecraft/screen/MerchantScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/MerchantScreenHandler.mapping
@@ -2,15 +2,15 @@ CLASS net/minecraft/class_1728 net/minecraft/screen/MerchantScreenHandler
 	FIELD field_18669 levelProgress I
 	FIELD field_18670 leveled Z
 	FIELD field_19358 canRefreshTrades Z
-	FIELD field_7861 traderInventory Lnet/minecraft/class_1725;
-	FIELD field_7863 trader Lnet/minecraft/class_1915;
+	FIELD field_7861 merchantInventory Lnet/minecraft/class_1725;
+	FIELD field_7863 merchant Lnet/minecraft/class_1915;
 	METHOD <init> (ILnet/minecraft/class_1661;)V
 		ARG 1 syncId
 		ARG 2 playerInventory
 	METHOD <init> (ILnet/minecraft/class_1661;Lnet/minecraft/class_1915;)V
 		ARG 1 syncId
 		ARG 2 playerInventory
-		ARG 3 trader
+		ARG 3 merchant
 	METHOD method_17437 setOffers (Lnet/minecraft/class_1916;)V
 		ARG 1 offers
 	METHOD method_17438 getRecipes ()Lnet/minecraft/class_1916;
@@ -19,7 +19,7 @@ CLASS net/minecraft/class_1728 net/minecraft/screen/MerchantScreenHandler
 	METHOD method_19254 getExperience ()I
 	METHOD method_19255 setExperienceFromServer (I)V
 		ARG 1 experience
-	METHOD method_19256 getTraderRewardedExperience ()I
+	METHOD method_19256 getMerchantRewardedExperience ()I
 	METHOD method_19257 setLevelProgress (I)V
 		ARG 1 progress
 	METHOD method_19258 getLevelProgress ()I

--- a/mappings/net/minecraft/screen/slot/TradeOutputSlot.mapping
+++ b/mappings/net/minecraft/screen/slot/TradeOutputSlot.mapping
@@ -1,12 +1,12 @@
 CLASS net/minecraft/class_1727 net/minecraft/screen/slot/TradeOutputSlot
 	FIELD field_7857 player Lnet/minecraft/class_1657;
-	FIELD field_7858 trader Lnet/minecraft/class_1915;
+	FIELD field_7858 merchant Lnet/minecraft/class_1915;
 	FIELD field_7859 amount I
-	FIELD field_7860 traderInventory Lnet/minecraft/class_1725;
+	FIELD field_7860 merchantInventory Lnet/minecraft/class_1725;
 	METHOD <init> (Lnet/minecraft/class_1657;Lnet/minecraft/class_1915;Lnet/minecraft/class_1725;III)V
 		ARG 1 player
-		ARG 2 trader
-		ARG 3 traderInventory
+		ARG 2 merchant
+		ARG 3 merchantInventory
 		ARG 4 index
 		ARG 5 x
 		ARG 6 y

--- a/mappings/net/minecraft/village/MerchantInventory.mapping
+++ b/mappings/net/minecraft/village/MerchantInventory.mapping
@@ -1,10 +1,10 @@
 CLASS net/minecraft/class_1725 net/minecraft/village/MerchantInventory
-	FIELD field_18668 traderRewardedExperience I
+	FIELD field_18668 merchantRewardedExperience I
 	FIELD field_7842 recipeIndex I
 	FIELD field_7843 tradeOffer Lnet/minecraft/class_1914;
 	FIELD field_7844 merchant Lnet/minecraft/class_1915;
 	FIELD field_7845 inventory Lnet/minecraft/class_2371;
-	METHOD method_19252 getTraderRewardedExperience ()I
+	METHOD method_19252 getMerchantRewardedExperience ()I
 	METHOD method_7642 getTradeOffer ()Lnet/minecraft/class_1914;
 	METHOD method_7643 setRecipeIndex (I)V
 		ARG 1 index

--- a/mappings/net/minecraft/village/TradeOffer.mapping
+++ b/mappings/net/minecraft/village/TradeOffer.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_1914 net/minecraft/village/TradeOffer
 	FIELD field_18676 specialPrice I
 	FIELD field_18677 demandBonus I
 	FIELD field_18678 priceMultiplier F
-	FIELD field_18679 traderExperience I
+	FIELD field_18679 merchantExperience I
 	FIELD field_9143 secondBuyItem Lnet/minecraft/class_1799;
 	FIELD field_9144 maxUses I
 	FIELD field_9145 rewardingPlayerExperience Z
@@ -45,7 +45,7 @@ CLASS net/minecraft/class_1914 net/minecraft/village/TradeOffer
 	METHOD method_19276 clearSpecialPrice ()V
 	METHOD method_19277 getSpecialPrice ()I
 	METHOD method_19278 getPriceMultiplier ()F
-	METHOD method_19279 getTraderExperience ()I
+	METHOD method_19279 getMerchantExperience ()I
 	METHOD method_21725 getDemandBonus ()I
 	METHOD method_8244 use ()V
 	METHOD method_8245 increaseSpecialPrice (I)V


### PR DESCRIPTION
This pull request continues #1760 by replacing the remaining references to `trader`, the outdated name for both villagers and wandering trades, with `merchant`, as indicated by translation keys such as `merchant.trades` and the identifier for `MerchantScreenHandler`.