### PR TITLE
Element charTyped wrong parameter

### DIFF
--- a/mappings/net/minecraft/client/gui/Element.mapping
+++ b/mappings/net/minecraft/client/gui/Element.mapping
@@ -40,8 +40,8 @@ CLASS net/minecraft/class_364 net/minecraft/client/gui/Element
 		COMMENT @see org.lwjgl.glfw.GLFWKeyCallbackI#invoke(long, int, int, int, int)
 		ARG 1 chr
 			COMMENT the captured character
-		ARG 2 keyCode
-			COMMENT the associated key code
+		ARG 2 modifiers
+			COMMENT a GLFW bitfield describing the modifier keys that are held down (see <a href="https://www.glfw.org/docs/3.3/group__mods.html">GLFW Modifier key flags</a>)
 	METHOD method_25401 mouseScrolled (DDD)Z
 		COMMENT Callback for when a mouse button scroll event
 		COMMENT has been captured.


### PR DESCRIPTION
The parameter was named keyCode but the modifier keys are passed as parameter (you can check by looking at `Keyboard.onChar` and `GLFWCharModsCallbackI.invoke`'s third parameter).

Also this is my first Pull request here and I wasn't sure whether to target the latest release or the latest snapshot because the issue is present on both.