### PR TITLE
Move registry lookup codec to dynamic

### DIFF
--- a/mappings/net/minecraft/util/dynamic/RegistryLookupCodec.mapping
+++ b/mappings/net/minecraft/util/dynamic/RegistryLookupCodec.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_5505 net/minecraft/util/registry/RegistryLookupCodec
+CLASS net/minecraft/class_5505 net/minecraft/util/dynamic/RegistryLookupCodec
 	FIELD field_26737 registryKey Lnet/minecraft/class_5321;
 	METHOD <init> (Lnet/minecraft/class_5321;)V
 		ARG 1 registryKey


### PR DESCRIPTION
Solves the one package warning for registry lookup codec.

Signed-off-by: liach <liach@users.noreply.github.com>