### PR TITLE
Switch to mappingpoet 0.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,33 +22,6 @@ plugins {
 	id 'java' // for jd gen
 }
 
-def lowestLanguageVersion = JavaLanguageVersion.of(15) // Javadoc taglet requires it for css behavior
-def toolchainLanguageVersion = JavaLanguageVersion.of(JavaVersion.current().getMajorVersion())
-
-if (!toolchainLanguageVersion.canCompileOrRun(lowestLanguageVersion)) {
-	logger.warn ":The current Java Version ${toolchainLanguageVersion} is too old."
-	logger.warn ":Gradle may download newer Java online and the build may be slower."
-
-	toolchainLanguageVersion = lowestLanguageVersion
-}
-
-java.toolchain { // defined in JavaPluginExtension
-	languageVersion = toolchainLanguageVersion
-}
-
-// currently gradle does not yet propagate that version above, so
-tasks.withType(JavaExec) {
-	javaLauncher = javaToolchains.launcherFor {
-		languageVersion = toolchainLanguageVersion
-	}
-}
-
-tasks.withType(Javadoc) {
-	javadocTool = javaToolchains.javadocToolFor {
-		languageVersion = toolchainLanguageVersion
-	}
-}
-
 def minecraft_version = "20w51a"
 
 def ENV = System.getenv()
@@ -58,7 +31,6 @@ def build_number = ENV.BUILD_NUMBER ?: "local"
 def yarnVersion = "${minecraft_version}+build.$build_number"
 
 repositories {
-	mavenLocal()
 	mavenCentral()
 	maven {
 		name "Fabric Repository"
@@ -94,7 +66,7 @@ dependencies {
 	javadocClasspath "net.fabricmc:fabric-loader:0.8.2+build.194"
 	javadocClasspath "com.google.code.findbugs:jsr305:3.0.2"
 	decompileClasspath "org.benf:cfr:0.150"
-	mappingPoetJar 'net.fabricmc:mappingpoet:0.2.5+local'
+	mappingPoetJar 'net.fabricmc:mappingpoet:0.2.6'
 }
 
 def setupGroup = "jar setup"
@@ -693,6 +665,12 @@ task genFakeSource(type: JavaExec, dependsOn: ["mergeV2", "mapNamedJar"]) {
 	group = "javadoc generation"
 	outputs.upToDateWhen { false }
 
+	if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
+		javaLauncher = javaToolchains.launcherFor {
+			languageVersion = JavaLanguageVersion.of(11)
+		}
+	}
+
 	main "net.fabricmc.mappingpoet.Main"
 	classpath configurations.mappingPoet
 	// use merged v2 so we have all namespaces in jd
@@ -723,10 +701,16 @@ javadoc {
 	def mappingPoetJar = project.provider { zipTree configurations.mappingPoetJar.singleFile }
 
 	failOnError = false
+
+	if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
+		javadocTool = javaToolchains.javadocToolFor {
+			languageVersion = JavaLanguageVersion.of(11)
+		}
+	}
 	// verbose = true // enable to debug
 	options {
 		// verbose() // enable to debug
-		source = toolchainLanguageVersion.toString()
+		source = "11"
 		encoding = 'UTF-8'
 		charSet = 'UTF-8'
 		memberLevel = JavadocMemberLevel.PRIVATE
@@ -753,12 +737,14 @@ javadoc {
 				'https://commons.apache.org/proper/commons-io/javadocs/api-2.5',
 				'https://commons.apache.org/proper/commons-codec/archives/1.10/apidocs',
 				'https://commons.apache.org/proper/commons-compress/javadocs/api-1.8.1/',
-				"https://docs.oracle.com/en/java/javase/${toolchainLanguageVersion.asInt()}/docs/api/"
+				"https://docs.oracle.com/en/java/javase/11/docs/api/"
 				// Need to add loader jd publication for env annotations!
 		)
 		// https://docs.oracle.com/en/java/javase/15/docs/specs/man/javadoc.html#additional-options-provided-by-the-standard-doclet
 		addBooleanOption 'Xdoclint:html', true
 		addBooleanOption 'Xdoclint:syntax', true
+		addBooleanOption 'Xdoclint:reference', true
+		addBooleanOption 'Xdoclint:accessibility', true
 	}
 	source fakeSourceDir
 	classpath = configurations.javadocClasspath.plus downloadMcLibs.outputs.files.asFileTree

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ buildscript {
 		classpath "commons-io:commons-io:2.6"
 		classpath 'de.undercouch:gradle-download-task:4.0.4'
 		classpath 'net.fabricmc:tiny-remapper:0.3.1.72'
-		classpath 'net.fabricmc:mappingpoet:0.1.0+build.2'
 	}
 }
 
@@ -21,6 +20,33 @@ plugins {
 	id 'base'
 	id 'maven-publish'
 	id 'java' // for jd gen
+}
+
+def lowestLanguageVersion = JavaLanguageVersion.of(15) // Javadoc taglet requires it for css behavior
+def toolchainLanguageVersion = JavaLanguageVersion.of(JavaVersion.current().getMajorVersion())
+
+if (!toolchainLanguageVersion.canCompileOrRun(lowestLanguageVersion)) {
+	logger.warn ":The current Java Version ${toolchainLanguageVersion} is too old."
+	logger.warn ":Gradle may download newer Java online and the build may be slower."
+
+	toolchainLanguageVersion = lowestLanguageVersion
+}
+
+java.toolchain { // defined in JavaPluginExtension
+	languageVersion = toolchainLanguageVersion
+}
+
+// currently gradle does not yet propagate that version above, so
+tasks.withType(JavaExec) {
+	javaLauncher = javaToolchains.launcherFor {
+		languageVersion = toolchainLanguageVersion
+	}
+}
+
+tasks.withType(Javadoc) {
+	javadocTool = javaToolchains.javadocToolFor {
+		languageVersion = toolchainLanguageVersion
+	}
 }
 
 def minecraft_version = "20w51a"
@@ -32,6 +58,7 @@ def build_number = ENV.BUILD_NUMBER ?: "local"
 def yarnVersion = "${minecraft_version}+build.$build_number"
 
 repositories {
+	mavenLocal()
 	mavenCentral()
 	maven {
 		name "Fabric Repository"
@@ -52,6 +79,13 @@ configurations {
 	}
 	javadocClasspath
 	decompileClasspath
+	mappingPoetJar {
+		transitive = false
+	}
+	mappingPoet {
+		extendsFrom mappingPoetJar
+		transitive = true
+	}
 }
 
 dependencies {
@@ -60,6 +94,7 @@ dependencies {
 	javadocClasspath "net.fabricmc:fabric-loader:0.8.2+build.194"
 	javadocClasspath "com.google.code.findbugs:jsr305:3.0.2"
 	decompileClasspath "org.benf:cfr:0.150"
+	mappingPoetJar 'net.fabricmc:mappingpoet:0.2.5+local'
 }
 
 def setupGroup = "jar setup"
@@ -80,7 +115,6 @@ def libs = new File("build/libs/")
 
 
 import com.google.common.hash.Hashing
-import com.google.common.collect.Iterables
 import cuchaz.enigma.command.CheckMappingsCommand
 import cuchaz.enigma.command.ComposeMappingsCommand
 import cuchaz.enigma.command.ConvertMappingsCommand
@@ -91,8 +125,8 @@ import net.fabricmc.stitch.commands.CommandMergeTiny
 import net.fabricmc.stitch.commands.CommandProposeFieldNames
 import net.fabricmc.stitch.commands.CommandReorderTiny
 import net.fabricmc.stitch.commands.CommandRewriteIntermediary
-import net.fabricmc.stitch.commands.tinyv2.CommandProposeV2FieldNames
 import net.fabricmc.stitch.commands.tinyv2.CommandMergeTinyV2
+import net.fabricmc.stitch.commands.tinyv2.CommandProposeV2FieldNames
 import net.fabricmc.stitch.commands.tinyv2.CommandReorderTinyV2
 import net.fabricmc.stitch.merge.JarMerger
 import net.fabricmc.tinyremapper.OutputConsumerPath
@@ -101,9 +135,6 @@ import net.fabricmc.tinyremapper.TinyUtils
 import org.apache.commons.io.FileUtils
 
 import java.nio.charset.StandardCharsets
-import java.nio.file.FileSystems
-import java.nio.file.Files
-import java.nio.file.Path
 import java.util.zip.GZIPOutputStream
 
 boolean validateChecksum(File file, String checksum) {
@@ -658,19 +689,16 @@ task v2MergedYarnJar(dependsOn: ["mergeV2"], type: Jar) {
 }
 
 def fakeSourceDir = file(".gradle/temp/fakeSource")
-task genFakeSource(dependsOn: ["buildYarnTiny", "mapNamedJar"]) {
+task genFakeSource(type: JavaExec, dependsOn: ["mergeV2", "mapNamedJar"]) {
 	group = "javadoc generation"
 	outputs.upToDateWhen { false }
 
+	main "net.fabricmc.mappingpoet.Main"
+	classpath configurations.mappingPoet
+	// use merged v2 so we have all namespaces in jd
+	args mergeV2.output.getAbsolutePath(), namedJar.getAbsolutePath(), fakeSourceDir.getAbsolutePath(), libraries.getAbsolutePath()
+
 	doLast {
-		String[] args = [
-			buildYarnTiny.v2Output.getAbsolutePath(),
-			namedJar.getAbsolutePath(),
-			fakeSourceDir.getAbsolutePath()
-		]
-
-		net.fabricmc.mappingpoet.Main.main(args)
-
 		logger.lifecycle ":Fake source generated"
 	}
 }
@@ -691,11 +719,27 @@ javadoc {
 	dependsOn downloadMcLibs
 	group = "javadoc generation"
 	outputs.upToDateWhen { false }
+
+	def mappingPoetJar = project.provider { zipTree configurations.mappingPoetJar.singleFile }
+
+	failOnError = false
+	// verbose = true // enable to debug
 	options {
-		source = "8"
+		// verbose() // enable to debug
+		source = toolchainLanguageVersion.toString()
 		encoding = 'UTF-8'
 		charSet = 'UTF-8'
 		memberLevel = JavadocMemberLevel.PRIVATE
+		splitIndex true
+		tags(
+				'apiNote:a:API Note:',
+				'implSpec:a:Implementation Requirements:',
+				'implNote:a:Implementation Note:'
+		)
+		taglets "net.fabricmc.mappingpoet.jd.MappingTaglet"
+		// taglet path, header, extra stylesheet settings deferred
+
+		addBooleanOption "-allow-script-in-comments", true
 		links(
 				'https://guava.dev/releases/21.0/api/docs/',
 				'https://www.javadoc.io/doc/com.google.code.gson/gson/2.8.0/',
@@ -709,14 +753,32 @@ javadoc {
 				'https://commons.apache.org/proper/commons-io/javadocs/api-2.5',
 				'https://commons.apache.org/proper/commons-codec/archives/1.10/apidocs',
 				'https://commons.apache.org/proper/commons-compress/javadocs/api-1.8.1/',
-				'https://docs.oracle.com/javase/8/docs/api/'
+				"https://docs.oracle.com/en/java/javase/${toolchainLanguageVersion.asInt()}/docs/api/"
 				// Need to add loader jd publication for env annotations!
 		)
-		// Disable the crazy super-strict doclint tool in Java 8
-		addStringOption('Xdoclint:none', '-quiet')
+		// https://docs.oracle.com/en/java/javase/15/docs/specs/man/javadoc.html#additional-options-provided-by-the-standard-doclet
+		addBooleanOption 'Xdoclint:html', true
+		addBooleanOption 'Xdoclint:syntax', true
 	}
 	source fakeSourceDir
-	classpath = configurations.javadocClasspath.plus downloadMcLibs.outputs.files.asFileTree 
+	classpath = configurations.javadocClasspath.plus downloadMcLibs.outputs.files.asFileTree
+
+	finalizedBy {
+		task copyCopyOnClickScript(type: Copy) {
+			from mappingPoetJar
+			include "copy_on_click.js"
+			into javadoc.outputDirectory
+		}
+	}
+
+	doFirst {
+		// lazy setting
+		options {
+			tagletPath configurations.mappingPoet.files.toList()
+			header mappingPoetJar.get().filter { it.name == 'javadoc_header.txt' }.singleFile.readLines()[0] // cannot include line breaks
+			addFileOption "-add-stylesheet", mappingPoetJar.get().filter { it.name == 'forms.css' }.singleFile
+		}
+	}
 }
 
 task javadocJar(type: Jar, dependsOn: ["javadoc"]) {
@@ -725,7 +787,7 @@ task javadocJar(type: Jar, dependsOn: ["javadoc"]) {
 	from javadoc.destinationDir
 
 	archiveVersion.set yarnVersion
-	classifier = 'javadoc'
+	archiveClassifier = 'javadoc'
 }
 
 publishing {

--- a/mappings/net/minecraft/client/MinecraftClient.mapping
+++ b/mappings/net/minecraft/client/MinecraftClient.mapping
@@ -6,7 +6,8 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 	COMMENT
 	COMMENT <p>Rendering on a Minecraft client is split into several facilities.
 	COMMENT The primary entrypoint for rendering is {@link net.minecraft.client.render.GameRenderer#render(float, long, boolean)}.
-	COMMENT <table border=1>
+	COMMENT <div class="fabric"><table border=1>
+	COMMENT <caption>Rendering facilities</caption>
 	COMMENT <tr>
 	COMMENT  <th><b>Thing to render</b></th> <th><b>Rendering facility</b></th>
 	COMMENT </tr>
@@ -34,7 +35,7 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 	COMMENT <tr>
 	COMMENT  <td>Game hud (health bar, hunger bar)</td> <td>{@link net.minecraft.client.gui.hud.InGameHud}</td>
 	COMMENT </tr>
-	COMMENT </table>
+	COMMENT </table></div>
 	COMMENT
 	COMMENT @see net.minecraft.server.integrated.IntegratedServer
 	COMMENT @see net.minecraft.client.render.GameRenderer

--- a/mappings/net/minecraft/resource/ResourceManager.mapping
+++ b/mappings/net/minecraft/resource/ResourceManager.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/class_3300 net/minecraft/resource/ResourceManager
 		COMMENT <p>Starts by scanning each resource pack from highest priority to lowest. If no resource packs were found
 		COMMENT to contain the requested entry, will throw a {@code FileNotFoundException}.
 		COMMENT
-		COMMENT @throws FileNotFoundException if the identified resource could not be found, or could not be loaded.
+		COMMENT @throws java.io.FileNotFoundException if the identified resource could not be found, or could not be loaded.
 		COMMENT @throws IOException if the identified resource was found but a stream to it could not be opened.
 		ARG 1 id
 			COMMENT the resource identifier to search for
@@ -32,7 +32,7 @@ CLASS net/minecraft/class_3300 net/minecraft/resource/ResourceManager
 		COMMENT <p>Resources are returned in load order, or ascending order of priority, so the last element in the returned
 		COMMENT list is what would be returned normally by {@link #getResource}
 		COMMENT
-		COMMENT @throws FileNotFoundException if no matching resources could be found (i.e. if the list would be empty)
+		COMMENT @throws java.io.FileNotFoundException if no matching resources could be found (i.e. if the list would be empty)
 		COMMENT @throws IOException if resources were found, but any one of them could not be opened to be read.
 		ARG 1 id
 			COMMENT the resource identifier to search for

--- a/mappings/net/minecraft/server/LanServerPinger.mapping
+++ b/mappings/net/minecraft/server/LanServerPinger.mapping
@@ -15,12 +15,12 @@ CLASS net/minecraft/class_1133 net/minecraft/server/LanServerPinger
 		COMMENT Creates a server announcement.
 		COMMENT
 		COMMENT <pre>
-		COMMENT <blockquote>[MOTD]</blockquote> // Specifies the beginning of the message of the day
-		COMMENT <blockquote>A message of the day</blockquote> // The message of the day
-		COMMENT <blockquote>[/MOTD]</blockquote> // Specifies the end of the message of the day.
-		COMMENT <blockquote>[AD]</blockquote> // Specifies the beginning of the address and the port of the local server.
-		COMMENT <blockquote>the address of the local server.</blockquote> // Such as {@code 192.146.2.1:23132}
-		COMMENT <blockquote>[/AD]</blockquote> // Specifies the end of the address and port of the local server.
+		COMMENT {@code [MOTD]} // Specifies the beginning of the message of the day
+		COMMENT {@code A message of the day} // The message of the day
+		COMMENT {@code [/MOTD]} // Specifies the end of the message of the day.
+		COMMENT {@code [AD]} // Specifies the beginning of the address and the port of the local server.
+		COMMENT {@code the address of the local server.} // Such as {@code 192.146.2.1:23132}
+		COMMENT {@code [/AD]} // Specifies the end of the address and port of the local server.
 		COMMENT </pre>
 		COMMENT
 		COMMENT <p>An example of a complete announcement:

--- a/mappings/net/minecraft/server/world/ServerWorld.mapping
+++ b/mappings/net/minecraft/server/world/ServerWorld.mapping
@@ -88,7 +88,7 @@ CLASS net/minecraft/class_3218 net/minecraft/server/world/ServerWorld
 	METHOD method_18198 getEntitiesByType (Lnet/minecraft/class_5575;Ljava/util/function/Predicate;)Ljava/util/List;
 		COMMENT Computes a list of entities of the given type.
 		COMMENT
-		COMMENT <strong>Warning:<strong> If {@code null} is passed as the entity type filter, care should be
+		COMMENT <strong>Warning:</strong> If {@code null} is passed as the entity type filter, care should be
 		COMMENT taken that the type argument {@code T} is set to {@link Entity}, otherwise heap pollution
 		COMMENT in the returned list or {@link ClassCastException} can occur.
 		COMMENT

--- a/mappings/net/minecraft/world/gen/feature/StructurePoolFeatureConfig.mapping
+++ b/mappings/net/minecraft/world/gen/feature/StructurePoolFeatureConfig.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_3812 net/minecraft/world/gen/feature/StructurePoolFeatureConfig
-	COMMENT A feature config that specifies a starting pool and a size for the first two parameters of
-	COMMENT {@link net.minecraft.structure.pool.StructurePoolBasedGenerator#addPieces(net.minecraft.util.Identifier, int, net.minecraft.structure.pool.StructurePoolBasedGenerator.PieceFactory, net.minecraft.world.gen.chunk.ChunkGenerator, net.minecraft.structure.StructureManager, net.minecraft.util.math.BlockPos, java.util.List, java.util.Random, boolean, boolean)}.
+	COMMENT A feature config that specifies a starting pool and a size for
+	COMMENT {@link net.minecraft.structure.pool.StructurePoolBasedGenerator#method_30419(net.minecraft.util.registry.DynamicRegistryManager, net.minecraft.world.gen.feature.StructurePoolFeatureConfig, net.minecraft.structure.pool.StructurePoolBasedGenerator.PieceFactory, net.minecraft.world.gen.chunk.ChunkGenerator, net.minecraft.structure.StructureManager, net.minecraft.util.math.BlockPos, java.util.List, java.util.Random, boolean, boolean)}.
 	FIELD field_16860 size I
 	FIELD field_16861 startPool Ljava/util/function/Supplier;
 	FIELD field_24886 CODEC Lcom/mojang/serialization/Codec;


### PR DESCRIPTION
## Goal
 - Integrate mappingpoet 0.2.0
   - Now includes mapping information on javadoc generated. Would support type annotations if mojang add them.
 - Removed mappingpoet from build.gradle dependencies. Now only used when generating fake source/javadoc
 - Uses gradle 6.7 toolchain feature so running `./gradlew javadoc -Dorg.gradle.java.home="C:/Program Files/Java/jdk1.8.0_211"` (using java 8 to run gradle buildscript) would work even though poet now depends on java 11
 - Enables doclint and adds the 3 JDK command line taglets.
   - Fixed places in mappings where it does not comply with the doclint standards.
## Non Goals
 - Does not set up the buildscript for FabricMC/Enigma#321.
   - The commands need to be moved over from direct method calls to javaexec tasks individually.