### PR TITLE
BlockEntity tick and creation

### DIFF
--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -575,6 +575,8 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 			ARG 2 pos
 			ARG 3 direction
 			ARG 4 shapeType
+		METHOD method_31708 getBlockEntityTicker (Lnet/minecraft/class_1937;Lnet/minecraft/class_2591;)Lnet/minecraft/class_5558;
+		METHOD method_31709 hasBlockEntity ()Z
 		CLASS class_3752 ShapeCache
 			FIELD field_16555 lightSubtracted I
 			FIELD field_16556 translucent Z

--- a/mappings/net/minecraft/block/BlockEntityProvider.mapping
+++ b/mappings/net/minecraft/block/BlockEntityProvider.mapping
@@ -1,3 +1,8 @@
 CLASS net/minecraft/class_2343 net/minecraft/block/BlockEntityProvider
 	METHOD method_10123 createBlockEntity (Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)Lnet/minecraft/class_2586;
+		ARG 1 pos
+		ARG 2 state
 	METHOD method_31645 getTicker (Lnet/minecraft/class_1937;Lnet/minecraft/class_2680;Lnet/minecraft/class_2591;)Lnet/minecraft/class_5558;
+		ARG 1 world
+		ARG 2 state
+		ARG 3 type

--- a/mappings/net/minecraft/block/BlockEntityProvider.mapping
+++ b/mappings/net/minecraft/block/BlockEntityProvider.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/class_2343 net/minecraft/block/BlockEntityProvider
 	METHOD method_10123 createBlockEntity (Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)Lnet/minecraft/class_2586;
+	METHOD method_31645 getTicker (Lnet/minecraft/class_1937;Lnet/minecraft/class_2680;Lnet/minecraft/class_2591;)Lnet/minecraft/class_5558;

--- a/mappings/net/minecraft/block/BlockWithEntity.mapping
+++ b/mappings/net/minecraft/block/BlockWithEntity.mapping
@@ -1,1 +1,5 @@
 CLASS net/minecraft/class_2237 net/minecraft/block/BlockWithEntity
+	METHOD method_31618 checkType (Lnet/minecraft/class_2591;Lnet/minecraft/class_2591;Lnet/minecraft/class_5558;)Lnet/minecraft/class_5558;
+		ARG 0 givenType
+		ARG 1 expectedType
+		ARG 2 ticker

--- a/mappings/net/minecraft/block/BlockWithEntity.mapping
+++ b/mappings/net/minecraft/block/BlockWithEntity.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_2237 net/minecraft/block/BlockWithEntity
 	METHOD method_31618 checkType (Lnet/minecraft/class_2591;Lnet/minecraft/class_2591;Lnet/minecraft/class_5558;)Lnet/minecraft/class_5558;
+		COMMENT Returns the ticker if the given type and expected type are the same, or null if they are different.
 		ARG 0 givenType
 		ARG 1 expectedType
 		ARG 2 ticker

--- a/mappings/net/minecraft/block/ChestBlock.mapping
+++ b/mappings/net/minecraft/block/ChestBlock.mapping
@@ -18,6 +18,7 @@ CLASS net/minecraft/class_2281 net/minecraft/block/ChestBlock
 	METHOD method_24166 getAnimationProgressRetriever (Lnet/minecraft/class_2618;)Lnet/minecraft/class_4732$class_3923;
 	METHOD method_24169 getDoubleBlockType (Lnet/minecraft/class_2680;)Lnet/minecraft/class_4732$class_4733;
 		ARG 0 state
+	METHOD method_31641 getExpectedEntityType ()Lnet/minecraft/class_2591;
 	METHOD method_9753 getNeighborChestDirection (Lnet/minecraft/class_1750;Lnet/minecraft/class_2350;)Lnet/minecraft/class_2350;
 		ARG 1 ctx
 		ARG 2 dir

--- a/mappings/net/minecraft/block/DaylightDetectorBlock.mapping
+++ b/mappings/net/minecraft/block/DaylightDetectorBlock.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/class_2309 net/minecraft/block/DaylightDetectorBlock
 	FIELD field_10898 SHAPE Lnet/minecraft/class_265;
 	FIELD field_10899 INVERTED Lnet/minecraft/class_2746;
 	METHOD method_31642 tick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2603;)V
+		ARG 1 pos
 	METHOD method_9983 updateState (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)V
 		ARG 0 state
 		ARG 1 world

--- a/mappings/net/minecraft/block/DaylightDetectorBlock.mapping
+++ b/mappings/net/minecraft/block/DaylightDetectorBlock.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/class_2309 net/minecraft/block/DaylightDetectorBlock
 	FIELD field_10897 POWER Lnet/minecraft/class_2758;
 	FIELD field_10898 SHAPE Lnet/minecraft/class_265;
 	FIELD field_10899 INVERTED Lnet/minecraft/class_2746;
+	METHOD method_31642 tick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2603;)V
 	METHOD method_9983 updateState (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)V
 		ARG 0 state
 		ARG 1 world

--- a/mappings/net/minecraft/block/entity/AbstractFurnaceBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/AbstractFurnaceBlockEntity.mapping
@@ -32,3 +32,4 @@ CLASS net/minecraft/class_2609 net/minecraft/block/entity/AbstractFurnaceBlockEn
 	METHOD method_17763 dropExperience (Lnet/minecraft/class_3222;)V
 	METHOD method_26395 isNonFlammableWood (Lnet/minecraft/class_1792;)Z
 		ARG 0 item
+	METHOD method_31651 tick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2609;)V

--- a/mappings/net/minecraft/block/entity/BeehiveBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BeehiveBlockEntity.mapping
@@ -25,7 +25,7 @@ CLASS net/minecraft/class_4482 net/minecraft/block/entity/BeehiveBlockEntity
 	METHOD method_23903 getBeeCount ()I
 	METHOD method_23904 isSmoked ()Z
 	METHOD method_29562 ageBee (ILnet/minecraft/class_4466;)V
-	METHOD method_31656 tickServer (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_4482;)V
+	METHOD method_31656 serverTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_4482;)V
 	CLASS class_4483 Bee
 		FIELD field_20425 entityData Lnet/minecraft/class_2487;
 		FIELD field_20426 ticksInHive I

--- a/mappings/net/minecraft/block/entity/BeehiveBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BeehiveBlockEntity.mapping
@@ -25,7 +25,7 @@ CLASS net/minecraft/class_4482 net/minecraft/block/entity/BeehiveBlockEntity
 	METHOD method_23903 getBeeCount ()I
 	METHOD method_23904 isSmoked ()Z
 	METHOD method_29562 ageBee (ILnet/minecraft/class_4466;)V
-	METHOD method_31656 tick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_4482;)V
+	METHOD method_31656 tickServer (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_4482;)V
 	CLASS class_4483 Bee
 		FIELD field_20425 entityData Lnet/minecraft/class_2487;
 		FIELD field_20426 ticksInHive I

--- a/mappings/net/minecraft/block/entity/BeehiveBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BeehiveBlockEntity.mapping
@@ -25,6 +25,7 @@ CLASS net/minecraft/class_4482 net/minecraft/block/entity/BeehiveBlockEntity
 	METHOD method_23903 getBeeCount ()I
 	METHOD method_23904 isSmoked ()Z
 	METHOD method_29562 ageBee (ILnet/minecraft/class_4466;)V
+	METHOD method_31656 tick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_4482;)V
 	CLASS class_4483 Bee
 		FIELD field_20425 entityData Lnet/minecraft/class_2487;
 		FIELD field_20426 ticksInHive I

--- a/mappings/net/minecraft/block/entity/BellBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BellBlockEntity.mapping
@@ -15,3 +15,5 @@ CLASS net/minecraft/class_3721 net/minecraft/block/entity/BellBlockEntity
 	METHOD method_20520 applyGlowToEntity (Lnet/minecraft/class_1309;)V
 	METHOD method_20521 applyGlowToRaiders (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Ljava/util/List;)V
 	METHOD method_20523 raidersHearBell (Lnet/minecraft/class_2338;Ljava/util/List;)Z
+	METHOD method_31657 tickClient (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3721;)V
+	METHOD method_31659 tickServer (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3721;)V

--- a/mappings/net/minecraft/block/entity/BellBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BellBlockEntity.mapping
@@ -15,5 +15,5 @@ CLASS net/minecraft/class_3721 net/minecraft/block/entity/BellBlockEntity
 	METHOD method_20520 applyGlowToEntity (Lnet/minecraft/class_1309;)V
 	METHOD method_20521 applyGlowToRaiders (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Ljava/util/List;)V
 	METHOD method_20523 raidersHearBell (Lnet/minecraft/class_2338;Ljava/util/List;)Z
-	METHOD method_31657 tickClient (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3721;)V
-	METHOD method_31659 tickServer (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3721;)V
+	METHOD method_31657 clientTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3721;)V
+	METHOD method_31659 serverTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3721;)V

--- a/mappings/net/minecraft/block/entity/BlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntity.mapping
@@ -28,5 +28,6 @@ CLASS net/minecraft/class_2586 net/minecraft/block/entity/BlockEntity
 	METHOD method_16886 toUpdatePacket ()Lnet/minecraft/class_2622;
 	METHOD method_16887 toInitialChunkDataTag ()Lnet/minecraft/class_2487;
 	METHOD method_31662 setWorld (Lnet/minecraft/class_1937;)V
+	METHOD method_31663 markDirty (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)V
 	METHOD method_31664 setCachedState (Lnet/minecraft/class_2680;)V
 	METHOD method_5431 markDirty ()V

--- a/mappings/net/minecraft/block/entity/BlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntity.mapping
@@ -27,4 +27,6 @@ CLASS net/minecraft/class_2586 net/minecraft/block/entity/BlockEntity
 	METHOD method_11017 getType ()Lnet/minecraft/class_2591;
 	METHOD method_16886 toUpdatePacket ()Lnet/minecraft/class_2622;
 	METHOD method_16887 toInitialChunkDataTag ()Lnet/minecraft/class_2487;
+	METHOD method_31662 setWorld (Lnet/minecraft/class_1937;)V
+	METHOD method_31664 setCachedState (Lnet/minecraft/class_2680;)V
 	METHOD method_5431 markDirty ()V

--- a/mappings/net/minecraft/block/entity/BlockEntityTicker.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntityTicker.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_5558 net/minecraft/block/entity/BlockEntityTicker

--- a/mappings/net/minecraft/block/entity/BlockEntityTicker.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntityTicker.mapping
@@ -1,1 +1,6 @@
 CLASS net/minecraft/class_5558 net/minecraft/block/entity/BlockEntityTicker
+	METHOD tick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2586;)V
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 state
+		ARG 4 blockEntity

--- a/mappings/net/minecraft/block/entity/BlockEntityType.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntityType.mapping
@@ -17,7 +17,12 @@ CLASS net/minecraft/class_2591 net/minecraft/block/entity/BlockEntityType
 		FIELD field_11915 supplier Lnet/minecraft/class_2591$class_5559;
 		FIELD field_19316 blocks Ljava/util/Set;
 		METHOD <init> (Lnet/minecraft/class_2591$class_5559;Ljava/util/Set;)V
+			ARG 1 creator
 			ARG 2 blocks
 		METHOD method_11034 build (Lcom/mojang/datafixers/types/Type;)Lnet/minecraft/class_2591;
 		METHOD method_20528 create (Lnet/minecraft/class_2591$class_5559;[Lnet/minecraft/class_2248;)Lnet/minecraft/class_2591$class_2592;
 			ARG 1 blocks
+	CLASS class_5559 BlockEntityCreator
+		METHOD create (Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)Lnet/minecraft/class_2586;
+			ARG 1 pos
+			ARG 2 state

--- a/mappings/net/minecraft/block/entity/BlockEntityType.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntityType.mapping
@@ -1,23 +1,25 @@
 CLASS net/minecraft/class_2591 net/minecraft/block/entity/BlockEntityType
-	FIELD field_11892 supplier Lnet/minecraft/class_2591$class_5559;
+	FIELD field_11892 factory Lnet/minecraft/class_2591$class_5559;
 	FIELD field_11893 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_11909 type Lcom/mojang/datafixers/types/Type;
 	FIELD field_19315 blocks Ljava/util/Set;
 	METHOD <init> (Lnet/minecraft/class_2591$class_5559;Ljava/util/Set;Lcom/mojang/datafixers/types/Type;)V
+		ARG 1 factory
 		ARG 2 blocks
 		ARG 3 type
 	METHOD method_11030 create (Ljava/lang/String;Lnet/minecraft/class_2591$class_2592;)Lnet/minecraft/class_2591;
 	METHOD method_11032 instantiate (Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)Lnet/minecraft/class_2586;
 	METHOD method_11033 getId (Lnet/minecraft/class_2591;)Lnet/minecraft/class_2960;
 	METHOD method_20526 supports (Lnet/minecraft/class_2680;)Z
+		ARG 1 state
 	METHOD method_24182 get (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Lnet/minecraft/class_2586;
 		ARG 1 world
 		ARG 2 pos
 	CLASS class_2592 Builder
-		FIELD field_11915 supplier Lnet/minecraft/class_2591$class_5559;
+		FIELD field_11915 factory Lnet/minecraft/class_2591$class_5559;
 		FIELD field_19316 blocks Ljava/util/Set;
 		METHOD <init> (Lnet/minecraft/class_2591$class_5559;Ljava/util/Set;)V
-			ARG 1 creator
+			ARG 1 factory
 			ARG 2 blocks
 		METHOD method_11034 build (Lcom/mojang/datafixers/types/Type;)Lnet/minecraft/class_2591;
 		METHOD method_20528 create (Lnet/minecraft/class_2591$class_5559;[Lnet/minecraft/class_2248;)Lnet/minecraft/class_2591$class_2592;

--- a/mappings/net/minecraft/block/entity/BlockEntityType.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntityType.mapping
@@ -22,7 +22,7 @@ CLASS net/minecraft/class_2591 net/minecraft/block/entity/BlockEntityType
 		METHOD method_11034 build (Lcom/mojang/datafixers/types/Type;)Lnet/minecraft/class_2591;
 		METHOD method_20528 create (Lnet/minecraft/class_2591$class_5559;[Lnet/minecraft/class_2248;)Lnet/minecraft/class_2591$class_2592;
 			ARG 1 blocks
-	CLASS class_5559 BlockEntityCreator
+	CLASS class_5559 BlockEntityFactory
 		METHOD create (Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)Lnet/minecraft/class_2586;
 			ARG 1 pos
 			ARG 2 state

--- a/mappings/net/minecraft/block/entity/BlockEntityType.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntityType.mapping
@@ -21,6 +21,7 @@ CLASS net/minecraft/class_2591 net/minecraft/block/entity/BlockEntityType
 			ARG 2 blocks
 		METHOD method_11034 build (Lcom/mojang/datafixers/types/Type;)Lnet/minecraft/class_2591;
 		METHOD method_20528 create (Lnet/minecraft/class_2591$class_5559;[Lnet/minecraft/class_2248;)Lnet/minecraft/class_2591$class_2592;
+			ARG 0 factory
 			ARG 1 blocks
 	CLASS class_5559 BlockEntityFactory
 		METHOD create (Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)Lnet/minecraft/class_2586;

--- a/mappings/net/minecraft/block/entity/BrewingStandBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BrewingStandBlockEntity.mapping
@@ -11,3 +11,4 @@ CLASS net/minecraft/class_2589 net/minecraft/block/entity/BrewingStandBlockEntit
 	METHOD method_11027 canCraft (Lnet/minecraft/class_2371;)Z
 	METHOD method_11028 getSlotsEmpty ()[Z
 	METHOD method_11029 craft (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2371;)V
+	METHOD method_31665 tick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2589;)V

--- a/mappings/net/minecraft/block/entity/CampfireBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/CampfireBlockEntity.mapping
@@ -12,6 +12,18 @@ CLASS net/minecraft/class_3924 net/minecraft/block/entity/CampfireBlockEntity
 	METHOD method_17507 saveInitialChunkData (Lnet/minecraft/class_2487;)Lnet/minecraft/class_2487;
 		ARG 1 tag
 	METHOD method_17510 updateListeners ()V
-	METHOD method_31666 tickLit (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3924;)V
-	METHOD method_31667 tickUnlit (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3924;)V
+	METHOD method_31666 litServerTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3924;)V
+		ARG 0 world
+		ARG 1 pos
+		ARG 2 state
+		ARG 3 campfire
+	METHOD method_31667 unlitServerTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3924;)V
+		ARG 0 world
+		ARG 1 pos
+		ARG 2 state
+		ARG 3 campfire
 	METHOD method_31668 clientTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3924;)V
+		ARG 0 world
+		ARG 1 pos
+		ARG 2 state
+		ARG 3 campfire

--- a/mappings/net/minecraft/block/entity/CampfireBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/CampfireBlockEntity.mapping
@@ -12,3 +12,6 @@ CLASS net/minecraft/class_3924 net/minecraft/block/entity/CampfireBlockEntity
 	METHOD method_17507 saveInitialChunkData (Lnet/minecraft/class_2487;)Lnet/minecraft/class_2487;
 		ARG 1 tag
 	METHOD method_17510 updateListeners ()V
+	METHOD method_31666 tickLit (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3924;)V
+	METHOD method_31667 tickUnlit (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3924;)V
+	METHOD method_31668 tickClient (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3924;)V

--- a/mappings/net/minecraft/block/entity/CampfireBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/CampfireBlockEntity.mapping
@@ -14,4 +14,4 @@ CLASS net/minecraft/class_3924 net/minecraft/block/entity/CampfireBlockEntity
 	METHOD method_17510 updateListeners ()V
 	METHOD method_31666 tickLit (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3924;)V
 	METHOD method_31667 tickUnlit (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3924;)V
-	METHOD method_31668 tickClient (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3924;)V
+	METHOD method_31668 clientTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3924;)V

--- a/mappings/net/minecraft/block/entity/ChestBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/ChestBlockEntity.mapping
@@ -8,3 +8,4 @@ CLASS net/minecraft/class_2595 net/minecraft/block/entity/ChestBlockEntity
 		ARG 1 pos
 	METHOD method_11049 onInvOpenOrClose (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;II)V
 	METHOD method_11050 playSound (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3414;)V
+	METHOD method_31670 tickClient (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2595;)V

--- a/mappings/net/minecraft/block/entity/ChestBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/ChestBlockEntity.mapping
@@ -8,4 +8,4 @@ CLASS net/minecraft/class_2595 net/minecraft/block/entity/ChestBlockEntity
 		ARG 1 pos
 	METHOD method_11049 onInvOpenOrClose (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;II)V
 	METHOD method_11050 playSound (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3414;)V
-	METHOD method_31670 tickClient (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2595;)V
+	METHOD method_31670 clientTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2595;)V

--- a/mappings/net/minecraft/block/entity/ConduitBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/ConduitBlockEntity.mapping
@@ -21,5 +21,5 @@ CLASS net/minecraft/class_2597 net/minecraft/block/entity/ConduitBlockEntity
 	METHOD method_11066 isEyeOpen ()Z
 	METHOD method_11068 attackHostileEntity (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Ljava/util/List;Lnet/minecraft/class_2597;)V
 	METHOD method_11069 updateActivatingBlocks (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Ljava/util/List;)Z
-	METHOD method_31675 tickClient (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2597;)V
-	METHOD method_31677 tickServer (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2597;)V
+	METHOD method_31675 clientTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2597;)V
+	METHOD method_31677 serverTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2597;)V

--- a/mappings/net/minecraft/block/entity/ConduitBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/ConduitBlockEntity.mapping
@@ -21,3 +21,5 @@ CLASS net/minecraft/class_2597 net/minecraft/block/entity/ConduitBlockEntity
 	METHOD method_11066 isEyeOpen ()Z
 	METHOD method_11068 attackHostileEntity (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Ljava/util/List;Lnet/minecraft/class_2597;)V
 	METHOD method_11069 updateActivatingBlocks (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Ljava/util/List;)Z
+	METHOD method_31675 tickClient (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2597;)V
+	METHOD method_31677 tickServer (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2597;)V

--- a/mappings/net/minecraft/block/entity/EnchantingTableBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/EnchantingTableBlockEntity.mapping
@@ -8,3 +8,4 @@ CLASS net/minecraft/class_2605 net/minecraft/block/entity/EnchantingTableBlockEn
 	FIELD field_11968 RANDOM Ljava/util/Random;
 	METHOD method_11179 setCustomName (Lnet/minecraft/class_2561;)V
 		ARG 1 value
+	METHOD method_31688 tick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2605;)V

--- a/mappings/net/minecraft/block/entity/EndGatewayBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/EndGatewayBlockEntity.mapping
@@ -27,3 +27,5 @@ CLASS net/minecraft/class_2643 net/minecraft/block/entity/EndGatewayBlockEntity
 	METHOD method_11419 findBestPortalExitPos (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)Lnet/minecraft/class_2338;
 	METHOD method_11420 isRecentlyGenerated ()Z
 	METHOD method_11421 needsCooldownBeforeTeleporting ()Z
+	METHOD method_31700 tickClient (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2643;)V
+	METHOD method_31702 tickServer (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2643;)V

--- a/mappings/net/minecraft/block/entity/EndGatewayBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/EndGatewayBlockEntity.mapping
@@ -27,5 +27,5 @@ CLASS net/minecraft/class_2643 net/minecraft/block/entity/EndGatewayBlockEntity
 	METHOD method_11419 findBestPortalExitPos (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)Lnet/minecraft/class_2338;
 	METHOD method_11420 isRecentlyGenerated ()Z
 	METHOD method_11421 needsCooldownBeforeTeleporting ()Z
-	METHOD method_31700 tickClient (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2643;)V
-	METHOD method_31702 tickServer (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2643;)V
+	METHOD method_31700 clientTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2643;)V
+	METHOD method_31702 serverTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2643;)V

--- a/mappings/net/minecraft/block/entity/EnderChestBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/EnderChestBlockEntity.mapping
@@ -2,4 +2,4 @@ CLASS net/minecraft/class_2611 net/minecraft/block/entity/EnderChestBlockEntity
 	METHOD method_11218 canPlayerUse (Lnet/minecraft/class_1657;)Z
 	METHOD method_11219 onOpen (Lnet/minecraft/class_1657;)V
 	METHOD method_11220 onClose (Lnet/minecraft/class_1657;)V
-	METHOD method_31689 tickClient (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2611;)V
+	METHOD method_31689 clientTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2611;)V

--- a/mappings/net/minecraft/block/entity/EnderChestBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/EnderChestBlockEntity.mapping
@@ -2,3 +2,4 @@ CLASS net/minecraft/class_2611 net/minecraft/block/entity/EnderChestBlockEntity
 	METHOD method_11218 canPlayerUse (Lnet/minecraft/class_1657;)Z
 	METHOD method_11219 onOpen (Lnet/minecraft/class_1657;)V
 	METHOD method_11220 onClose (Lnet/minecraft/class_1657;)V
+	METHOD method_31689 tickClient (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2611;)V

--- a/mappings/net/minecraft/block/entity/HopperBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/HopperBlockEntity.mapping
@@ -58,3 +58,4 @@ CLASS net/minecraft/class_2614 net/minecraft/block/entity/HopperBlockEntity
 	METHOD method_17767 getAvailableSlots (Lnet/minecraft/class_1263;Lnet/minecraft/class_2350;)Ljava/util/stream/IntStream;
 		ARG 0 inventory
 		ARG 1 side
+	METHOD method_31692 tickServer (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2614;)V

--- a/mappings/net/minecraft/block/entity/HopperBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/HopperBlockEntity.mapping
@@ -58,4 +58,4 @@ CLASS net/minecraft/class_2614 net/minecraft/block/entity/HopperBlockEntity
 	METHOD method_17767 getAvailableSlots (Lnet/minecraft/class_1263;Lnet/minecraft/class_2350;)Ljava/util/stream/IntStream;
 		ARG 0 inventory
 		ARG 1 side
-	METHOD method_31692 tickServer (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2614;)V
+	METHOD method_31692 serverTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2614;)V

--- a/mappings/net/minecraft/block/entity/MobSpawnerBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/MobSpawnerBlockEntity.mapping
@@ -1,3 +1,5 @@
 CLASS net/minecraft/class_2636 net/minecraft/block/entity/MobSpawnerBlockEntity
 	FIELD field_12114 logic Lnet/minecraft/class_1917;
 	METHOD method_11390 getLogic ()Lnet/minecraft/class_1917;
+	METHOD method_31696 tickClient (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2636;)V
+	METHOD method_31697 tickServer (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2636;)V

--- a/mappings/net/minecraft/block/entity/MobSpawnerBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/MobSpawnerBlockEntity.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_2636 net/minecraft/block/entity/MobSpawnerBlockEntity
 	FIELD field_12114 logic Lnet/minecraft/class_1917;
 	METHOD method_11390 getLogic ()Lnet/minecraft/class_1917;
-	METHOD method_31696 tickClient (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2636;)V
-	METHOD method_31697 tickServer (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2636;)V
+	METHOD method_31696 clientTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2636;)V
+	METHOD method_31697 serverTick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2636;)V

--- a/mappings/net/minecraft/block/entity/PistonBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/PistonBlockEntity.mapping
@@ -37,3 +37,4 @@ CLASS net/minecraft/class_2669 net/minecraft/block/entity/PistonBlockEntity
 		ARG 3 amount
 	METHOD method_11515 isSource ()Z
 	METHOD method_23364 isPushingHoneyBlock ()Z
+	METHOD method_31707 tick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2669;)V

--- a/mappings/net/minecraft/block/entity/ShulkerBoxBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/ShulkerBoxBlockEntity.mapping
@@ -23,4 +23,5 @@ CLASS net/minecraft/class_2627 net/minecraft/block/entity/ShulkerBoxBlockEntity
 	METHOD method_11320 getColor ()Lnet/minecraft/class_1767;
 	METHOD method_20047 updateNeighborStates (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)V
 	METHOD method_27093 suffocates ()Z
+	METHOD method_31694 tick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2627;)V
 	CLASS class_2628 AnimationStage

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -8,6 +8,8 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 	FIELD field_25179 OVERWORLD Lnet/minecraft/class_5321;
 	FIELD field_25180 NETHER Lnet/minecraft/class_5321;
 	FIELD field_25181 END Lnet/minecraft/class_5321;
+	FIELD field_27081 pendingBlockEntityTickers Ljava/util/List;
+	FIELD field_27082 blockEntityTickers Ljava/util/List;
 	FIELD field_9223 border Lnet/minecraft/class_2784;
 	FIELD field_9224 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_9226 ambientDarkness I
@@ -75,6 +77,7 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		COMMENT <p>Debug worlds are not modifiable and are typically meant for development and debug use only.
 		COMMENT See <a href="https://minecraft.gamepedia.com/Debug_mode">the minecraft wiki</a> as well.
 	METHOD method_27983 getRegistryKey ()Lnet/minecraft/class_5321;
+	METHOD method_31594 addBlockEntityTicker (Lnet/minecraft/class_5562;)V
 	METHOD method_8413 updateListeners (Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2680;I)V
 		ARG 1 pos
 		ARG 2 oldState

--- a/mappings/net/minecraft/world/chunk/BlockEntityTickInvoker.mapping
+++ b/mappings/net/minecraft/world/chunk/BlockEntityTickInvoker.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_5562 net/minecraft/world/chunk/ChunkBlockEntityTicker
+CLASS net/minecraft/class_5562 net/minecraft/world/chunk/BlockEntityTickInvoker
 	METHOD method_31703 tick ()V
 	METHOD method_31704 isRemoved ()Z
 	METHOD method_31705 getPos ()Lnet/minecraft/class_2338;

--- a/mappings/net/minecraft/world/chunk/ChunkBlockEntityTicker.mapping
+++ b/mappings/net/minecraft/world/chunk/ChunkBlockEntityTicker.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_5562 net/minecraft/world/chunk/ChunkBlockEntityTicker
+	METHOD method_31703 tick ()V
+	METHOD method_31704 isRemoved ()Z
+	METHOD method_31705 getPos ()Lnet/minecraft/class_2338;

--- a/mappings/net/minecraft/world/chunk/ChunkBlockEntityTicker.mapping
+++ b/mappings/net/minecraft/world/chunk/ChunkBlockEntityTicker.mapping
@@ -2,3 +2,4 @@ CLASS net/minecraft/class_5562 net/minecraft/world/chunk/ChunkBlockEntityTicker
 	METHOD method_31703 tick ()V
 	METHOD method_31704 isRemoved ()Z
 	METHOD method_31705 getPos ()Lnet/minecraft/class_2338;
+	METHOD method_31706 getName ()Ljava/lang/String;

--- a/mappings/net/minecraft/world/chunk/WorldChunk.mapping
+++ b/mappings/net/minecraft/world/chunk/WorldChunk.mapping
@@ -85,7 +85,7 @@ CLASS net/minecraft/class_2818 net/minecraft/world/chunk/WorldChunk
 	METHOD method_31723 updateTicker (Lnet/minecraft/class_2586;)V
 	METHOD method_31724 canTickBlockEntity (Lnet/minecraft/class_2338;)Z
 	METHOD method_31725 removeBlockEntityTicker (Lnet/minecraft/class_2338;)V
-	CLASS 1 NullBlockEntityTickInvoker
+	CLASS 1 EmptyBlockEntityTickInvoker
 	CLASS class_2819 CreationType
 	CLASS class_5563 DirectBlockEntityTickInvoker
 		FIELD field_27224 blockEntity Lnet/minecraft/class_2586;

--- a/mappings/net/minecraft/world/chunk/WorldChunk.mapping
+++ b/mappings/net/minecraft/world/chunk/WorldChunk.mapping
@@ -20,6 +20,7 @@ CLASS net/minecraft/class_2818 net/minecraft/world/chunk/WorldChunk
 	FIELD field_12857 fluidTickScheduler Lnet/minecraft/class_1951;
 	FIELD field_12858 world Lnet/minecraft/class_1937;
 	FIELD field_20655 biomeArray Lnet/minecraft/class_4548;
+	FIELD field_27221 emptyBlockEntityTicker Lnet/minecraft/class_5562;
 	METHOD <init> (Lnet/minecraft/class_1937;Lnet/minecraft/class_1923;Lnet/minecraft/class_4548;)V
 		ARG 1 world
 		ARG 2 pos
@@ -76,4 +77,10 @@ CLASS net/minecraft/class_2818 net/minecraft/world/chunk/WorldChunk
 	METHOD method_20471 enableTickSchedulers (Lnet/minecraft/class_3218;)V
 		ARG 1 world
 	METHOD method_20530 disableTickSchedulers ()V
+	CLASS 1 NullBlockEntityTicker
 	CLASS class_2819 CreationType
+	CLASS class_5563
+		FIELD field_27224 blockEntity Lnet/minecraft/class_2586;
+		FIELD field_27225 ticker Lnet/minecraft/class_5558;
+	CLASS class_5564 WrappedBlockEntityTicker
+		FIELD field_27228 wrapped Lnet/minecraft/class_5562;

--- a/mappings/net/minecraft/world/chunk/WorldChunk.mapping
+++ b/mappings/net/minecraft/world/chunk/WorldChunk.mapping
@@ -87,7 +87,7 @@ CLASS net/minecraft/class_2818 net/minecraft/world/chunk/WorldChunk
 	METHOD method_31725 removeBlockEntityTicker (Lnet/minecraft/class_2338;)V
 	CLASS 1 NullBlockEntityTickInvoker
 	CLASS class_2819 CreationType
-	CLASS class_5563 BlockEntityTickInvokerImpl
+	CLASS class_5563 DirectBlockEntityTickInvoker
 		FIELD field_27224 blockEntity Lnet/minecraft/class_2586;
 		FIELD field_27225 ticker Lnet/minecraft/class_5558;
 		FIELD field_27226 hasWarned Z

--- a/mappings/net/minecraft/world/chunk/WorldChunk.mapping
+++ b/mappings/net/minecraft/world/chunk/WorldChunk.mapping
@@ -20,7 +20,7 @@ CLASS net/minecraft/class_2818 net/minecraft/world/chunk/WorldChunk
 	FIELD field_12857 fluidTickScheduler Lnet/minecraft/class_1951;
 	FIELD field_12858 world Lnet/minecraft/class_1937;
 	FIELD field_20655 biomeArray Lnet/minecraft/class_4548;
-	FIELD field_27221 emptyBlockEntityTicker Lnet/minecraft/class_5562;
+	FIELD field_27221 EMPTY_BLOCK_ENTITY_TICKER Lnet/minecraft/class_5562;
 	FIELD field_27222 blockEntityTickers Ljava/util/Map;
 	METHOD <init> (Lnet/minecraft/class_1937;Lnet/minecraft/class_1923;Lnet/minecraft/class_4548;)V
 		ARG 1 world

--- a/mappings/net/minecraft/world/chunk/WorldChunk.mapping
+++ b/mappings/net/minecraft/world/chunk/WorldChunk.mapping
@@ -87,7 +87,7 @@ CLASS net/minecraft/class_2818 net/minecraft/world/chunk/WorldChunk
 	METHOD method_31725 removeBlockEntityTicker (Lnet/minecraft/class_2338;)V
 	CLASS 1 NullBlockEntityTicker
 	CLASS class_2819 CreationType
-	CLASS class_5563 DirectBlockEntityTicker
+	CLASS class_5563 BlockEntityTickInvoker
 		FIELD field_27224 blockEntity Lnet/minecraft/class_2586;
 		FIELD field_27225 ticker Lnet/minecraft/class_5558;
 		FIELD field_27226 hasWarned Z

--- a/mappings/net/minecraft/world/chunk/WorldChunk.mapping
+++ b/mappings/net/minecraft/world/chunk/WorldChunk.mapping
@@ -21,6 +21,7 @@ CLASS net/minecraft/class_2818 net/minecraft/world/chunk/WorldChunk
 	FIELD field_12858 world Lnet/minecraft/class_1937;
 	FIELD field_20655 biomeArray Lnet/minecraft/class_4548;
 	FIELD field_27221 emptyBlockEntityTicker Lnet/minecraft/class_5562;
+	FIELD field_27222 blockEntityTickers Ljava/util/Map;
 	METHOD <init> (Lnet/minecraft/class_1937;Lnet/minecraft/class_1923;Lnet/minecraft/class_4548;)V
 		ARG 1 world
 		ARG 2 pos
@@ -77,6 +78,10 @@ CLASS net/minecraft/class_2818 net/minecraft/world/chunk/WorldChunk
 	METHOD method_20471 enableTickSchedulers (Lnet/minecraft/class_3218;)V
 		ARG 1 world
 	METHOD method_20530 disableTickSchedulers ()V
+	METHOD method_31713 updateAllBlockEntityTickers ()V
+	METHOD method_31718 createTicker (Lnet/minecraft/class_2586;Lnet/minecraft/class_5558;)Lnet/minecraft/class_5562;
+	METHOD method_31723 updateTicker (Lnet/minecraft/class_2586;)V
+	METHOD method_31725 removeBlockEntityTicker (Lnet/minecraft/class_2338;)V
 	CLASS 1 NullBlockEntityTicker
 	CLASS class_2819 CreationType
 	CLASS class_5563
@@ -84,3 +89,4 @@ CLASS net/minecraft/class_2818 net/minecraft/world/chunk/WorldChunk
 		FIELD field_27225 ticker Lnet/minecraft/class_5558;
 	CLASS class_5564 WrappedBlockEntityTicker
 		FIELD field_27228 wrapped Lnet/minecraft/class_5562;
+		METHOD method_31727 setWrapped (Lnet/minecraft/class_5562;)V

--- a/mappings/net/minecraft/world/chunk/WorldChunk.mapping
+++ b/mappings/net/minecraft/world/chunk/WorldChunk.mapping
@@ -79,7 +79,7 @@ CLASS net/minecraft/class_2818 net/minecraft/world/chunk/WorldChunk
 		ARG 1 world
 	METHOD method_20530 disableTickSchedulers ()V
 	METHOD method_31713 updateAllBlockEntityTickers ()V
-	METHOD method_31718 createTicker (Lnet/minecraft/class_2586;Lnet/minecraft/class_5558;)Lnet/minecraft/class_5562;
+	METHOD method_31718 wrapTicker (Lnet/minecraft/class_2586;Lnet/minecraft/class_5558;)Lnet/minecraft/class_5562;
 	METHOD method_31721 canTickBlockEntity (Lnet/minecraft/class_2818;Lnet/minecraft/class_2338;)Z
 	METHOD method_31723 updateTicker (Lnet/minecraft/class_2586;)V
 	METHOD method_31724 canTickBlockEntity (Lnet/minecraft/class_2338;)Z

--- a/mappings/net/minecraft/world/chunk/WorldChunk.mapping
+++ b/mappings/net/minecraft/world/chunk/WorldChunk.mapping
@@ -85,12 +85,12 @@ CLASS net/minecraft/class_2818 net/minecraft/world/chunk/WorldChunk
 	METHOD method_31723 updateTicker (Lnet/minecraft/class_2586;)V
 	METHOD method_31724 canTickBlockEntity (Lnet/minecraft/class_2338;)Z
 	METHOD method_31725 removeBlockEntityTicker (Lnet/minecraft/class_2338;)V
-	CLASS 1 NullBlockEntityTicker
+	CLASS 1 NullBlockEntityTickInvoker
 	CLASS class_2819 CreationType
-	CLASS class_5563 BlockEntityTickInvoker
+	CLASS class_5563 BlockEntityTickInvokerImpl
 		FIELD field_27224 blockEntity Lnet/minecraft/class_2586;
 		FIELD field_27225 ticker Lnet/minecraft/class_5558;
 		FIELD field_27226 hasWarned Z
-	CLASS class_5564 WrappedBlockEntityTicker
+	CLASS class_5564 WrappedBlockEntityTickInvoker
 		FIELD field_27228 wrapped Lnet/minecraft/class_5562;
 		METHOD method_31727 setWrapped (Lnet/minecraft/class_5562;)V

--- a/mappings/net/minecraft/world/chunk/WorldChunk.mapping
+++ b/mappings/net/minecraft/world/chunk/WorldChunk.mapping
@@ -79,6 +79,7 @@ CLASS net/minecraft/class_2818 net/minecraft/world/chunk/WorldChunk
 		ARG 1 world
 	METHOD method_20530 disableTickSchedulers ()V
 	METHOD method_31713 updateAllBlockEntityTickers ()V
+	METHOD method_31715 canTickBlockEntities ()Z
 	METHOD method_31718 wrapTicker (Lnet/minecraft/class_2586;Lnet/minecraft/class_5558;)Lnet/minecraft/class_5562;
 	METHOD method_31721 canTickBlockEntity (Lnet/minecraft/class_2818;Lnet/minecraft/class_2338;)Z
 	METHOD method_31723 updateTicker (Lnet/minecraft/class_2586;)V

--- a/mappings/net/minecraft/world/chunk/WorldChunk.mapping
+++ b/mappings/net/minecraft/world/chunk/WorldChunk.mapping
@@ -80,13 +80,16 @@ CLASS net/minecraft/class_2818 net/minecraft/world/chunk/WorldChunk
 	METHOD method_20530 disableTickSchedulers ()V
 	METHOD method_31713 updateAllBlockEntityTickers ()V
 	METHOD method_31718 createTicker (Lnet/minecraft/class_2586;Lnet/minecraft/class_5558;)Lnet/minecraft/class_5562;
+	METHOD method_31721 canTickBlockEntity (Lnet/minecraft/class_2818;Lnet/minecraft/class_2338;)Z
 	METHOD method_31723 updateTicker (Lnet/minecraft/class_2586;)V
+	METHOD method_31724 canTickBlockEntity (Lnet/minecraft/class_2338;)Z
 	METHOD method_31725 removeBlockEntityTicker (Lnet/minecraft/class_2338;)V
 	CLASS 1 NullBlockEntityTicker
 	CLASS class_2819 CreationType
-	CLASS class_5563
+	CLASS class_5563 DirectBlockEntityTicker
 		FIELD field_27224 blockEntity Lnet/minecraft/class_2586;
 		FIELD field_27225 ticker Lnet/minecraft/class_5558;
+		FIELD field_27226 hasWarned Z
 	CLASS class_5564 WrappedBlockEntityTicker
 		FIELD field_27228 wrapped Lnet/minecraft/class_5562;
 		METHOD method_31727 setWrapped (Lnet/minecraft/class_5562;)V


### PR DESCRIPTION
Major changes:

* Named the new `Tickable` replacement class `BlockEntityTicker`
* Named the per-world chunk holder interface for `BlockEntityTicker` `BlockEntityTickInvoker`.
* Named the (package-private) functional interface for constructing BlockEntities (in `BlockEntityType`) `BlockEntityFactory`
* Named the side-agnostic various static BlockEntity tick methods `tick`, and the server-specific and client-specific tick methods `serverTick` and `clientTick` respectively.