### PR TITLE
Add missing mappings in LevelSummary

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/SplashScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/SplashScreen.mapping
@@ -7,12 +7,20 @@ CLASS net/minecraft/class_425 net/minecraft/client/gui/screen/SplashScreen
 	FIELD field_18219 reloading Z
 	FIELD field_18220 prepareCompleteTime J
 	FIELD field_2483 LOGO Lnet/minecraft/class_2960;
+	FIELD field_25041 BRAND_ARGB I
+	FIELD field_25042 BRAND_RGB I
 	METHOD <init> (Lnet/minecraft/class_310;Lnet/minecraft/class_4011;Ljava/util/function/Consumer;Z)V
 		ARG 1 client
 		ARG 2 monitor
 		ARG 3 exceptionHandler
 		ARG 4 reloading
 	METHOD method_18103 renderProgressBar (Lnet/minecraft/class_4587;IIIIF)V
+		ARG 1 matrices
+		ARG 2 x1
+		ARG 3 y1
+		ARG 4 x2
+		ARG 5 y2
+		ARG 6 opacity
 	METHOD method_18819 init (Lnet/minecraft/class_310;)V
 		ARG 0 client
 	CLASS class_4070 LogoTexture

--- a/mappings/net/minecraft/world/level/storage/LevelSummary.mapping
+++ b/mappings/net/minecraft/world/level/storage/LevelSummary.mapping
@@ -3,9 +3,9 @@ CLASS net/minecraft/class_34 net/minecraft/world/level/storage/LevelSummary
 	FIELD field_209 requiresConversion Z
 	FIELD field_23772 locked Z
 	FIELD field_23773 file Ljava/io/File;
+	FIELD field_24191 details Lnet/minecraft/class_2561;
 	FIELD field_25022 levelInfo Lnet/minecraft/class_1940;
 	FIELD field_25023 versionInfo Lnet/minecraft/class_5315;
-	FIELD field_24191 details Lnet/minecraft/class_2561;
 	METHOD method_247 getGameMode ()Lnet/minecraft/class_1934;
 	METHOD method_248 getName ()Ljava/lang/String;
 	METHOD method_249 getLastPlayed ()J

--- a/mappings/net/minecraft/world/level/storage/LevelSummary.mapping
+++ b/mappings/net/minecraft/world/level/storage/LevelSummary.mapping
@@ -4,6 +4,8 @@ CLASS net/minecraft/class_34 net/minecraft/world/level/storage/LevelSummary
 	FIELD field_23772 locked Z
 	FIELD field_23773 file Ljava/io/File;
 	FIELD field_25022 levelInfo Lnet/minecraft/class_1940;
+	FIELD field_25023 versionInfo Lnet/minecraft/class_5315;
+	FIELD field_24191 details Lnet/minecraft/class_2561;
 	METHOD method_247 getGameMode ()Lnet/minecraft/class_1934;
 	METHOD method_248 getName ()Ljava/lang/String;
 	METHOD method_249 getLastPlayed ()J
@@ -17,3 +19,5 @@ CLASS net/minecraft/class_34 net/minecraft/world/level/storage/LevelSummary
 	METHOD method_260 isFutureLevel ()Z
 	METHOD method_27020 getFile ()Ljava/io/File;
 	METHOD method_27021 isLocked ()Z
+	METHOD method_27429 getDetails ()Lnet/minecraft/class_2561;
+	METHOD method_27430 createDetails ()Lnet/minecraft/class_2561;


### PR DESCRIPTION
`field_24191` contains a `net.minecraft.text.Text` storing game mode, version, and other level details (such as if cheats are enabled) as a formatted string (This is the third line of text for each level in the list on the world selection screen).
The value of this field is created by `method_27430` and publicly accessible via `method_27429`.

Also mapped the `SaveVersionInfo` member to `versionInfo`, which seems like a no-brainer.