### PR TITLE
Map some sky properties

### DIFF
--- a/mappings/net/minecraft/client/item/ModelPredicateProviderRegistry.mapping
+++ b/mappings/net/minecraft/client/item/ModelPredicateProviderRegistry.mapping
@@ -35,7 +35,7 @@ CLASS net/minecraft/class_5272 net/minecraft/client/item/ModelPredicateProviderR
 			ARG 2 entity
 		METHOD method_27899 getSpawnPos (Lnet/minecraft/class_638;)Lnet/minecraft/class_2338;
 			ARG 1 world
-	CLASS class_5171 AngleRandomizer
+	CLASS class_5171 AngleInterpolator
 		FIELD field_23980 value D
 		FIELD field_23981 speed D
 		FIELD field_23982 lastUpdateTime J

--- a/mappings/net/minecraft/client/render/SkyProperties.mapping
+++ b/mappings/net/minecraft/client/render/SkyProperties.mapping
@@ -3,31 +3,44 @@ CLASS net/minecraft/class_5294 net/minecraft/client/render/SkyProperties
 	FIELD field_24610 rgba [F
 	FIELD field_24611 cloudsHeight F
 	FIELD field_24612 alternateSkyColor Z
-	FIELD field_24613 shouldRenderSky Z
+	FIELD field_24613 brightenLighting Z
 	FIELD field_25637 skyType Lnet/minecraft/class_5294$class_5401;
 	FIELD field_25638 darkened Z
 	METHOD <init> (FZLnet/minecraft/class_5294$class_5401;ZZ)V
 		ARG 1 cloudsHeight
 		ARG 2 alternateSkyColor
 		ARG 3 skyType
-		ARG 4 shouldRenderSky
+		ARG 4 brightenLighting
 		ARG 5 darkened
 	METHOD method_28108 getCloudsHeight ()F
-	METHOD method_28109 getSkyColor (FF)[F
+	METHOD method_28109 getFogColorOverride (FF)[F
+		COMMENT Returns a fog color override based on the current sky angle. This is used in vanilla to render sunset and
+		COMMENT sunrise fog.
+		COMMENT
+		COMMENT @return an RGBA array of four floats, or {@code null} if fog color should not be overridden
 		ARG 1 skyAngle
+			COMMENT
 		ARG 2 tickDelta
 	METHOD method_28110 useThickFog (II)Z
 		ARG 1 camX
 		ARG 2 camY
 	METHOD method_28111 byDimensionType (Lnet/minecraft/class_2874;)Lnet/minecraft/class_5294;
-	METHOD method_28112 adjustSkyColor (Lnet/minecraft/class_243;F)Lnet/minecraft/class_243;
+	METHOD method_28112 adjustFogColor (Lnet/minecraft/class_243;F)Lnet/minecraft/class_243;
+		COMMENT Transforms the given fog color based on the current height of the sun. This is used in vanilla to darken
+		COMMENT fog during night.
 		ARG 1 color
 		ARG 2 sunHeight
 	METHOD method_28113 isAlternateSkyColor ()Z
-	METHOD method_28114 shouldRenderSky ()Z
+	METHOD method_28114 shouldBrightenLighting ()Z
 	METHOD method_29992 getSkyType ()Lnet/minecraft/class_5294$class_5401;
 	METHOD method_29993 isDarkened ()Z
 	CLASS class_5295 End
 	CLASS class_5296 Nether
 	CLASS class_5297 Overworld
 	CLASS class_5401 SkyType
+		FIELD field_25639 Lnet/minecraft/class_5294$class_5401;
+			COMMENT Signals the renderer not to render a sky.
+		FIELD field_25640 Lnet/minecraft/class_5294$class_5401;
+			COMMENT Signals the renderer to render a normal sky (as in the vanilla Overworld).
+		FIELD field_25641 Lnet/minecraft/class_5294$class_5401;
+			COMMENT Signals the renderer to draw the end sky box over the sky (as in the vanilla End).

--- a/mappings/net/minecraft/client/render/SkyProperties.mapping
+++ b/mappings/net/minecraft/client/render/SkyProperties.mapping
@@ -19,7 +19,6 @@ CLASS net/minecraft/class_5294 net/minecraft/client/render/SkyProperties
 		COMMENT
 		COMMENT @return an RGBA array of four floats, or {@code null} if fog color should not be overridden
 		ARG 1 skyAngle
-			COMMENT
 		ARG 2 tickDelta
 	METHOD method_28110 useThickFog (II)Z
 		ARG 1 camX

--- a/mappings/net/minecraft/client/render/SkyProperties.mapping
+++ b/mappings/net/minecraft/client/render/SkyProperties.mapping
@@ -37,9 +37,9 @@ CLASS net/minecraft/class_5294 net/minecraft/client/render/SkyProperties
 	CLASS class_5296 Nether
 	CLASS class_5297 Overworld
 	CLASS class_5401 SkyType
-		FIELD field_25639 Lnet/minecraft/class_5294$class_5401;
+		FIELD field_25639 NONE Lnet/minecraft/class_5294$class_5401;
 			COMMENT Signals the renderer not to render a sky.
-		FIELD field_25640 Lnet/minecraft/class_5294$class_5401;
+		FIELD field_25640 NORMAL Lnet/minecraft/class_5294$class_5401;
 			COMMENT Signals the renderer to render a normal sky (as in the vanilla Overworld).
-		FIELD field_25641 Lnet/minecraft/class_5294$class_5401;
+		FIELD field_25641 END Lnet/minecraft/class_5294$class_5401;
 			COMMENT Signals the renderer to draw the end sky box over the sky (as in the vanilla End).


### PR DESCRIPTION
- `AngleRandomizer` -> `AngleInterpolator` - this class helps with interpolating angles.
- `shouldRenderSky` -> `shouldBrightenLighting` - this is called in `LightmapTextureManager` after getting the sky and block brightnesses.
- `getSkyColor` -> `getFogColorOverride` - this is used to retrieve the sunrise and sunset colors.
- `adjustSkyColor` -> `adjustFogColor` - this is used for the fog color, not the sky color.