### PR TITLE
Make BossBar names more consistent

### DIFF
--- a/mappings/net/minecraft/entity/boss/BossBar.mapping
+++ b/mappings/net/minecraft/entity/boss/BossBar.mapping
@@ -17,7 +17,7 @@ CLASS net/minecraft/class_1259 net/minecraft/entity/boss/BossBar
 	METHOD method_5407 getUuid ()Ljava/util/UUID;
 	METHOD method_5408 setPercent (F)V
 		ARG 1 percentage
-	METHOD method_5409 setOverlay (Lnet/minecraft/class_1259$class_1261;)V
+	METHOD method_5409 setStyle (Lnet/minecraft/class_1259$class_1261;)V
 		ARG 1 style
 	METHOD method_5410 setDragonMusic (Z)Lnet/minecraft/class_1259;
 		ARG 1 dragonMusic
@@ -27,7 +27,7 @@ CLASS net/minecraft/class_1259 net/minecraft/entity/boss/BossBar
 	METHOD method_5413 setName (Lnet/minecraft/class_2561;)V
 		ARG 1 name
 	METHOD method_5414 getName ()Lnet/minecraft/class_2561;
-	METHOD method_5415 getOverlay ()Lnet/minecraft/class_1259$class_1261;
+	METHOD method_5415 getStyle ()Lnet/minecraft/class_1259$class_1261;
 	METHOD method_5416 setColor (Lnet/minecraft/class_1259$class_1260;)V
 		ARG 1 color
 	METHOD method_5417 shouldDarkenSky ()Z

--- a/mappings/net/minecraft/network/packet/s2c/play/BossBarS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/BossBarS2CPacket.mapping
@@ -12,7 +12,7 @@ CLASS net/minecraft/class_2629 net/minecraft/network/packet/s2c/play/BossBarS2CP
 	METHOD method_34090 remove (Ljava/util/UUID;)Lnet/minecraft/class_2629;
 		ARG 0 uuid
 	METHOD method_34091 accept (Lnet/minecraft/class_2629$class_5881;)V
-		ARG 1 visitor
+		ARG 1 consumer
 	METHOD method_34093 getRemoveAction ()Lnet/minecraft/class_2629$class_5882;
 	METHOD method_34094 updateProgress (Lnet/minecraft/class_1259;)Lnet/minecraft/class_2629;
 		ARG 0 bar
@@ -30,7 +30,7 @@ CLASS net/minecraft/class_2629 net/minecraft/network/packet/s2c/play/BossBarS2CP
 		FIELD field_29100 name Lnet/minecraft/class_2561;
 		FIELD field_29101 percent F
 		FIELD field_29102 color Lnet/minecraft/class_1259$class_1260;
-		FIELD field_29103 overlay Lnet/minecraft/class_1259$class_1261;
+		FIELD field_29103 style Lnet/minecraft/class_1259$class_1261;
 		FIELD field_29104 darkenSky Z
 		FIELD field_29105 dragonMusic Z
 		FIELD field_29106 thickenFog Z
@@ -47,7 +47,7 @@ CLASS net/minecraft/class_2629 net/minecraft/network/packet/s2c/play/BossBarS2CP
 		METHOD method_34101 updateStyle (Ljava/util/UUID;Lnet/minecraft/class_1259$class_1260;Lnet/minecraft/class_1259$class_1261;)V
 			ARG 1 id
 			ARG 2 color
-			ARG 3 overlay
+			ARG 3 style
 		METHOD method_34102 updateName (Ljava/util/UUID;Lnet/minecraft/class_2561;)V
 			ARG 1 uuid
 			ARG 2 name
@@ -56,7 +56,7 @@ CLASS net/minecraft/class_2629 net/minecraft/network/packet/s2c/play/BossBarS2CP
 			ARG 2 name
 			ARG 3 percent
 			ARG 4 color
-			ARG 5 overlay
+			ARG 5 style
 			ARG 6 darkenSky
 			ARG 7 dragonMusic
 			ARG 8 thickenFog
@@ -112,6 +112,9 @@ CLASS net/minecraft/class_2629 net/minecraft/network/packet/s2c/play/BossBarS2CP
 			ARG 3 thickenFog
 	CLASS class_5887 UpdateStyleAction
 		FIELD field_29120 color Lnet/minecraft/class_1259$class_1260;
-		FIELD field_29121 overlay Lnet/minecraft/class_1259$class_1261;
+		FIELD field_29121 style Lnet/minecraft/class_1259$class_1261;
+		METHOD <init> (Lnet/minecraft/class_1259$class_1260;Lnet/minecraft/class_1259$class_1261;)V
+			ARG 1 color
+			ARG 2 style
 		METHOD <init> (Lnet/minecraft/class_2540;)V
 			ARG 1 buf


### PR DESCRIPTION
Renamed BossBar's `Overlay` to `Style`.