### PR TITLE
Fix getStateForNeighborUpdate parameters and document it

### DIFF
--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 	FIELD field_23154 dynamicBounds Z
 	FIELD field_23155 settings Lnet/minecraft/class_4970$class_2251;
 	FIELD field_23156 lootTableId Lnet/minecraft/class_2960;
-	FIELD field_23157 FACINGS [Lnet/minecraft/class_2350;
+	FIELD field_23157 DIRECTIONS [Lnet/minecraft/class_2350;
 	FIELD field_23158 material Lnet/minecraft/class_3614;
 	FIELD field_23159 collidable Z
 	FIELD field_23160 resistance F
@@ -125,12 +125,21 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		ARG 2 world
 		ARG 3 pos
 	METHOD method_9559 getStateForNeighborUpdate (Lnet/minecraft/class_2680;Lnet/minecraft/class_2350;Lnet/minecraft/class_2680;Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;Lnet/minecraft/class_2338;)Lnet/minecraft/class_2680;
+		COMMENT Gets the possibly updated block state of this block when a neighboring block is updated.
+		COMMENT
+		COMMENT @return the new state of this block
 		ARG 1 state
+			COMMENT the state of this block
 		ARG 2 direction
-		ARG 3 newState
+			COMMENT the direction from this block to the neighbor
+		ARG 3 neighborState
+			COMMENT the state of the updated neighbor block
 		ARG 4 world
+			COMMENT the world
 		ARG 5 pos
-		ARG 6 posFrom
+			COMMENT the position of this block
+		ARG 6 neighborPos
+			COMMENT the position of the neighbor block
 	METHOD method_9560 getDroppedStacks (Lnet/minecraft/class_2680;Lnet/minecraft/class_47$class_48;)Ljava/util/List;
 		ARG 1 state
 		ARG 2 builder
@@ -452,11 +461,19 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		METHOD method_26190 getRenderingSeed (Lnet/minecraft/class_2338;)J
 			ARG 1 pos
 		METHOD method_26191 getStateForNeighborUpdate (Lnet/minecraft/class_2350;Lnet/minecraft/class_2680;Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;Lnet/minecraft/class_2338;)Lnet/minecraft/class_2680;
+			COMMENT Gets the possibly updated block state of this block when a neighboring block is updated.
+			COMMENT
+			COMMENT @return the new state of this block
 			ARG 1 direction
-			ARG 2 state
+				COMMENT the direction from this block to the neighbor
+			ARG 2 neighborState
+				COMMENT the state of the updated neighbor block
 			ARG 3 world
+				COMMENT the world
 			ARG 4 pos
-			ARG 5 fromPos
+				COMMENT the position of this block
+			ARG 5 neighborPos
+				COMMENT the position of the neighbor block
 		METHOD method_26192 scheduledTick (Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;Ljava/util/Random;)V
 			ARG 1 world
 			ARG 2 pos


### PR DESCRIPTION
- Renamed some `getStateForNeighborUpdate` parameters:
  - `newState` (in `AbstractBlock`) / `state` (in `AbstractBlockState`) to `neighborState`
    It's not some "new state", it's the state of the neighboring block.
  - `posFrom` (in `AbstractBlock`) / `fromPos` (in `AbstractBlockState`) to `neighborPos`
    For consistency with the `neighborState` parameter.
  - These names can be verified by taking a look at `AbstractBlockState.updateNeighbors`, which is their main call site.
- Documented `getStateForNeighborUpdate` in both `AbstractBlock` and `AbstractBlockState`.
- Also renamed `AbstractBlock.FACINGS` to `DIRECTIONS` as the array is not used for block facings (`facing` property of a block).