### PR TITLE
Scoreboard mappings

### DIFF
--- a/mappings/net/minecraft/client/gui/hud/PlayerListHud.mapping
+++ b/mappings/net/minecraft/client/gui/hud/PlayerListHud.mapping
@@ -10,6 +10,7 @@ CLASS net/minecraft/class_355 net/minecraft/client/gui/hud/PlayerListHud
 		ARG 1 client
 		ARG 2 inGameHud
 	METHOD method_1918 getPlayerName (Lnet/minecraft/class_640;)Lnet/minecraft/class_2561;
+		ARG 1 entry
 	METHOD method_1919 render (Lnet/minecraft/class_4587;ILnet/minecraft/class_269;Lnet/minecraft/class_266;)V
 	METHOD method_1920 clear ()V
 	METHOD method_1921 tick (Z)V
@@ -20,4 +21,7 @@ CLASS net/minecraft/class_355 net/minecraft/client/gui/hud/PlayerListHud
 		ARG 1 footer
 	METHOD method_1925 setHeader (Lnet/minecraft/class_2561;)V
 		ARG 1 header
+	METHOD method_27538 applyGameModeFormatting (Lnet/minecraft/class_640;Lnet/minecraft/class_5250;)Lnet/minecraft/class_2561;
+		ARG 1 entry
+		ARG 2 name
 	CLASS class_356 EntryOrderComparator

--- a/mappings/net/minecraft/scoreboard/AbstractTeam.mapping
+++ b/mappings/net/minecraft/scoreboard/AbstractTeam.mapping
@@ -1,7 +1,9 @@
 CLASS net/minecraft/class_270 net/minecraft/scoreboard/AbstractTeam
 	METHOD method_1197 getName ()Ljava/lang/String;
 	METHOD method_1198 decorateName (Lnet/minecraft/class_2561;)Lnet/minecraft/class_5250;
+		COMMENT Decorates the name of an entity with the prefix, suffix and color of this team.
 		ARG 1 name
+			COMMENT the name to be decorated
 	METHOD method_1199 shouldShowFriendlyInvisibles ()Z
 	METHOD method_1200 getDeathMessageVisibilityRule ()Lnet/minecraft/class_270$class_272;
 	METHOD method_1201 getNameTagVisibilityRule ()Lnet/minecraft/class_270$class_272;

--- a/mappings/net/minecraft/scoreboard/AbstractTeam.mapping
+++ b/mappings/net/minecraft/scoreboard/AbstractTeam.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_270 net/minecraft/scoreboard/AbstractTeam
 	METHOD method_1197 getName ()Ljava/lang/String;
-	METHOD method_1198 modifyText (Lnet/minecraft/class_2561;)Lnet/minecraft/class_5250;
+	METHOD method_1198 decorateName (Lnet/minecraft/class_2561;)Lnet/minecraft/class_5250;
+		ARG 1 name
 	METHOD method_1199 shouldShowFriendlyInvisibles ()Z
 	METHOD method_1200 getDeathMessageVisibilityRule ()Lnet/minecraft/class_270$class_272;
 	METHOD method_1201 getNameTagVisibilityRule ()Lnet/minecraft/class_270$class_272;

--- a/mappings/net/minecraft/scoreboard/ScoreboardCriterion.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardCriterion.mapping
@@ -1,6 +1,8 @@
 CLASS net/minecraft/class_274 net/minecraft/scoreboard/ScoreboardCriterion
 	FIELD field_1454 name Ljava/lang/String;
-	FIELD field_1455 OBJECTIVES Ljava/util/Map;
+	FIELD field_1455 CRITERIA Ljava/util/Map;
+		COMMENT A map of all scoreboard criteria by their names.
+		COMMENT Updated automatically in the constructor.
 	FIELD field_1458 KILLED_BY_TEAMS [Lnet/minecraft/class_274;
 	FIELD field_1461 readOnly Z
 	FIELD field_1466 TEAM_KILLS [Lnet/minecraft/class_274;

--- a/mappings/net/minecraft/scoreboard/ScoreboardCriterion.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardCriterion.mapping
@@ -4,12 +4,13 @@ CLASS net/minecraft/class_274 net/minecraft/scoreboard/ScoreboardCriterion
 	FIELD field_1458 KILLED_BY_TEAMS [Lnet/minecraft/class_274;
 	FIELD field_1461 readOnly Z
 	FIELD field_1466 TEAM_KILLS [Lnet/minecraft/class_274;
-	FIELD field_1467 criterionType Lnet/minecraft/class_274$class_275;
+	FIELD field_1467 defaultRenderType Lnet/minecraft/class_274$class_275;
 	METHOD <init> (Ljava/lang/String;)V
 		ARG 1 name
 	METHOD <init> (Ljava/lang/String;ZLnet/minecraft/class_274$class_275;)V
 		ARG 1 name
 		ARG 2 readOnly
+		ARG 3 defaultRenderType
 	METHOD method_1223 createStatCriterion (Lnet/minecraft/class_3448;Lnet/minecraft/class_2960;)Ljava/util/Optional;
 		ARG 0 statType
 		ARG 1 id
@@ -17,7 +18,7 @@ CLASS net/minecraft/class_274 net/minecraft/scoreboard/ScoreboardCriterion
 		ARG 0 name
 	METHOD method_1225 getName ()Ljava/lang/String;
 	METHOD method_1226 isReadOnly ()Z
-	METHOD method_1227 getCriterionType ()Lnet/minecraft/class_274$class_275;
+	METHOD method_1227 getDefaultRenderType ()Lnet/minecraft/class_274$class_275;
 	CLASS class_275 RenderType
 		FIELD field_1469 name Ljava/lang/String;
 		FIELD field_1470 CRITERION_TYPES Ljava/util/Map;

--- a/mappings/net/minecraft/scoreboard/ScoreboardCriterion.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardCriterion.mapping
@@ -13,10 +13,10 @@ CLASS net/minecraft/class_274 net/minecraft/scoreboard/ScoreboardCriterion
 		ARG 1 name
 		ARG 2 readOnly
 		ARG 3 defaultRenderType
-	METHOD method_1223 createStatCriterion (Lnet/minecraft/class_3448;Lnet/minecraft/class_2960;)Ljava/util/Optional;
+	METHOD method_1223 getOrCreateStatCriterion (Lnet/minecraft/class_3448;Lnet/minecraft/class_2960;)Ljava/util/Optional;
 		ARG 0 statType
 		ARG 1 id
-	METHOD method_1224 createStatCriterion (Ljava/lang/String;)Ljava/util/Optional;
+	METHOD method_1224 getOrCreateStatCriterion (Ljava/lang/String;)Ljava/util/Optional;
 		ARG 0 name
 	METHOD method_1225 getName ()Ljava/lang/String;
 	METHOD method_1226 isReadOnly ()Z

--- a/mappings/net/minecraft/scoreboard/ScoreboardObjective.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardObjective.mapping
@@ -4,11 +4,13 @@ CLASS net/minecraft/class_266 net/minecraft/scoreboard/ScoreboardObjective
 	FIELD field_1404 scoreboard Lnet/minecraft/class_269;
 	FIELD field_1405 name Ljava/lang/String;
 	FIELD field_1406 criterion Lnet/minecraft/class_274;
+	FIELD field_24194 bracketedDisplayName Lnet/minecraft/class_2561;
 	METHOD <init> (Lnet/minecraft/class_269;Ljava/lang/String;Lnet/minecraft/class_274;Lnet/minecraft/class_2561;Lnet/minecraft/class_274$class_275;)V
 		ARG 1 scoreboard
 		ARG 2 name
 		ARG 3 criterion
 		ARG 4 displayName
+		ARG 5 renderType
 	METHOD method_1113 getName ()Ljava/lang/String;
 	METHOD method_1114 getDisplayName ()Lnet/minecraft/class_2561;
 	METHOD method_1115 setRenderType (Lnet/minecraft/class_274$class_275;)V
@@ -21,3 +23,4 @@ CLASS net/minecraft/class_266 net/minecraft/scoreboard/ScoreboardObjective
 	METHOD method_1120 toHoverableText ()Lnet/minecraft/class_2561;
 	METHOD method_1121 setDisplayName (Lnet/minecraft/class_2561;)V
 		ARG 1 name
+	METHOD method_27441 generateBracketedDisplayName ()Lnet/minecraft/class_2561;

--- a/mappings/net/minecraft/scoreboard/ScoreboardPlayerScore.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardPlayerScore.mapping
@@ -12,7 +12,7 @@ CLASS net/minecraft/class_267 net/minecraft/scoreboard/ScoreboardPlayerScore
 		ARG 3 playerName
 	METHOD method_1122 getScoreboard ()Lnet/minecraft/class_269;
 	METHOD method_1124 incrementScore (I)V
-		ARG 1 increment
+		ARG 1 amount
 	METHOD method_1125 setLocked (Z)V
 		ARG 1 locked
 	METHOD method_1126 getScore ()I

--- a/mappings/net/minecraft/scoreboard/ScoreboardPlayerScore.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardPlayerScore.mapping
@@ -12,6 +12,7 @@ CLASS net/minecraft/class_267 net/minecraft/scoreboard/ScoreboardPlayerScore
 		ARG 3 playerName
 	METHOD method_1122 getScoreboard ()Lnet/minecraft/class_269;
 	METHOD method_1124 incrementScore (I)V
+		ARG 1 increment
 	METHOD method_1125 setLocked (Z)V
 		ARG 1 locked
 	METHOD method_1126 getScore ()I

--- a/mappings/net/minecraft/scoreboard/ScoreboardState.mapping
+++ b/mappings/net/minecraft/scoreboard/ScoreboardState.mapping
@@ -1,9 +1,19 @@
 CLASS net/minecraft/class_273 net/minecraft/scoreboard/ScoreboardState
-	METHOD method_1215 deserializeTeamPlayers (Lnet/minecraft/class_268;Lnet/minecraft/class_2499;)V
+	FIELD field_27936 scoreboard Lnet/minecraft/class_269;
+	METHOD <init> (Lnet/minecraft/class_269;)V
+		ARG 1 scoreboard
+	METHOD method_1215 teamPlayersFromTag (Lnet/minecraft/class_268;Lnet/minecraft/class_2499;)V
 		ARG 1 team
-	METHOD method_1216 serializeObjectives ()Lnet/minecraft/class_2499;
-	METHOD method_1217 serializeTeams ()Lnet/minecraft/class_2499;
-	METHOD method_1219 deserializeTeams (Lnet/minecraft/class_2499;)V
-	METHOD method_1220 deserializeObjectives (Lnet/minecraft/class_2499;)V
-	METHOD method_1221 deserializeDisplaySlots (Lnet/minecraft/class_2487;)V
-	METHOD method_1222 serializeSlots (Lnet/minecraft/class_2487;)V
+		ARG 2 tag
+	METHOD method_1216 objectivesToTag ()Lnet/minecraft/class_2499;
+	METHOD method_1217 teamsToTag ()Lnet/minecraft/class_2499;
+	METHOD method_1219 teamsFromTag (Lnet/minecraft/class_2499;)V
+		ARG 1 tag
+	METHOD method_1220 objectivesFromTag (Lnet/minecraft/class_2499;)V
+		ARG 1 tag
+	METHOD method_1221 displaySlotsFromTag (Lnet/minecraft/class_2487;)V
+		ARG 1 tag
+	METHOD method_1222 displaySlotsToTag (Lnet/minecraft/class_2487;)V
+		ARG 1 tag
+	METHOD method_32481 fromTag (Lnet/minecraft/class_2487;)Lnet/minecraft/class_273;
+		ARG 1 tag

--- a/mappings/net/minecraft/scoreboard/Team.mapping
+++ b/mappings/net/minecraft/scoreboard/Team.mapping
@@ -30,8 +30,12 @@ CLASS net/minecraft/class_268 net/minecraft/scoreboard/Team
 	METHOD method_1141 setColor (Lnet/minecraft/class_124;)V
 		ARG 1 color
 	METHOD method_1142 decorateName (Lnet/minecraft/class_270;Lnet/minecraft/class_2561;)Lnet/minecraft/class_5250;
+		COMMENT Decorates the name of an entity with the prefix, suffix and color of the team.
+		COMMENT If the team is null, returns a copy of the name.
 		ARG 0 team
+			COMMENT the team, can be null
 		ARG 1 name
+			COMMENT the name to be decorated
 	METHOD method_1143 setShowFriendlyInvisibles (Z)V
 		ARG 1 showFriendlyInvisible
 	METHOD method_1144 getPrefix ()Lnet/minecraft/class_2561;

--- a/mappings/net/minecraft/scoreboard/Team.mapping
+++ b/mappings/net/minecraft/scoreboard/Team.mapping
@@ -11,25 +11,34 @@ CLASS net/minecraft/class_268 net/minecraft/scoreboard/Team
 	FIELD field_1423 nameTagVisibilityRule Lnet/minecraft/class_270$class_272;
 	FIELD field_1424 color Lnet/minecraft/class_124;
 	FIELD field_1425 collisionRule Lnet/minecraft/class_270$class_271;
+	FIELD field_24195 nameStyle Lnet/minecraft/class_2583;
 	METHOD <init> (Lnet/minecraft/class_269;Ljava/lang/String;)V
 		ARG 1 scoreboard
 		ARG 2 name
 	METHOD method_1133 setDeathMessageVisibilityRule (Lnet/minecraft/class_270$class_272;)V
+		ARG 1 deathMessageVisibilityRule
 	METHOD method_1135 setFriendlyFireAllowed (Z)V
 		ARG 1 friendlyFire
 	METHOD method_1136 getSuffix ()Lnet/minecraft/class_2561;
 	METHOD method_1137 setDisplayName (Lnet/minecraft/class_2561;)V
+		ARG 1 displayName
 	METHOD method_1138 setPrefix (Lnet/minecraft/class_2561;)V
+		ARG 1 prefix
 	METHOD method_1139 setSuffix (Lnet/minecraft/class_2561;)V
+		ARG 1 suffix
 	METHOD method_1140 getDisplayName ()Lnet/minecraft/class_2561;
 	METHOD method_1141 setColor (Lnet/minecraft/class_124;)V
 		ARG 1 color
-	METHOD method_1142 modifyText (Lnet/minecraft/class_270;Lnet/minecraft/class_2561;)Lnet/minecraft/class_5250;
+	METHOD method_1142 decorateName (Lnet/minecraft/class_270;Lnet/minecraft/class_2561;)Lnet/minecraft/class_5250;
+		ARG 0 team
+		ARG 1 name
 	METHOD method_1143 setShowFriendlyInvisibles (Z)V
 		ARG 1 showFriendlyInvisible
 	METHOD method_1144 getPrefix ()Lnet/minecraft/class_2561;
 	METHOD method_1145 setCollisionRule (Lnet/minecraft/class_270$class_271;)V
+		ARG 1 collisionRule
 	METHOD method_1146 setFriendlyFlagsBitwise (I)V
 	METHOD method_1147 getFriendlyFlagsBitwise ()I
 	METHOD method_1148 getFormattedName ()Lnet/minecraft/class_5250;
 	METHOD method_1149 setNameTagVisibilityRule (Lnet/minecraft/class_270$class_272;)V
+		ARG 1 nameTagVisibilityRule


### PR DESCRIPTION
- `PlayerListHud.method_27538` -> `applyGameModeFormatting`: makes the name italic if the player is in spectator mode
- `AbstractTeam.modifyText` and `Team.modifyText` -> `decorateName`: decorates an entity's name with the prefix, suffix and colour of a team
- `Team.field_24195` -> `nameStyle`: used in `Team.getFormattedName` to apply the name insertion and hover event to the name text
- `ScoreboardCriterion.OBJECTIVES` -> `CRITERIA`: it's a map of criteria, not objectives
- `ScoreboardCriterion.createStatCriterion` -> `getOrCreateStatCriterion`: the method checks the `CRITERIA` map for an existing criterion first
- `ScoreboardState`: changed all names to follow `from/toTag` format. The conventions say:
  > Use "read" for non-static methods that load data into the object. Use "write" for methods that save data to an existing object passed as a parameter.

  However, the superclass (`PersistentState`) uses `toTag` like many other classes for this purpose, so I used the same format to be consistent in the same class hierarchy.