### PR TITLE
ItemStack.areStacksEqual -> canCombine

### DIFF
--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -56,7 +56,7 @@ CLASS net/minecraft/class_1799 net/minecraft/item/ItemStack
 		ARG 2 slot
 		ARG 3 clickType
 		ARG 4 playerInventory
-	METHOD method_31577 areStacksEqual (Lnet/minecraft/class_1799;Lnet/minecraft/class_1799;)Z
+	METHOD method_31577 canCombine (Lnet/minecraft/class_1799;Lnet/minecraft/class_1799;)Z
 		ARG 0 stack
 		ARG 1 otherStack
 	METHOD method_31578 isItemBarVisible ()Z


### PR DESCRIPTION
It's equivalent to the removed (in 1.17 snapshots) method in `ScreenHandler` with that name. It doesn't check whether the stacks are equal, as it only checks the items and the NBT data.

Closes #1897.