### PR TITLE
Improve github actions for updating the base of a PR

### DIFF
--- a/.github/workflows/update-base.yml
+++ b/.github/workflows/update-base.yml
@@ -1,13 +1,12 @@
 name: Update Base Branch
 
-# Run every 20 mins or manually
 on:
-  schedule:
-    - cron: '*/20 * * * *'
-  workflow_dispatch:
+  pull_request_target:
+    types: [ labeled ]
 
 jobs:
   update:
+    if: ${{ github.event.label.name == 'update-base' }}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/github-script@v3
@@ -17,37 +16,32 @@ jobs:
             const updateLabel = 'update-base';
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const pull_number = issue_number = ${{ github.event.number }};
 
-            const response = await github.repos.get({ owner, repo })
-            const base = response.data.default_branch
+            const { data: repoData } = await github.repos.get({ owner, repo });
+            const base = repoData.default_branch;
 
-            async function updateBase(pull) {
-                const pull_number = issue_number = pull.number;
+            const { data: pull } = await github.pulls.get({ owner, repo, pull_number });
 
-                if (pull.base.ref == base) {
-                    await github.issues.createComment({ owner, repo, issue_number, body: '🚨 Target branch is already set to ' + base });
-                    await github.issues.removeLabel({ owner, repo, issue_number, name: updateLabel });
-                    return;
-                }
+            if (pull.base.ref == base) {
+                await github.issues.createComment({ owner, repo, issue_number, body: '🚨 Target branch is already set to ' + base });
 
-                // Update target PR branch
+            } else {
                 await github.pulls.update({ owner, repo, pull_number, base });
                 await github.issues.createComment({ owner, repo, issue_number, body: '🚀 Target branch has been updated to ' + base });
                 await github.issues.removeLabel({ owner, repo, issue_number, name: updateLabel });
-            }
 
-            // Query all of the open pull requests
-            const pulls = await github.pulls.list({
-                owner,
-                repo,
-                state: 'open'
-            });
+                try {
+                    // Updates the pull request with the latest upstream changes.
+                    await github.pulls.updateBranch({ owner, repo, pull_number })
+                } catch (error) {
+                    // 422 is returned when there is a merge conflict
+                    if (error.status === 422) {
+                        await github.issues.createComment({ owner, repo, issue_number, body: '🚨 Please fix merge conflicts before this can be merged' });
+                        await github.issues.addLabels({ owner, repo, issue_number, labels: ['outdated'] });
+                        return;
+                    }
 
-            // Loop all of the pull requests, finding any with the target label.
-            for (const pull of pulls.data) {
-                const requiresUpdate = pull.labels.some((label) => label.name === updateLabel);
-
-                if (requiresUpdate) {
-                    await updateBase(pull);
+                    throw error;
                 }
             }


### PR DESCRIPTION
Opend a PR to try and see if there is any more input on this, I have tested it and it works as expected.

Now runs on pull_request_target, should save having to loop all prs every 20 mins.
Now also atempts to merge the changes into the PR, will add a comment + the outdated label when this fails due to merge conflicts.

I might look at moving these scripts out into their own repo as its a little gross having JS in yml, and having typescript would aid a lot when writing them (as the test feedback is really slow).

Do note this wont work on older PRs where the existing target is something that doesnt have this workflow. I dont think its a major issue as it will be much better going forward.