### PR TITLE
Update enigma and javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ configurations {
 dependencies {
 	enigmaRuntime "cuchaz:enigma-swing:${project.enigma_version}"
 	enigmaRuntime "net.fabricmc:stitch:${project.stitch_version}"
-	javadocClasspath "net.fabricmc:fabric-loader:0.8.2+build.194"
+	javadocClasspath "net.fabricmc:fabric-loader:${project.fabric_loader_version}"
 	javadocClasspath "com.google.code.findbugs:jsr305:3.0.2"
 	decompileClasspath "org.benf:cfr:0.150"
 	mappingPoetJar 'net.fabricmc:mappingpoet:0.2.6'
@@ -732,11 +732,13 @@ javadoc {
 				'https://www.javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.2/',
 				'https://javadoc.lwjgl.org/',
 				'http://fastutil.di.unimi.it/docs/',
+				'https://netty.io/4.1/api/',
 				'https://commons.apache.org/proper/commons-logging/javadocs/api-1.1.3/',
 				'https://commons.apache.org/proper/commons-lang/javadocs/api-3.5',
 				'https://commons.apache.org/proper/commons-io/javadocs/api-2.5',
 				'https://commons.apache.org/proper/commons-codec/archives/1.10/apidocs',
 				'https://commons.apache.org/proper/commons-compress/javadocs/api-1.8.1/',
+				"https://maven.fabricmc.net/docs/fabric-loader-${project.fabric_loader_version}/",
 				"https://docs.oracle.com/en/java/javase/11/docs/api/"
 				// Need to add loader jd publication for env annotations!
 		)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,7 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-enigma_version=0.22.0
+enigma_version=0.23.0
 stitch_version=0.5.1+build.77
+# Loader is only used by javadoc generation/linking
+fabric_loader_version=0.11.1

--- a/mappings/net/minecraft/block/MapColor.mapping
+++ b/mappings/net/minecraft/block/MapColor.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_3620 net/minecraft/block/MapColor
-	COMMENT Represents the surface color of a block when rendered from the {@link net.minecraft.client.gui.MapRenderer}.
+	COMMENT Represents the surface color of a block when rendered from the {@link net.minecraft.client.render.MapRenderer}.
 	COMMENT Color names refer to a material or an object which refers to their vanilla Minecraft textures, not their real-world counterparts, eg. "emerald green".
 	COMMENT Names are in the form of either <i>blockReference_baseColor</i> or <i>color</i>.
 	FIELD field_15976 LIGHT_BLUE_GRAY Lnet/minecraft/class_3620;


### PR DESCRIPTION
Updates enigma to 0.23.0, one with better cfr and definition browsing bug fix.

Now links to netty and loader (for env annotations, thanks to FabricMC/fabric-loader#369); also fixed a minor broken link from #1969

Signed-off-by: liach <liach@users.noreply.github.com>