### PR TITLE
ScreenHandler adjacent

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/ingame/HandledScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/HandledScreen.mapping
@@ -31,6 +31,7 @@ CLASS net/minecraft/class_465 net/minecraft/client/gui/screen/ingame/HandledScre
 	FIELD field_2801 BACKGROUND_TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_2802 touchDropOriginSlot Lnet/minecraft/class_1735;
 	FIELD field_2803 draggedStackRemainder I
+	FIELD field_29347 displayName Lnet/minecraft/class_2561;
 	METHOD <init> (Lnet/minecraft/class_1703;Lnet/minecraft/class_1661;Lnet/minecraft/class_2561;)V
 		ARG 1 handler
 		ARG 2 inventory

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -33,10 +33,10 @@ CLASS net/minecraft/class_1792 net/minecraft/item/Item
 		ARG 3 slot
 		ARG 4 clickType
 		ARG 5 player
-		ARG 6 commandItemSlot
+		ARG 6 cursorSlot
 	METHOD method_31567 isItemBarVisible (Lnet/minecraft/class_1799;)Z
 		ARG 1 stack
-	METHOD method_31568 hasStoredInventory ()Z
+	METHOD method_31568 canBeStoredInItems ()Z
 	METHOD method_31569 getItemBarStep (Lnet/minecraft/class_1799;)I
 		ARG 1 stack
 	METHOD method_31570 getEquipSound ()Lnet/minecraft/class_3414;

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -36,7 +36,8 @@ CLASS net/minecraft/class_1792 net/minecraft/item/Item
 		ARG 6 cursorSlot
 	METHOD method_31567 isItemBarVisible (Lnet/minecraft/class_1799;)Z
 		ARG 1 stack
-	METHOD method_31568 canBeStoredInItems ()Z
+	METHOD method_31568 canBeNested ()Z
+		COMMENT @return true if the item can be placed inside of shulker boxes or bundles.
 	METHOD method_31569 getItemBarStep (Lnet/minecraft/class_1799;)I
 		ARG 1 stack
 	METHOD method_31570 getEquipSound ()Lnet/minecraft/class_3414;

--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -51,10 +51,13 @@ CLASS net/minecraft/class_1799 net/minecraft/item/ItemStack
 	METHOD method_31575 onStackClicked (Lnet/minecraft/class_1735;Lnet/minecraft/class_5536;Lnet/minecraft/class_1657;)Z
 		ARG 1 slot
 		ARG 2 clickType
+		ARG 3 player
 	METHOD method_31576 onClicked (Lnet/minecraft/class_1799;Lnet/minecraft/class_1735;Lnet/minecraft/class_5536;Lnet/minecraft/class_1657;Lnet/minecraft/class_5630;)Z
 		ARG 1 stack
 		ARG 2 slot
 		ARG 3 clickType
+		ARG 4 player
+		ARG 5 cursorSlot
 	METHOD method_31577 canCombine (Lnet/minecraft/class_1799;Lnet/minecraft/class_1799;)Z
 		ARG 0 stack
 		ARG 1 otherStack

--- a/mappings/net/minecraft/network/packet/c2s/play/ClickSlotC2SPacket.mapping
+++ b/mappings/net/minecraft/network/packet/c2s/play/ClickSlotC2SPacket.mapping
@@ -4,6 +4,14 @@ CLASS net/minecraft/class_2813 net/minecraft/network/packet/c2s/play/ClickSlotC2
 	FIELD field_12817 clickData I
 	FIELD field_12818 slot I
 	FIELD field_12819 syncId I
+	FIELD field_29540 modifiedStacks Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
+	METHOD <init> (IIILnet/minecraft/class_1713;Lnet/minecraft/class_1799;Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;)V
+		ARG 1 syncId
+		ARG 2 slot
+		ARG 3 clickData
+		ARG 4 actionType
+		ARG 5 stack
+		ARG 6 modifiedStacks
 	METHOD <init> (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD method_12190 getStack ()Lnet/minecraft/class_1799;
@@ -11,3 +19,4 @@ CLASS net/minecraft/class_2813 net/minecraft/network/packet/c2s/play/ClickSlotC2
 	METHOD method_12193 getClickData ()I
 	METHOD method_12194 getSyncId ()I
 	METHOD method_12195 getActionType ()Lnet/minecraft/class_1713;
+	METHOD method_34678 getModifiedStacks ()Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;

--- a/mappings/net/minecraft/screen/ScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/ScreenHandler.mapping
@@ -5,6 +5,7 @@ CLASS net/minecraft/class_1703 net/minecraft/screen/ScreenHandler
 	FIELD field_29206 previousTrackedStacks Lnet/minecraft/class_2371;
 	FIELD field_29207 previousCursorStack Lnet/minecraft/class_1799;
 	FIELD field_29208 syncHandler Lnet/minecraft/class_5916;
+	FIELD field_29209 disableSync Z
 	FIELD field_7757 quickCraftSlots Ljava/util/Set;
 	FIELD field_7759 quickCraftStage I
 	FIELD field_7761 slots Lnet/minecraft/class_2371;
@@ -55,6 +56,8 @@ CLASS net/minecraft/class_1703 net/minecraft/screen/ScreenHandler
 		ARG 1 slot
 		ARG 2 stack
 		ARG 3 copySupplier
+	METHOD method_34247 (Lnet/minecraft/class_1703;)V
+		ARG 1 handler
 	METHOD method_34248 updateSyncHandler (Lnet/minecraft/class_5916;)V
 		ARG 1 handler
 	METHOD method_34250 setPreviousCursorStack (Lnet/minecraft/class_1799;)V
@@ -65,7 +68,10 @@ CLASS net/minecraft/class_1703 net/minecraft/screen/ScreenHandler
 		ARG 2 stack
 		ARG 3 copySupplier
 	METHOD method_34254 setCursorStack (Lnet/minecraft/class_1799;)V
+		ARG 1 stack
 	METHOD method_34255 getCursorStack ()Lnet/minecraft/class_1799;
+	METHOD method_34256 disableSyncing ()V
+	METHOD method_34257 enableSyncing ()V
 	METHOD method_34258 updateCursorStack ()V
 	METHOD method_34259 getCursorCommandItemSlot ()Lnet/minecraft/class_5630;
 	METHOD method_7591 packQuickCraftData (II)I

--- a/mappings/net/minecraft/screen/ScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/ScreenHandler.mapping
@@ -56,7 +56,7 @@ CLASS net/minecraft/class_1703 net/minecraft/screen/ScreenHandler
 		ARG 1 slot
 		ARG 2 stack
 		ARG 3 copySupplier
-	METHOD method_34247 (Lnet/minecraft/class_1703;)V
+	METHOD method_34247 copySharedSlots (Lnet/minecraft/class_1703;)V
 		ARG 1 handler
 	METHOD method_34248 updateSyncHandler (Lnet/minecraft/class_5916;)V
 		ARG 1 handler

--- a/mappings/net/minecraft/screen/ScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/ScreenHandler.mapping
@@ -1,6 +1,10 @@
 CLASS net/minecraft/class_1703 net/minecraft/screen/ScreenHandler
 	FIELD field_17285 properties Ljava/util/List;
 	FIELD field_17493 type Lnet/minecraft/class_3917;
+	FIELD field_29205 cursorStack Lnet/minecraft/class_1799;
+	FIELD field_29206 previousTrackedStacks Lnet/minecraft/class_2371;
+	FIELD field_29207 previousCursorStack Lnet/minecraft/class_1799;
+	FIELD field_29208 syncHandler Lnet/minecraft/class_5916;
 	FIELD field_7757 quickCraftSlots Ljava/util/Set;
 	FIELD field_7759 quickCraftStage I
 	FIELD field_7761 slots Lnet/minecraft/class_2371;
@@ -44,6 +48,26 @@ CLASS net/minecraft/class_1703 net/minecraft/screen/ScreenHandler
 		ARG 2 clickData
 		ARG 3 actionType
 		ARG 4 player
+	METHOD method_34245 setPreviousTrackedSlot (ILnet/minecraft/class_1799;)V
+		ARG 1 slot
+		ARG 2 stack
+	METHOD method_34246 updateTrackedSlot (ILnet/minecraft/class_1799;Ljava/util/function/Supplier;)V
+		ARG 1 slot
+		ARG 2 stack
+		ARG 3 copySupplier
+	METHOD method_34248 updateSyncHandler (Lnet/minecraft/class_5916;)V
+		ARG 1 handler
+	METHOD method_34250 setPreviousCursorStack (Lnet/minecraft/class_1799;)V
+		ARG 1 stack
+	METHOD method_34252 syncState ()V
+	METHOD method_34253 updateSlot (ILnet/minecraft/class_1799;Ljava/util/function/Supplier;)V
+		ARG 1 slot
+		ARG 2 stack
+		ARG 3 copySupplier
+	METHOD method_34254 setCursorStack (Lnet/minecraft/class_1799;)V
+	METHOD method_34255 getCursorStack ()Lnet/minecraft/class_1799;
+	METHOD method_34258 updateCursorStack ()V
+	METHOD method_34259 getCursorCommandItemSlot ()Lnet/minecraft/class_5630;
 	METHOD method_7591 packQuickCraftData (II)I
 		ARG 0 quickCraftStage
 		ARG 1 buttonId

--- a/mappings/net/minecraft/screen/ScreenHandlerSyncHandler.mapping
+++ b/mappings/net/minecraft/screen/ScreenHandlerSyncHandler.mapping
@@ -1,0 +1,17 @@
+CLASS net/minecraft/class_5916 net/minecraft/screen/ScreenHandlerSyncHandler
+	METHOD method_34260 updateProperty (Lnet/minecraft/class_1703;II)V
+		ARG 1 handler
+		ARG 2 property
+		ARG 3 value
+	METHOD method_34261 updateSlot (Lnet/minecraft/class_1703;ILnet/minecraft/class_1799;)V
+		ARG 1 handler
+		ARG 2 slot
+		ARG 3 stack
+	METHOD method_34262 updateCursorStack (Lnet/minecraft/class_1703;Lnet/minecraft/class_1799;)V
+		ARG 1 handler
+		ARG 2 stack
+	METHOD method_34263 updateState (Lnet/minecraft/class_1703;Lnet/minecraft/class_2371;Lnet/minecraft/class_1799;[I)V
+		ARG 1 handler
+		ARG 2 stacks
+		ARG 3 cursorStack
+		ARG 4 properties

--- a/mappings/net/minecraft/screen/slot/Slot.mapping
+++ b/mappings/net/minecraft/screen/slot/Slot.mapping
@@ -9,6 +9,24 @@ CLASS net/minecraft/class_1735 net/minecraft/screen/slot/Slot
 		ARG 2 index
 		ARG 3 x
 		ARG 4 y
+	METHOD method_32753 takeStackRange (IILnet/minecraft/class_1657;)Lnet/minecraft/class_1799;
+		ARG 1 min
+		ARG 2 max
+		ARG 3 player
+	METHOD method_32754 canTakePartial (Lnet/minecraft/class_1657;)Z
+		ARG 1 player
+	METHOD method_32755 insertStack (Lnet/minecraft/class_1799;I)Lnet/minecraft/class_1799;
+		ARG 1 stack
+		ARG 2 count
+	METHOD method_32756 insertStack (Lnet/minecraft/class_1799;)Lnet/minecraft/class_1799;
+		ARG 1 stack
+	METHOD method_34264 tryTakeStackRange (IILnet/minecraft/class_1657;)Ljava/util/Optional;
+		ARG 1 min
+		ARG 2 max
+		ARG 3 player
+	METHOD method_34265 (Lnet/minecraft/class_1657;Lnet/minecraft/class_1799;)V
+		ARG 2 stack
+	METHOD method_34266 getIndex ()I
 	METHOD method_7667 onTakeItem (Lnet/minecraft/class_1657;Lnet/minecraft/class_1799;)V
 		ARG 1 player
 		ARG 2 stack

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -173,3 +173,10 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 		ARG 1 player
 	METHOD method_7336 changeGameMode (Lnet/minecraft/class_1934;)Z
 		ARG 1 gameMode
+	CLASS 1
+		METHOD method_34226 sendCursorStackUpdate (Lnet/minecraft/class_1799;)V
+			ARG 1 stack
+		METHOD method_34227 sendPropertyUpdate (Lnet/minecraft/class_1703;II)V
+			ARG 1 handler
+			ARG 2 property
+			ARG 3 value

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -38,6 +38,8 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	FIELD field_26353 spawnAngle F
 	FIELD field_26821 textStream Lnet/minecraft/class_5513;
 	FIELD field_28860 filterText Z
+	FIELD field_29180 screenHandlerSyncHandler Lnet/minecraft/class_5916;
+	FIELD field_29181 screenHandlerListener Lnet/minecraft/class_1712;
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/class_3218;Lcom/mojang/authlib/GameProfile;)V
 		ARG 1 server
 		ARG 2 world


### PR DESCRIPTION
There were a good number of changes to screen handlers, so I mapped them, I also cleaned up the unmapped slot methods that have been around for a while. I also finally remapped `Item.canBeStoredInItems` as the previous name was straight up wrong.

`ScreenHandlerSyncHandler` is the only new class name, and I imagine it'll be contentious.

Something that should be discussed for changing the name of `CommandItemSlot` as it's now passed by screen handlers to `ItemStack.onStackClicked` and serves as a mutable reference to the cursor stack and seems to be pretty off base.