### PR TITLE
Add mapping for TallPlantBlock.method_30036

### DIFF
--- a/mappings/net/minecraft/block/TallPlantBlock.mapping
+++ b/mappings/net/minecraft/block/TallPlantBlock.mapping
@@ -4,3 +4,12 @@ CLASS net/minecraft/class_2320 net/minecraft/block/TallPlantBlock
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 flags
+	METHOD method_30036 onBreakInCreative (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_1657;)V
+		COMMENT Destroys a bottom half of a tall double block (such as a plant or a door)
+		COMMENT without dropping an item when broken in creative.
+		COMMENT
+		COMMENT @see Block#onBreak(World, BlockPos, BlockState, PlayerEntity)
+		ARG 0 world
+		ARG 1 pos
+		ARG 2 state
+		ARG 3 player


### PR DESCRIPTION
The method destroys a bottom half of a tall double block (such as a plant or a door) when the top half is broken in creative, but does not drop the item.