### PR TITLE
CommandBlockExecutor name modernization

### DIFF
--- a/mappings/net/minecraft/world/CommandBlockExecutor.mapping
+++ b/mappings/net/minecraft/world/CommandBlockExecutor.mapping
@@ -1,7 +1,8 @@
 CLASS net/minecraft/class_1918 net/minecraft/world/CommandBlockExecutor
-	COMMENT A common logic for command {@linkplain net.minecraft.block.entity.CommandBlockBlockEntity
-	COMMENT block} and {@linkplain net.minecraft.entity.vehicle.CommandBlockMinecartEntity
-	COMMENT minecart}, to reduce duplicate code.
+	COMMENT A common logic for command-block behaviors shared by
+	COMMENT {@linkplain net.minecraft.block.entity.CommandBlockBlockEntity
+	COMMENT command blocks} and {@linkplain net.minecraft.entity.vehicle.CommandBlockMinecartEntity
+	COMMENT command block minecarts}.
 	COMMENT
 	COMMENT @see MobSpawnerLogic
 	FIELD field_21515 DEFAULT_NAME Lnet/minecraft/class_2561;

--- a/mappings/net/minecraft/world/CommandBlockExecutor.mapping
+++ b/mappings/net/minecraft/world/CommandBlockExecutor.mapping
@@ -1,4 +1,9 @@
 CLASS net/minecraft/class_1918 net/minecraft/world/CommandBlockExecutor
+	COMMENT A common logic for command {@linkplain net.minecraft.block.entity.CommandBlockBlockEntity
+	COMMENT block} and {@linkplain net.minecraft.entity.vehicle.CommandBlockMinecartEntity
+	COMMENT minecart}, to reduce duplicate code.
+	COMMENT
+	COMMENT @see MobSpawnerLogic
 	FIELD field_21515 DEFAULT_NAME Lnet/minecraft/class_2561;
 	FIELD field_9162 customName Lnet/minecraft/class_2561;
 	FIELD field_9163 successCount I
@@ -10,7 +15,7 @@ CLASS net/minecraft/class_1918 net/minecraft/world/CommandBlockExecutor
 	FIELD field_9169 DATE_FORMAT Ljava/text/SimpleDateFormat;
 	METHOD method_8286 setCommand (Ljava/lang/String;)V
 		ARG 1 command
-	METHOD method_8287 shouldTrackOutput (Z)V
+	METHOD method_8287 setTrackingOutput (Z)V
 		ARG 1 trackOutput
 	METHOD method_8288 interact (Lnet/minecraft/class_1657;)Lnet/minecraft/class_1269;
 		ARG 1 player
@@ -23,7 +28,7 @@ CLASS net/minecraft/class_1918 net/minecraft/world/CommandBlockExecutor
 	METHOD method_8293 getWorld ()Lnet/minecraft/class_3218;
 	METHOD method_8295 markDirty ()V
 	METHOD method_8296 isTrackingOutput ()Z
-	METHOD method_8297 serialize (Lnet/minecraft/class_2487;)Lnet/minecraft/class_2487;
+	METHOD method_8297 writeNbt (Lnet/minecraft/class_2487;)Lnet/minecraft/class_2487;
 		ARG 1 tag
 	METHOD method_8298 setSuccessCount (I)V
 		ARG 1 successCount
@@ -33,5 +38,5 @@ CLASS net/minecraft/class_1918 net/minecraft/world/CommandBlockExecutor
 		ARG 1 world
 	METHOD method_8303 getSource ()Lnet/minecraft/class_2168;
 	METHOD method_8304 getSuccessCount ()I
-	METHOD method_8305 deserialize (Lnet/minecraft/class_2487;)V
+	METHOD method_8305 readNbt (Lnet/minecraft/class_2487;)V
 		ARG 1 tag


### PR DESCRIPTION
`shouldTrackOutput` -> `setTrackingOutput` (getter is `isTrackingOutput`, field is `trackOutput` as its nbt key)
Fixes #2194
and modernizes nbt read/write method names

Signed-off-by: liach <liach@users.noreply.github.com>