### PR TITLE
class_5423 -> RegistryWorldView

### DIFF
--- a/mappings/net/minecraft/class_5423.mapping
+++ b/mappings/net/minecraft/class_5423.mapping
@@ -1,4 +1,0 @@
-CLASS net/minecraft/class_5423
-	METHOD method_30349 getRegistryManager ()Lnet/minecraft/class_5455;
-	METHOD method_31081 getBiomeKey (Lnet/minecraft/class_2338;)Ljava/util/Optional;
-		ARG 1 pos

--- a/mappings/net/minecraft/world/RegistryWorldView.mapping
+++ b/mappings/net/minecraft/world/RegistryWorldView.mapping
@@ -1,0 +1,8 @@
+CLASS net/minecraft/class_5423 net/minecraft/world/RegistryWorldView
+	COMMENT A world view or {@link World}'s superinterface that exposes access to
+	COMMENT a registry manager.
+	COMMENT
+	COMMENT @see #getRegistryManager()
+	METHOD method_30349 getRegistryManager ()Lnet/minecraft/class_5455;
+	METHOD method_31081 getBiomeKey (Lnet/minecraft/class_2338;)Ljava/util/Optional;
+		ARG 1 pos

--- a/mappings/net/minecraft/world/WorldAccess.mapping
+++ b/mappings/net/minecraft/world/WorldAccess.mapping
@@ -14,6 +14,9 @@ CLASS net/minecraft/class_1936 net/minecraft/world/WorldAccess
 	METHOD method_32889 emitGameEvent (Lnet/minecraft/class_5712;Lnet/minecraft/class_2338;)V
 		ARG 1 event
 		ARG 2 pos
+	METHOD method_33596 emitGameEvent (Lnet/minecraft/class_5712;Lnet/minecraft/class_1297;)V
+		ARG 1 event
+		ARG 2 emitter
 	METHOD method_8396 playSound (Lnet/minecraft/class_1657;Lnet/minecraft/class_2338;Lnet/minecraft/class_3414;Lnet/minecraft/class_3419;FF)V
 		ARG 1 player
 		ARG 2 pos


### PR DESCRIPTION
the collision methods are just overrides to specify from which interfaces should their default impl be inherited. So this is really valuable for the `getRegistryManager` which exposes a dynamic registry manager.

Signed-off-by: liach <liach@users.noreply.github.com>