### PR TITLE
Move chunk data access related stuff to storage

### DIFF
--- a/mappings/net/minecraft/world/storage/ChunkDataAccess.mapping
+++ b/mappings/net/minecraft/world/storage/ChunkDataAccess.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_5571 net/minecraft/world/chunk/ChunkDataAccess
+CLASS net/minecraft/class_5571 net/minecraft/world/storage/ChunkDataAccess
 	METHOD method_31758 awaitAll ()V
 	METHOD method_31759 readChunkData (Lnet/minecraft/class_1923;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 pos

--- a/mappings/net/minecraft/world/storage/ChunkDataList.mapping
+++ b/mappings/net/minecraft/world/storage/ChunkDataList.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_5566 net/minecraft/world/chunk/ChunkDataList
+CLASS net/minecraft/class_5566 net/minecraft/world/storage/ChunkDataList
 	FIELD field_27241 pos Lnet/minecraft/class_1923;
 	FIELD field_27242 backingList Ljava/util/List;
 	METHOD <init> (Lnet/minecraft/class_1923;Ljava/util/List;)V

--- a/mappings/net/minecraft/world/storage/EntityChunkDataAccess.mapping
+++ b/mappings/net/minecraft/world/storage/EntityChunkDataAccess.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_5565 net/minecraft/world/chunk/EntityChunkDataAccess
+CLASS net/minecraft/class_5565 net/minecraft/world/storage/EntityChunkDataAccess
 	FIELD field_27231 dataFixer Lcom/mojang/datafixers/DataFixer;
 	FIELD field_27232 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_27233 world Lnet/minecraft/class_3218;


### PR DESCRIPTION
I added them when I mapped entity system. They fit storage well too

Resolves Entity chunk data access must be in same package as storage stuff

Signed-off-by: liach <liach@users.noreply.github.com>