### PR TITLE
Some renames concerning the hotbar

### DIFF
--- a/mappings/net/minecraft/entity/player/PlayerInventory.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerInventory.mapping
@@ -15,7 +15,7 @@ CLASS net/minecraft/class_1661 net/minecraft/entity/player/PlayerInventory
 		ARG 3 craftingInventory
 	METHOD method_7364 getChangeCount ()I
 	METHOD method_7365 swapSlotWithHotbar (I)V
-		ARG 1 hotbarSlot
+		ARG 1 slot
 	METHOD method_7366 addStack (Lnet/minecraft/class_1799;)I
 		ARG 1 stack
 	METHOD method_7367 insertStack (ILnet/minecraft/class_1799;)Z

--- a/mappings/net/minecraft/network/packet/s2c/play/HeldItemChangeS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/HeldItemChangeS2CPacket.mapping
@@ -1,5 +1,0 @@
-CLASS net/minecraft/class_2735 net/minecraft/network/packet/s2c/play/HeldItemChangeS2CPacket
-	FIELD field_12463 slot I
-	METHOD <init> (I)V
-		ARG 1 slot
-	METHOD method_11803 getSlot ()I

--- a/mappings/net/minecraft/network/packet/s2c/play/UpdateSelectedSlotS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/UpdateSelectedSlotS2CPacket.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_2735 net/minecraft/network/packet/s2c/play/UpdateSelectedSlotS2CPacket
+	FIELD field_12463 selectedSlot I
+	METHOD <init> (I)V
+		ARG 1 slot
+	METHOD method_11803 getSlot ()I


### PR DESCRIPTION
Renames `HeldItemChangeS2CPacket` to `UpdateSelectedSlotS2CPacket` to be consistent with the client packet `UpdateSelectedSlotC2SPacket`.
Both packets do the same: They request the other side to change the selected hotbar slot.
Also renamed the field of that packet to match the client packet.

Renamed an unintuitive method parameter I came across:
`swapSlotWithHotbar` picks the given Slot **from the inventory** and swap it with the hotbar. The old parameter name `hotbarSlot` implicates the opposite.

Note: this pr is not snapshot specific - let me know if you want me to rebase it to 1.16.