### PR TITLE
Rename TooltipComponent factory methods to of

### DIFF
--- a/mappings/net/minecraft/client/gui/tooltip/TooltipComponent.mapping
+++ b/mappings/net/minecraft/client/gui/tooltip/TooltipComponent.mapping
@@ -1,13 +1,19 @@
 CLASS net/minecraft/class_5684 net/minecraft/client/gui/tooltip/TooltipComponent
 	METHOD method_32661 getHeight ()I
-	METHOD method_32662 createOrderedTextTooltipComponent (Lnet/minecraft/class_5481;)Lnet/minecraft/class_5684;
-	METHOD method_32663 createTooltipComponent (Lnet/minecraft/class_5632;)Lnet/minecraft/class_5684;
+	METHOD method_32662 of (Lnet/minecraft/class_5481;)Lnet/minecraft/class_5684;
+		ARG 0 text
+	METHOD method_32663 of (Lnet/minecraft/class_5632;)Lnet/minecraft/class_5684;
+		ARG 0 data
 	METHOD method_32664 getWidth (Lnet/minecraft/class_327;)I
+		ARG 1 textRenderer
 	METHOD method_32665 drawText (Lnet/minecraft/class_327;IILnet/minecraft/class_1159;Lnet/minecraft/class_4597$class_4598;)V
+		ARG 1 textRenderer
 		ARG 2 x
 		ARG 3 y
 	METHOD method_32666 drawItems (Lnet/minecraft/class_327;IILnet/minecraft/class_4587;Lnet/minecraft/class_918;ILnet/minecraft/class_1060;)V
+		ARG 1 textRenderer
 		ARG 2 x
 		ARG 3 y
 		ARG 4 matrices
+		ARG 5 itemRenderer
 		ARG 6 z


### PR DESCRIPTION
`of` results in cleaner code, such as `TooltipComponent.createOrderedTextTooltipComponent` => `TooltipComponent.of`. `of` is also used in other places in Yarn such as `DefaultedList`.