### PR TITLE
Massive networking renames

### DIFF
--- a/mappings/net/minecraft/client/network/ClientLoginNetworkHandler.mapping
+++ b/mappings/net/minecraft/client/network/ClientLoginNetworkHandler.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_635 net/minecraft/client/network/ClientLoginNetworkHandler
-	FIELD field_3706 parentGui Lnet/minecraft/class_437;
+	FIELD field_3706 parentScreen Lnet/minecraft/class_437;
 	FIELD field_3707 connection Lnet/minecraft/class_2535;
 	FIELD field_3708 client Lnet/minecraft/class_310;
 	FIELD field_3709 profile Lcom/mojang/authlib/GameProfile;

--- a/mappings/net/minecraft/client/network/ServerAddress.mapping
+++ b/mappings/net/minecraft/client/network/ServerAddress.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_639 net/minecraft/network/ServerAddress
+CLASS net/minecraft/class_639 net/minecraft/client/network/ServerAddress
 	FIELD field_3734 address Ljava/lang/String;
 	FIELD field_3735 port I
 	METHOD <init> (Ljava/lang/String;I)V

--- a/mappings/net/minecraft/client/network/ServerInfo.mapping
+++ b/mappings/net/minecraft/client/network/ServerInfo.mapping
@@ -1,8 +1,11 @@
 CLASS net/minecraft/class_642 net/minecraft/client/network/ServerInfo
+	COMMENT The information of a server entry in the list of servers available in
+	COMMENT the multiplayer screen from the menu. The list of these servers is
+	COMMENT stored in the {@code servers.dat} file within the client game directory.
 	FIELD field_3752 name Ljava/lang/String;
 	FIELD field_3753 playerCountLabel Lnet/minecraft/class_2561;
 	FIELD field_3754 online Z
-	FIELD field_3755 resourcePackState Lnet/minecraft/class_642$class_643;
+	FIELD field_3755 resourcePackPolicy Lnet/minecraft/class_642$class_643;
 	FIELD field_3756 protocolVersion I
 	FIELD field_3757 label Lnet/minecraft/class_2561;
 	FIELD field_3758 ping J
@@ -17,17 +20,35 @@ CLASS net/minecraft/class_642 net/minecraft/client/network/ServerInfo
 		ARG 3 local
 	METHOD method_2989 setIcon (Ljava/lang/String;)V
 		ARG 1 icon
-	METHOD method_2990 getResourcePack ()Lnet/minecraft/class_642$class_643;
+	METHOD method_2990 getResourcePackPolicy ()Lnet/minecraft/class_642$class_643;
+		COMMENT Returns the policy on resource packs sent by this server.
 	METHOD method_2991 getIcon ()Ljava/lang/String;
-	METHOD method_2992 serialize ()Lnet/minecraft/class_2487;
-	METHOD method_2993 deserialize (Lnet/minecraft/class_2487;)Lnet/minecraft/class_642;
-		ARG 0 tag
+	METHOD method_2992 toNbt ()Lnet/minecraft/class_2487;
+	METHOD method_2993 fromNbt (Lnet/minecraft/class_2487;)Lnet/minecraft/class_642;
+		ARG 0 root
 	METHOD method_2994 isLocal ()Z
-	METHOD method_2995 setResourcePackState (Lnet/minecraft/class_642$class_643;)V
+	METHOD method_2995 setResourcePackPolicy (Lnet/minecraft/class_642$class_643;)V
+		COMMENT Sets the resource pack policy on this server.
+		COMMENT
+		COMMENT <p>This is called when a user has responded to the prompt on whether to
+		COMMENT accept server resource packs from this server in the future.
+		ARG 1 policy
 	METHOD method_2996 copyFrom (Lnet/minecraft/class_642;)V
 		ARG 1 serverInfo
-	CLASS class_643 ResourcePackState
+	CLASS class_643 ResourcePackPolicy
+		COMMENT The policy of the client when this server sends a {@linkplain
+		COMMENT net.minecraft.network.packet.s2c.play.ResourcePackSendS2CPacket server
+		COMMENT resource pack}.
+		COMMENT
+		COMMENT @see ServerInfo#getResourcePackPolicy()
+		FIELD field_3764 DISABLED Lnet/minecraft/class_642$class_643;
+			COMMENT Always rejects the resource pack.
 		FIELD field_3765 name Lnet/minecraft/class_2561;
+		FIELD field_3767 PROMPT Lnet/minecraft/class_642$class_643;
+			COMMENT Opens a screen on whether to always accept or reject resource packs from
+			COMMENT this server for the current pack or any pack in the future.
+		FIELD field_3768 ENABLED Lnet/minecraft/class_642$class_643;
+			COMMENT Always accepts the resource pack and starts downloading it.
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
 			ARG 3 name
 		METHOD method_2997 getName ()Lnet/minecraft/class_2561;

--- a/mappings/net/minecraft/client/util/NetworkUtils.mapping
+++ b/mappings/net/minecraft/client/util/NetworkUtils.mapping
@@ -1,5 +1,10 @@
 CLASS net/minecraft/class_3521 net/minecraft/client/util/NetworkUtils
-	FIELD field_15664 downloadExecutor Lcom/google/common/util/concurrent/ListeningExecutorService;
+	COMMENT A few client-side networking utilities.
+	COMMENT
+	COMMENT @implNote This is not marked as client-only because it's used by the
+	COMMENT {@code /publish} command, which is only available to integrated servers
+	COMMENT yet was retained by proguard.
+	FIELD field_15664 DOWNLOAD_EXECUTOR Lcom/google/common/util/concurrent/ListeningExecutorService;
 	FIELD field_15665 LOGGER Lorg/apache/logging/log4j/Logger;
-	METHOD method_15301 download (Ljava/io/File;Ljava/lang/String;Ljava/util/Map;ILnet/minecraft/class_3536;Ljava/net/Proxy;)Ljava/util/concurrent/CompletableFuture;
+	METHOD method_15301 downloadResourcePack (Ljava/io/File;Ljava/lang/String;Ljava/util/Map;ILnet/minecraft/class_3536;Ljava/net/Proxy;)Ljava/util/concurrent/CompletableFuture;
 	METHOD method_15302 findLocalPort ()I

--- a/mappings/net/minecraft/client/util/NetworkUtils.mapping
+++ b/mappings/net/minecraft/client/util/NetworkUtils.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_3521 net/minecraft/client/util/NetworkUtils
 	COMMENT @implNote This is not marked as client-only because it's used by the
 	COMMENT {@code /publish} command, which is only available to integrated servers
 	COMMENT yet was retained by proguard.
-	FIELD field_15664 DOWNLOAD_EXECUTOR Lcom/google/common/util/concurrent/ListeningExecutorService;
+	FIELD field_15664 EXECUTOR Lcom/google/common/util/concurrent/ListeningExecutorService;
 	FIELD field_15665 LOGGER Lorg/apache/logging/log4j/Logger;
 	METHOD method_15301 downloadResourcePack (Ljava/io/File;Ljava/lang/String;Ljava/util/Map;ILnet/minecraft/class_3536;Ljava/net/Proxy;)Ljava/util/concurrent/CompletableFuture;
 	METHOD method_15302 findLocalPort ()I

--- a/mappings/net/minecraft/network/ClientConnection.mapping
+++ b/mappings/net/minecraft/network/ClientConnection.mapping
@@ -1,27 +1,42 @@
 CLASS net/minecraft/class_2535 net/minecraft/network/ClientConnection
-	FIELD field_11639 MARKER_NETWORK_PACKETS Lorg/apache/logging/log4j/Marker;
+	COMMENT A connection backed by a netty channel. It can be one to a client on the
+	COMMENT server or one to a server on a client.
+	FIELD field_11639 NETWORK_PACKETS_MARKER Lorg/apache/logging/log4j/Marker;
 	FIELD field_11640 errored Z
-	FIELD field_11641 MARKER_NETWORK Lorg/apache/logging/log4j/Marker;
+	FIELD field_11641 NETWORK_MARKER Lorg/apache/logging/log4j/Marker;
 	FIELD field_11642 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_11643 side Lnet/minecraft/class_2598;
+		COMMENT The side this connection is to.
 	FIELD field_11644 packetQueue Ljava/util/Queue;
 	FIELD field_11645 address Ljava/net/SocketAddress;
 	FIELD field_11646 disconnected Z
 	FIELD field_11647 encrypted Z
-	FIELD field_11648 ATTR_KEY_PROTOCOL Lio/netty/util/AttributeKey;
-	FIELD field_11649 CLIENT_IO_GROUP_LOCAL Lnet/minecraft/class_3528;
+	FIELD field_11648 PROTOCOL_ATTRIBUTE_KEY Lio/netty/util/AttributeKey;
+		COMMENT The attribute key for the current network state of the backing netty
+		COMMENT channel.
+	FIELD field_11649 LOCAL_CLIENT_IO_GROUP Lnet/minecraft/class_3528;
 	FIELD field_11650 CLIENT_IO_GROUP Lnet/minecraft/class_3528;
 	FIELD field_11651 channel Lio/netty/channel/Channel;
 	FIELD field_11652 packetListener Lnet/minecraft/class_2547;
-	FIELD field_11653 avgPacketsSent F
-	FIELD field_11654 avgPacketsReceived F
+	FIELD field_11653 averagePacketsSent F
+	FIELD field_11654 averagePacketsReceived F
 	FIELD field_11655 ticks I
 	FIELD field_11656 packetsSentCounter I
-	FIELD field_11657 CLIENT_IO_GROUP_EPOLL Lnet/minecraft/class_3528;
+	FIELD field_11657 EPOLL_CLIENT_IO_GROUP Lnet/minecraft/class_3528;
 	FIELD field_11658 packetsReceivedCounter I
 	FIELD field_11660 disconnectReason Lnet/minecraft/class_2561;
 	METHOD <init> (Lnet/minecraft/class_2598;)V
 		ARG 1 side
+	METHOD channelActive (Lio/netty/channel/ChannelHandlerContext;)V
+		ARG 1 context
+	METHOD channelInactive (Lio/netty/channel/ChannelHandlerContext;)V
+		ARG 1 context
+	METHOD channelRead0 (Lio/netty/channel/ChannelHandlerContext;Ljava/lang/Object;)V
+		ARG 1 context
+		ARG 2 packet
+	METHOD exceptionCaught (Lio/netty/channel/ChannelHandlerContext;Ljava/lang/Throwable;)V
+		ARG 1 context
+		ARG 2 ex
 	METHOD method_10743 send (Lnet/minecraft/class_2596;)V
 		ARG 1 packet
 	METHOD method_10744 getPacketListener ()Lnet/minecraft/class_2547;
@@ -62,6 +77,8 @@ CLASS net/minecraft/class_2535 net/minecraft/network/ClientConnection
 	METHOD method_10771 isEncrypted ()Z
 	METHOD method_10772 hasChannel ()Z
 	METHOD method_30615 updateStats ()V
+	METHOD method_32306 getState ()Lnet/minecraft/class_2539;
+		COMMENT Returns the current network state of this connection.
 	CLASS class_2536 QueuedPacket
 		FIELD field_11661 packet Lnet/minecraft/class_2596;
 		FIELD field_11662 callback Lio/netty/util/concurrent/GenericFutureListener;

--- a/mappings/net/minecraft/network/ClientConnection.mapping
+++ b/mappings/net/minecraft/network/ClientConnection.mapping
@@ -67,6 +67,11 @@ CLASS net/minecraft/class_2535 net/minecraft/network/ClientConnection
 		ARG 1 compressionThreshold
 	METHOD method_10762 getAveragePacketsReceived ()F
 	METHOD method_10763 setPacketListener (Lnet/minecraft/class_2547;)V
+		COMMENT Sets the packet listener that will handle oncoming packets, including
+		COMMENT ones that are not yet handled by the current packet listener.
+		COMMENT
+		COMMENT @apiNote This may be called from the {@linkplain #packetListener} stored
+		COMMENT in this connection.
 		ARG 1 listener
 	METHOD method_10764 sendImmediately (Lnet/minecraft/class_2596;Lio/netty/util/concurrent/GenericFutureListener;)V
 		ARG 1 packet

--- a/mappings/net/minecraft/network/OffThreadException.mapping
+++ b/mappings/net/minecraft/network/OffThreadException.mapping
@@ -1,2 +1,11 @@
 CLASS net/minecraft/class_2987 net/minecraft/network/OffThreadException
+	COMMENT An exception thrown on netty's event loop to quit handling of one packet,
+	COMMENT usually as it is scheduled to be handled on the game engine thread.
+	COMMENT
+	COMMENT <p>This is a {@linkplain #INSTANCE singleton}. It ignores stack traces
+	COMMENT in order to be efficient.
+	COMMENT
+	COMMENT @see NetworkThreadUtils
+	COMMENT @see ClientConnection#channelRead0
 	FIELD field_13400 INSTANCE Lnet/minecraft/class_2987;
+		COMMENT The singleton instance, to reduce object allocations.

--- a/mappings/net/minecraft/network/PacketByteBuf.mapping
+++ b/mappings/net/minecraft/network/PacketByteBuf.mapping
@@ -51,7 +51,7 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 	COMMENT  <td>{@link UUID}</td><td>{@link #readUuid()}</td><td>{@link #writeUuid(UUID)}</td>
 	COMMENT </tr>
 	COMMENT <tr>
-	COMMENT  <td>{@link CompoundTag}</td><td>{@link #readCompoundTag()}</td><td>{@link #writeCompoundTag(CompoundTag)}</td>
+	COMMENT  <td>{@link NbtCompound}</td><td>{@link #readCompound()}</td><td>{@link #writeCompound(NbtCompound)}</td>
 	COMMENT </tr>
 	COMMENT <tr>
 	COMMENT  <td>{@link ItemStack}</td><td>{@link #readItemStack()}</td><td>{@link #writeItemStack(ItemStack)}</td>
@@ -148,7 +148,7 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 		COMMENT @see #readItemStack()
 		ARG 1 stack
 			COMMENT the stack to write
-	METHOD method_10794 writeCompoundTag (Lnet/minecraft/class_2487;)Lnet/minecraft/class_2540;
+	METHOD method_10794 writeCompound (Lnet/minecraft/class_2487;)Lnet/minecraft/class_2540;
 		COMMENT Writes an NBT compound to this buf. The binary representation of NBT is
 		COMMENT handled by {@link net.minecraft.nbt.NbtIo}. If {@code compound} is {@code
 		COMMENT null}, it is treated as an END tag.
@@ -156,9 +156,9 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 		COMMENT @return this buf, for chaining
 		COMMENT @throws io.netty.handler.codec.EncoderException if the NBT cannot be
 		COMMENT written
-		COMMENT @see #readCompoundTag()
-		COMMENT @see #readUnlimitedCompoundTag()
-		COMMENT @see #readCompoundTag(PositionTracker)
+		COMMENT @see #readCompound()
+		COMMENT @see #readUnlimitedCompound()
+		COMMENT @see #readCompound(NbtTagSizeTracker)
 		ARG 1 compound
 			COMMENT the compound to write
 	METHOD method_10795 readByteArray ()[B
@@ -185,7 +185,7 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 		COMMENT @see #readUuid()
 		ARG 1 uuid
 			COMMENT the UUID to write
-	METHOD method_10798 readCompoundTag ()Lnet/minecraft/class_2487;
+	METHOD method_10798 readCompound ()Lnet/minecraft/class_2487;
 		COMMENT Reads an NBT compound from this buf. The binary representation of NBT is
 		COMMENT handled by {@link net.minecraft.nbt.NbtIo}. If an END tag is encountered,
 		COMMENT this method returns {@code null}. The compound can have a maximum size of
@@ -194,9 +194,9 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 		COMMENT @return the read compound, may be {@code null}
 		COMMENT @throws io.netty.handler.codec.EncoderException if the NBT cannot be read
 		COMMENT @throws RuntimeException if the compound exceeds the allowed maximum size
-		COMMENT @see #writeCompoundTag(CompoundTag)
-		COMMENT @see #readUnlimitedCompoundTag()
-		COMMENT @see #readCompoundTag(PositionTracker)
+		COMMENT @see #writeCompound(NbtCompound)
+		COMMENT @see #readUnlimitedCompound()
+		COMMENT @see #readCompound(NbtTagSizeTracker)
 	METHOD method_10799 readIntArray (I)[I
 		COMMENT Reads an array of primitive ints from this buf. The array first has a
 		COMMENT var int indicating its length, followed by the var int entries. The array
@@ -465,7 +465,7 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 			COMMENT the codec to encode the object
 		ARG 2 object
 			COMMENT the object to write to this buf
-	METHOD method_30616 readCompoundTag (Lnet/minecraft/class_2505;)Lnet/minecraft/class_2487;
+	METHOD method_30616 readCompound (Lnet/minecraft/class_2505;)Lnet/minecraft/class_2487;
 		COMMENT Reads an NBT compound from this buf. The binary representation of NBT is
 		COMMENT handled by {@link net.minecraft.nbt.NbtIo}. If an END tag is encountered,
 		COMMENT this method returns {@code null}. The compound can have a maximum size
@@ -474,11 +474,11 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 		COMMENT @return the read compound, may be {@code null}
 		COMMENT @throws io.netty.handler.codec.EncoderException if the NBT cannot be read
 		COMMENT @throws RuntimeException if the compound exceeds the allowed maximum size
-		COMMENT @see #writeCompoundTag(CompoundTag)
-		COMMENT @see #readCompoundTag()
-		COMMENT @see #readUnlimitedCompoundTag()
+		COMMENT @see #writeCompound(NbtCompound)
+		COMMENT @see #readCompound()
+		COMMENT @see #readUnlimitedCompound()
 		ARG 1 sizeTracker
-	METHOD method_30617 readUnlimitedCompoundTag ()Lnet/minecraft/class_2487;
+	METHOD method_30617 readUnlimitedCompound ()Lnet/minecraft/class_2487;
 		COMMENT Reads an NBT compound from this buf. The binary representation of NBT is
 		COMMENT handled by {@link net.minecraft.nbt.NbtIo}. If an END tag is encountered,
 		COMMENT this method returns {@code null}. The compound does not have a size limit.
@@ -488,9 +488,9 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 		COMMENT
 		COMMENT @return the read compound, may be {@code null}
 		COMMENT @throws io.netty.handler.codec.EncoderException if the NBT cannot be read
-		COMMENT @see #writeCompoundTag(CompoundTag)
-		COMMENT @see #readCompoundTag()
-		COMMENT @see #readCompoundTag(PositionTracker)
+		COMMENT @see #writeCompound(NbtCompound)
+		COMMENT @see #readCompound()
+		COMMENT @see #readCompound(NbtTagSizeTracker)
 	METHOD method_33134 readLongArray ()[J
 		COMMENT Reads an array of primitive longs from this buf. The array first has a
 		COMMENT var int indicating its length, followed by the regular long (not var

--- a/mappings/net/minecraft/network/RateLimitedConnection.mapping
+++ b/mappings/net/minecraft/network/RateLimitedConnection.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_5472 net/minecraft/network/RateLimitedConnection
+	COMMENT A connection that disconnects from the backing netty channel if too
+	COMMENT many packets are received.
 	FIELD field_26342 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_26343 RATE_LIMIT_EXCEEDED_MESSAGE Lnet/minecraft/class_2561;
 	FIELD field_26344 rateLimit I

--- a/mappings/net/minecraft/network/encryption/NetworkEncryptionUtils.mapping
+++ b/mappings/net/minecraft/network/encryption/NetworkEncryptionUtils.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3515 net/minecraft/network/NetworkEncryptionUtils
+CLASS net/minecraft/class_3515 net/minecraft/network/encryption/NetworkEncryptionUtils
 	METHOD method_15234 decryptSecretKey (Ljava/security/PrivateKey;[B)Ljavax/crypto/SecretKey;
 		ARG 0 privateKey
 		ARG 1 encryptedSecretKey

--- a/mappings/net/minecraft/network/listener/PacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/PacketListener.mapping
@@ -1,4 +1,18 @@
 CLASS net/minecraft/class_2547 net/minecraft/network/listener/PacketListener
+	COMMENT A packet listener listens to packets on a {@linkplain ClientConnection
+	COMMENT connection}.
+	COMMENT
+	COMMENT <p>Its listener methods will be called on the netty event loop than the
+	COMMENT client or server game engine threads.
 	METHOD method_10839 onDisconnected (Lnet/minecraft/class_2561;)V
+		COMMENT Called when the connection this listener listens to has disconnected.
+		COMMENT Can be used to display the disconnection reason.
 		ARG 1 reason
+			COMMENT the reason of disconnection; may be a generic message
 	METHOD method_2872 getConnection ()Lnet/minecraft/class_2535;
+		COMMENT Returns the connection this packet listener intends to listening to.
+		COMMENT
+		COMMENT @apiNote The returned connection may or may not have this listener as
+		COMMENT its current packet listener.
+		COMMENT
+		COMMENT @see ClientConnection#getPacketListener()

--- a/mappings/net/minecraft/network/listener/PacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/PacketListener.mapping
@@ -10,7 +10,7 @@ CLASS net/minecraft/class_2547 net/minecraft/network/listener/PacketListener
 		ARG 1 reason
 			COMMENT the reason of disconnection; may be a generic message
 	METHOD method_2872 getConnection ()Lnet/minecraft/class_2535;
-		COMMENT Returns the connection this packet listener intends to listening to.
+		COMMENT Returns the connection this packet listener intends to listen to.
 		COMMENT
 		COMMENT @apiNote The returned connection may or may not have this listener as
 		COMMENT its current packet listener.

--- a/mappings/net/minecraft/server/network/IntegratedServerHandshakeNetworkHandler.mapping
+++ b/mappings/net/minecraft/server/network/IntegratedServerHandshakeNetworkHandler.mapping
@@ -1,6 +1,0 @@
-CLASS net/minecraft/class_3240 net/minecraft/server/network/IntegratedServerHandshakeNetworkHandler
-	FIELD field_14103 connection Lnet/minecraft/class_2535;
-	FIELD field_14104 server Lnet/minecraft/server/MinecraftServer;
-	METHOD <init> (Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/class_2535;)V
-		ARG 1 server
-		ARG 2 connection

--- a/mappings/net/minecraft/server/network/LocalServerHandshakeNetworkHandler.mapping
+++ b/mappings/net/minecraft/server/network/LocalServerHandshakeNetworkHandler.mapping
@@ -1,0 +1,13 @@
+CLASS net/minecraft/class_3240 net/minecraft/server/network/LocalServerHandshakeNetworkHandler
+	COMMENT A server handshake network handler that exclusively handles local
+	COMMENT connections.
+	COMMENT
+	COMMENT <p>A local connection is one between a Minecraft client and the
+	COMMENT Integrated Server it is running.
+	COMMENT
+	COMMENT @see net.minecraft.server.ServerNetworkIo#bindLocal()
+	FIELD field_14103 connection Lnet/minecraft/class_2535;
+	FIELD field_14104 server Lnet/minecraft/server/MinecraftServer;
+	METHOD <init> (Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/class_2535;)V
+		ARG 1 server
+		ARG 2 connection

--- a/mappings/net/minecraft/server/network/ServerLoginNetworkHandler.mapping
+++ b/mappings/net/minecraft/server/network/ServerLoginNetworkHandler.mapping
@@ -3,6 +3,14 @@ CLASS net/minecraft/class_3248 net/minecraft/server/network/ServerLoginNetworkHa
 	COMMENT
 	COMMENT <p>It listens to packets on the netty event loop and is ticked on the
 	COMMENT server thread simultaneously.
+	COMMENT
+	COMMENT @implSpec The vanilla implementation is created by a handshake network
+	COMMENT handler. It first receives a hello packet from the client. If it's in
+	COMMENT online mode, it goes through an additional authentication process. Then
+	COMMENT it optionally sends a network compression packet next. Finally, when it
+	COMMENT can accept the player (no player UUID conflicts), it will accept the
+	COMMENT player by sending a login success packet and then transitions the
+	COMMENT connection's packet listener to a server play network handler.
 	FIELD field_14156 loginTicks I
 	FIELD field_14157 NEXT_AUTHENTICATOR_THREAD_ID Ljava/util/concurrent/atomic/AtomicInteger;
 	FIELD field_14158 connection Lnet/minecraft/class_2535;

--- a/mappings/net/minecraft/server/network/ServerLoginNetworkHandler.mapping
+++ b/mappings/net/minecraft/server/network/ServerLoginNetworkHandler.mapping
@@ -1,9 +1,18 @@
 CLASS net/minecraft/class_3248 net/minecraft/server/network/ServerLoginNetworkHandler
+	COMMENT The server login network handler.
+	COMMENT
+	COMMENT <p>It listens to packets on the netty event loop and is ticked on the
+	COMMENT server thread simultaneously.
 	FIELD field_14156 loginTicks I
-	FIELD field_14157 authenticatorThreadId Ljava/util/concurrent/atomic/AtomicInteger;
+	FIELD field_14157 NEXT_AUTHENTICATOR_THREAD_ID Ljava/util/concurrent/atomic/AtomicInteger;
 	FIELD field_14158 connection Lnet/minecraft/class_2535;
 	FIELD field_14160 profile Lcom/mojang/authlib/GameProfile;
-	FIELD field_14161 player Lnet/minecraft/class_3222;
+	FIELD field_14161 delayedPlayer Lnet/minecraft/class_3222;
+		COMMENT The delayed player, waiting to join the server once the existing player
+		COMMENT with the same UUID is gone.
+		COMMENT
+		COMMENT <p>This will only be non-{@code null} if the state is delay-accept, and is reset
+		COMMENT to {@code null} once the player is accepted.
 	FIELD field_14162 server Lnet/minecraft/server/MinecraftServer;
 	FIELD field_14163 state Lnet/minecraft/class_3248$class_3249;
 	FIELD field_14164 RANDOM Ljava/util/Random;
@@ -19,7 +28,22 @@ CLASS net/minecraft/class_3248 net/minecraft/server/network/ServerLoginNetworkHa
 		ARG 1 reason
 	METHOD method_14383 getConnectionInfo ()Ljava/lang/String;
 	METHOD method_14384 acceptPlayer ()V
+		COMMENT Creates the player to be added to the server and adds it to the server.
+		COMMENT
+		COMMENT <p>If a player with the same UUID is in the world, it will create the
+		COMMENT player and transition to the delay accept state.
+		COMMENT
+		COMMENT @apiNote This method should only be called on the server thread.
 	METHOD method_18785 tick ()V
+		COMMENT Ticks this login network handler.
+		COMMENT
+		COMMENT <p>This accepts the player to the server if ready. If the state is delay
+		COMMENT accept, it checks if the old player with the same UUID is gone and
+		COMMENT admits the player.
+		COMMENT
+		COMMENT @apiNote This should only be called on the server thread.
+	METHOD method_33800 addToServer (Lnet/minecraft/class_3222;)V
+		ARG 1 player
 	CLASS 1
 		METHOD method_14386 getClientAddress ()Ljava/net/InetAddress;
 	CLASS class_3249 State


### PR DESCRIPTION
Closes #1321, fixes a few legacy names, also some stuff from #2174
Moved ServerAddress to client package (as it's client only)
Moved NetworkEncryptionUtils to the encryption package
Fixed some javadoc problems and perform associated renames from nbt rename

Signed-off-by: liach <liach@users.noreply.github.com>