### PR TITLE
Add a simple `decompileCFR` task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 build/
 out/
 mappings_official/
-src/
+namedSrc/
 
 # idea
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 build/
 out/
 mappings_official/
+src/
 
 # idea
 .idea/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Build a GZip'd archive containing a tiny mapping between official (obfuscated), 
 ### `mapNamedJar`
 Builds a deobfuscated jar with yarn mappings and automapped fields (enums, etc.). Unmapped names will be filled with [intermediary](https://github.com/FabricMC/Intermediary) names.
 
+### `decompileCFR`
+Decompile the mapped source code. **Note:** This is not designed to be recompiled.
+
 ### `download`
 Downloads the client and server Minecraft jars for the current Minecraft version to `.gradle/minecraft`
 

--- a/build.gradle
+++ b/build.gradle
@@ -679,10 +679,10 @@ task decompileCFR(type: JavaExec, dependsOn: "mapNamedJar") {
 	classpath = configurations.decompileClasspath
 	main = "org.benf.cfr.reader.Main"
 
-	args namedJar.getAbsolutePath(), "--outputdir", file("src").absolutePath
+	args namedJar.getAbsolutePath(), "--outputdir", file("namedSrc").absolutePath
 
 	doFirst {
-		file("src").deleteDir()
+		file("namedSrc").deleteDir()
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ repositories {
 		name "Fabric Repository"
 		url 'https://maven.fabricmc.net'
 	}
+	maven {
+		name "Mojang"
+		url 'https://libraries.minecraft.net/'
+	}
 }
 
 configurations {
@@ -47,6 +51,7 @@ configurations {
 		}
 	}
 	javadocClasspath
+	decompileClasspath
 }
 
 dependencies {
@@ -54,6 +59,7 @@ dependencies {
 	enigmaRuntime "net.fabricmc:stitch:${project.stitch_version}"
 	javadocClasspath "net.fabricmc:fabric-loader:0.8.2+build.194"
 	javadocClasspath "com.google.code.findbugs:jsr305:3.0.2"
+	decompileClasspath "org.benf:cfr:0.150"
 }
 
 def setupGroup = "jar setup"
@@ -265,6 +271,8 @@ task downloadMcLibs(dependsOn: downloadWantedVersionManifest) {
 				dest new File(libraries, downloadUrl.substring(downloadUrl.lastIndexOf("/") + 1))
 				overwrite false
 			}
+
+			project.dependencies.add("decompileClasspath", it.name)
 		}
 	}
 }
@@ -664,6 +672,17 @@ task genFakeSource(dependsOn: ["buildYarnTiny", "mapNamedJar"]) {
 		net.fabricmc.mappingpoet.Main.main(args)
 
 		logger.lifecycle ":Fake source generated"
+	}
+}
+
+task decompileCFR(type: JavaExec, dependsOn: "mapNamedJar") {
+	classpath = configurations.decompileClasspath
+	main = "org.benf.cfr.reader.Main"
+
+	args namedJar.getAbsolutePath(), "--outputdir", file("src").absolutePath
+
+	doFirst {
+		file("src").deleteDir()
 	}
 }
 


### PR DESCRIPTION
I have seen a number of people trying to use enigma's export source with mixed results. 

This provides a quick and simple way to export the source.