### PR TITLE
TreeFeature.isDirtOrGrass -> canPlaceTreeOn

### DIFF
--- a/mappings/net/minecraft/world/gen/feature/TreeFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/TreeFeature.mapping
@@ -36,7 +36,7 @@ CLASS net/minecraft/class_2944 net/minecraft/world/gen/feature/TreeFeature
 	METHOD method_16432 canTreeReplace (Lnet/minecraft/class_3746;Lnet/minecraft/class_2338;)Z
 		ARG 0 world
 		ARG 1 pos
-	METHOD method_16433 isSoilOrFarmland (Lnet/minecraft/class_3746;Lnet/minecraft/class_2338;)Z
+	METHOD method_16433 canPlaceTreeOn (Lnet/minecraft/class_3746;Lnet/minecraft/class_2338;)Z
 		ARG 0 world
 		ARG 1 pos
 	METHOD method_23380 placeLogsAndLeaves (Lnet/minecraft/class_1936;Lnet/minecraft/class_3341;Ljava/util/Set;Ljava/util/Set;)Lnet/minecraft/class_251;

--- a/mappings/net/minecraft/world/gen/feature/TreeFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/TreeFeature.mapping
@@ -4,6 +4,7 @@ CLASS net/minecraft/class_2944 net/minecraft/world/gen/feature/TreeFeature
 		ARG 1 pos
 		ARG 2 state
 	METHOD method_12775 generate (Lnet/minecraft/class_5281;Ljava/util/Random;Lnet/minecraft/class_2338;Ljava/util/Set;Ljava/util/Set;Lnet/minecraft/class_3341;Lnet/minecraft/class_4643;)Z
+		ARG 1 world
 		ARG 2 random
 		ARG 3 pos
 		ARG 4 logPositions
@@ -35,7 +36,7 @@ CLASS net/minecraft/class_2944 net/minecraft/world/gen/feature/TreeFeature
 	METHOD method_16432 canTreeReplace (Lnet/minecraft/class_3746;Lnet/minecraft/class_2338;)Z
 		ARG 0 world
 		ARG 1 pos
-	METHOD method_16433 isDirtOrGrass (Lnet/minecraft/class_3746;Lnet/minecraft/class_2338;)Z
+	METHOD method_16433 isSoilOrFarmland (Lnet/minecraft/class_3746;Lnet/minecraft/class_2338;)Z
 		ARG 0 world
 		ARG 1 pos
 	METHOD method_23380 placeLogsAndLeaves (Lnet/minecraft/class_1936;Lnet/minecraft/class_3341;Ljava/util/Set;Ljava/util/Set;)Lnet/minecraft/class_251;


### PR DESCRIPTION
It prevents the feature from placing a tree if it's false. The logic is pretty much `isSoil(block) || block == FARMLAND`.