### PR TITLE
Some AgrumentType mappings

### DIFF
--- a/mappings/net/minecraft/command/argument/ArgumentTypes.mapping
+++ b/mappings/net/minecraft/command/argument/ArgumentTypes.mapping
@@ -4,6 +4,7 @@ CLASS net/minecraft/class_2316 net/minecraft/command/argument/ArgumentTypes
 	FIELD field_10923 LOGGER Lorg/apache/logging/log4j/Logger;
 	METHOD method_10013 byClass (Lcom/mojang/brigadier/arguments/ArgumentType;)Lnet/minecraft/class_2316$class_2317;
 	METHOD method_10014 fromPacket (Lnet/minecraft/class_2540;)Lcom/mojang/brigadier/arguments/ArgumentType;
+		ARG 0 buf
 	METHOD method_10015 register ()V
 	METHOD method_10016 toJson (Lcom/mojang/brigadier/CommandDispatcher;Lcom/mojang/brigadier/tree/CommandNode;)Lcom/google/gson/JsonObject;
 	METHOD method_10017 register (Ljava/lang/String;Ljava/lang/Class;Lnet/minecraft/class_2314;)V
@@ -13,6 +14,15 @@ CLASS net/minecraft/class_2316 net/minecraft/command/argument/ArgumentTypes
 	METHOD method_10018 byId (Lnet/minecraft/class_2960;)Lnet/minecraft/class_2316$class_2317;
 	METHOD method_10019 toPacket (Lnet/minecraft/class_2540;Lcom/mojang/brigadier/arguments/ArgumentType;)V
 	METHOD method_10020 toJson (Lcom/google/gson/JsonObject;Lcom/mojang/brigadier/arguments/ArgumentType;)V
+	METHOD method_30923 hasClass (Lcom/mojang/brigadier/arguments/ArgumentType;)Z
+	METHOD method_30924 getAllArgumentTypes (Lcom/mojang/brigadier/tree/CommandNode;)Ljava/util/Set;
+		ARG 0 node
+	METHOD method_30925 getAllArgumentTypes (Lcom/mojang/brigadier/tree/CommandNode;Ljava/util/Set;Ljava/util/Set;)V
+		ARG 0 node
+		ARG 1 argumentTypes
+		ARG 2 ignoredNodes
+	METHOD method_30926 (Ljava/util/Set;Ljava/util/Set;Lcom/mojang/brigadier/tree/CommandNode;)V
+		ARG 2 node
 	CLASS class_2317 Entry
 		FIELD field_10924 argClass Ljava/lang/Class;
 		FIELD field_10925 id Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/server/command/CommandManager.mapping
+++ b/mappings/net/minecraft/server/command/CommandManager.mapping
@@ -5,6 +5,7 @@ CLASS net/minecraft/class_2170 net/minecraft/server/command/CommandManager
 		ARG 1 environment
 	METHOD method_23917 getException (Lcom/mojang/brigadier/ParseResults;)Lcom/mojang/brigadier/exceptions/CommandSyntaxException;
 		ARG 0 parse
+	METHOD method_30852 checkMissing ()V
 	METHOD method_9235 getDispatcher ()Lcom/mojang/brigadier/CommandDispatcher;
 	METHOD method_9238 getCommandValidator (Lnet/minecraft/class_2170$class_2171;)Ljava/util/function/Predicate;
 		ARG 0 parser


### PR DESCRIPTION
Focuses on some methods that seem to be involved with making sure that all argument types have an associated class. This is only run in a Mojang development environment.