### PR TITLE
Added some recipe things

### DIFF
--- a/mappings/net/minecraft/recipe/Ingredient.mapping
+++ b/mappings/net/minecraft/recipe/Ingredient.mapping
@@ -35,6 +35,7 @@ CLASS net/minecraft/class_1856 net/minecraft/recipe/Ingredient
 	METHOD method_8107 entryFromJson (Lcom/google/gson/JsonObject;)Lnet/minecraft/class_1856$class_1859;
 		ARG 0 json
 	METHOD test testStack (Ljava/lang/Object;)Z
+		ARG 1 itemStack
 	CLASS class_1857 StackEntry
 		FIELD field_9021 stack Lnet/minecraft/class_1799;
 		METHOD <init> (Lnet/minecraft/class_1799;)V

--- a/mappings/net/minecraft/recipe/Ingredient.mapping
+++ b/mappings/net/minecraft/recipe/Ingredient.mapping
@@ -18,7 +18,7 @@ CLASS net/minecraft/class_1856 net/minecraft/recipe/Ingredient
 		ARG 0 items
 	METHOD method_8092 ofEntries (Ljava/util/stream/Stream;)Lnet/minecraft/class_1856;
 		ARG 0 entries
-	METHOD method_8093 test (Ljava/lang/Object;)Z
+	METHOD method_8093 test (Lnet/minecraft/class_1799;)Z
 		ARG 1 stack
 	METHOD method_8094 (Lnet/minecraft/class_1799;)Lnet/minecraft/class_1856$class_1857;
 		ARG 0 stack

--- a/mappings/net/minecraft/recipe/Ingredient.mapping
+++ b/mappings/net/minecraft/recipe/Ingredient.mapping
@@ -18,6 +18,8 @@ CLASS net/minecraft/class_1856 net/minecraft/recipe/Ingredient
 		ARG 0 items
 	METHOD method_8092 ofEntries (Ljava/util/stream/Stream;)Lnet/minecraft/class_1856;
 		ARG 0 entries
+	METHOD method_8093 test (Ljava/lang/Object;)Z
+		ARG 1 stack
 	METHOD method_8094 (Lnet/minecraft/class_1799;)Lnet/minecraft/class_1856$class_1857;
 		ARG 0 stack
 	METHOD method_8096 cacheMatchingStacks ()V
@@ -32,8 +34,7 @@ CLASS net/minecraft/class_1856 net/minecraft/recipe/Ingredient
 		ARG 0 tag
 	METHOD method_8107 entryFromJson (Lcom/google/gson/JsonObject;)Lnet/minecraft/class_1856$class_1859;
 		ARG 0 json
-	METHOD test (Ljava/lang/Object;)Z
-		ARG 1 stack
+	METHOD test testStack (Ljava/lang/Object;)Z
 	CLASS class_1857 StackEntry
 		FIELD field_9021 stack Lnet/minecraft/class_1799;
 		METHOD <init> (Lnet/minecraft/class_1799;)V

--- a/mappings/net/minecraft/recipe/Ingredient.mapping
+++ b/mappings/net/minecraft/recipe/Ingredient.mapping
@@ -34,8 +34,8 @@ CLASS net/minecraft/class_1856 net/minecraft/recipe/Ingredient
 		ARG 0 tag
 	METHOD method_8107 entryFromJson (Lcom/google/gson/JsonObject;)Lnet/minecraft/class_1856$class_1859;
 		ARG 0 json
-	METHOD test testStack (Ljava/lang/Object;)Z
-		ARG 1 itemStack
+	METHOD test (Ljava/lang/Object;)Z
+		ARG 1 stack
 	CLASS class_1857 StackEntry
 		FIELD field_9021 stack Lnet/minecraft/class_1799;
 		METHOD <init> (Lnet/minecraft/class_1799;)V

--- a/mappings/net/minecraft/recipe/Recipe.mapping
+++ b/mappings/net/minecraft/recipe/Recipe.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_1860 net/minecraft/recipe/Recipe
 	METHOD method_17447 getRecipeKindIcon ()Lnet/minecraft/class_1799;
 	METHOD method_17716 getType ()Lnet/minecraft/class_3956;
+	METHOD method_31584 isEmpty ()Z
 	METHOD method_8110 getOutput ()Lnet/minecraft/class_1799;
 	METHOD method_8111 getRemainingStacks (Lnet/minecraft/class_1263;)Lnet/minecraft/class_2371;
 	METHOD method_8112 getGroup ()Ljava/lang/String;

--- a/mappings/net/minecraft/recipe/RecipeFinder.mapping
+++ b/mappings/net/minecraft/recipe/RecipeFinder.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_1662 net/minecraft/recipe/RecipeFinder
 	FIELD field_7550 idToAmountMap Lit/unimi/dsi/fastutil/ints/Int2IntMap;
+	METHOD method_20478 addItem (Lnet/minecraft/class_1799;I)V
 	METHOD method_7400 addItem (Lnet/minecraft/class_1799;)V
 	METHOD method_7401 addItem (II)V
 		ARG 1 id

--- a/mappings/net/minecraft/recipe/SmithingRecipe.mapping
+++ b/mappings/net/minecraft/recipe/SmithingRecipe.mapping
@@ -8,4 +8,5 @@ CLASS net/minecraft/class_5357 net/minecraft/recipe/SmithingRecipe
 		ARG 2 base
 		ARG 3 addition
 		ARG 4 result
+	METHOD method_30029 testAddition (Lnet/minecraft/class_1799;)Z
 	CLASS class_5358 Serializer


### PR DESCRIPTION
~~For some reason `Ingredient.test` was in some kind of limbo stage where it existed, but had no intermediary, but simultaneously had one in Enigma, but was not unique. This seemed like a massive problem as any file that used it called it `method_8093` as opposed to `test`. To fix it, I have renamed it altogether as this way it will be working again.~~ **This was me being a moron, ignore.**

I've also patched up some other missing method names that are related to recipes, if something is not right/not up to convention then do let me know.