### PR TITLE
Map atomic stack

### DIFF
--- a/mappings/net/minecraft/server/world/ChunkHolder.mapping
+++ b/mappings/net/minecraft/server/world/ChunkHolder.mapping
@@ -27,6 +27,7 @@ CLASS net/minecraft/class_3193 net/minecraft/server/world/ChunkHolder
 		COMMENT by {@link #markForBlockUpdate}, grouped by their vertical chunk section.
 		COMMENT <p>
 		COMMENT Entries for a section are null if the section has no positions marked for update.
+	FIELD field_28806 actionStack Lnet/minecraft/class_5831;
 	METHOD <init> (Lnet/minecraft/class_1923;ILnet/minecraft/class_5539;Lnet/minecraft/class_3568;Lnet/minecraft/class_3193$class_3896;Lnet/minecraft/class_3193$class_3897;)V
 		ARG 1 pos
 		ARG 2 level
@@ -58,6 +59,7 @@ CLASS net/minecraft/class_3193 net/minecraft/server/world/ChunkHolder
 		ARG 1 level
 	METHOD method_16143 combineSavingFuture (Ljava/util/concurrent/CompletableFuture;Ljava/lang/String;)V
 		ARG 1 then
+		ARG 2 thenDesc
 	METHOD method_16144 getWorldChunk ()Lnet/minecraft/class_2818;
 	METHOD method_16145 getTickingFuture ()Ljava/util/concurrent/CompletableFuture;
 	METHOD method_16146 getFutureFor (Lnet/minecraft/class_2806;)Ljava/util/concurrent/CompletableFuture;
@@ -90,3 +92,11 @@ CLASS net/minecraft/class_3193 net/minecraft/server/world/ChunkHolder
 		METHOD method_17210 getPlayersWatchingChunk (Lnet/minecraft/class_1923;Z)Ljava/util/stream/Stream;
 			ARG 1 chunkPos
 			ARG 2 onlyOnWatchDistanceEdge
+	CLASS class_5830 MultithreadAction
+		FIELD field_28807 thread Ljava/lang/Thread;
+		FIELD field_28808 action Ljava/util/concurrent/CompletableFuture;
+		FIELD field_28809 actionDesc Ljava/lang/String;
+		METHOD <init> (Ljava/lang/Thread;Ljava/util/concurrent/CompletableFuture;Ljava/lang/String;)V
+			ARG 1 thread
+			ARG 2 action
+			ARG 3 actionDesc

--- a/mappings/net/minecraft/util/thread/AtomicStack.mapping
+++ b/mappings/net/minecraft/util/thread/AtomicStack.mapping
@@ -1,0 +1,25 @@
+CLASS net/minecraft/class_5831 net/minecraft/util/thread/AtomicStack
+	COMMENT A fixed-size atomic stack, useful for tracking multithreaded access to
+	COMMENT an object. When the stack is full on addition, it overrides the earliest
+	COMMENT content in the stack.
+	COMMENT
+	COMMENT @apiNote This class has final fields but its constructor has been removed
+	COMMENT by proguard, so it's not easily usable. Vanilla uses this for debugging
+	COMMENT purpose on palletted container and chunk holder's asynchrous access checks.
+	FIELD field_28810 contents Ljava/util/concurrent/atomic/AtomicReferenceArray;
+	FIELD field_28811 size Ljava/util/concurrent/atomic/AtomicInteger;
+	METHOD method_33720 toList ()Ljava/util/List;
+		COMMENT Builds a list of the contents of the stack.
+		COMMENT
+		COMMENT <p>The more recently pushed elements will appear earlier in the returned
+		COMMENT list. The returned list is immutable and its size won't exceed this stack's
+		COMMENT size.
+		COMMENT
+		COMMENT @return a list of contents
+	METHOD method_33721 push (Ljava/lang/Object;)V
+		COMMENT Adds a value to this stack.
+		COMMENT
+		COMMENT <p>If the stack is already at full capacity, the earliest pushed item in
+		COMMENT the stack is discarded.
+		ARG 1 value
+			COMMENT the value to add

--- a/mappings/net/minecraft/util/thread/AtomicStack.mapping
+++ b/mappings/net/minecraft/util/thread/AtomicStack.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/class_5831 net/minecraft/util/thread/AtomicStack
 	COMMENT
 	COMMENT @apiNote This class has final fields but its constructor has been removed
 	COMMENT by proguard, so it's not easily usable. Vanilla uses this for debugging
-	COMMENT purpose on palletted container and chunk holder's asynchrous access checks.
+	COMMENT purpose on paletted container and chunk holder's asynchronous access checks.
 	FIELD field_28810 contents Ljava/util/concurrent/atomic/AtomicReferenceArray;
 	FIELD field_28811 size Ljava/util/concurrent/atomic/AtomicInteger;
 	METHOD method_33720 toList ()Ljava/util/List;

--- a/mappings/net/minecraft/util/thread/LockHelper.mapping
+++ b/mappings/net/minecraft/util/thread/LockHelper.mapping
@@ -1,4 +1,8 @@
 CLASS net/minecraft/class_5798 net/minecraft/util/thread/LockHelper
 	METHOD method_33564 crash (Ljava/lang/String;Lnet/minecraft/class_5831;)Lnet/minecraft/class_148;
 		ARG 0 message
+		ARG 1 lockStack
 	METHOD method_33566 checkLock (Ljava/util/concurrent/Semaphore;Lnet/minecraft/class_5831;Ljava/lang/String;)V
+		ARG 0 semaphore
+		ARG 1 lockStack
+		ARG 2 message

--- a/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
+++ b/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
@@ -9,6 +9,7 @@ CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
 	FIELD field_12941 data Lnet/minecraft/class_3508;
 	FIELD field_12942 noOpPaletteResizeHandler Lnet/minecraft/class_2835;
 	FIELD field_12943 elementDeserializer Ljava/util/function/Function;
+	FIELD field_28812 lockStack Lnet/minecraft/class_5831;
 	METHOD <init> (Lnet/minecraft/class_2837;Lnet/minecraft/class_2361;Ljava/util/function/Function;Ljava/util/function/Function;Ljava/lang/Object;)V
 		ARG 2 idList
 		ARG 3 elementDeserializer


### PR DESCRIPTION
Now all top level classes are mapped, or at least have a pr that maps them

Signed-off-by: liach <liach@users.noreply.github.com>