### PR TITLE
Move all feature util stuff to feature

### DIFF
--- a/mappings/net/minecraft/world/gen/feature/DripstoneColumn.mapping
+++ b/mappings/net/minecraft/world/gen/feature/DripstoneColumn.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_5721 net/minecraft/world/gen/feature/util/DripstoneColumn
+CLASS net/minecraft/class_5721 net/minecraft/world/gen/feature/DripstoneColumn
 	METHOD method_32980 createEmpty ()Lnet/minecraft/class_5721;
 	METHOD method_32981 createHalfWithCeiling (I)Lnet/minecraft/class_5721;
 		ARG 0 ceiling

--- a/mappings/net/minecraft/world/gen/feature/DripstoneHelper.mapping
+++ b/mappings/net/minecraft/world/gen/feature/DripstoneHelper.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_5726 net/minecraft/world/gen/feature/util/DripstoneHelper
+CLASS net/minecraft/class_5726 net/minecraft/world/gen/feature/DripstoneHelper
 	METHOD method_33005 scaleHeightFromRadius (DDDD)D
 		ARG 0 radius
 		ARG 2 scale

--- a/mappings/net/minecraft/world/gen/feature/FeatureContext.mapping
+++ b/mappings/net/minecraft/world/gen/feature/FeatureContext.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_5821 net/minecraft/world/gen/feature/util/FeatureContext
+CLASS net/minecraft/class_5821 net/minecraft/world/gen/feature/FeatureContext
 	FIELD field_28769 world Lnet/minecraft/class_5281;
 	FIELD field_28770 generator Lnet/minecraft/class_2794;
 	FIELD field_28771 random Ljava/util/Random;


### PR DESCRIPTION
Since DripstoneHelper has to be in same package as dripstone features and util isn't really meaningful

Alleviates the Error: must be in one package spree

Signed-off-by: liach <liach@users.noreply.github.com>