### PR TITLE
Readd documentation for the ServerPlayerEntity.closeHandledScreen method

### DIFF
--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -141,3 +141,5 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 		ARG 2 centerPos
 	METHOD method_30631 getSpawnAngle ()F
 	METHOD method_31273 getTextStream ()Lnet/minecraft/class_5513;
+	METHOD method_7346 ()V
+		COMMENT Closes the current handled screen and sends a screen closing packet to the client.


### PR DESCRIPTION
This should also be merged into the 1.17 snapshot branches because it was removed [here](https://github.com/FabricMC/yarn/commit/c91f48214181289cfe3485646ef0e254934684db#diff-8ce52bd08b24691684887c72b113c8da5e7901e5cd679ededc78c9914cea8926L144-L145) as well.