### PR TITLE
Renamed BlockColors#getColor and some comments for ChunkSection

### DIFF
--- a/mappings/net/minecraft/client/color/block/BlockColors.mapping
+++ b/mappings/net/minecraft/client/color/block/BlockColors.mapping
@@ -30,7 +30,7 @@ CLASS net/minecraft/class_324 net/minecraft/client/color/block/BlockColors
 	METHOD method_1690 registerColorProvider (Lnet/minecraft/class_322;[Lnet/minecraft/class_2248;)V
 		ARG 1 provider
 		ARG 2 blocks
-	METHOD method_1691 getDefaultColor (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)I
+	METHOD method_1691 getMaterialColor (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)I
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
@@ -59,7 +59,7 @@ CLASS net/minecraft/class_324 net/minecraft/client/color/block/BlockColors
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 tintIndex
-	METHOD method_1697 getColor (Lnet/minecraft/class_2680;Lnet/minecraft/class_1920;Lnet/minecraft/class_2338;I)I
+	METHOD method_1697 getBiomeColor (Lnet/minecraft/class_2680;Lnet/minecraft/class_1920;Lnet/minecraft/class_2338;I)I
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos

--- a/mappings/net/minecraft/client/color/block/BlockColors.mapping
+++ b/mappings/net/minecraft/client/color/block/BlockColors.mapping
@@ -30,7 +30,7 @@ CLASS net/minecraft/class_324 net/minecraft/client/color/block/BlockColors
 	METHOD method_1690 registerColorProvider (Lnet/minecraft/class_322;[Lnet/minecraft/class_2248;)V
 		ARG 1 provider
 		ARG 2 blocks
-	METHOD method_1691 getColor (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)I
+	METHOD method_1691 getDefaultColor (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)I
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos

--- a/mappings/net/minecraft/world/chunk/ChunkSection.mapping
+++ b/mappings/net/minecraft/world/chunk/ChunkSection.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_2826 net/minecraft/world/chunk/ChunkSection
+	COMMENT a 16x16x16 subchunk
 	FIELD field_12877 nonEmptyBlockCount S
 	FIELD field_12878 container Lnet/minecraft/class_2841;
 	FIELD field_12879 palette Lnet/minecraft/class_2837;

--- a/mappings/net/minecraft/world/chunk/WorldChunk.mapping
+++ b/mappings/net/minecraft/world/chunk/WorldChunk.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/class_2818 net/minecraft/world/chunk/WorldChunk
 	FIELD field_12838 structureStarts Ljava/util/Map;
 	FIELD field_12839 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_12840 sections [Lnet/minecraft/class_2826;
+		COMMENT a ChunkSection[16] with 0 being Y0-Y15. If a ChunkSection is Empty it will be {@code null}
 	FIELD field_12841 blockTickScheduler Lnet/minecraft/class_1951;
 	FIELD field_12843 inhabitedTime J
 	FIELD field_12844 lastSaveTime J


### PR DESCRIPTION
BlockColors#getColor(3 args) only gets the default or material color for the blockstate you supply which is misleading as it needs a world and blockpos.

BlockColors#getColor(4args) actually gets the proper colors for the blockstate depending on the location and world