### PR TITLE
Map the new method in 1.16.5-rc1

### DIFF
--- a/mappings/net/minecraft/util/math/Direction.mapping
+++ b/mappings/net/minecraft/util/math/Direction.mapping
@@ -112,5 +112,7 @@ CLASS net/minecraft/class_2350 net/minecraft/util/math/Direction
 		METHOD method_10183 random (Ljava/util/Random;)Lnet/minecraft/class_2350;
 			ARG 1 random
 		METHOD method_29716 stream ()Ljava/util/stream/Stream;
+		METHOD method_33325 randomAxis (Ljava/util/Random;)Lnet/minecraft/class_2350$class_2351;
+			ARG 1 random
 		METHOD test (Ljava/lang/Object;)Z
 			ARG 1 direction


### PR DESCRIPTION
This new method chooses a random axis from a direction type, and is used in the fix for the downwards dispenser portal bug.