### PR TITLE
Map resource factory

### DIFF
--- a/mappings/net/minecraft/class_5912.mapping
+++ b/mappings/net/minecraft/class_5912.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/class_5912
-	METHOD method_14486 getResource (Lnet/minecraft/class_2960;)Lnet/minecraft/class_3298;

--- a/mappings/net/minecraft/client/MinecraftClient.mapping
+++ b/mappings/net/minecraft/client/MinecraftClient.mapping
@@ -206,7 +206,7 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 	METHOD method_1513 reloadResourcesConcurrently ()Ljava/util/concurrent/CompletableFuture;
 	METHOD method_1514 run ()V
 	METHOD method_1515 getGameVersion ()Ljava/lang/String;
-	METHOD method_1516 getResourcePackDownloader ()Lnet/minecraft/class_1066;
+	METHOD method_1516 getResourcePackProvider ()Lnet/minecraft/class_1066;
 	METHOD method_1517 isFancyGraphicsOrBetter ()Z
 	METHOD method_1519 cleanUpAfterCrash ()V
 	METHOD method_1520 getResourcePackManager ()Lnet/minecraft/class_3283;

--- a/mappings/net/minecraft/client/render/GameRenderer.mapping
+++ b/mappings/net/minecraft/client/render/GameRenderer.mapping
@@ -83,3 +83,5 @@ CLASS net/minecraft/class_757 net/minecraft/client/render/GameRenderer
 	METHOD method_3202 shouldRenderBlockOutline ()Z
 	METHOD method_3203 reset ()V
 	METHOD method_3207 disableShader ()V
+	METHOD method_34521 (Lnet/minecraft/class_5912;)V
+		ARG 1 factory

--- a/mappings/net/minecraft/resource/DefaultResourcePack.mapping
+++ b/mappings/net/minecraft/resource/DefaultResourcePack.mapping
@@ -14,12 +14,23 @@ CLASS net/minecraft/class_3268 net/minecraft/resource/DefaultResourcePack
 	METHOD method_14417 getInputStream (Ljava/lang/String;)Ljava/io/InputStream;
 		ARG 1 path
 	METHOD method_14418 getIdentifiers (Ljava/util/Collection;ILjava/lang/String;Ljava/nio/file/Path;Ljava/lang/String;Ljava/util/function/Predicate;)V
+		ARG 0 results
 		ARG 1 maxDepth
 		ARG 2 namespace
-		ARG 4 searchLocation
+		ARG 3 root
+		ARG 4 prefix
+		ARG 5 pathFilter
+	METHOD method_18220 (Ljava/util/HashMap;)V
+		ARG 0 map
 	METHOD method_20728 isValidUrl (Ljava/lang/String;Ljava/net/URL;)Z
 		ARG 0 fileName
 		ARG 1 url
 	METHOD method_20729 getPath (Lnet/minecraft/class_3264;Lnet/minecraft/class_2960;)Ljava/lang/String;
 		ARG 0 type
 		ARG 1 id
+	METHOD method_23857 (Ljava/lang/String;Ljava/nio/file/Path;Ljava/nio/file/Path;)Lnet/minecraft/class_2960;
+		ARG 2 path
+	METHOD method_23858 (Ljava/util/function/Predicate;Ljava/nio/file/Path;)Z
+		ARG 1 path
+	CLASS 1
+		FIELD field_29185 stream Ljava/io/InputStream;

--- a/mappings/net/minecraft/resource/ResourceFactory.mapping
+++ b/mappings/net/minecraft/resource/ResourceFactory.mapping
@@ -1,0 +1,12 @@
+CLASS net/minecraft/class_5912 net/minecraft/resource/ResourceFactory
+	COMMENT Provides resource access.
+	METHOD method_14486 getResource (Lnet/minecraft/class_2960;)Lnet/minecraft/class_3298;
+		COMMENT Finds and returns the corresponding resource for a resource's identifier.
+		COMMENT
+		COMMENT <p>Starts by scanning each resource pack from highest priority to lowest. If no resource packs were found
+		COMMENT to contain the requested entry, will throw a {@code FileNotFoundException}.
+		COMMENT
+		COMMENT @throws java.io.FileNotFoundException if the identified resource could not be found, or could not be loaded.
+		COMMENT @throws IOException if the identified resource was found but a stream to it could not be opened.
+		ARG 1 id
+			COMMENT the resource identifier to search for


### PR DESCRIPTION
It's used in creating class_5944 instances and GameRenderer.method_34521,
both of which only uses the DefaultResourcePack as the only resource
factory impl effectively.

Restored removed javadoc. Dunno why matcher removed it

Renamed a method in MinecraftClient as that is not just a downloader but a general resource pack provider that provides both the default and the server specific resource packs. the field is called `builtinPackProvider`, and imo that's ok so didn't rename it.