### PR TITLE
Minor javadoc updates around unpick

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: gradle/wrapper-validation-action@v1
-      - run: ./gradlew build javadocJar checkMappings mapNamedJar --stacktrace
+      - run: ./gradlew checkLicenses build javadocJar checkMappings --stacktrace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: gradle/wrapper-validation-action@v1
-      - run: ./gradlew checkLicenses build javadocJar checkMappings --stacktrace
+      - run: ./gradlew build javadocJar checkMappings --stacktrace

--- a/HEADER
+++ b/HEADER
@@ -1,0 +1,1 @@
+This file is free for everyone to use under the Creative Commons Zero license.

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ plugins {
 	id 'base'
 	id 'maven-publish'
 	id 'java' // for jd gen
+	id 'org.cadixdev.licenser' version '0.5.1'
 }
 
 def minecraft_version = "21w11a"
@@ -745,6 +746,12 @@ sourceSets {
 	constants
 }
 
+license {
+	header file("HEADER")
+	sourceSets = [sourceSets.constants]
+	include '**/*.java'
+}
+
 task constantsJar(type: Jar) {
 	from sourceSets.constants.output
 	archiveClassifier = "constants"
@@ -933,7 +940,7 @@ javadoc {
 		addBooleanOption 'Xdoclint:reference', true
 		addBooleanOption 'Xdoclint:accessibility', true
 	}
-	source fakeSourceDir
+	source fileTree(fakeSourceDir) + sourceSets.constants.allJava
 	classpath = configurations.javadocClasspath.plus downloadMcLibs.outputs.files.asFileTree
 
 	finalizedBy {

--- a/mappings/net/minecraft/block/entity/AbstractFurnaceBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/AbstractFurnaceBlockEntity.mapping
@@ -50,7 +50,8 @@ CLASS net/minecraft/class_2609 net/minecraft/block/entity/AbstractFurnaceBlockEn
 	METHOD method_17763 dropExperienceForRecipesUsed (Lnet/minecraft/class_3222;)V
 		ARG 1 player
 	METHOD method_26395 isNonFlammableWood (Lnet/minecraft/class_1792;)Z
-		COMMENT Returns whether the provided {@code item} is in the {@linkplain ItemTags#NON_FLAMMABLE_WOOD} tag.
+		COMMENT Returns whether the provided {@code item} is in the {@linkplain
+		COMMENT net.minecraft.tag.ItemTags#NON_FLAMMABLE_WOOD non_flammable_wood} tag.
 		ARG 0 item
 	METHOD method_27354 getRecipesUsedAndDropExperience (Lnet/minecraft/class_3218;Lnet/minecraft/class_243;)Ljava/util/List;
 		ARG 1 world

--- a/mappings/net/minecraft/block/entity/AbstractFurnaceBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/AbstractFurnaceBlockEntity.mapping
@@ -50,7 +50,7 @@ CLASS net/minecraft/class_2609 net/minecraft/block/entity/AbstractFurnaceBlockEn
 	METHOD method_17763 dropExperienceForRecipesUsed (Lnet/minecraft/class_3222;)V
 		ARG 1 player
 	METHOD method_26395 isNonFlammableWood (Lnet/minecraft/class_1792;)Z
-		COMMENT Returns whether the provided {@code item} is in the {@linkplain
+		COMMENT Returns whether the provided {@code item} is in the {@link
 		COMMENT net.minecraft.tag.ItemTags#NON_FLAMMABLE_WOOD non_flammable_wood} tag.
 		ARG 0 item
 	METHOD method_27354 getRecipesUsedAndDropExperience (Lnet/minecraft/class_3218;Lnet/minecraft/class_243;)Ljava/util/List;

--- a/mappings/net/minecraft/world/ModifiableWorld.mapping
+++ b/mappings/net/minecraft/world/ModifiableWorld.mapping
@@ -11,16 +11,9 @@ CLASS net/minecraft/class_1945 net/minecraft/world/ModifiableWorld
 		COMMENT change persisted across loads. It's recommended to check whether this world is client before
 		COMMENT interacting with the world in this way.</p>
 		COMMENT
-		COMMENT <p>Accepted values of the flags are a bitset combination of the following:</p>
-		COMMENT <ul>
-		COMMENT <li>0b0000001 // 1 - PROPAGATE_CHANGE - Propagates a change event to surrounding blocks.</li>
-		COMMENT <li>0b0000010 // 2 - NOTIFY_LISTENERS - Notifies listeners and clients who need to react when the block changes</li>
-		COMMENT <li>0b0000100 // 4 - NO_REDRAW - Used in conjunction with NOTIFY_LISTENERS to suppress the render pass on clients.</li>
-		COMMENT <li>0b0001000 // 8 - REDRAW_ON_MAIN_THREAD - Forces a synchronous redraw on clients.</li>
-		COMMENT <li>0b0010000 // 16 - FORCE_STATE - Bypass virtual block state changes and forces the passed state to be stored as-is.</li>
-		COMMENT <li>0b0100000 // 32 - SKIP_DROPS - Prevents the previous block (container) from dropping items when destroyed.</li>
-		COMMENT <li>0b1000000 // 64 - MOVED - Signals that the current block is being moved to a different location, usually because of a piston.</li>
-		COMMENT </ul>
+		COMMENT <p>For the accepted values of the flags, see {@link net.fabricmc.yarn.constants.SetBlockStateFlags}.
+		COMMENT
+		COMMENT @see net.fabricmc.yarn.constants.SetBlockStateFlags
 		ARG 1 pos
 			COMMENT the target position
 		ARG 2 state
@@ -51,16 +44,10 @@ CLASS net/minecraft/class_1945 net/minecraft/world/ModifiableWorld
 		COMMENT change persisted across loads. It's recommended to check whether this world is client before
 		COMMENT interacting with the world in this way.</p>
 		COMMENT
-		COMMENT <p>Accepted values of the flags are a bitset combination of the following:</p>
-		COMMENT <ul>
-		COMMENT <li>0b0000001 // 1 - PROPAGATE_CHANGE - Propagates a change event to surrounding blocks.</li>
-		COMMENT <li>0b0000010 // 2 - NOTIFY_LISTENERS - Notifies listeners and clients who need to react when the block changes</li>
-		COMMENT <li>0b0000100 // 4 - NO_REDRAW - Used in conjunction with NOTIFY_LISTENERS to suppress the render pass on clients.</li>
-		COMMENT <li>0b0001000 // 8 - REDRAW_ON_MAIN_THREAD - Forces a synchronous redraw on clients.</li>
-		COMMENT <li>0b0010000 // 16 - FORCE_STATE - Bypass virtual block state changes and forces the passed state to be stored as-is.</li>
-		COMMENT <li>0b0100000 // 32 - SKIP_DROPS - Prevents the previous block (container) from dropping items when destroyed.</li>
-		COMMENT <li>0b1000000 // 64 - MOVED - Signals that the current block is being moved to a different location, usually because of a piston.</li>
-		COMMENT </ul>
+		COMMENT <p>For the accepted values of the flags, see {@link net.fabricmc.yarn.constants.SetBlockStateFlags}.
+		COMMENT
+		COMMENT @see #setBlockState(BlockPos, BlockState, int, int)
+		COMMENT @see net.fabricmc.yarn.constants.SetBlockStateFlags
 		ARG 1 pos
 			COMMENT the target position
 		ARG 2 state

--- a/src/constants/java/net/fabricmc/yarn/constants/SetBlockStateFlags.java
+++ b/src/constants/java/net/fabricmc/yarn/constants/SetBlockStateFlags.java
@@ -1,5 +1,19 @@
+/*
+ * This file is free for everyone to use under the Creative Commons Zero license.
+ */
+
 package net.fabricmc.yarn.constants;
 
+/**
+ * A few flag bits for the {@code flag} argument of {@code world.setBlockState(pos, state, flag)}
+ * and other related block state setting methods.
+ *
+ * <p>The accepted values of the {@code flag} argument is usually a bitset combination of the
+ * fields in this class.
+ *
+ * @see net.minecraft.world.ModifiableWorld#setBlockState(net.minecraft.util.math.BlockPos,
+ * net.minecraft.block.BlockState, int)
+ */
 public final class SetBlockStateFlags {
 	/**
 	 * Propagates a change event to surrounding blocks.
@@ -17,7 +31,7 @@ public final class SetBlockStateFlags {
 	public static final int DEFAULT = PROPAGATE_CHANGE | NOTIFY_LISTENERS;
 
 	/**
-	 * Used in conjunction with {@link NOTIFY_LISTENERS} to suppress the render pass on clients.
+	 * Used in conjunction with {@link #NOTIFY_LISTENERS} to suppress the render pass on clients.
 	 */
 	public static final int NO_REDRAW = 4;
 

--- a/src/constants/java/net/fabricmc/yarn/constants/package-info.java
+++ b/src/constants/java/net/fabricmc/yarn/constants/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * This file is free for everyone to use under the Creative Commons Zero license.
+ */
+
+/**
+ * Provides a few classes holding constants that possibly existed for better understanding
+ * of the Minecraft codebase.
+ *
+ * <p><strong>Warning:</strong> These classes are absent at runtime. They are exclusively
+ * for use during compile time, in which the Java Compiler will replace the field references
+ * with <a href="{@docRoot}/constant-values.html#net.fabricmc">constant values</a>.
+ */
+package net.fabricmc.yarn.constants;


### PR DESCRIPTION
A few things:
1. Added licenser and cc0 message to constant classes
2. Add constant classes to jd gen, wrote a package info that partially addressed #2195 
3. Fixed one javadoc error in current yarn
4. Changed set block state method doc to use the doc of the constant holding class instead