### PR TITLE
Rename FenceBlock.isFence

### DIFF
--- a/mappings/net/minecraft/block/FenceBlock.mapping
+++ b/mappings/net/minecraft/block/FenceBlock.mapping
@@ -4,5 +4,5 @@ CLASS net/minecraft/class_2354 net/minecraft/block/FenceBlock
 		ARG 1 state
 		ARG 2 neighborIsFullSquare
 		ARG 3 dir
-	METHOD method_26375 isCompatibleFence (Lnet/minecraft/class_2680;)Z
+	METHOD method_26375 canConnectToFence (Lnet/minecraft/class_2680;)Z
 		ARG 1 state

--- a/mappings/net/minecraft/block/FenceBlock.mapping
+++ b/mappings/net/minecraft/block/FenceBlock.mapping
@@ -4,5 +4,5 @@ CLASS net/minecraft/class_2354 net/minecraft/block/FenceBlock
 		ARG 1 state
 		ARG 2 neighborIsFullSquare
 		ARG 3 dir
-	METHOD method_26375 isFence (Lnet/minecraft/class_2680;)Z
+	METHOD method_26375 isCompatibleFence (Lnet/minecraft/class_2680;)Z
 		ARG 1 state


### PR DESCRIPTION
This method is used for determining whether a fence can connect to another fence, and can return false even if the argument is a fence.

Please also backport this change to at least 1.16.4.