### PR TITLE
Map new methods added to the MathHelper class in 21w06a

### DIFF
--- a/mappings/net/minecraft/util/math/MathHelper.mapping
+++ b/mappings/net/minecraft/util/math/MathHelper.mapping
@@ -239,7 +239,7 @@ CLASS net/minecraft/class_3532 net/minecraft/util/math/MathHelper
 		ARG 0 random
 		ARG 1 min
 		ARG 2 max
-	METHOD method_32854 lerpFromProgress (DDDDD)D
+	METHOD method_32854 clampedLerpFromProgress (DDDDD)D
 		ARG 0 lerpValue
 		ARG 2 lerpStart
 		ARG 4 lerpEnd
@@ -249,3 +249,11 @@ CLASS net/minecraft/class_3532 net/minecraft/util/math/MathHelper
 		ARG 0 random
 		ARG 1 mean
 		ARG 2 deviation
+	METHOD method_33722 lerpFromProgress (DDDDD)D
+		ARG 0 larpValue
+		ARG 2 lerpStart
+		ARG 4 lerpEnd
+		ARG 6 start
+		ARG 8 end
+	METHOD method_33723 square (D)D
+		ARG 0 n

--- a/mappings/net/minecraft/util/math/MathHelper.mapping
+++ b/mappings/net/minecraft/util/math/MathHelper.mapping
@@ -250,7 +250,7 @@ CLASS net/minecraft/class_3532 net/minecraft/util/math/MathHelper
 		ARG 1 mean
 		ARG 2 deviation
 	METHOD method_33722 lerpFromProgress (DDDDD)D
-		ARG 0 larpValue
+		ARG 0 lerpValue
 		ARG 2 lerpStart
 		ARG 4 lerpEnd
 		ARG 6 start


### PR DESCRIPTION
This pull request maps a double variant of `square` and an unclamped variant of `lerpFromProgress` in the `MathHelper` class. Because the two `lerpFromProgress` methods are differentiated by whether they are clamped, the old, clamped one has been renamed to `clampedLerpFromProgress`.