### PR TITLE
Map custom packet identifiers for game event debugging

### DIFF
--- a/mappings/net/minecraft/network/packet/s2c/play/CustomPayloadS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/CustomPayloadS2CPacket.mapping
@@ -18,6 +18,8 @@ CLASS net/minecraft/class_2658 net/minecraft/network/packet/s2c/play/CustomPaylo
 	FIELD field_20600 DEBUG_GAME_TEST_CLEAR Lnet/minecraft/class_2960;
 	FIELD field_21559 DEBUG_BEE Lnet/minecraft/class_2960;
 	FIELD field_21560 DEBUG_HIVE Lnet/minecraft/class_2960;
+	FIELD field_28284 DEBUG_GAME_EVENT Lnet/minecraft/class_2960;
+	FIELD field_28285 DEBUG_GAME_EVENT_LISTENERS Lnet/minecraft/class_2960;
 	METHOD <init> (Lnet/minecraft/class_2960;Lnet/minecraft/class_2540;)V
 		ARG 1 channel
 		ARG 2 data


### PR DESCRIPTION
The fields `DEBUG_GAME_EVENT` and `DEBUG_GAME_EVENT_LISTENERS` store the `minecraft:debug/game_event` and `minecraft:debug/game_event_listeners` identifiers respectively, so they have been named to match the other identifiers.