### PR TITLE
Complete StairsBlock mapping

### DIFF
--- a/mappings/net/minecraft/block/StairsBlock.mapping
+++ b/mappings/net/minecraft/block/StairsBlock.mapping
@@ -44,7 +44,7 @@ CLASS net/minecraft/class_2510 net/minecraft/block/StairsBlock
 		ARG 2 pos
 	METHOD method_10676 isStairs (Lnet/minecraft/class_2680;)Z
 		ARG 0 state
-	METHOD method_10678 (Lnet/minecraft/class_2680;Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Z
+	METHOD method_10678 isDifferentOrientation (Lnet/minecraft/class_2680;Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Z
 		ARG 0 state
 		ARG 1 world
 		ARG 2 pos


### PR DESCRIPTION
```java
BlockState otherState = world.getBlockState(pos.offset(dir));
return !isStairs(otherState)
        || otherState.get(StairsBlock.FACING) != state.get(StairsBlock.FACING)
        || otherState.get(StairsBlock.HALF) != state.get(StairsBlock.HALF);
```

Pretty self-explanatory.

The `isStairs(otherState)` case is irrelevant and only exists to avoid exceptions, this function should only receive other stair blocks.
I don't see a need for `isDifferentlyOrientatedStair` because of this.