### PR TITLE
RenderPhase and RenderLayer Mappings

### DIFF
--- a/mappings/net/minecraft/client/render/RenderLayer.mapping
+++ b/mappings/net/minecraft/client/render/RenderLayer.mapping
@@ -7,6 +7,24 @@ CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 	FIELD field_21850 optionalThis Ljava/util/Optional;
 	FIELD field_25487 DIRECT_GLINT Lnet/minecraft/class_1921;
 	FIELD field_25488 DIRECT_ENTITY_GLINT Lnet/minecraft/class_1921;
+	FIELD field_29622 ARMOR_CUTOUT_NO_CULL Ljava/util/function/Function;
+	FIELD field_29623 ENTITY_SOLID Ljava/util/function/Function;
+	FIELD field_29624 ENTITY_CUTOUT Ljava/util/function/Function;
+	FIELD field_29625 ENTITY_CUTOUT_NO_CULL Ljava/util/function/BiFunction;
+	FIELD field_29626 ENTITY_CUTOUT_NO_CULL_Z_OFFSET Ljava/util/function/BiFunction;
+	FIELD field_29627 ITEM_ENTITY_TRANSLUCENT_CULL Ljava/util/function/Function;
+	FIELD field_29628 ENTITY_TRANSLUCENT_CULL Ljava/util/function/Function;
+	FIELD field_29629 ENTITY_TRANSLUCENT Ljava/util/function/BiFunction;
+	FIELD field_29630 ENTITY_SMOOTH_CUTOUT Ljava/util/function/Function;
+	FIELD field_29631 BEACON_BEAM Ljava/util/function/BiFunction;
+	FIELD field_29632 ENTITY_DECAL Ljava/util/function/Function;
+	FIELD field_29633 ENTITY_NO_OUTLINE Ljava/util/function/Function;
+	FIELD field_29634 ENTITY_SHADOW Ljava/util/function/Function;
+	FIELD field_29635 ENTITY_ALPHA Ljava/util/function/Function;
+	FIELD field_29636 EYES Ljava/util/function/Function;
+	FIELD field_29637 CRUMBLING Ljava/util/function/Function;
+	FIELD field_29638 TEXT Ljava/util/function/Function;
+	FIELD field_29639 TEXT_SEE_THROUGH Ljava/util/function/Function;
 	METHOD <init> (Ljava/lang/String;Lnet/minecraft/class_293;Lnet/minecraft/class_293$class_5596;IZZLjava/lang/Runnable;Ljava/lang/Runnable;)V
 		ARG 1 name
 		ARG 2 vertexFormat
@@ -112,6 +130,48 @@ CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 	METHOD method_29707 getDirectEntityGlint ()Lnet/minecraft/class_1921;
 	METHOD method_29996 getTripwirePhaseData ()Lnet/minecraft/class_1921$class_4688;
 	METHOD method_29997 getTripwire ()Lnet/minecraft/class_1921;
+	METHOD method_34569 of (Lnet/minecraft/class_4668$class_5942;)Lnet/minecraft/class_1921$class_4688;
+		ARG 0 shader
+	METHOD method_34822 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
+		ARG 0 texture
+	METHOD method_34823 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
+		ARG 0 texture
+	METHOD method_34824 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
+		ARG 0 texture
+	METHOD method_34825 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
+		ARG 0 texture
+	METHOD method_34826 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
+		ARG 0 texture
+	METHOD method_34827 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
+		ARG 0 texture
+	METHOD method_34829 (Lnet/minecraft/class_2960;Ljava/lang/Boolean;)Lnet/minecraft/class_1921;
+		ARG 0 texture
+		ARG 1 affectsOutline
+	METHOD method_34830 (Lnet/minecraft/class_2960;Ljava/lang/Boolean;)Lnet/minecraft/class_1921;
+		ARG 0 texture
+		ARG 1 affectsOutline
+	METHOD method_34831 (Lnet/minecraft/class_2960;Ljava/lang/Boolean;)Lnet/minecraft/class_1921;
+		ARG 0 texture
+		ARG 1 affectsOutline
+	METHOD method_34832 (Lnet/minecraft/class_2960;Ljava/lang/Boolean;)Lnet/minecraft/class_1921;
+		ARG 0 texture
+		ARG 1 affectsOutline
+	METHOD method_34833 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
+		ARG 0 texture
+	METHOD method_34834 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
+		ARG 0 texture
+	METHOD method_34835 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
+		ARG 0 texture
+	METHOD method_34836 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
+		ARG 0 texture
+	METHOD method_34837 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
+		ARG 0 texture
+	METHOD method_34838 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
+		ARG 0 texture
+	METHOD method_34839 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
+		ARG 0 texture
+	METHOD method_34840 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
+		ARG 0 texture
 	CLASS class_4687 MultiPhase
 		FIELD field_21403 phases Lnet/minecraft/class_1921$class_4688;
 		FIELD field_21697 affectedOutline Ljava/util/Optional;
@@ -149,6 +209,8 @@ CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 			FIELD field_21435 texturing Lnet/minecraft/class_4668$class_4684;
 			FIELD field_21436 writeMaskState Lnet/minecraft/class_4668$class_4686;
 			FIELD field_21437 lineWidth Lnet/minecraft/class_4668$class_4677;
+			FIELD field_29462 texture Lnet/minecraft/class_4668$class_5939;
+			FIELD field_29463 shader Lnet/minecraft/class_4668$class_5942;
 			METHOD method_23603 cull (Lnet/minecraft/class_4668$class_4671;)Lnet/minecraft/class_1921$class_4688$class_4689;
 				ARG 1 cull
 			METHOD method_23604 depthTest (Lnet/minecraft/class_4668$class_4672;)Lnet/minecraft/class_1921$class_4688$class_4689;
@@ -173,6 +235,10 @@ CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 				ARG 1 affectsOutline
 			METHOD method_24297 build (Lnet/minecraft/class_1921$class_4750;)Lnet/minecraft/class_1921$class_4688;
 				ARG 1 outlineMode
+			METHOD method_34577 texture (Lnet/minecraft/class_4668$class_5939;)Lnet/minecraft/class_1921$class_4688$class_4689;
+				ARG 1 texture
+			METHOD method_34578 shader (Lnet/minecraft/class_4668$class_5942;)Lnet/minecraft/class_1921$class_4688$class_4689;
+				ARG 1 shader
 	CLASS class_4750 OutlineMode
 		FIELD field_22243 name Ljava/lang/String;
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V

--- a/mappings/net/minecraft/client/render/RenderPhase.mapping
+++ b/mappings/net/minecraft/client/render/RenderPhase.mapping
@@ -161,6 +161,6 @@ CLASS net/minecraft/class_4668 net/minecraft/client/render/RenderPhase
 				ARG 2 blur
 				ARG 3 mipmap
 	CLASS class_5942 Shader
-		FIELD field_29455 shaderSupplier Ljava/util/Optional;
+		FIELD field_29455 supplier Ljava/util/Optional;
 		METHOD <init> (Ljava/util/function/Supplier;)V
 			ARG 1 shaderSupplier

--- a/mappings/net/minecraft/client/render/RenderPhase.mapping
+++ b/mappings/net/minecraft/client/render/RenderPhase.mapping
@@ -63,7 +63,7 @@ CLASS net/minecraft/class_4668 net/minecraft/client/render/RenderPhase
 	FIELD field_29427 TEXT_SHADER Lnet/minecraft/class_4668$class_5942;
 	FIELD field_29428 TRANSPARENT_TEXT_SHADER Lnet/minecraft/class_4668$class_5942;
 	FIELD field_29429 LIGHTNING_SHADER Lnet/minecraft/class_4668$class_5942;
-	FIELD field_29430 TRIP_WIRE_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29430 TRIPWIRE_SHADER Lnet/minecraft/class_4668$class_5942;
 	FIELD field_29431 END_PORTAL_SHADER Lnet/minecraft/class_4668$class_5942;
 	FIELD field_29432 END_GATEWAY_SHADER Lnet/minecraft/class_4668$class_5942;
 	FIELD field_29433 LINES_SHADER Lnet/minecraft/class_4668$class_5942;

--- a/mappings/net/minecraft/client/render/RenderPhase.mapping
+++ b/mappings/net/minecraft/client/render/RenderPhase.mapping
@@ -138,8 +138,8 @@ CLASS net/minecraft/class_4668 net/minecraft/client/render/RenderPhase
 	CLASS class_4684 Texturing
 	CLASS class_4685 Transparency
 	CLASS class_4686 WriteMaskState
-		FIELD field_21400 writeColor Z
-		FIELD field_21401 writeDepth Z
+		FIELD field_21400 color Z
+		FIELD field_21401 depth Z
 		METHOD <init> (ZZ)V
 			ARG 1 color
 			ARG 2 depth

--- a/mappings/net/minecraft/client/render/RenderPhase.mapping
+++ b/mappings/net/minecraft/client/render/RenderPhase.mapping
@@ -37,6 +37,55 @@ CLASS net/minecraft/class_4668 net/minecraft/client/render/RenderPhase
 	FIELD field_25282 WEATHER_TARGET Lnet/minecraft/class_4668$class_4678;
 	FIELD field_25283 CLOUDS_TARGET Lnet/minecraft/class_4668$class_4678;
 	FIELD field_25643 ITEM_TARGET Lnet/minecraft/class_4668$class_4678;
+	FIELD field_29404 ENTITY_CUTOUT_NONULL_OFFSET_Z_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29405 ITEM_ENTITY_TRANSLUCENT_CULL_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29406 ENTITY_TRANSLUCENT_CULL_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29407 ENTITY_TRANSLUCENT_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29408 ENTITY_SMOOTH_CUTOUT_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29409 BEACON_BEAM_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29410 ENTITY_DECAL_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29411 ENTITY_NO_OUTLINE_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29412 ENTITY_SHADOW_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29413 ENTITY_ALPHA_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29414 EYES_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29415 ENERGY_SWIRL_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29416 LEASH_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29417 WATER_MASK_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29418 OUTLINE_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29419 ARMOR_GLINT_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29420 ARMOR_ENTITY_GLINT_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29421 TRANSLUCENT_GLINT_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29422 GLINT_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29423 DIRECT_GLINT_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29424 ENTITY_GLINT_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29425 DIRECT_ENTITY_GLINT_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29426 CRUMBLING_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29427 TEXT_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29428 TRANSPARENT_TEXT_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29429 LIGHTNING_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29430 TRIP_WIRE_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29431 END_PORTAL_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29432 END_GATEWAY_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29433 LINES_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29434 NO_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29435 BLOCK_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29436 NEW_ENTITY_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29437 POSITION_COLOR_LIGHTMAP_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29438 POSITION_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29439 POSITION_COLOR_TEX_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29440 POSITION_TEX_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29441 POSITION_COLOR_TEX_LIGHTMAP_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29442 COLOR_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29443 SOLID_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29444 CUTOUT_MIPPED_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29445 CUTOUT_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29446 TRANSLUCENT_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29447 TRANSLUCENT_MOVING_BLOCK_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29448 TRANSLUCENT_NO_CRUMBLING_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29449 ARMOR_CUTOUT_NO_CULL_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29450 ENTITY_SOLID_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29451 ENTITY_CUTOUT_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29452 ENTITY_CUTOUT_NONULL_SHADER Lnet/minecraft/class_4668$class_5942;
 	METHOD <init> (Ljava/lang/String;Ljava/lang/Runnable;Ljava/lang/Runnable;)V
 		ARG 1 name
 		ARG 2 beginAction
@@ -47,19 +96,29 @@ CLASS net/minecraft/class_4668 net/minecraft/client/render/RenderPhase
 	METHOD method_23518 endDrawing ()V
 	CLASS class_4670 Toggleable
 		FIELD field_21390 enabled Z
+		METHOD <init> (Ljava/lang/String;Ljava/lang/Runnable;Ljava/lang/Runnable;Z)V
+			ARG 1 name
+			ARG 2 apply
+			ARG 3 unapply
+			ARG 4 enabled
 	CLASS class_4671 Cull
 		METHOD <init> (Z)V
 			ARG 1 culling
 	CLASS class_4672 DepthTest
-		FIELD field_22242 depthFunction Ljava/lang/String;
+		FIELD field_22242 depthFunctionName Ljava/lang/String;
 			COMMENT A string representation of the comparison function used by this {@code DepthTest} phase.
 			COMMENT @see org.lwjgl.opengl.GL11#glDepthFunc(int)
+		METHOD <init> (Ljava/lang/String;I)V
+			ARG 1 depthFunctionName
+			ARG 2 depthFunction
 	CLASS class_4675 Layering
 	CLASS class_4676 Lightmap
 		METHOD <init> (Z)V
 			ARG 1 lightmap
 	CLASS class_4677 LineWidth
 		FIELD field_21392 width Ljava/util/OptionalDouble;
+		METHOD <init> (Ljava/util/OptionalDouble;)V
+			ARG 1 width
 	CLASS class_4678 Target
 	CLASS class_4679 Overlay
 		METHOD <init> (Z)V
@@ -70,15 +129,38 @@ CLASS net/minecraft/class_4668 net/minecraft/client/render/RenderPhase
 			ARG 2 y
 	CLASS class_4683 Texture
 		FIELD field_21397 id Ljava/util/Optional;
-		FIELD field_21398 bilinear Z
+		FIELD field_21398 blur Z
 		FIELD field_21399 mipmap Z
+		METHOD <init> (Lnet/minecraft/class_2960;ZZ)V
+			ARG 1 id
+			ARG 2 blur
+			ARG 3 mipmap
 	CLASS class_4684 Texturing
 	CLASS class_4685 Transparency
 	CLASS class_4686 WriteMaskState
-		FIELD field_21400 color Z
-		FIELD field_21401 depth Z
+		FIELD field_21400 writeColor Z
+		FIELD field_21401 writeDepth Z
 		METHOD <init> (ZZ)V
 			ARG 1 color
 			ARG 2 depth
-	CLASS class_5939
+	CLASS class_5939 TextureBase
+		METHOD <init> (Ljava/lang/Runnable;Ljava/lang/Runnable;)V
+			ARG 1 apply
+			ARG 2 unapply
 		METHOD method_23564 getId ()Ljava/util/Optional;
+	CLASS class_5940 Textures
+		FIELD field_29453 id Ljava/util/Optional;
+		METHOD <init> (Lcom/google/common/collect/ImmutableList;)V
+			ARG 1 textures
+		METHOD method_34560 create ()Lnet/minecraft/class_4668$class_5940$class_5941;
+		CLASS class_5941 Builder
+			FIELD field_29454 textures Lcom/google/common/collect/ImmutableList$Builder;
+			METHOD method_34562 build ()Lnet/minecraft/class_4668$class_5940;
+			METHOD method_34563 add (Lnet/minecraft/class_2960;ZZ)Lnet/minecraft/class_4668$class_5940$class_5941;
+				ARG 1 id
+				ARG 2 blur
+				ARG 3 mipmap
+	CLASS class_5942 Shader
+		FIELD field_29455 shaderSupplier Ljava/util/Optional;
+		METHOD <init> (Ljava/util/function/Supplier;)V
+			ARG 1 shaderSupplier

--- a/mappings/net/minecraft/client/render/RenderPhase.mapping
+++ b/mappings/net/minecraft/client/render/RenderPhase.mapping
@@ -163,4 +163,4 @@ CLASS net/minecraft/class_4668 net/minecraft/client/render/RenderPhase
 	CLASS class_5942 Shader
 		FIELD field_29455 supplier Ljava/util/Optional;
 		METHOD <init> (Ljava/util/function/Supplier;)V
-			ARG 1 shaderSupplier
+			ARG 1 supplier

--- a/mappings/net/minecraft/client/render/RenderPhase.mapping
+++ b/mappings/net/minecraft/client/render/RenderPhase.mapping
@@ -72,9 +72,9 @@ CLASS net/minecraft/class_4668 net/minecraft/client/render/RenderPhase
 	FIELD field_29436 NEW_ENTITY_SHADER Lnet/minecraft/class_4668$class_5942;
 	FIELD field_29437 POSITION_COLOR_LIGHTMAP_SHADER Lnet/minecraft/class_4668$class_5942;
 	FIELD field_29438 POSITION_SHADER Lnet/minecraft/class_4668$class_5942;
-	FIELD field_29439 POSITION_COLOR_TEX_SHADER Lnet/minecraft/class_4668$class_5942;
-	FIELD field_29440 POSITION_TEX_SHADER Lnet/minecraft/class_4668$class_5942;
-	FIELD field_29441 POSITION_COLOR_TEX_LIGHTMAP_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29439 POSITION_COLOR_TEXTURE_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29440 POSITION_TEXTURE_SHADER Lnet/minecraft/class_4668$class_5942;
+	FIELD field_29441 POSITION_COLOR_TEXTURE_LIGHTMAP_SHADER Lnet/minecraft/class_4668$class_5942;
 	FIELD field_29442 COLOR_SHADER Lnet/minecraft/class_4668$class_5942;
 	FIELD field_29443 SOLID_SHADER Lnet/minecraft/class_4668$class_5942;
 	FIELD field_29444 CUTOUT_MIPPED_SHADER Lnet/minecraft/class_4668$class_5942;


### PR DESCRIPTION
This maps all of the new fields in RenderPhase and RenderLayer where Mojang has changed things to use shaders, and also restores names of some render layers that look like they were lost because Mojang changed those fields to suppliers (so the auto-detected names didn't come through).

Notable additions are:
`RenderPhase$class_5942` -> `RenderPhase$Shader` (it sets a shader to use based on a particular supplier)
`RenderPhase$class_5940` -> `RenderPhase$Textures` (this sets multiple textures for use by the shaders. Note that `RenderPhase$Texture` works the same as before, but will only set the primary texture - index 0. This was added to allow for setting any number of texture layers. Also with it's own Builder class.)
`RenderPhase$class_5940$class_5941` -> `RenderPhase$Textures$Builder`
`RenderPhase$class_5939` -> `RenderPhase$TextureBase` (it's the parent class for `RenderPhase$Texture` and `RenderPhase$Textures`

Static field names are derived from constants or existing names. i.e.

```
Function<Identifier, RenderLayer> ARMOR_CUTOUT_NO_CULL = Util.memoize(texture -> {
   ...
   return RenderLayer.of("armor_cutout_no_cull", ...);
});
```

```
RenderPhase.Shader BLOCK_SHADER = new RenderPhase.Shader(GameRenderer::getBlockShader);
```

Minor exception is a refactor for some fields name where Mojang has provided us with the correct name for the field:
`bilinear` -> `blur` (based on `RenderPhase$Texture#toString`)
```
@Override
public String toString() {
    return this.name+ '[' + this.id + "(blur=" + this.blur + ", mipmap=" + this.mipmap + ")]";
}
```
`color` -> `writeColor` and `depth` -> `writeDepth`
```
@Override
public String toString() {
    return this.name+ "[writeColor=" + this.writeColor + ", writeDepth=" + this.writeDepth + ']';
}
```