### PR TITLE
Add a settings.gradle to ensure consistency

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "yarn"


### PR DESCRIPTION
If no settings file is found, Gradle will assume the project could be a subproject and will scan any containing directories for a settings.gradle. This can cause issues if such a file exists but doesn't `include()` yarn as a subproject, which can happen when using a composite build to set up a local development workspace.