### PR TITLE
Map the candles property in the Properties class

### DIFF
--- a/mappings/net/minecraft/state/property/Properties.mapping
+++ b/mappings/net/minecraft/state/property/Properties.mapping
@@ -202,6 +202,8 @@ CLASS net/minecraft/class_2741 net/minecraft/state/property/Properties
 		COMMENT A property that specifies the amount of charges a respawn anchor has.
 	FIELD field_23333 ORIENTATION Lnet/minecraft/class_2754;
 		COMMENT A property that specifies the orientation of a jigsaw.
+	FIELD field_27220 CANDLES Lnet/minecraft/class_2758;
+		COMMENT A property that specifies the amount of candles in a candle block.
 	METHOD method_11813 (Lnet/minecraft/class_2768;)Z
 		ARG 0 shape
 	METHOD method_11814 (Lnet/minecraft/class_2350;)Z


### PR DESCRIPTION
This pull request extends #1844 by mapping the equivalent candles property in the `Properties` class in addition to the one duplicated in `CandleBlock`.