### PR TITLE
Move option hierarchy out of option subpackage. Leave pojos there

### DIFF
--- a/mappings/net/minecraft/client/CyclingOption.mapping
+++ b/mappings/net/minecraft/client/CyclingOption.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4064 net/minecraft/client/option/CyclingOption
+CLASS net/minecraft/class_4064 net/minecraft/client/CyclingOption
 	FIELD field_18169 setter Lnet/minecraft/class_4064$class_5675;
 	FIELD field_27953 getter Ljava/util/function/Function;
 	METHOD <init> (Ljava/lang/String;Ljava/util/function/Function;Lnet/minecraft/class_4064$class_5675;Ljava/util/function/Supplier;)V

--- a/mappings/net/minecraft/client/DoubleOption.mapping
+++ b/mappings/net/minecraft/client/DoubleOption.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4067 net/minecraft/client/option/DoubleOption
+CLASS net/minecraft/class_4067 net/minecraft/client/DoubleOption
 	FIELD field_18204 step F
 	FIELD field_18205 min D
 	FIELD field_18206 max D

--- a/mappings/net/minecraft/client/FullscreenOption.mapping
+++ b/mappings/net/minecraft/client/FullscreenOption.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_4454 net/minecraft/client/FullscreenOption
+	COMMENT @implNote This must be in the same package as {@link Option} as it calls
+	COMMENT protected {@code Option.getGenericLabel} on a double option instance than
+	COMMENT itself, which is illegal outside of the same package.

--- a/mappings/net/minecraft/client/LogarithmicOption.mapping
+++ b/mappings/net/minecraft/client/LogarithmicOption.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_4287 net/minecraft/client/LogarithmicOption

--- a/mappings/net/minecraft/client/Option.mapping
+++ b/mappings/net/minecraft/client/Option.mapping
@@ -1,4 +1,6 @@
-CLASS net/minecraft/class_316 net/minecraft/client/option/Option
+CLASS net/minecraft/class_316 net/minecraft/client/Option
+	COMMENT @implNote This should stay in the same package as {@link MinecraftClient}
+	COMMENT as it calls its {@code initFont(boolean)}, a package-private method.
 	FIELD field_18184 ENTITY_SHADOWS Lnet/minecraft/class_4064;
 	FIELD field_18185 FORCE_UNICODE_FONT Lnet/minecraft/class_4064;
 	FIELD field_18186 REALMS_NOTIFICATIONS Lnet/minecraft/class_4064;

--- a/mappings/net/minecraft/client/option/FullscreenOption.mapping
+++ b/mappings/net/minecraft/client/option/FullscreenOption.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_4454 net/minecraft/client/option/FullscreenOption

--- a/mappings/net/minecraft/client/option/LogarithmicOption.mapping
+++ b/mappings/net/minecraft/client/option/LogarithmicOption.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_4287 net/minecraft/client/option/LogarithmicOption


### PR DESCRIPTION
Reasons for package privacy in implnotes. Strange indeed!

Preferably merge #2060 before this one.

Signed-off-by: liach <liach@users.noreply.github.com>