### PR TITLE
Some client javadoc

### DIFF
--- a/mappings/net/minecraft/client/MinecraftClient.mapping
+++ b/mappings/net/minecraft/client/MinecraftClient.mapping
@@ -1,4 +1,43 @@
 CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
+	COMMENT Represents a logical Minecraft client.
+	COMMENT The logical Minecraft client is responsible for rendering, sound playback and control input.
+	COMMENT The Minecraft client also manages connections to a logical server which may be the client's {@link net.minecraft.server.integrated.IntegratedServer} or a remote server.
+	COMMENT The Minecraft client instance may be obtained using {@link MinecraftClient#getInstance()}.
+	COMMENT
+	COMMENT <p>Rendering on a Minecraft client is split into several facilities.
+	COMMENT The primary entrypoint for rendering is {@link net.minecraft.client.render.GameRenderer#render(float, long, boolean)}.
+	COMMENT <table border=1>
+	COMMENT <tr>
+	COMMENT  <th><b>Thing to render</b></th> <th><b>Rendering facility</b></th>
+	COMMENT </tr>
+	COMMENT <tr>
+	COMMENT  <td>World</td> <td>{@link net.minecraft.client.render.WorldRenderer}</td>
+	COMMENT </tr>
+	COMMENT <tr>
+	COMMENT  <td>Blocks and Fluids</td> <td>{@link net.minecraft.client.render.block.BlockRenderManager}</td>
+	COMMENT </tr>
+	COMMENT <tr>
+	COMMENT  <td>Entities</td> <td>{@link net.minecraft.client.render.entity.EntityRenderDispatcher}</td>
+	COMMENT </tr>
+	COMMENT <tr>
+	COMMENT  <td>Block entities</td> <td>{@link net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher}</td>
+	COMMENT </tr>
+	COMMENT <tr>
+	COMMENT  <td>Items</td> <td>{@link net.minecraft.client.render.item.ItemRenderer}</td>
+	COMMENT </tr>
+	COMMENT <tr>
+	COMMENT  <td>Items held in hand</td> <td>{@link net.minecraft.client.render.item.HeldItemRenderer}</td>
+	COMMENT </tr>
+	COMMENT <tr>
+	COMMENT  <td>Text</td> <td>{@link net.minecraft.client.font.TextRenderer}</td>
+	COMMENT </tr>
+	COMMENT <tr>
+	COMMENT  <td>Game hud (health bar, hunger bar)</td> <td>{@link net.minecraft.client.gui.hud.InGameHud}</td>
+	COMMENT </tr>
+	COMMENT </table>
+	COMMENT
+	COMMENT @see net.minecraft.server.integrated.IntegratedServer
+	COMMENT @see net.minecraft.client.render.GameRenderer
 	FIELD field_16240 profiler Lnet/minecraft/class_3695;
 	FIELD field_16762 game Lnet/minecraft/class_3799;
 	FIELD field_1686 windowProvider Lnet/minecraft/class_3682;
@@ -61,7 +100,11 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 	FIELD field_1743 skipGameRender Z
 	FIELD field_1744 connectedToRealms Z
 	FIELD field_1745 resourceManager Lnet/minecraft/class_3296;
-	FIELD field_1746 connection Lnet/minecraft/class_2535;
+	FIELD field_1746 integratedServerConnection Lnet/minecraft/class_2535;
+		COMMENT The client connection to the integrated server.
+		COMMENT This is only used when connecting to the integrated server.
+		COMMENT
+		COMMENT @see net.minecraft.client.gui.screen.ConnectScreen
 	FIELD field_1747 crashReport Lnet/minecraft/class_128;
 	FIELD field_1748 levelStorage Lnet/minecraft/class_32;
 	FIELD field_1749 ALT_TEXT_RENDERER_ID Lnet/minecraft/class_2960;
@@ -69,6 +112,11 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 	FIELD field_1751 blockColors Lnet/minecraft/class_324;
 	FIELD field_1752 itemUseCooldown I
 	FIELD field_1755 currentScreen Lnet/minecraft/class_437;
+		COMMENT The Minecraft client's currently open screen.
+		COMMENT This field should only be used to getting the current screen.
+		COMMENT For changing the screen use {@link MinecraftClient#openScreen(Screen)}
+		COMMENT
+		COMMENT @see MinecraftClient.openScreen(Screen)
 	FIELD field_1756 blockRenderManager Lnet/minecraft/class_776;
 	FIELD field_1757 resourcePackDir Ljava/io/File;
 	FIELD field_1758 tutorialManager Lnet/minecraft/class_1156;
@@ -142,6 +190,11 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 		ARG 1 error
 		ARG 2 description
 	METHOD method_1507 openScreen (Lnet/minecraft/class_437;)V
+		COMMENT Opens a new screen. changing the current screen if needed.
+		COMMENT
+		COMMENT <p>If the screen being opened is {@code null} and the client is not in game, the title screen will be opened.
+		COMMENT If the currently opened screen is {@code null} and player is dead then the death screen will be opened.
+		COMMENT Otherwise the currently open screen will be closed.
 		ARG 1 screen
 	METHOD method_1508 handleInputEvents ()V
 	METHOD method_1511 doItemPick ()V
@@ -303,6 +356,7 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 	METHOD method_29611 isFabulousGraphicsOrBetter ()Z
 	METHOD method_30049 getVideoWarningManager ()Lnet/minecraft/class_5407;
 	METHOD method_31320 getSocialInteractionsManager ()Lnet/minecraft/class_5520;
+	METHOD method_31321 isConnectedToServer ()Z
 	METHOD method_31974 getEntityModelLoader ()Lnet/minecraft/class_5599;
 	CLASS class_5366 WorldLoadAction
 	CLASS class_5367 IntegratedResourceManager

--- a/mappings/net/minecraft/client/MinecraftClient.mapping
+++ b/mappings/net/minecraft/client/MinecraftClient.mapping
@@ -190,7 +190,7 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 		ARG 1 error
 		ARG 2 description
 	METHOD method_1507 openScreen (Lnet/minecraft/class_437;)V
-		COMMENT Opens a new screen. changing the current screen if needed.
+		COMMENT Opens a new screen, changing the current screen if needed.
 		COMMENT
 		COMMENT <p>If the screen being opened is {@code null} and the client is not in game, the title screen will be opened.
 		COMMENT If the currently opened screen is {@code null} and player is dead then the death screen will be opened.

--- a/mappings/net/minecraft/client/MinecraftClient.mapping
+++ b/mappings/net/minecraft/client/MinecraftClient.mapping
@@ -113,10 +113,10 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 	FIELD field_1752 itemUseCooldown I
 	FIELD field_1755 currentScreen Lnet/minecraft/class_437;
 		COMMENT The Minecraft client's currently open screen.
-		COMMENT This field should only be used to getting the current screen.
+		COMMENT This field should only be used to get the current screen.
 		COMMENT For changing the screen use {@link MinecraftClient#openScreen(Screen)}
 		COMMENT
-		COMMENT @see MinecraftClient.openScreen(Screen)
+		COMMENT @see MinecraftClient#openScreen(Screen)
 	FIELD field_1756 blockRenderManager Lnet/minecraft/class_776;
 	FIELD field_1757 resourcePackDir Ljava/io/File;
 	FIELD field_1758 tutorialManager Lnet/minecraft/class_1156;

--- a/mappings/net/minecraft/client/gui/screen/ConnectScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ConnectScreen.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_412 net/minecraft/client/gui/screen/ConnectScreen
 		COMMENT The client connection to the remote server.
 		COMMENT This is not used when connecting to the client's own integrated server.
 		COMMENT
-		COMMENT @see net.minecraft.client.MinecraftClient.integratedServerConnection
+		COMMENT @see net.minecraft.client.MinecraftClient#integratedServerConnection
 	FIELD field_2412 parent Lnet/minecraft/class_437;
 	FIELD field_2413 status Lnet/minecraft/class_2561;
 	METHOD <init> (Lnet/minecraft/class_437;Lnet/minecraft/class_310;Ljava/lang/String;I)V

--- a/mappings/net/minecraft/client/gui/screen/ConnectScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ConnectScreen.mapping
@@ -1,9 +1,15 @@
 CLASS net/minecraft/class_412 net/minecraft/client/gui/screen/ConnectScreen
+	COMMENT The connection screen is used initiate a connection to a remote server.
+	COMMENT This is only used when connecting over LAN or to a remote dedicated server.
 	FIELD field_19097 narratorTimer J
 	FIELD field_2408 CONNECTOR_THREADS_COUNT Ljava/util/concurrent/atomic/AtomicInteger;
 	FIELD field_2409 connectingCancelled Z
 	FIELD field_2410 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_2411 connection Lnet/minecraft/class_2535;
+		COMMENT The client connection to the remote server.
+		COMMENT This is not used when connecting to the client's own integrated server.
+		COMMENT
+		COMMENT @see net.minecraft.client.MinecraftClient.integratedServerConnection
 	FIELD field_2412 parent Lnet/minecraft/class_437;
 	FIELD field_2413 status Lnet/minecraft/class_2561;
 	METHOD <init> (Lnet/minecraft/class_437;Lnet/minecraft/class_310;Ljava/lang/String;I)V

--- a/mappings/net/minecraft/client/gui/screen/ConnectScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ConnectScreen.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_412 net/minecraft/client/gui/screen/ConnectScreen
-	COMMENT The connection screen is used initiate a connection to a remote server.
+	COMMENT The connection screen is used to initiate a connection to a remote server.
 	COMMENT This is only used when connecting over LAN or to a remote dedicated server.
 	FIELD field_19097 narratorTimer J
 	FIELD field_2408 CONNECTOR_THREADS_COUNT Ljava/util/concurrent/atomic/AtomicInteger;

--- a/mappings/net/minecraft/client/gui/screen/DeathScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/DeathScreen.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/class_418 net/minecraft/client/gui/screen/DeathScreen
 	FIELD field_18974 isHardcore Z
 	FIELD field_2450 message Lnet/minecraft/class_2561;
 	FIELD field_2451 ticksSinceDeath I
+	FIELD field_26537 score Lnet/minecraft/class_2561;
 	METHOD <init> (Lnet/minecraft/class_2561;Z)V
 		ARG 1 message
 		ARG 2 isHardcore


### PR DESCRIPTION
This adds some javadoc which may be useful for beginners trying to understand what the MinecraftClient does, some javadoc related to screens and some javadoc related to the client connections on MinecraftClient and in ConnectScreen.

Also includes like 3 names, one of which clarifies what the client connection field in MinecraftClient is for.