### PR TITLE
Correct parameter names in PlayerSkinTexture for strip*

### DIFF
--- a/mappings/net/minecraft/client/texture/PlayerSkinTexture.mapping
+++ b/mappings/net/minecraft/client/texture/PlayerSkinTexture.mapping
@@ -14,18 +14,18 @@ CLASS net/minecraft/class_1046 net/minecraft/client/texture/PlayerSkinTexture
 		ARG 5 callback
 	METHOD method_22794 stripColor (Lnet/minecraft/class_1011;IIII)V
 		ARG 0 image
-		ARG 1 x
-		ARG 2 y
-		ARG 3 width
-		ARG 4 height
+		ARG 1 x1
+		ARG 2 y1
+		ARG 3 x2
+		ARG 4 y2
 	METHOD method_22795 loadTexture (Ljava/io/InputStream;)Lnet/minecraft/class_1011;
 		ARG 1 stream
 	METHOD method_22796 stripAlpha (Lnet/minecraft/class_1011;IIII)V
 		ARG 0 image
-		ARG 1 x
-		ARG 2 y
-		ARG 3 width
-		ARG 4 height
+		ARG 1 x1
+		ARG 2 y1
+		ARG 3 x2
+		ARG 4 y2
 	METHOD method_22798 remapTexture (Lnet/minecraft/class_1011;)Lnet/minecraft/class_1011;
 		ARG 0 image
 	METHOD method_4531 uploadTexture (Lnet/minecraft/class_1011;)V


### PR DESCRIPTION
The third and fourth parameters are not width or height; they are the coordinates for the lower-right corner of the area.