### PR TITLE
Model part names

### DIFF
--- a/mappings/net/minecraft/client/render/block/entity/SkullBlockEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/block/entity/SkullBlockEntityModel.mapping
@@ -1,1 +1,5 @@
 CLASS net/minecraft/class_5598 net/minecraft/client/render/block/entity/SkullBlockEntityModel
+	METHOD method_2821 setHeadRotation (FFF)V
+		ARG 1 animationProgress
+		ARG 2 yaw
+		ARG 3 pitch

--- a/mappings/net/minecraft/client/render/entity/model/AbstractZombieModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/AbstractZombieModel.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/class_3968 net/minecraft/client/render/entity/model/AbstractZombieModel
 	METHOD method_17790 isAttacking (Lnet/minecraft/class_1588;)Z
+		ARG 1 entity

--- a/mappings/net/minecraft/client/render/entity/model/AnimalModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/AnimalModel.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/class_4592 net/minecraft/client/render/entity/model/AnimalMo
 	FIELD field_20919 invertedChildBodyScale F
 	FIELD field_20920 childBodyYOffset F
 	METHOD <init> (Ljava/util/function/Function;ZFFFFF)V
+		ARG 1 renderLayerFactory
 		ARG 2 headScaled
 		ARG 3 childHeadYOffset
 		ARG 4 childHeadZOffset

--- a/mappings/net/minecraft/client/render/entity/model/ArmorStandEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/ArmorStandEntityModel.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_551 net/minecraft/client/render/entity/model/ArmorStandEntityModel
-	FIELD field_3312 plate Lnet/minecraft/class_630;
-	FIELD field_3313 hip Lnet/minecraft/class_630;
+	FIELD field_27391 rightBodyStick Lnet/minecraft/class_630;
+	FIELD field_27392 leftBodyStick Lnet/minecraft/class_630;
+	FIELD field_3312 basePlate Lnet/minecraft/class_630;
+	FIELD field_3313 shoulderStick Lnet/minecraft/class_630;
 	METHOD method_31979 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/BatEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BatEntityModel.mapping
@@ -1,8 +1,11 @@
 CLASS net/minecraft/class_553 net/minecraft/client/render/entity/model/BatEntityModel
+	FIELD field_27393 root Lnet/minecraft/class_630;
 	FIELD field_3319 rightWingTip Lnet/minecraft/class_630;
 	FIELD field_3320 leftWing Lnet/minecraft/class_630;
 	FIELD field_3321 head Lnet/minecraft/class_630;
 	FIELD field_3322 rightWing Lnet/minecraft/class_630;
 	FIELD field_3323 body Lnet/minecraft/class_630;
 	FIELD field_3324 leftWingTip Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_31980 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/BeeEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BeeEntityModel.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_4495 net/minecraft/client/render/entity/model/BeeEntityModel
-	FIELD field_20504 body Lnet/minecraft/class_630;
+	FIELD field_20504 bone Lnet/minecraft/class_630;
 	FIELD field_20506 rightWing Lnet/minecraft/class_630;
 	FIELD field_20507 leftWing Lnet/minecraft/class_630;
 	FIELD field_20508 frontLegs Lnet/minecraft/class_630;
@@ -9,4 +9,6 @@ CLASS net/minecraft/class_4495 net/minecraft/client/render/entity/model/BeeEntit
 	FIELD field_20512 leftAntenna Lnet/minecraft/class_630;
 	FIELD field_20513 rightAntenna Lnet/minecraft/class_630;
 	FIELD field_20514 bodyPitch F
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_31981 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/BipedEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BipedEntityModel.mapping
@@ -14,7 +14,7 @@ CLASS net/minecraft/class_572 net/minecraft/client/render/entity/model/BipedEnti
 		ARG 1 root
 	METHOD <init> (Lnet/minecraft/class_630;Ljava/util/function/Function;)V
 		ARG 1 root
-		ARG 2 renderLayer
+		ARG 2 renderLayerFactory
 	METHOD method_2804 lerpAngle (FFF)F
 		ARG 1 angleOne
 		ARG 2 angleTwo

--- a/mappings/net/minecraft/client/render/entity/model/BipedEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BipedEntityModel.mapping
@@ -1,8 +1,8 @@
 CLASS net/minecraft/class_572 net/minecraft/client/render/entity/model/BipedEntityModel
 	FIELD field_27433 leftArm Lnet/minecraft/class_630;
-	FIELD field_3391 torso Lnet/minecraft/class_630;
+	FIELD field_3391 body Lnet/minecraft/class_630;
 	FIELD field_3392 rightLeg Lnet/minecraft/class_630;
-	FIELD field_3394 helmet Lnet/minecraft/class_630;
+	FIELD field_3394 hat Lnet/minecraft/class_630;
 	FIELD field_3395 rightArmPose Lnet/minecraft/class_572$class_573;
 	FIELD field_3396 leaningPitch F
 	FIELD field_3397 leftLeg Lnet/minecraft/class_630;
@@ -11,8 +11,14 @@ CLASS net/minecraft/class_572 net/minecraft/client/render/entity/model/BipedEnti
 	FIELD field_3400 sneaking Z
 	FIELD field_3401 rightArm Lnet/minecraft/class_630;
 	METHOD <init> (Lnet/minecraft/class_630;)V
-		ARG 1 part
+		ARG 1 root
+	METHOD <init> (Lnet/minecraft/class_630;Ljava/util/function/Function;)V
+		ARG 1 root
+		ARG 2 renderLayer
 	METHOD method_2804 lerpAngle (FFF)F
+		ARG 1 angleOne
+		ARG 2 angleTwo
+		ARG 3 magnitude
 	METHOD method_2805 setVisible (Z)V
 		ARG 1 visible
 	METHOD method_2806 getPreferredArm (Lnet/minecraft/class_1309;)Lnet/minecraft/class_1306;
@@ -20,10 +26,21 @@ CLASS net/minecraft/class_572 net/minecraft/client/render/entity/model/BipedEnti
 	METHOD method_2808 getArm (Lnet/minecraft/class_1306;)Lnet/minecraft/class_630;
 		ARG 1 arm
 	METHOD method_2818 setAttributes (Lnet/minecraft/class_572;)V
+		ARG 1 model
+	METHOD method_29353 animateArms (Lnet/minecraft/class_1309;F)V
+		ARG 1 entity
+		ARG 2 animationProgress
+	METHOD method_30154 positionRightArm (Lnet/minecraft/class_1309;)V
+		ARG 1 entity
+	METHOD method_30155 positionLeftArm (Lnet/minecraft/class_1309;)V
+		ARG 1 entity
 	METHOD method_32011 getModelData (Lnet/minecraft/class_5605;F)Lnet/minecraft/class_5609;
 		ARG 0 dilation
 		ARG 1 pivotOffsetY
 	CLASS class_573 ArmPose
+		FIELD field_25722 twoHanded Z
 		METHOD <init> (Ljava/lang/String;IZ)V
 			ARG 1 name
 			ARG 2 id
+			ARG 3 twoHanded
+		METHOD method_30156 isTwoHanded ()Z

--- a/mappings/net/minecraft/client/render/entity/model/BlazeEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BlazeEntityModel.mapping
@@ -1,3 +1,9 @@
 CLASS net/minecraft/class_555 net/minecraft/client/render/entity/model/BlazeEntityModel
+	FIELD field_27394 root Lnet/minecraft/class_630;
+	FIELD field_27395 head Lnet/minecraft/class_630;
 	FIELD field_3328 rods [Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_31982 getTexturedModelData ()Lnet/minecraft/class_5607;
+	METHOD method_31983 getRodName (I)Ljava/lang/String;
+		ARG 0 index

--- a/mappings/net/minecraft/client/render/entity/model/BoatEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BoatEntityModel.mapping
@@ -1,7 +1,14 @@
 CLASS net/minecraft/class_554 net/minecraft/client/render/entity/model/BoatEntityModel
 	FIELD field_20922 parts Lcom/google/common/collect/ImmutableList;
-	FIELD field_3326 bottom Lnet/minecraft/class_630;
+	FIELD field_27396 leftPaddle Lnet/minecraft/class_630;
+	FIELD field_27397 rightPaddle Lnet/minecraft/class_630;
+	FIELD field_3326 waterPatch Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_22954 getBottom ()Lnet/minecraft/class_630;
 	METHOD method_2797 setPaddleAngle (Lnet/minecraft/class_1690;ILnet/minecraft/class_630;F)V
+		ARG 0 entity
+		ARG 1 sigma
+		ARG 2 part
 		ARG 3 angle
 	METHOD method_31985 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/BookModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BookModel.mapping
@@ -11,7 +11,7 @@ CLASS net/minecraft/class_557 net/minecraft/client/render/entity/model/BookModel
 	METHOD method_17073 setPageAngles (FFFF)V
 		ARG 1 pageTurnAmount
 		ARG 2 leftFlipAmount
-		ARG 3 rightflipAmount
+		ARG 3 rightFlipAmount
 		ARG 4 pageTurnSpeed
 	METHOD method_24184 renderBook (Lnet/minecraft/class_4587;Lnet/minecraft/class_4588;IIFFFF)V
 		ARG 1 matrices

--- a/mappings/net/minecraft/client/render/entity/model/BookModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BookModel.mapping
@@ -1,12 +1,19 @@
 CLASS net/minecraft/class_557 net/minecraft/client/render/entity/model/BookModel
+	FIELD field_27398 root Lnet/minecraft/class_630;
 	FIELD field_3334 leftPage Lnet/minecraft/class_630;
-	FIELD field_3335 rightBlock Lnet/minecraft/class_630;
+	FIELD field_3335 rightPages Lnet/minecraft/class_630;
 	FIELD field_3336 leftCover Lnet/minecraft/class_630;
-	FIELD field_3337 leftBlock Lnet/minecraft/class_630;
+	FIELD field_3337 leftPages Lnet/minecraft/class_630;
 	FIELD field_3338 rightCover Lnet/minecraft/class_630;
 	FIELD field_3339 rightPage Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_17073 setPageAngles (FFFF)V
-	METHOD method_24184 (Lnet/minecraft/class_4587;Lnet/minecraft/class_4588;IIFFFF)V
+		ARG 1 pageTurnAmount
+		ARG 2 leftFlipAmount
+		ARG 3 rightflipAmount
+		ARG 4 pageTurnSpeed
+	METHOD method_24184 renderBook (Lnet/minecraft/class_4587;Lnet/minecraft/class_4588;IIFFFF)V
 		ARG 1 matrices
 		ARG 2 vertices
 		ARG 3 light

--- a/mappings/net/minecraft/client/render/entity/model/ChickenEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/ChickenEntityModel.mapping
@@ -1,6 +1,12 @@
 CLASS net/minecraft/class_558 net/minecraft/client/render/entity/model/ChickenEntityModel
+	FIELD field_27401 rightLeg Lnet/minecraft/class_630;
+	FIELD field_27402 leftLeg Lnet/minecraft/class_630;
+	FIELD field_27403 rightWing Lnet/minecraft/class_630;
+	FIELD field_27404 leftWing Lnet/minecraft/class_630;
 	FIELD field_3340 beak Lnet/minecraft/class_630;
 	FIELD field_3342 wattle Lnet/minecraft/class_630;
 	FIELD field_3344 head Lnet/minecraft/class_630;
-	FIELD field_3346 torso Lnet/minecraft/class_630;
+	FIELD field_3346 body Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_31988 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/CodEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/CodEntityModel.mapping
@@ -1,3 +1,6 @@
 CLASS net/minecraft/class_561 net/minecraft/client/render/entity/model/CodEntityModel
-	FIELD field_3350 tail Lnet/minecraft/class_630;
+	FIELD field_27405 root Lnet/minecraft/class_630;
+	FIELD field_3350 tailFin Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_31989 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/CowEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/CowEntityModel.mapping
@@ -1,3 +1,5 @@
 CLASS net/minecraft/class_560 net/minecraft/client/render/entity/model/CowEntityModel
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_2800 getHead ()Lnet/minecraft/class_630;
 	METHOD method_31990 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/CreeperEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/CreeperEntityModel.mapping
@@ -1,3 +1,11 @@
 CLASS net/minecraft/class_562 net/minecraft/client/render/entity/model/CreeperEntityModel
+	FIELD field_27406 root Lnet/minecraft/class_630;
+	FIELD field_27407 leftHindLeg Lnet/minecraft/class_630;
+	FIELD field_27408 rightHindLeg Lnet/minecraft/class_630;
+	FIELD field_27409 leftFrontLeg Lnet/minecraft/class_630;
+	FIELD field_27410 rightFrontLeg Lnet/minecraft/class_630;
 	FIELD field_3360 head Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_31991 getTexturedModelData (Lnet/minecraft/class_5605;)Lnet/minecraft/class_5607;
+		ARG 0 dilation

--- a/mappings/net/minecraft/client/render/entity/model/CrossbowPosing.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/CrossbowPosing.mapping
@@ -21,7 +21,7 @@ CLASS net/minecraft/class_4896 net/minecraft/client/render/entity/model/Crossbow
 		ARG 4 animationProgress
 	METHOD method_29352 meleeAttack (Lnet/minecraft/class_630;Lnet/minecraft/class_630;ZFF)V
 		ARG 0 leftArm
-		ARG 1 rightarm
+		ARG 1 rightArm
 		ARG 2 attacking
 		ARG 3 swingProgress
 		ARG 4 animationProgress

--- a/mappings/net/minecraft/client/render/entity/model/CrossbowPosing.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/CrossbowPosing.mapping
@@ -9,3 +9,23 @@ CLASS net/minecraft/class_4896 net/minecraft/client/render/entity/model/Crossbow
 		ARG 1 otherArm
 		ARG 2 head
 		ARG 3 rightArmed
+	METHOD method_29350 swingArm (Lnet/minecraft/class_630;FF)V
+		ARG 0 arm
+		ARG 1 animationProgress
+		ARG 2 sigma
+	METHOD method_29351 meleeAttack (Lnet/minecraft/class_630;Lnet/minecraft/class_630;Lnet/minecraft/class_1308;FF)V
+		ARG 0 leftArm
+		ARG 1 rightArm
+		ARG 2 actor
+		ARG 3 swingProgress
+		ARG 4 animationProgress
+	METHOD method_29352 meleeAttack (Lnet/minecraft/class_630;Lnet/minecraft/class_630;ZFF)V
+		ARG 0 leftArm
+		ARG 1 rightarm
+		ARG 2 attacking
+		ARG 3 swingProgress
+		ARG 4 animationProgress
+	METHOD method_32789 swingArms (Lnet/minecraft/class_630;Lnet/minecraft/class_630;F)V
+		ARG 0 leftArm
+		ARG 1 rightArm
+		ARG 2 animationProgress

--- a/mappings/net/minecraft/client/render/entity/model/DolphinEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/DolphinEntityModel.mapping
@@ -1,5 +1,8 @@
 CLASS net/minecraft/class_889 net/minecraft/client/render/entity/model/DolphinEntityModel
-	FIELD field_4655 flukes Lnet/minecraft/class_630;
+	FIELD field_27411 root Lnet/minecraft/class_630;
+	FIELD field_4655 tailFin Lnet/minecraft/class_630;
 	FIELD field_4657 tail Lnet/minecraft/class_630;
 	FIELD field_4658 body Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_31992 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/DonkeyEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/DonkeyEntityModel.mapping
@@ -1,2 +1,4 @@
 CLASS net/minecraft/class_559 net/minecraft/client/render/entity/model/DonkeyEntityModel
+	FIELD field_27399 leftChest Lnet/minecraft/class_630;
+	FIELD field_27400 rightChest Lnet/minecraft/class_630;
 	METHOD method_31987 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/DragonHeadEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/DragonHeadEntityModel.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_626 net/minecraft/client/render/entity/model/DragonHeadEntityModel
 	FIELD field_3638 head Lnet/minecraft/class_630;
 	FIELD field_3639 jaw Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32071 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/DrownedEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/DrownedEntityModel.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/class_564 net/minecraft/client/render/entity/model/DrownedEntityModel
 	METHOD method_31993 getTexturedModelData (Lnet/minecraft/class_5605;)Lnet/minecraft/class_5607;
+		ARG 0 dilation

--- a/mappings/net/minecraft/client/render/entity/model/ElytraEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/ElytraEntityModel.mapping
@@ -1,2 +1,6 @@
 CLASS net/minecraft/class_563 net/minecraft/client/render/entity/model/ElytraEntityModel
+	FIELD field_27412 rightWing Lnet/minecraft/class_630;
+	FIELD field_3365 leftWing Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_31994 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/EndermiteEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/EndermiteEntityModel.mapping
@@ -1,2 +1,10 @@
 CLASS net/minecraft/class_565 net/minecraft/client/render/entity/model/EndermiteEntityModel
+	FIELD field_27413 root Lnet/minecraft/class_630;
+	FIELD field_3366 SEGMENT_DIMENSIONS [[I
+	FIELD field_3368 bodySegments [Lnet/minecraft/class_630;
+	FIELD field_3369 SEGMENT_UVS [[I
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_31996 getTexturedModelData ()Lnet/minecraft/class_5607;
+	METHOD method_31997 getSegmentName (I)Ljava/lang/String;
+		ARG 0 index

--- a/mappings/net/minecraft/client/render/entity/model/EntityModelLayer.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/EntityModelLayer.mapping
@@ -1,8 +1,8 @@
 CLASS net/minecraft/class_5601 net/minecraft/client/render/entity/model/EntityModelLayer
-	FIELD field_27546 identifier Lnet/minecraft/class_2960;
-	FIELD field_27547 layer Ljava/lang/String;
+	FIELD field_27546 id Lnet/minecraft/class_2960;
+	FIELD field_27547 name Ljava/lang/String;
 	METHOD <init> (Lnet/minecraft/class_2960;Ljava/lang/String;)V
-		ARG 1 identifier
-		ARG 2 layer
+		ARG 1 id
+		ARG 2 name
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 other

--- a/mappings/net/minecraft/client/render/entity/model/EvokerFangsEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/EvokerFangsEntityModel.mapping
@@ -1,2 +1,8 @@
 CLASS net/minecraft/class_568 net/minecraft/client/render/entity/model/EvokerFangsEntityModel
+	FIELD field_27414 root Lnet/minecraft/class_630;
+	FIELD field_3374 base Lnet/minecraft/class_630;
+	FIELD field_3375 lowerJaw Lnet/minecraft/class_630;
+	FIELD field_3376 upperJaw Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_31998 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/FoxEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/FoxEntityModel.mapping
@@ -1,6 +1,12 @@
 CLASS net/minecraft/class_4041 net/minecraft/client/render/entity/model/FoxEntityModel
 	FIELD field_18015 head Lnet/minecraft/class_630;
-	FIELD field_18019 torso Lnet/minecraft/class_630;
+	FIELD field_18019 body Lnet/minecraft/class_630;
 	FIELD field_18024 tail Lnet/minecraft/class_630;
 	FIELD field_18025 legPitchModifier F
+	FIELD field_27415 rightHindLeg Lnet/minecraft/class_630;
+	FIELD field_27416 leftHindLeg Lnet/minecraft/class_630;
+	FIELD field_27417 rightFrontLeg Lnet/minecraft/class_630;
+	FIELD field_27418 leftFrontLeg Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_31999 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/GhastEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/GhastEntityModel.mapping
@@ -1,3 +1,8 @@
 CLASS net/minecraft/class_567 net/minecraft/client/render/entity/model/GhastEntityModel
+	FIELD field_27419 root Lnet/minecraft/class_630;
 	FIELD field_3372 tentacles [Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32000 getTexturedModelData ()Lnet/minecraft/class_5607;
+	METHOD method_32001 getTentacleName (I)Ljava/lang/String;
+		ARG 0 index

--- a/mappings/net/minecraft/client/render/entity/model/GuardianEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/GuardianEntityModel.mapping
@@ -7,7 +7,7 @@ CLASS net/minecraft/class_570 net/minecraft/client/render/entity/model/GuardianE
 	FIELD field_17136 SPIKE_PIVOTS_Z [F
 	FIELD field_27420 root Lnet/minecraft/class_630;
 	FIELD field_3378 tail [Lnet/minecraft/class_630;
-	FIELD field_3379 body Lnet/minecraft/class_630;
+	FIELD field_3379 head Lnet/minecraft/class_630;
 	FIELD field_3380 spikes [Lnet/minecraft/class_630;
 	FIELD field_3381 eye Lnet/minecraft/class_630;
 	METHOD <init> (Lnet/minecraft/class_630;)V

--- a/mappings/net/minecraft/client/render/entity/model/GuardianEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/GuardianEntityModel.mapping
@@ -1,4 +1,36 @@
 CLASS net/minecraft/class_570 net/minecraft/client/render/entity/model/GuardianEntityModel
+	FIELD field_17131 SPIKE_PITCHES [F
+	FIELD field_17132 SPIKE_YAWS [F
+	FIELD field_17133 SPIKE_ROLLS [F
+	FIELD field_17134 SPIKE_PIVOTS_X [F
+	FIELD field_17135 SPIKE_PIVOTS_Y [F
+	FIELD field_17136 SPIKE_PIVOTS_Z [F
+	FIELD field_27420 root Lnet/minecraft/class_630;
+	FIELD field_3378 tail [Lnet/minecraft/class_630;
 	FIELD field_3379 body Lnet/minecraft/class_630;
+	FIELD field_3380 spikes [Lnet/minecraft/class_630;
 	FIELD field_3381 eye Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
+	METHOD method_24185 updateSpikeExtensions (FF)V
+		ARG 1 animationProgress
+		ARG 2 extension
 	METHOD method_32002 getTexturedModelData ()Lnet/minecraft/class_5607;
+	METHOD method_32003 getSpikeName (I)Ljava/lang/String;
+		ARG 0 index
+	METHOD method_32004 getAngle (IFF)F
+		ARG 0 index
+		ARG 1 animationProgress
+		ARG 2 magnitude
+	METHOD method_32005 getSpikePivotX (IFF)F
+		ARG 0 index
+		ARG 1 animationProgress
+		ARG 2 extension
+	METHOD method_32006 getSpikePivotY (IFF)F
+		ARG 0 index
+		ARG 1 animationProgress
+		ARG 2 extension
+	METHOD method_32007 getSpikePivotZ (IFF)F
+		ARG 0 index
+		ARG 1 animationProgress
+		ARG 2 extension

--- a/mappings/net/minecraft/client/render/entity/model/HoglinEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/HoglinEntityModel.mapping
@@ -2,5 +2,12 @@ CLASS net/minecraft/class_4791 net/minecraft/client/render/entity/model/HoglinEn
 	FIELD field_22227 head Lnet/minecraft/class_630;
 	FIELD field_22228 rightEar Lnet/minecraft/class_630;
 	FIELD field_22229 leftEar Lnet/minecraft/class_630;
-	FIELD field_22230 torso Lnet/minecraft/class_630;
+	FIELD field_22230 body Lnet/minecraft/class_630;
+	FIELD field_25484 mane Lnet/minecraft/class_630;
+	FIELD field_27421 rightFrontLeg Lnet/minecraft/class_630;
+	FIELD field_27422 leftFrontLeg Lnet/minecraft/class_630;
+	FIELD field_27423 rightHindLeg Lnet/minecraft/class_630;
+	FIELD field_27424 leftHindLeg Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32009 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/HorseEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/HorseEntityModel.mapping
@@ -1,5 +1,18 @@
 CLASS net/minecraft/class_549 net/minecraft/client/render/entity/model/HorseEntityModel
+	FIELD field_27425 rightHindLeg Lnet/minecraft/class_630;
+	FIELD field_27426 leftHindLeg Lnet/minecraft/class_630;
+	FIELD field_27427 rightFrontLeg Lnet/minecraft/class_630;
+	FIELD field_27428 leftFrontLeg Lnet/minecraft/class_630;
+	FIELD field_27429 rightHindBabyLeg Lnet/minecraft/class_630;
+	FIELD field_27430 leftHindBabyLeg Lnet/minecraft/class_630;
+	FIELD field_27431 rightFrontBabyLeg Lnet/minecraft/class_630;
+	FIELD field_27432 leftFrontBabyLeg Lnet/minecraft/class_630;
 	FIELD field_3300 tail Lnet/minecraft/class_630;
-	FIELD field_3305 torso Lnet/minecraft/class_630;
+	FIELD field_3301 straps [Lnet/minecraft/class_630;
+	FIELD field_3304 saddle [Lnet/minecraft/class_630;
+	FIELD field_3305 body Lnet/minecraft/class_630;
 	FIELD field_3307 head Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32010 getModelData (Lnet/minecraft/class_5605;)Lnet/minecraft/class_5609;
+		ARG 0 dilation

--- a/mappings/net/minecraft/client/render/entity/model/IllagerEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/IllagerEntityModel.mapping
@@ -1,11 +1,14 @@
 CLASS net/minecraft/class_575 net/minecraft/client/render/entity/model/IllagerEntityModel
-	FIELD field_3417 leftAttackingArm Lnet/minecraft/class_630;
-	FIELD field_3418 leftLeg Lnet/minecraft/class_630;
+	FIELD field_27435 root Lnet/minecraft/class_630;
+	FIELD field_3417 leftArm Lnet/minecraft/class_630;
+	FIELD field_3418 rightLeg Lnet/minecraft/class_630;
 	FIELD field_3419 hat Lnet/minecraft/class_630;
-	FIELD field_3420 rightLeg Lnet/minecraft/class_630;
+	FIELD field_3420 leftLeg Lnet/minecraft/class_630;
 	FIELD field_3422 head Lnet/minecraft/class_630;
 	FIELD field_3423 arms Lnet/minecraft/class_630;
-	FIELD field_3426 rightAttackingArm Lnet/minecraft/class_630;
+	FIELD field_3426 rightArm Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_2812 getHat ()Lnet/minecraft/class_630;
 	METHOD method_2813 getAttackingArm (Lnet/minecraft/class_1306;)Lnet/minecraft/class_630;
 		ARG 1 arm

--- a/mappings/net/minecraft/client/render/entity/model/IronGolemEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/IronGolemEntityModel.mapping
@@ -1,4 +1,11 @@
 CLASS net/minecraft/class_574 net/minecraft/client/render/entity/model/IronGolemEntityModel
+	FIELD field_27436 root Lnet/minecraft/class_630;
+	FIELD field_27437 rightArm Lnet/minecraft/class_630;
+	FIELD field_27438 leftArm Lnet/minecraft/class_630;
+	FIELD field_27439 rightLeg Lnet/minecraft/class_630;
+	FIELD field_27440 leftLeg Lnet/minecraft/class_630;
 	FIELD field_3415 head Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_2809 getRightArm ()Lnet/minecraft/class_630;
 	METHOD method_32013 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/LargePufferfishEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/LargePufferfishEntityModel.mapping
@@ -1,2 +1,7 @@
 CLASS net/minecraft/class_592 net/minecraft/client/render/entity/model/LargePufferfishEntityModel
+	FIELD field_27467 root Lnet/minecraft/class_630;
+	FIELD field_27468 leftBlueFin Lnet/minecraft/class_630;
+	FIELD field_27469 rightBlueFin Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32030 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/LargeTropicalFishEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/LargeTropicalFishEntityModel.mapping
@@ -1,2 +1,7 @@
 CLASS net/minecraft/class_615 net/minecraft/client/render/entity/model/LargeTropicalFishEntityModel
+	FIELD field_27524 root Lnet/minecraft/class_630;
+	FIELD field_3599 tail Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32061 getTexturedModelData (Lnet/minecraft/class_5605;)Lnet/minecraft/class_5607;
+		ARG 0 dilation

--- a/mappings/net/minecraft/client/render/entity/model/LeashKnotEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/LeashKnotEntityModel.mapping
@@ -1,3 +1,6 @@
 CLASS net/minecraft/class_579 net/minecraft/client/render/entity/model/LeashKnotEntityModel
-	FIELD field_3431 leashKnot Lnet/minecraft/class_630;
+	FIELD field_27442 root Lnet/minecraft/class_630;
+	FIELD field_3431 knot Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 knot
 	METHOD method_32017 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/LeashKnotEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/LeashKnotEntityModel.mapping
@@ -2,5 +2,5 @@ CLASS net/minecraft/class_579 net/minecraft/client/render/entity/model/LeashKnot
 	FIELD field_27442 root Lnet/minecraft/class_630;
 	FIELD field_3431 knot Lnet/minecraft/class_630;
 	METHOD <init> (Lnet/minecraft/class_630;)V
-		ARG 1 knot
+		ARG 1 root
 	METHOD method_32017 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/LlamaEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/LlamaEntityModel.mapping
@@ -1,2 +1,13 @@
 CLASS net/minecraft/class_578 net/minecraft/client/render/entity/model/LlamaEntityModel
+	FIELD field_27443 head Lnet/minecraft/class_630;
+	FIELD field_27444 body Lnet/minecraft/class_630;
+	FIELD field_27445 rightHindLeg Lnet/minecraft/class_630;
+	FIELD field_27446 leftHindLeg Lnet/minecraft/class_630;
+	FIELD field_27447 rightFrontLeg Lnet/minecraft/class_630;
+	FIELD field_27448 leftFrontLeg Lnet/minecraft/class_630;
+	FIELD field_27449 rightChest Lnet/minecraft/class_630;
+	FIELD field_27450 leftChest Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32018 getTexturedModelData (Lnet/minecraft/class_5605;)Lnet/minecraft/class_5607;
+		ARG 0 dilation

--- a/mappings/net/minecraft/client/render/entity/model/LlamaSpitEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/LlamaSpitEntityModel.mapping
@@ -1,2 +1,5 @@
 CLASS net/minecraft/class_581 net/minecraft/client/render/entity/model/LlamaSpitEntityModel
+	FIELD field_27451 root Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32019 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/MagmaCubeEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/MagmaCubeEntityModel.mapping
@@ -1,2 +1,8 @@
 CLASS net/minecraft/class_576 net/minecraft/client/render/entity/model/MagmaCubeEntityModel
+	FIELD field_27441 root Lnet/minecraft/class_630;
+	FIELD field_3427 slices [Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32014 getTexturedModelData ()Lnet/minecraft/class_5607;
+	METHOD method_32015 getSliceName (I)Ljava/lang/String;
+		ARG 0 index

--- a/mappings/net/minecraft/client/render/entity/model/MediumPufferfishEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/MediumPufferfishEntityModel.mapping
@@ -1,2 +1,7 @@
 CLASS net/minecraft/class_595 net/minecraft/client/render/entity/model/MediumPufferfishEntityModel
+	FIELD field_27470 root Lnet/minecraft/class_630;
+	FIELD field_27471 leftBlueFin Lnet/minecraft/class_630;
+	FIELD field_27472 rightBlueFin Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32031 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/MinecartEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/MinecartEntityModel.mapping
@@ -1,2 +1,6 @@
 CLASS net/minecraft/class_580 net/minecraft/client/render/entity/model/MinecartEntityModel
+	FIELD field_27452 root Lnet/minecraft/class_630;
+	FIELD field_27453 contents Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32020 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/OcelotEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/OcelotEntityModel.mapping
@@ -1,7 +1,14 @@
 CLASS net/minecraft/class_582 net/minecraft/client/render/entity/model/OcelotEntityModel
+	FIELD field_27454 leftHindLeg Lnet/minecraft/class_630;
+	FIELD field_27455 rightHindLeg Lnet/minecraft/class_630;
+	FIELD field_27456 leftFrontLeg Lnet/minecraft/class_630;
+	FIELD field_27457 rightFrontLeg Lnet/minecraft/class_630;
 	FIELD field_3434 animationState I
 	FIELD field_3435 head Lnet/minecraft/class_630;
 	FIELD field_3436 upperTail Lnet/minecraft/class_630;
-	FIELD field_3437 torso Lnet/minecraft/class_630;
+	FIELD field_3437 body Lnet/minecraft/class_630;
 	FIELD field_3442 lowerTail Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32021 getModelData (Lnet/minecraft/class_5605;)Lnet/minecraft/class_5609;
+		ARG 0 dilation

--- a/mappings/net/minecraft/client/render/entity/model/PandaEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/PandaEntityModel.mapping
@@ -2,4 +2,6 @@ CLASS net/minecraft/class_586 net/minecraft/client/render/entity/model/PandaEnti
 	FIELD field_3468 playAnimationProgress F
 	FIELD field_3469 lieOnBackAnimationProgress F
 	FIELD field_3470 scaredAnimationProgress F
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32022 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/ParrotEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/ParrotEntityModel.mapping
@@ -1,8 +1,15 @@
 CLASS net/minecraft/class_584 net/minecraft/client/render/entity/model/ParrotEntityModel
+	FIELD field_27458 root Lnet/minecraft/class_630;
+	FIELD field_27459 leftWing Lnet/minecraft/class_630;
+	FIELD field_27460 rightWing Lnet/minecraft/class_630;
+	FIELD field_27461 leftLeg Lnet/minecraft/class_630;
+	FIELD field_27462 rightLeg Lnet/minecraft/class_630;
 	FIELD field_3452 head Lnet/minecraft/class_630;
-	FIELD field_3456 headFeathers Lnet/minecraft/class_630;
-	FIELD field_3458 torso Lnet/minecraft/class_630;
+	FIELD field_3456 feather Lnet/minecraft/class_630;
+	FIELD field_3458 body Lnet/minecraft/class_630;
 	FIELD field_3460 tail Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_17106 poseOnShoulder (Lnet/minecraft/class_4587;Lnet/minecraft/class_4588;IIFFFFI)V
 		ARG 1 matrices
 		ARG 2 vertexConsumer

--- a/mappings/net/minecraft/client/render/entity/model/PhantomEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/PhantomEntityModel.mapping
@@ -1,8 +1,11 @@
 CLASS net/minecraft/class_588 net/minecraft/client/render/entity/model/PhantomEntityModel
-	FIELD field_3471 tail Lnet/minecraft/class_630;
+	FIELD field_27463 root Lnet/minecraft/class_630;
+	FIELD field_3471 tailBase Lnet/minecraft/class_630;
 	FIELD field_3472 rightWingTip Lnet/minecraft/class_630;
-	FIELD field_3473 lowerTail Lnet/minecraft/class_630;
-	FIELD field_3474 rightWing Lnet/minecraft/class_630;
+	FIELD field_3473 tailTip Lnet/minecraft/class_630;
+	FIELD field_3474 rightWingBase Lnet/minecraft/class_630;
 	FIELD field_3476 leftWingTip Lnet/minecraft/class_630;
-	FIELD field_3477 leftWing Lnet/minecraft/class_630;
+	FIELD field_3477 leftWingBase Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32024 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/PigEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/PigEntityModel.mapping
@@ -1,2 +1,5 @@
 CLASS net/minecraft/class_587 net/minecraft/client/render/entity/model/PigEntityModel
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32025 getTexturedModelData (Lnet/minecraft/class_5605;)Lnet/minecraft/class_5607;
+		ARG 0 dilation

--- a/mappings/net/minecraft/client/render/entity/model/PiglinEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/PiglinEntityModel.mapping
@@ -1,9 +1,11 @@
 CLASS net/minecraft/class_4840 net/minecraft/client/render/entity/model/PiglinEntityModel
 	FIELD field_25632 leftArmRotation Lnet/minecraft/class_5603;
 	FIELD field_25633 rightArmRotation Lnet/minecraft/class_5603;
-	FIELD field_25634 torsoRotation Lnet/minecraft/class_5603;
+	FIELD field_25634 bodyRotation Lnet/minecraft/class_5603;
 	FIELD field_25635 headRotation Lnet/minecraft/class_5603;
 	FIELD field_27464 rightEar Lnet/minecraft/class_630;
 	FIELD field_27465 leftEar Lnet/minecraft/class_630;
+	METHOD method_29354 rotateMainArm (Lnet/minecraft/class_1308;)V
+		ARG 1 entity
 	METHOD method_32026 getModelData (Lnet/minecraft/class_5605;)Lnet/minecraft/class_5609;
 		ARG 0 dilation

--- a/mappings/net/minecraft/client/render/entity/model/PlayerEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/PlayerEntityModel.mapping
@@ -1,13 +1,16 @@
 CLASS net/minecraft/class_591 net/minecraft/client/render/entity/model/PlayerEntityModel
-	FIELD field_3479 rightPantLeg Lnet/minecraft/class_630;
+	FIELD field_27466 parts Ljava/util/List;
+		COMMENT All the parts. Used when picking a part to render stuck arrows.
+	FIELD field_3479 rightPants Lnet/minecraft/class_630;
 	FIELD field_3480 thinArms Z
-	FIELD field_3481 ears Lnet/minecraft/class_630;
-	FIELD field_3482 leftPantLeg Lnet/minecraft/class_630;
+	FIELD field_3481 ear Lnet/minecraft/class_630;
+	FIELD field_3482 leftPants Lnet/minecraft/class_630;
 	FIELD field_3483 jacket Lnet/minecraft/class_630;
 	FIELD field_3484 leftSleeve Lnet/minecraft/class_630;
-	FIELD field_3485 cape Lnet/minecraft/class_630;
+	FIELD field_3485 cloak Lnet/minecraft/class_630;
 	FIELD field_3486 rightSleeve Lnet/minecraft/class_630;
 	METHOD <init> (Lnet/minecraft/class_630;Z)V
+		ARG 1 root
 		ARG 2 thinArms
 	METHOD method_22697 getRandomPart (Ljava/util/Random;)Lnet/minecraft/class_630;
 		ARG 1 random

--- a/mappings/net/minecraft/client/render/entity/model/PolarBearEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/PolarBearEntityModel.mapping
@@ -1,2 +1,4 @@
 CLASS net/minecraft/class_590 net/minecraft/client/render/entity/model/PolarBearEntityModel
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32029 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/QuadrupedEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/QuadrupedEntityModel.mapping
@@ -1,3 +1,18 @@
 CLASS net/minecraft/class_597 net/minecraft/client/render/entity/model/QuadrupedEntityModel
+	FIELD field_27476 rightHindLeg Lnet/minecraft/class_630;
+	FIELD field_27477 leftHindLeg Lnet/minecraft/class_630;
+	FIELD field_27478 rightFrontLeg Lnet/minecraft/class_630;
+	FIELD field_27479 leftFrontLeg Lnet/minecraft/class_630;
 	FIELD field_3535 head Lnet/minecraft/class_630;
 	FIELD field_3538 torso Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;ZFFFFI)V
+		ARG 1 root
+		ARG 2 headScaled
+		ARG 3 childHeadYOffset
+		ARG 4 childHeadZOffset
+		ARG 5 invertedChildHeadScale
+		ARG 6 invertedChildBodyScale
+		ARG 7 childBodyYOffset
+	METHOD method_32033 getModelData (ILnet/minecraft/class_5605;)Lnet/minecraft/class_5609;
+		ARG 0 stanceWidth
+		ARG 1 dilation

--- a/mappings/net/minecraft/client/render/entity/model/QuadrupedEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/QuadrupedEntityModel.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_597 net/minecraft/client/render/entity/model/Quadruped
 	FIELD field_27478 rightFrontLeg Lnet/minecraft/class_630;
 	FIELD field_27479 leftFrontLeg Lnet/minecraft/class_630;
 	FIELD field_3535 head Lnet/minecraft/class_630;
-	FIELD field_3538 torso Lnet/minecraft/class_630;
+	FIELD field_3538 body Lnet/minecraft/class_630;
 	METHOD <init> (Lnet/minecraft/class_630;ZFFFFI)V
 		ARG 1 root
 		ARG 2 headScaled

--- a/mappings/net/minecraft/client/render/entity/model/RabbitEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/RabbitEntityModel.mapping
@@ -1,5 +1,17 @@
 CLASS net/minecraft/class_596 net/minecraft/client/render/entity/model/RabbitEntityModel
+	FIELD field_27480 leftHindLeg Lnet/minecraft/class_630;
+	FIELD field_27481 rightHindLeg Lnet/minecraft/class_630;
+	FIELD field_27482 leftHaunch Lnet/minecraft/class_630;
+	FIELD field_27483 rightHaunch Lnet/minecraft/class_630;
+	FIELD field_27484 leftFrontLeg Lnet/minecraft/class_630;
+	FIELD field_27485 rightFrontLeg Lnet/minecraft/class_630;
+	FIELD field_27486 head Lnet/minecraft/class_630;
+	FIELD field_27487 rightEar Lnet/minecraft/class_630;
+	FIELD field_27488 leftEar Lnet/minecraft/class_630;
 	FIELD field_3524 tail Lnet/minecraft/class_630;
-	FIELD field_3528 torso Lnet/minecraft/class_630;
+	FIELD field_3528 body Lnet/minecraft/class_630;
 	FIELD field_3530 nose Lnet/minecraft/class_630;
+	FIELD field_3531 jumpProgress F
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32034 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/RavagerEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/RavagerEntityModel.mapping
@@ -1,5 +1,12 @@
 CLASS net/minecraft/class_571 net/minecraft/client/render/entity/model/RavagerEntityModel
+	FIELD field_27489 root Lnet/minecraft/class_630;
+	FIELD field_27490 rightHindLeg Lnet/minecraft/class_630;
+	FIELD field_27491 leftHindLeg Lnet/minecraft/class_630;
+	FIELD field_27492 rightFrontLeg Lnet/minecraft/class_630;
+	FIELD field_27493 leftFrontLeg Lnet/minecraft/class_630;
 	FIELD field_3384 neck Lnet/minecraft/class_630;
 	FIELD field_3386 head Lnet/minecraft/class_630;
 	FIELD field_3388 jaw Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32035 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/SalmonEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SalmonEntityModel.mapping
@@ -1,3 +1,6 @@
 CLASS net/minecraft/class_599 net/minecraft/client/render/entity/model/SalmonEntityModel
+	FIELD field_27494 root Lnet/minecraft/class_630;
 	FIELD field_3548 tail Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32036 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/SheepEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SheepEntityModel.mapping
@@ -1,3 +1,5 @@
 CLASS net/minecraft/class_601 net/minecraft/client/render/entity/model/SheepEntityModel
 	FIELD field_3552 headPitchModifier F
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32038 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/SheepWoolEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SheepWoolEntityModel.mapping
@@ -1,2 +1,5 @@
 CLASS net/minecraft/class_598 net/minecraft/client/render/entity/model/SheepWoolEntityModel
+	FIELD field_3541 headAngle F
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32037 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/ShieldEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/ShieldEntityModel.mapping
@@ -1,6 +1,9 @@
 CLASS net/minecraft/class_600 net/minecraft/client/render/entity/model/ShieldEntityModel
+	FIELD field_27495 root Lnet/minecraft/class_630;
 	FIELD field_3550 plate Lnet/minecraft/class_630;
 	FIELD field_3551 handle Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_23774 getPlate ()Lnet/minecraft/class_630;
 	METHOD method_23775 getHandle ()Lnet/minecraft/class_630;
 	METHOD method_32039 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/ShulkerBulletEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/ShulkerBulletEntityModel.mapping
@@ -1,3 +1,6 @@
 CLASS net/minecraft/class_603 net/minecraft/client/render/entity/model/ShulkerBulletEntityModel
+	FIELD field_27496 root Lnet/minecraft/class_630;
 	FIELD field_3556 bullet Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32040 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/ShulkerEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/ShulkerEntityModel.mapping
@@ -1,7 +1,9 @@
 CLASS net/minecraft/class_602 net/minecraft/client/render/entity/model/ShulkerEntityModel
-	FIELD field_3553 bottomShell Lnet/minecraft/class_630;
+	FIELD field_3553 base Lnet/minecraft/class_630;
 	FIELD field_3554 head Lnet/minecraft/class_630;
-	FIELD field_3555 topShell Lnet/minecraft/class_630;
+	FIELD field_3555 lid Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_2829 getTopShell ()Lnet/minecraft/class_630;
 	METHOD method_2830 getHead ()Lnet/minecraft/class_630;
 	METHOD method_32041 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/SilverfishEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SilverfishEntityModel.mapping
@@ -1,6 +1,13 @@
 CLASS net/minecraft/class_604 net/minecraft/client/render/entity/model/SilverfishEntityModel
+	FIELD field_27497 root Lnet/minecraft/class_630;
 	FIELD field_3557 scales [Lnet/minecraft/class_630;
 	FIELD field_3558 segmentLocations [[I
 	FIELD field_3559 segmentSizes [[I
 	FIELD field_3560 body [Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32042 getTexturedModelData ()Lnet/minecraft/class_5607;
+	METHOD method_32043 getLayerName (I)Ljava/lang/String;
+		ARG 0 index
+	METHOD method_32045 getSegmentName (I)Ljava/lang/String;
+		ARG 0 index

--- a/mappings/net/minecraft/client/render/entity/model/SkullEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SkullEntityModel.mapping
@@ -1,5 +1,8 @@
 CLASS net/minecraft/class_607 net/minecraft/client/render/entity/model/SkullEntityModel
-	FIELD field_3564 skull Lnet/minecraft/class_630;
+	FIELD field_27498 root Lnet/minecraft/class_630;
+	FIELD field_3564 head Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32048 getModelData ()Lnet/minecraft/class_5609;
 	METHOD method_32049 getHeadTexturedModelData ()Lnet/minecraft/class_5607;
 	METHOD method_32050 getSkullTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/SlimeEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SlimeEntityModel.mapping
@@ -1,3 +1,6 @@
 CLASS net/minecraft/class_609 net/minecraft/client/render/entity/model/SlimeEntityModel
+	FIELD field_27499 root Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32051 getOuterTexturedModelData ()Lnet/minecraft/class_5607;
 	METHOD method_32052 getInnerTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/SmallPufferfishEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SmallPufferfishEntityModel.mapping
@@ -1,2 +1,7 @@
 CLASS net/minecraft/class_594 net/minecraft/client/render/entity/model/SmallPufferfishEntityModel
+	FIELD field_27473 root Lnet/minecraft/class_630;
+	FIELD field_27474 leftFin Lnet/minecraft/class_630;
+	FIELD field_27475 rightFin Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32032 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/SmallTropicalFishEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SmallTropicalFishEntityModel.mapping
@@ -1,2 +1,7 @@
 CLASS net/minecraft/class_612 net/minecraft/client/render/entity/model/SmallTropicalFishEntityModel
+	FIELD field_27522 root Lnet/minecraft/class_630;
+	FIELD field_27523 tail Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32060 getTexturedModelData (Lnet/minecraft/class_5605;)Lnet/minecraft/class_5607;
+		ARG 0 dilation

--- a/mappings/net/minecraft/client/render/entity/model/SnowGolemEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SnowGolemEntityModel.mapping
@@ -1,4 +1,10 @@
 CLASS net/minecraft/class_608 net/minecraft/client/render/entity/model/SnowGolemEntityModel
-	FIELD field_3568 topSnowball Lnet/minecraft/class_630;
+	FIELD field_27500 root Lnet/minecraft/class_630;
+	FIELD field_27501 upperBody Lnet/minecraft/class_630;
+	FIELD field_27502 leftArm Lnet/minecraft/class_630;
+	FIELD field_27503 rightArm Lnet/minecraft/class_630;
+	FIELD field_3568 head Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_2834 getTopSnowball ()Lnet/minecraft/class_630;
 	METHOD method_32053 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/SpiderEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SpiderEntityModel.mapping
@@ -1,3 +1,14 @@
 CLASS net/minecraft/class_611 net/minecraft/client/render/entity/model/SpiderEntityModel
+	FIELD field_27504 root Lnet/minecraft/class_630;
+	FIELD field_27505 rightHindLeg Lnet/minecraft/class_630;
+	FIELD field_27506 leftHindLeg Lnet/minecraft/class_630;
+	FIELD field_27507 rightMiddleLeg Lnet/minecraft/class_630;
+	FIELD field_27508 leftMiddleLeg Lnet/minecraft/class_630;
+	FIELD field_27509 rightMiddleFrontLeg Lnet/minecraft/class_630;
+	FIELD field_27510 leftMiddleFrontLeg Lnet/minecraft/class_630;
+	FIELD field_27511 rightFrontLeg Lnet/minecraft/class_630;
+	FIELD field_27512 leftFrontLeg Lnet/minecraft/class_630;
 	FIELD field_3583 head Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32054 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/SquidEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SquidEntityModel.mapping
@@ -4,5 +4,5 @@ CLASS net/minecraft/class_610 net/minecraft/client/render/entity/model/SquidEnti
 	METHOD <init> (Lnet/minecraft/class_630;)V
 		ARG 1 root
 	METHOD method_32055 getTexturedModelData ()Lnet/minecraft/class_5607;
-	METHOD method_32056 getTentaclename (I)Ljava/lang/String;
+	METHOD method_32056 getTentacleName (I)Ljava/lang/String;
 		ARG 0 index

--- a/mappings/net/minecraft/client/render/entity/model/SquidEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SquidEntityModel.mapping
@@ -1,3 +1,8 @@
 CLASS net/minecraft/class_610 net/minecraft/client/render/entity/model/SquidEntityModel
+	FIELD field_27513 root Lnet/minecraft/class_630;
 	FIELD field_3574 tentacles [Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32055 getTexturedModelData ()Lnet/minecraft/class_5607;
+	METHOD method_32056 getTentaclename (I)Ljava/lang/String;
+		ARG 0 index

--- a/mappings/net/minecraft/client/render/entity/model/StriderEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/StriderEntityModel.mapping
@@ -1,2 +1,14 @@
 CLASS net/minecraft/class_4997 net/minecraft/client/render/entity/model/StriderEntityModel
+	FIELD field_23353 rightLeg Lnet/minecraft/class_630;
+	FIELD field_23354 leftLeg Lnet/minecraft/class_630;
+	FIELD field_23355 body Lnet/minecraft/class_630;
+	FIELD field_27514 root Lnet/minecraft/class_630;
+	FIELD field_27515 rightBottomBristle Lnet/minecraft/class_630;
+	FIELD field_27516 rightMiddleBristle Lnet/minecraft/class_630;
+	FIELD field_27517 rightTopBristle Lnet/minecraft/class_630;
+	FIELD field_27518 leftTopBristle Lnet/minecraft/class_630;
+	FIELD field_27519 leftMiddleBristle Lnet/minecraft/class_630;
+	FIELD field_27520 leftBottomBristle Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32058 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/TridentEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/TridentEntityModel.mapping
@@ -1,3 +1,6 @@
 CLASS net/minecraft/class_613 net/minecraft/client/render/entity/model/TridentEntityModel
+	FIELD field_27521 root Lnet/minecraft/class_630;
 	FIELD field_3592 TEXTURE Lnet/minecraft/class_2960;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32059 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/TurtleEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/TurtleEntityModel.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_614 net/minecraft/client/render/entity/model/TurtleEntityModel
 	FIELD field_3594 plastron Lnet/minecraft/class_630;
 		COMMENT The belly side of the turtle's shell.
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32062 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/VillagerResemblingModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/VillagerResemblingModel.mapping
@@ -1,2 +1,11 @@
 CLASS net/minecraft/class_620 net/minecraft/client/render/entity/model/VillagerResemblingModel
+	FIELD field_27525 nose Lnet/minecraft/class_630;
+	FIELD field_27526 root Lnet/minecraft/class_630;
+	FIELD field_27527 head Lnet/minecraft/class_630;
+	FIELD field_27528 hat Lnet/minecraft/class_630;
+	FIELD field_27529 hatRim Lnet/minecraft/class_630;
+	FIELD field_27530 rightLeg Lnet/minecraft/class_630;
+	FIELD field_27531 leftLeg Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32064 getModelData ()Lnet/minecraft/class_5609;

--- a/mappings/net/minecraft/client/render/entity/model/WitchEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/WitchEntityModel.mapping
@@ -2,5 +2,5 @@ CLASS net/minecraft/class_622 net/minecraft/client/render/entity/model/WitchEnti
 	FIELD field_3614 liftingNose Z
 	METHOD method_2839 getNose ()Lnet/minecraft/class_630;
 	METHOD method_2840 setLiftingNose (Z)V
-		ARG 1 liftingNode
+		ARG 1 liftingNose
 	METHOD method_32065 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/WitchEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/WitchEntityModel.mapping
@@ -2,4 +2,5 @@ CLASS net/minecraft/class_622 net/minecraft/client/render/entity/model/WitchEnti
 	FIELD field_3614 liftingNose Z
 	METHOD method_2839 getNose ()Lnet/minecraft/class_630;
 	METHOD method_2840 setLiftingNose (Z)V
+		ARG 1 liftingNode
 	METHOD method_32065 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/WitherEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/WitherEntityModel.mapping
@@ -1,2 +1,15 @@
 CLASS net/minecraft/class_621 net/minecraft/client/render/entity/model/WitherEntityModel
+	FIELD field_27532 root Lnet/minecraft/class_630;
+	FIELD field_27533 centerHead Lnet/minecraft/class_630;
+	FIELD field_27534 rightHead Lnet/minecraft/class_630;
+	FIELD field_27535 leftHead Lnet/minecraft/class_630;
+	FIELD field_27536 ribcage Lnet/minecraft/class_630;
+	FIELD field_27537 tail Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
+	METHOD method_32066 rotateHead (Lnet/minecraft/class_1528;Lnet/minecraft/class_630;I)V
+		ARG 0 entity
+		ARG 1 head
+		ARG 2 sigma
 	METHOD method_32067 getTexturedModelData (Lnet/minecraft/class_5605;)Lnet/minecraft/class_5607;
+		ARG 0 dilation

--- a/mappings/net/minecraft/client/render/entity/model/WolfEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/WolfEntityModel.mapping
@@ -1,6 +1,16 @@
 CLASS net/minecraft/class_624 net/minecraft/client/render/entity/model/WolfEntityModel
+	FIELD field_20788 realHead Lnet/minecraft/class_630;
+	FIELD field_20789 realTail Lnet/minecraft/class_630;
+	FIELD field_27538 rightHindLeg Lnet/minecraft/class_630;
+	FIELD field_27539 leftHindLeg Lnet/minecraft/class_630;
+	FIELD field_27540 rightFrontLeg Lnet/minecraft/class_630;
+	FIELD field_27541 leftFrontLeg Lnet/minecraft/class_630;
 	FIELD field_3617 tail Lnet/minecraft/class_630;
+		COMMENT This is the main bone used to animate the tail. It contains {@link #real_tail} as one of its children.
 	FIELD field_3619 neck Lnet/minecraft/class_630;
 	FIELD field_3621 head Lnet/minecraft/class_630;
+		COMMENT This is the main bone used to animate the head. It contains the {@link #real_head} as one of its children.
 	FIELD field_3623 torso Lnet/minecraft/class_630;
+	METHOD <init> (Lnet/minecraft/class_630;)V
+		ARG 1 root
 	METHOD method_32068 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/model/ZombieVillagerEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/ZombieVillagerEntityModel.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_619 net/minecraft/client/render/entity/model/ZombieVillagerEntityModel
-	FIELD field_17144 hat Lnet/minecraft/class_630;
+	FIELD field_17144 hatRim Lnet/minecraft/class_630;
 	METHOD method_32069 getArmorTexturedModelData (Lnet/minecraft/class_5605;)Lnet/minecraft/class_5607;
+		ARG 0 dilation
 	METHOD method_32070 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/entity/mob/GuardianEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/GuardianEntity.mapping
@@ -3,10 +3,10 @@ CLASS net/minecraft/class_1577 net/minecraft/entity/mob/GuardianEntity
 	FIELD field_7281 spikesExtensionRate F
 	FIELD field_7282 beamTicks I
 	FIELD field_7283 flopping Z
-	FIELD field_7284 prevSpikesExtension F
-	FIELD field_7285 tailAngle F
-	FIELD field_7286 spikesExtension F
-	FIELD field_7287 prevTailAngle F
+	FIELD field_7284 prevTailAngle F
+	FIELD field_7285 spikesExtension F
+	FIELD field_7286 tailAngle F
+	FIELD field_7287 prevSpikesExtension F
 	FIELD field_7288 cachedBeamTarget Lnet/minecraft/class_1309;
 	FIELD field_7289 wanderGoal Lnet/minecraft/class_1379;
 	FIELD field_7290 BEAM_TARGET_ID Lnet/minecraft/class_2940;
@@ -18,12 +18,12 @@ CLASS net/minecraft/class_1577 net/minecraft/entity/mob/GuardianEntity
 		ARG 4 random
 	METHOD method_26915 createGuardianAttributes ()Lnet/minecraft/class_5132$class_5133;
 	METHOD method_7052 getBeamTarget ()Lnet/minecraft/class_1309;
-	METHOD method_7053 getTailAngle (F)F
+	METHOD method_7053 getSpikesExtension (F)F
 		ARG 1 tickDelta
 	METHOD method_7054 setSpikesRetracted (Z)V
 		ARG 1 retracted
 	METHOD method_7055 getWarmupTime ()I
-	METHOD method_7057 getSpikesExtension (F)F
+	METHOD method_7057 getTailAngle (F)F
 		ARG 1 tickDelta
 	METHOD method_7058 areSpikesRetracted ()Z
 	METHOD method_7060 setBeamTarget (I)V

--- a/mappings/net/minecraft/util/math/MathHelper.mapping
+++ b/mappings/net/minecraft/util/math/MathHelper.mapping
@@ -129,6 +129,7 @@ CLASS net/minecraft/class_3532 net/minecraft/util/math/MathHelper
 		ARG 1 min
 		ARG 2 max
 	METHOD method_16435 perlinFade (D)D
+		ARG 0 value
 	METHOD method_16436 lerp (DDD)D
 		ARG 0 delta
 		ARG 2 start
@@ -180,6 +181,7 @@ CLASS net/minecraft/class_3532 net/minecraft/util/math/MathHelper
 		ARG 1 start
 		ARG 2 end
 	METHOD method_17822 sign (D)I
+		ARG 0 value
 	METHOD method_20306 stepAngleTowards (FFF)F
 		COMMENT Steps from {@code from} degrees towards {@code to} degrees, changing the value by at most {@code step} degrees.
 		ARG 0 from
@@ -204,8 +206,21 @@ CLASS net/minecraft/class_3532 net/minecraft/util/math/MathHelper
 		ARG 0 value
 		ARG 2 min
 		ARG 4 max
+	METHOD method_24504 wrap (FF)F
+		ARG 0 value
+		ARG 1 maxDeviation
 	METHOD method_27285 square (F)F
 		ARG 0 n
 	METHOD method_28139 roundUpToMultiple (II)I
 		COMMENT Returns a value farther than or as far as {@code value} from zero that
 		COMMENT is a multiple of {@code divisor}.
+		ARG 0 value
+		ARG 1 divisor
+	METHOD method_32750 nextBetween (Ljava/util/Random;FF)F
+		ARG 0 random
+		ARG 1 min
+		ARG 2 max
+	METHOD method_32751 nextBetween (Ljava/util/Random;II)I
+		ARG 0 random
+		ARG 1 min
+		ARG 2 max


### PR DESCRIPTION
1. Filled in all of the part names based on what Mojang gaves us in their json models work.
2. Unswapped the `spikeExtension` and `tailAngle` field and methods in GuardianEntity.
3. Unswapped the left and right legs in IllagerEntityModel
4. Provided names for some of the missing pieces in MathHelper (Thanks to some help from @UpcraftLP )

Notable changes to existing names:
`helmet` -> `hat`
`cape` -> `cloak`
`torso` -> `body`
`plate` -> `basePlate` (Armour stands) (Mojang's pick)
`hip` -> `shoulderStick` (Armour stands) (Mojang's pick)

*ModelPart named `root` when used as the parameter to a model's constructor, as it serves as the root node to the model's hierarchy of elements. As such, any places where that part is saved in a model's field is named similarly.

`BipedEntityModel.ArmPose.method_30156` -> `isTwoHanded` (true for BOW_AND_ARROW and all crossbow poses)

