### PR TITLE
Map some parts of the OpenGL state managing mechanisms

### DIFF
--- a/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
+++ b/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
@@ -210,24 +210,24 @@ CLASS net/minecraft/class_4493 com/mojang/blaze3d/platform/GlStateManager
 		ARG 0 program
 		ARG 1 maxLength
 	METHOD method_22053 disableBlend ()V
-	METHOD method_22054 deleteBuffers (I)V
+	METHOD method_22054 deleteBuffer (I)V
 		ARG 0 buffer
 	METHOD method_22056 enableBlend ()V
 	METHOD method_22058 polygonMode (II)V
 		ARG 0 face
 		ARG 1 mode
-	METHOD method_22060 deleteFramebuffers (I)V
-		ARG 0 framebuffers
+	METHOD method_22060 deleteFramebuffer (I)V
+		ARG 0 framebuffer
 	METHOD method_22062 createProgram ()I
 	METHOD method_22063 checkFramebufferStatus (I)I
 		ARG 0 target
-	METHOD method_22065 genBuffers ()I
+	METHOD method_22065 genBuffer ()I
 	METHOD method_22066 activeTextureUntracked (I)V
 		ARG 0 texture
 	METHOD method_22067 pixelStore (II)V
 		ARG 0 pname
 		ARG 1 param
-	METHOD method_22068 genFramebuffers ()I
+	METHOD method_22068 genFramebuffer ()I
 	METHOD method_22075 logicOp (I)V
 		ARG 0 op
 	METHOD method_22076 enableCull ()V
@@ -246,7 +246,7 @@ CLASS net/minecraft/class_4493 com/mojang/blaze3d/platform/GlStateManager
 		ARG 0 stencil
 	METHOD method_22606 enableVertexAttribArray (I)V
 		ARG 0 index
-	METHOD method_22607 (I)V
+	METHOD method_22607 disableVertexAttribArray (I)V
 		ARG 0 index
 	METHOD method_22609 vertexAttribPointer (IIIZIJ)V
 		ARG 0 index
@@ -276,6 +276,7 @@ CLASS net/minecraft/class_4493 com/mojang/blaze3d/platform/GlStateManager
 		ARG 1 y
 		ARG 2 width
 		ARG 3 height
+	METHOD method_31318 disableScissorTest ()V
 	METHOD method_31319 enableScissorTest ()V
 	METHOD method_31945 bufferData (IJI)V
 		ARG 0 target
@@ -286,6 +287,24 @@ CLASS net/minecraft/class_4493 com/mojang/blaze3d/platform/GlStateManager
 		ARG 1 access
 	METHOD method_31947 unmapBuffer (I)V
 		ARG 0 target
+	METHOD method_34404 bindAttribLocation (IILjava/lang/CharSequence;)V
+		ARG 0 program
+		ARG 1 index
+		ARG 2 name
+	METHOD method_34405 shaderSource (ILjava/util/List;)V
+		ARG 0 shader
+		ARG 1 strings
+	METHOD method_34406 vertexAttribIPointer (IIIIJ)V
+		ARG 0 index
+		ARG 1 size
+		ARG 2 type
+		ARG 3 stride
+		ARG 4 pointer
+	METHOD method_34407 genVertexArray ()I
+	METHOD method_34408 bindVertexArray (I)V
+		ARG 0 array
+	METHOD method_34409 deleteVertexArray (I)V
+		ARG 0 array
 	CLASS class_1017 BlendFuncState
 		FIELD field_5045 capState Lnet/minecraft/class_4493$class_1018;
 		FIELD field_5046 dstFactorAlpha I

--- a/mappings/net/minecraft/client/render/BufferRenderer.mapping
+++ b/mappings/net/minecraft/client/render/BufferRenderer.mapping
@@ -1,3 +1,8 @@
 CLASS net/minecraft/class_286 net/minecraft/client/render/BufferRenderer
+	FIELD field_29331 currentVertexArrayObject I
+	FIELD field_29332 currentVertexBufferObject I
+	FIELD field_29333 currentElementBufferObject I
 	METHOD method_1309 draw (Lnet/minecraft/class_287;)V
 		ARG 0 bufferBuilder
+	METHOD method_34420 unbindAll ()V
+	METHOD method_34423 unbindElementBuffer ()V

--- a/mappings/net/minecraft/client/util/math/MatrixStack.mapping
+++ b/mappings/net/minecraft/client/util/math/MatrixStack.mapping
@@ -16,6 +16,7 @@ CLASS net/minecraft/class_4587 net/minecraft/client/util/math/MatrixStack
 	METHOD method_22909 pop ()V
 	METHOD method_22911 isEmpty ()Z
 	METHOD method_23760 peek ()Lnet/minecraft/class_4587$class_4665;
+	METHOD method_34426 loadIdentity ()V
 	CLASS class_4665 Entry
 		FIELD field_21327 modelMatrix Lnet/minecraft/class_1159;
 		FIELD field_21328 normalMatrix Lnet/minecraft/class_4581;


### PR DESCRIPTION
This also changes some plural names to singular where it makes sense (as the LWJGL method handles creating the buffers, so they only ever deal with single OpenGL objects).
