### PR TITLE
Readd lost mappings

### DIFF
--- a/mappings/net/minecraft/world/entity/EntityLike.mapping
+++ b/mappings/net/minecraft/world/entity/EntityLike.mapping
@@ -1,6 +1,16 @@
 CLASS net/minecraft/class_5568 net/minecraft/world/entity/EntityLike
 	COMMENT A prototype of entity that's suitable for entity manager to handle.
 	METHOD method_24204 streamSelfAndPassengers ()Ljava/util/stream/Stream;
+		COMMENT Returns a stream consisting of this entity and its passengers recursively.
+		COMMENT Each entity will appear before any of its passengers.
+		COMMENT
+		COMMENT <p>This may be less costly than {@link #streamPassengersAndSelf()} if the
+		COMMENT stream's iteration would terminates fast, such as finding an arbitrary
+		COMMENT match of entity in the passengers tree.
+		COMMENT
+		COMMENT @implNote The default implementation is not very efficient.
+		COMMENT
+		COMMENT @see #streamPassengersAndSelf()
 	METHOD method_24515 getBlockPos ()Lnet/minecraft/class_2338;
 	METHOD method_31744 setListener (Lnet/minecraft/class_5569;)V
 		ARG 1 listener
@@ -19,7 +29,7 @@ CLASS net/minecraft/class_5568 net/minecraft/world/entity/EntityLike
 		COMMENT
 		COMMENT @implNote The default implementation is very costly.
 		COMMENT
-		COMMENT @see net.minecraft.entity.Entity#streamSelfAndPassengers()
+		COMMENT @see #streamSelfAndPassengers()
 	METHOD method_5628 getId ()I
 		COMMENT Returns the network ID of this entity.
 	METHOD method_5667 getUuid ()Ljava/util/UUID;


### PR DESCRIPTION
Epic github edit

See https://github.com/FabricMC/yarn/commit/414cedb22f8cb477719f6e1789dfad04108d75fa#diff-73a11ecff5477b460d191d612ad8a47f4d1a7895673479fc8d79d4e6dd2d916bL211-L221
and https://github.com/FabricMC/yarn/commit/414cedb22f8cb477719f6e1789dfad04108d75fa#r48954183

This is not the first time matcher lost javadoc in a port. See #2127 for how it lost the javadoc on getResource