### PR TITLE
Rename the FeatureContext#pos field to origin

### DIFF
--- a/mappings/net/minecraft/world/biome/Biome.mapping
+++ b/mappings/net/minecraft/world/biome/Biome.mapping
@@ -55,7 +55,7 @@ CLASS net/minecraft/class_1959 net/minecraft/world/biome/Biome
 		ARG 3 region
 		ARG 4 populationSeed
 		ARG 6 random
-		ARG 7 pos
+		ARG 7 origin
 	METHOD method_8703 buildSurface (Ljava/util/Random;Lnet/minecraft/class_2791;IIIDLnet/minecraft/class_2680;Lnet/minecraft/class_2680;IJ)V
 		ARG 1 random
 		ARG 2 chunk

--- a/mappings/net/minecraft/world/gen/feature/ConfiguredFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/ConfiguredFeature.mapping
@@ -11,7 +11,7 @@ CLASS net/minecraft/class_2975 net/minecraft/world/gen/feature/ConfiguredFeature
 		ARG 1 world
 		ARG 2 chunkGenerator
 		ARG 3 random
-		ARG 4 pos
+		ARG 4 origin
 	METHOD method_23387 withChance (F)Lnet/minecraft/class_3226;
 		ARG 1 chance
 	METHOD method_30380 getFeature ()Lnet/minecraft/class_3031;

--- a/mappings/net/minecraft/world/gen/feature/util/FeatureContext.mapping
+++ b/mappings/net/minecraft/world/gen/feature/util/FeatureContext.mapping
@@ -2,16 +2,16 @@ CLASS net/minecraft/class_5821 net/minecraft/world/gen/feature/util/FeatureConte
 	FIELD field_28769 world Lnet/minecraft/class_5281;
 	FIELD field_28770 generator Lnet/minecraft/class_2794;
 	FIELD field_28771 random Ljava/util/Random;
-	FIELD field_28772 pos Lnet/minecraft/class_2338;
+	FIELD field_28772 origin Lnet/minecraft/class_2338;
 	FIELD field_28773 config Lnet/minecraft/class_3037;
 	METHOD <init> (Lnet/minecraft/class_5281;Lnet/minecraft/class_2794;Ljava/util/Random;Lnet/minecraft/class_2338;Lnet/minecraft/class_3037;)V
 		ARG 1 world
 		ARG 2 generator
 		ARG 3 random
-		ARG 4 pos
+		ARG 4 origin
 		ARG 5 config
 	METHOD method_33652 getWorld ()Lnet/minecraft/class_5281;
 	METHOD method_33653 getGenerator ()Lnet/minecraft/class_2794;
 	METHOD method_33654 getRandom ()Ljava/util/Random;
-	METHOD method_33655 getPos ()Lnet/minecraft/class_2338;
+	METHOD method_33655 getOrigin ()Lnet/minecraft/class_2338;
 	METHOD method_33656 getConfig ()Lnet/minecraft/class_3037;


### PR DESCRIPTION
This pull request renames the `FeatureContext#pos` field and its associated parameters and getter method to `origin`.

Most of the time, features generate over multiple blocks, so naming a singular position the `pos` would not make sense. In addition, the `SmallDripstoneFeatureConfig` codec contains the `max_offset_from_origin` field, which is used alongside this value in the `SmallDripstoneFeature#randomPos` method.