### PR TITLE
Make mapping check work again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -393,11 +393,15 @@ task checkMappings {
 		logger.lifecycle(":checking mappings")
 
 		String[] args = [
-				mergedFile.getAbsolutePath(),
+				intermediaryJar.getAbsolutePath(),
 				mappingsDir.getAbsolutePath()
 		]
 
-		new CheckMappingsCommand().run(args)
+		try {
+			new CheckMappingsCommand().run(args)
+		} catch (IllegalStateException ignored) {
+			// just print, don't fail the task
+		}
 	}
 }
 


### PR DESCRIPTION
It never worked since the intermediary update. So 2 years of "Error: Must be in one package"

Now made the task only print and swallows the illegal state it throws

See #2057. It's quite debatable if we should merge these packages or keep them split; I recall we had a similar debate when we were eliminating the `impl` packages for blocks, entities, etc.

Signed-off-by: liach <liach@users.noreply.github.com>