### PR TITLE
`getFirst` -> `build`

### DIFF
--- a/mappings/net/minecraft/client/render/model/WeightedBakedModel.mapping
+++ b/mappings/net/minecraft/client/render/model/WeightedBakedModel.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/class_1097 net/minecraft/client/render/model/WeightedBakedMo
 		ARG 1 models
 	CLASS class_1098 Builder
 		FIELD field_5436 models Ljava/util/List;
-		METHOD method_4751 getFirst ()Lnet/minecraft/class_1087;
+		METHOD method_4751 build ()Lnet/minecraft/class_1087;
 		METHOD method_4752 add (Lnet/minecraft/class_1087;I)Lnet/minecraft/class_1097$class_1098;
 			ARG 1 model
 			ARG 2 weight


### PR DESCRIPTION
As an optimization, this method returns the first model if there was only one model added. In the general case, this returns a `new WeightedBakedModel`