### PR TITLE
Fix the name of and add documentation to the ItemStack#isSectionVisible method

### DIFF
--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -37,7 +37,7 @@ CLASS net/minecraft/class_1799 net/minecraft/item/ItemStack
 	METHOD method_27320 setHolder (Lnet/minecraft/class_1297;)V
 		ARG 1 holder
 	METHOD method_30266 getHideFlags ()I
-	METHOD method_30267 isSectionHidden (ILnet/minecraft/class_1799$class_5422;)Z
+	METHOD method_30267 isSectionVisible (ILnet/minecraft/class_1799$class_5422;)Z
 		ARG 0 flags
 		ARG 1 tooltipSection
 	METHOD method_30268 addHideFlag (Lnet/minecraft/class_1799$class_5422;)V

--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -38,6 +38,7 @@ CLASS net/minecraft/class_1799 net/minecraft/item/ItemStack
 		ARG 1 holder
 	METHOD method_30266 getHideFlags ()I
 	METHOD method_30267 isSectionVisible (ILnet/minecraft/class_1799$class_5422;)Z
+		COMMENT Determines whether the given tooltip section will be visible according to the given flags.
 		ARG 0 flags
 		ARG 1 tooltipSection
 	METHOD method_30268 addHideFlag (Lnet/minecraft/class_1799$class_5422;)V


### PR DESCRIPTION
This pull request corrects the name of the `ItemStack#isSectionHidden` method to `ItemStack#isSectionVisible` and adds documentation to it.

Fixes #2095