### PR TITLE
Finish BlockHitResult mapping

### DIFF
--- a/mappings/net/minecraft/util/hit/BlockHitResult.mapping
+++ b/mappings/net/minecraft/util/hit/BlockHitResult.mapping
@@ -23,3 +23,5 @@ CLASS net/minecraft/class_3965 net/minecraft/util/hit/BlockHitResult
 		ARG 1 side
 	METHOD method_17780 getSide ()Lnet/minecraft/class_2350;
 	METHOD method_17781 isInsideBlock ()Z
+	METHOD method_29328 withBlockPos (Lnet/minecraft/class_2338;)Lnet/minecraft/class_3965;
+		ARG 1 blockPos


### PR DESCRIPTION
Note: I had to use `blockPos` because `pos` is already used for other thing. (See the parent class `HitResult`.)