### PR TITLE
Update ModelBakeSettings

### DIFF
--- a/mappings/net/minecraft/client/render/model/ModelBakeSettings.mapping
+++ b/mappings/net/minecraft/client/render/model/ModelBakeSettings.mapping
@@ -1,3 +1,3 @@
 CLASS net/minecraft/class_3665 net/minecraft/client/render/model/ModelBakeSettings
 	METHOD method_3509 getRotation ()Lnet/minecraft/class_4590;
-	METHOD method_3512 isShaded ()Z
+	METHOD method_3512 isUvLocked ()Z


### PR DESCRIPTION
This method used to be called `isUvLocked`, and was at some point renamed to `isShaded`, which is a horribly misleading name. I'd just like to change it back to actually describing what it does.