### PR TITLE
Map the NetworkEncryptionException class

### DIFF
--- a/mappings/net/minecraft/network/encryption/NetworkEncryptionException.mapping
+++ b/mappings/net/minecraft/network/encryption/NetworkEncryptionException.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_5525 net/minecraft/network/encryption/NetworkEncryptionException
+	METHOD <init> (Ljava/lang/Throwable;)V
+		ARG 1 throwable


### PR DESCRIPTION
This pull request simply maps the `class_5525` class introduced in 1.16.4 pre-release 2 as `NetworkEncryptionException`, as it is solely used in a class introduced in 1.16.4 pre-release 1.