### PR TITLE
Improve ScreenHandlerContext mappings

### DIFF
--- a/mappings/net/minecraft/screen/ScreenHandlerContext.mapping
+++ b/mappings/net/minecraft/screen/ScreenHandlerContext.mapping
@@ -8,9 +8,24 @@ CLASS net/minecraft/class_3914 net/minecraft/screen/ScreenHandlerContext
 		ARG 0 world
 		ARG 1 pos
 	METHOD method_17393 run (Ljava/util/function/BiConsumer;)V
+		COMMENT Runs a {@link BiConsumer} with this context's world and position
+		COMMENT if this context is active.
 		ARG 1 function
-	METHOD method_17395 run (Ljava/util/function/BiFunction;)Ljava/util/Optional;
-		ARG 1 function
-	METHOD method_17396 run (Ljava/util/function/BiFunction;Ljava/lang/Object;)Ljava/lang/Object;
-		ARG 1 function
+	METHOD method_17395 get (Ljava/util/function/BiFunction;)Ljava/util/Optional;
+		COMMENT Gets an optional value from this context's world and position
+		COMMENT with a {@link BiFunction} getter.
+		COMMENT
+		COMMENT @return a present {@link Optional} with the getter's return value,
+		COMMENT         or {@link Optional#empty()} if this context is empty
+		ARG 1 getter
+			COMMENT a function that gets a non-null value from this context's world and position
+	METHOD method_17396 get (Ljava/util/function/BiFunction;Ljava/lang/Object;)Ljava/lang/Object;
+		COMMENT Gets a value from this context's world and position
+		COMMENT with a {@link BiFunction} getter.
+		COMMENT
+		COMMENT @return the getter's return value if this context is active,
+		COMMENT         the default value otherwise
+		ARG 1 getter
+			COMMENT a function that gets a non-null value from this context's world and position
 		ARG 2 defaultValue
+			COMMENT a fallback default value, used if this context is empty


### PR DESCRIPTION
- Both getter methods renamed to `get` instead of `run`.
  - `run` was confusing as it's used more for getting a world value than running a function.
  - Side note: having two `run`s just taking a lambda also confused kotlinc's SAM interface conversions; this should make it nicer for Kotlin modders if JetBrains hasn't fixed it yet
- Improved documentation for `get` and `run`.
- Renamed `get`'s `function` parameter to `getter`.