### PR TITLE
TextFieldWidget tweaks

### DIFF
--- a/mappings/net/minecraft/client/gui/widget/TextFieldWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/TextFieldWidget.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_342 net/minecraft/client/gui/widget/TextFieldWidget
 	FIELD field_2088 changedListener Ljava/util/function/Consumer;
 	FIELD field_2092 text Ljava/lang/String;
 	FIELD field_2094 editable Z
-	FIELD field_2095 focused Z
+	FIELD field_2095 drawsBackground Z
 	FIELD field_2096 focusUnlocked Z
 	FIELD field_2098 uneditableColor I
 	FIELD field_2099 renderTextProvider Ljava/util/function/BiFunction;
@@ -35,7 +35,7 @@ CLASS net/minecraft/class_342 net/minecraft/client/gui/widget/TextFieldWidget
 		ARG 1 x
 	METHOD method_16873 erase (I)V
 		ARG 1 offset
-	METHOD method_1851 hasBorder ()Z
+	METHOD method_1851 drawsBackground ()Z
 	METHOD method_1852 setText (Ljava/lang/String;)V
 		ARG 1 text
 	METHOD method_1853 getWordSkipPosition (I)I
@@ -46,8 +46,8 @@ CLASS net/minecraft/class_342 net/minecraft/client/gui/widget/TextFieldWidget
 		ARG 1 offset
 	METHOD method_1856 setFocusUnlocked (Z)V
 		ARG 1 focusUnlocked
-	METHOD method_1858 setHasBorder (Z)V
-		ARG 1 hasBorder
+	METHOD method_1858 setDrawsBackground (Z)V
+		ARG 1 drawsBackground
 	METHOD method_1859 getInnerWidth ()I
 	METHOD method_1860 setUneditableColor (I)V
 		ARG 1 color
@@ -74,8 +74,8 @@ CLASS net/minecraft/class_342 net/minecraft/client/gui/widget/TextFieldWidget
 		ARG 1 newText
 	METHOD method_1875 setSelectionStart (I)V
 		ARG 1 cursor
-	METHOD method_1876 setSelected (Z)V
-		ARG 1 selected
+	METHOD method_1876 setTextFieldFocused (Z)V
+		ARG 1 focused
 	METHOD method_1877 eraseWords (I)V
 		ARG 1 wordOffset
 	METHOD method_1878 eraseCharacters (I)V


### PR DESCRIPTION
The field focused clashes with superclass field, and is not accurate. It
actually controls whether the background is drawn. The getter and setter
methods are also not correct, as the field does not just control the
border:
![image](https://user-images.githubusercontent.com/7091588/108016278-22ac3280-6fe0-11eb-9bed-c6ac701bb954.png)

The setSelected method does not set whether the field is selected, but
focused. It only exists to expose the protected AbstractButtonWidget.setFocused
method. It's named setTextFieldFocused not setFocused because that would
clash with the superclass name.