### PR TITLE
Update gradle and improve realiablitity of actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java-version: [jdk8, jdk11, jdk15]
+        java: [jdk8, jdk11, jdk15]
     runs-on: ubuntu-20.04
     container:
       image: openjdk:${{ matrix.java }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [jdk8, jdk11, jdk15]
+        java: [8-jdk, 11-jdk, 14-jdk]
     runs-on: ubuntu-20.04
     container:
       image: openjdk:${{ matrix.java }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,15 +4,12 @@ jobs:
   build:
     strategy:
       matrix:
-        java-version: [1.8, 11, 14]
+        java-version: [jdk8, jdk11, jdk15]
     runs-on: ubuntu-20.04
+    container:
+      image: openjdk:${{ matrix.java }}
+      options: --user root
     steps:
       - uses: actions/checkout@v1
       - uses: gradle/wrapper-validation-action@v1
-      - uses: actions/setup-java@v1
-        with:
-          java-version: ${{ matrix.java-version }}
-      - uses: eskatos/gradle-command-action@v1.3.2
-        with:
-          gradle-version: wrapper
-          arguments: build javadocJar checkMappings --stacktrace
+      - run: ./gradlew build javadocJar checkMappings --stacktrace

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The `gradle-command-action` has been failing randomly for quite some time, this moves over to using a docker based approach the same as loom uses.

Also updated gradle, java 14 is still used as the latest java to test with due to gradle's java 15 support not in a stable release quite yet.