### PR TITLE
Some server javadoc and mappings

### DIFF
--- a/mappings/net/minecraft/server/MinecraftServer.mapping
+++ b/mappings/net/minecraft/server/MinecraftServer.mapping
@@ -109,7 +109,7 @@ CLASS net/minecraft/server/MinecraftServer
 	METHOD method_29439 reloadResources (Ljava/util/Collection;)Ljava/util/concurrent/CompletableFuture;
 		COMMENT Reloads this server's datapacks.
 		COMMENT
-		COMMENT @return a completable future which specifies whether the reload was successful.
+		COMMENT @return a completable future which specifies whether the reload was successful
 		COMMENT A reload has failed when the future is exceptionally completed.
 		COMMENT @see CompletableFuture
 		ARG 1 datapacks
@@ -141,7 +141,7 @@ CLASS net/minecraft/server/MinecraftServer
 	METHOD method_3732 shouldBroadcastRconToOps ()Z
 	METHOD method_3734 getCommandManager ()Lnet/minecraft/class_2170;
 		COMMENT Gets the server's command manager.
-		COMMENT The command manager is responsible for parsing and dispatching commands
+		COMMENT The command manager is responsible for parsing and dispatching commands.
 	METHOD method_3735 loadWorld ()V
 	METHOD method_3736 shouldSpawnNpcs ()Z
 	METHOD method_3738 getWorlds ()Ljava/lang/Iterable;
@@ -178,7 +178,7 @@ CLASS net/minecraft/server/MinecraftServer
 		ARG 2 cheatsAllowed
 			COMMENT whether players on the server have operator permissions
 		ARG 3 port
-			COMMENT the port to open up to LAN connections.
+			COMMENT the port to open up to LAN connections
 	METHOD method_3764 setPreventProxyConnections (Z)V
 		ARG 1 preventProxyConnections
 	METHOD method_3765 getServerMetadata ()Lnet/minecraft/class_2926;

--- a/mappings/net/minecraft/server/MinecraftServer.mapping
+++ b/mappings/net/minecraft/server/MinecraftServer.mapping
@@ -107,6 +107,13 @@ CLASS net/minecraft/server/MinecraftServer
 		ARG 1 initialDistance
 	METHOD method_29435 getWorldRegistryKeys ()Ljava/util/Set;
 	METHOD method_29439 reloadResources (Ljava/util/Collection;)Ljava/util/concurrent/CompletableFuture;
+		COMMENT Reloads this server's datapacks.
+		COMMENT
+		COMMENT @return a completable future which specifies whether the reload was successful.
+		COMMENT A reload has failed when the future is exceptionally completed.
+		COMMENT @see CompletableFuture
+		ARG 1 datapacks
+			COMMENT a collection of datapacks to reload with
 	METHOD method_29736 loadDataPacks (Lnet/minecraft/class_3283;Lnet/minecraft/class_5359;Z)Lnet/minecraft/class_5359;
 		ARG 0 resourcePackManager
 		ARG 2 safeMode
@@ -133,10 +140,13 @@ CLASS net/minecraft/server/MinecraftServer
 		ARG 1 whitelistEnabled
 	METHOD method_3732 shouldBroadcastRconToOps ()Z
 	METHOD method_3734 getCommandManager ()Lnet/minecraft/class_2170;
+		COMMENT Gets the server's command manager.
+		COMMENT The command manager is responsible for parsing and dispatching commands
 	METHOD method_3735 loadWorld ()V
 	METHOD method_3736 shouldSpawnNpcs ()Z
 	METHOD method_3738 getWorlds ()Ljava/lang/Iterable;
 	METHOD method_3739 getCommandSource ()Lnet/minecraft/class_2168;
+		COMMENT Creates a command source which represents this Minecraft server instance.
 	METHOD method_3740 getCommandFunctionManager ()Lnet/minecraft/class_2991;
 	METHOD method_3742 addServerGuiTickable (Ljava/lang/Runnable;)V
 		ARG 1 tickable
@@ -157,10 +167,18 @@ CLASS net/minecraft/server/MinecraftServer
 	METHOD method_3759 isUsingNativeTransport ()Z
 	METHOD method_3760 getPlayerManager ()Lnet/minecraft/class_3324;
 	METHOD method_3761 shouldForceGameMode ()Z
+		COMMENT Checks whether a player's current game mode should be set to the server's current game mode when a player has connected.
 	METHOD method_3763 openToLan (Lnet/minecraft/class_1934;ZI)Z
+		COMMENT Opens a server for LAN connections.
+		COMMENT This is only supported on an integrated server, a dedicated server will always fail to open to LAN.
+		COMMENT
+		COMMENT @returns whether the server was successfully opened to LAN.
 		ARG 1 gameMode
+			COMMENT the game mode connecting players will have set by default
 		ARG 2 cheatsAllowed
+			COMMENT whether players on the server have operator permissions
 		ARG 3 port
+			COMMENT the port to open up to LAN connections.
 	METHOD method_3764 setPreventProxyConnections (Z)V
 		ARG 1 preventProxyConnections
 	METHOD method_3765 getServerMetadata ()Lnet/minecraft/class_2926;
@@ -175,6 +193,7 @@ CLASS net/minecraft/server/MinecraftServer
 	METHOD method_3779 setServerPort (I)V
 		ARG 1 serverPort
 	METHOD method_3780 getTicks ()I
+		COMMENT Gets the amount of ticks the server has been running for.
 	METHOD method_3782 shutdown ()V
 	METHOD method_3783 isMonsterSpawningEnabled ()Z
 	METHOD method_3784 getResourcePackUrl ()Ljava/lang/String;
@@ -190,6 +209,7 @@ CLASS net/minecraft/server/MinecraftServer
 		ARG 1 metadata
 	METHOD method_3793 getUserCache ()Lnet/minecraft/class_3312;
 	METHOD method_3794 setForceGameMode (Z)V
+		COMMENT Sets whether a player's current game mode should be set to the server's current game mode when a player has connected.
 		ARG 1 forceGameMode
 	METHOD method_3795 getSnooper ()Lnet/minecraft/class_1276;
 	METHOD method_3796 shouldSpawnAnimals ()Z
@@ -203,6 +223,7 @@ CLASS net/minecraft/server/MinecraftServer
 	METHOD method_3806 isRunning ()Z
 	METHOD method_3811 getUserName ()Ljava/lang/String;
 	METHOD method_3812 areCommandBlocksEnabled ()Z
+		COMMENT Specifies whether command blocks can execute commands on the server.
 	METHOD method_3813 tickWorlds (Ljava/util/function/BooleanSupplier;)V
 		ARG 1 shouldKeepTicking
 	METHOD method_3815 setPvpEnabled (Z)V

--- a/mappings/net/minecraft/server/MinecraftServer.mapping
+++ b/mappings/net/minecraft/server/MinecraftServer.mapping
@@ -172,7 +172,7 @@ CLASS net/minecraft/server/MinecraftServer
 		COMMENT Opens a server for LAN connections.
 		COMMENT This is only supported on an integrated server, a dedicated server will always fail to open to LAN.
 		COMMENT
-		COMMENT @returns whether the server was successfully opened to LAN.
+		COMMENT @return whether the server was successfully opened to LAN
 		ARG 1 gameMode
 			COMMENT the game mode connecting players will have set by default
 		ARG 2 cheatsAllowed

--- a/mappings/net/minecraft/server/PlayerManager.mapping
+++ b/mappings/net/minecraft/server/PlayerManager.mapping
@@ -85,7 +85,6 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		ARG 1 scoreboard
 		ARG 2 player
 	METHOD method_14589 sendToDimension (Lnet/minecraft/class_2596;Lnet/minecraft/class_5321;)V
-		COMMENT
 		ARG 1 packet
 		ARG 2 dimension
 	METHOD method_14590 getWhitelist ()Lnet/minecraft/class_3337;

--- a/mappings/net/minecraft/server/PlayerManager.mapping
+++ b/mappings/net/minecraft/server/PlayerManager.mapping
@@ -46,9 +46,9 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 	METHOD method_14566 getPlayer (Ljava/lang/String;)Lnet/minecraft/class_3222;
 		ARG 1 name
 	METHOD method_14567 getUserData ()Lnet/minecraft/class_2487;
-		COMMENT Gets the user data for the player hosting the Minecraft server.
+		COMMENT Gets the user data of the player hosting the Minecraft server.
 		COMMENT
-		COMMENT @return the user data of the host of the server if the server is an integrated server, otherwise {@code null}.
+		COMMENT @return the user data of the host of the server if the server is an integrated server, otherwise {@code null}
 	METHOD method_14568 getViewDistance ()I
 	METHOD method_14569 isOperator (Lcom/mojang/authlib/GameProfile;)Z
 		ARG 1 profile

--- a/mappings/net/minecraft/server/PlayerManager.mapping
+++ b/mappings/net/minecraft/server/PlayerManager.mapping
@@ -46,6 +46,9 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 	METHOD method_14566 getPlayer (Ljava/lang/String;)Lnet/minecraft/class_3222;
 		ARG 1 name
 	METHOD method_14567 getUserData ()Lnet/minecraft/class_2487;
+		COMMENT Gets the user data for the player hosting the Minecraft server.
+		COMMENT
+		COMMENT @return the user data of the host of the server if the server is an integrated server, otherwise {@code null}.
 	METHOD method_14568 getViewDistance ()I
 	METHOD method_14569 isOperator (Lcom/mojang/authlib/GameProfile;)Z
 		ARG 1 profile
@@ -53,6 +56,8 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		ARG 1 connection
 		ARG 2 player
 	METHOD method_14571 getPlayerList ()Ljava/util/List;
+		COMMENT Gets a list of all players on a Minecraft server.
+		COMMENT This list should not be modified!
 	METHOD method_14572 onDataPacksReloaded ()V
 	METHOD method_14574 getCurrentPlayerCount ()I
 	METHOD method_14576 sendCommandTree (Lnet/minecraft/class_3222;)V
@@ -80,6 +85,7 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		ARG 1 scoreboard
 		ARG 2 player
 	METHOD method_14589 sendToDimension (Lnet/minecraft/class_2596;Lnet/minecraft/class_5321;)V
+		COMMENT
 		ARG 1 packet
 		ARG 2 dimension
 	METHOD method_14590 getWhitelist ()Lnet/minecraft/class_3337;

--- a/mappings/net/minecraft/server/dedicated/MinecraftDedicatedServer.mapping
+++ b/mappings/net/minecraft/server/dedicated/MinecraftDedicatedServer.mapping
@@ -11,7 +11,7 @@ CLASS net/minecraft/class_3176 net/minecraft/server/dedicated/MinecraftDedicated
 	METHOD method_13942 sleepFiveSeconds ()V
 	METHOD method_13944 getMaxTickTime ()J
 	METHOD method_13947 enqueueCommand (Ljava/lang/String;Lnet/minecraft/class_2168;)V
-		ARG 1 input
+		ARG 1 command
 		ARG 2 commandSource
 	METHOD method_13948 createGui ()V
 	METHOD method_13950 createResourcePackHash ()Ljava/lang/String;

--- a/mappings/net/minecraft/server/dedicated/MinecraftDedicatedServer.mapping
+++ b/mappings/net/minecraft/server/dedicated/MinecraftDedicatedServer.mapping
@@ -11,6 +11,8 @@ CLASS net/minecraft/class_3176 net/minecraft/server/dedicated/MinecraftDedicated
 	METHOD method_13942 sleepFiveSeconds ()V
 	METHOD method_13944 getMaxTickTime ()J
 	METHOD method_13947 enqueueCommand (Ljava/lang/String;Lnet/minecraft/class_2168;)V
+		ARG 1 input
+		ARG 2 commandSource
 	METHOD method_13948 createGui ()V
 	METHOD method_13950 createResourcePackHash ()Ljava/lang/String;
 	METHOD method_13951 convertData ()Z

--- a/mappings/net/minecraft/server/rcon/QueryResponseHandler.mapping
+++ b/mappings/net/minecraft/server/rcon/QueryResponseHandler.mapping
@@ -14,6 +14,7 @@ CLASS net/minecraft/class_3364 net/minecraft/server/rcon/QueryResponseHandler
 	FIELD field_14457 port I
 	METHOD <init> (Lnet/minecraft/class_2994;I)V
 		ARG 1 server
+		ARG 2 queryPort
 	METHOD method_14746 cleanUp ()V
 	METHOD method_14747 createRulesReply (Ljava/net/DatagramPacket;)[B
 		ARG 1 packet
@@ -27,6 +28,8 @@ CLASS net/minecraft/class_3364 net/minecraft/server/rcon/QueryResponseHandler
 		ARG 1 e
 	METHOD method_14753 isValidQuery (Ljava/net/DatagramPacket;)Ljava/lang/Boolean;
 	METHOD method_14754 initialize ()Z
+	METHOD method_30737 create (Lnet/minecraft/class_2994;)Lnet/minecraft/class_3364;
+		ARG 0 server
 	CLASS class_3365 Query
 		FIELD field_14458 id I
 		FIELD field_14459 startTime J

--- a/mappings/net/minecraft/server/rcon/RconListener.mapping
+++ b/mappings/net/minecraft/server/rcon/RconListener.mapping
@@ -7,3 +7,5 @@ CLASS net/minecraft/class_3408 net/minecraft/server/rcon/RconListener
 	METHOD method_14820 removeStoppedClients ()V
 	METHOD method_27176 closeSocket (Ljava/net/ServerSocket;)V
 		ARG 1 socket
+	METHOD method_30738 create (Lnet/minecraft/class_2994;)Lnet/minecraft/class_3408;
+		ARG 0 server


### PR DESCRIPTION
This mainly adds javadoc to a few server related classes and maps two `create` methods for the query response handler and rcon listener.