### PR TITLE
ServerPlayerEntity.openHandledScreen(ScreenHandler) -> refreshScreenHandler

### DIFF
--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -45,7 +45,8 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	METHOD method_14203 copyFrom (Lnet/minecraft/class_3222;Z)V
 		ARG 1 oldPlayer
 		ARG 2 alive
-	METHOD method_14204 openHandledScreen (Lnet/minecraft/class_1703;)V
+	METHOD method_14204 refreshScreenHandler (Lnet/minecraft/class_1703;)V
+		COMMENT Sends packets to the client that refresh the current screen handler's items.
 		ARG 1 handler
 	METHOD method_14205 sendInitialChunkPackets (Lnet/minecraft/class_1923;Lnet/minecraft/class_2596;Lnet/minecraft/class_2596;)V
 	METHOD method_14206 getPlayerListName ()Lnet/minecraft/class_2561;


### PR DESCRIPTION
Closes #1816.

The method is called when the game needs to refresh the items in the current screen handler, and does not handle the screen opening itself.