### PR TITLE
Fixes javadoc gen for 21w13a

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ buildscript {
 			url 'https://maven.fabricmc.net'
 		}
 		mavenCentral()
-		mavenLocal()
 	}
 	dependencies {
 		classpath "cuchaz:enigma-cli:${project.enigma_version}"
@@ -13,7 +12,6 @@ buildscript {
 		classpath "commons-io:commons-io:2.6"
 		classpath 'de.undercouch:gradle-download-task:4.0.4'
 		classpath 'net.fabricmc:tiny-remapper:0.3.1.72'
-		classpath 'net.fabricmc:mappingpoet:0.1.0+build.2'
 		classpath "net.fabricmc.unpick:unpick:${project.unpick_version}"
 		classpath "net.fabricmc.unpick:unpick-format-utils:${project.unpick_version}"
 	}
@@ -75,8 +73,9 @@ dependencies {
 	enigmaRuntime "net.fabricmc:stitch:${project.stitch_version}"
 	javadocClasspath "net.fabricmc:fabric-loader:${project.fabric_loader_version}"
 	javadocClasspath "org.jetbrains:annotations:${project.jetbrains_annotations_version}"
+	javadocClasspath "com.google.code.findbugs:jsr305:3.0.2" // for some other jsr annotations
 	decompileClasspath "org.benf:cfr:0.150"
-	mappingPoetJar 'net.fabricmc:mappingpoet:0.2.6'
+	mappingPoetJar 'net.fabricmc:mappingpoet:0.2.7'
 	unpick "net.fabricmc.unpick:unpick-cli:${project.unpick_version}"
 }
 
@@ -937,6 +936,7 @@ javadoc {
 				'https://www.javadoc.io/doc/com.google.code.gson/gson/2.8.0/',
 				'https://logging.apache.org/log4j/2.x/log4j-api/apidocs/',
 				"https://javadoc.io/doc/org.jetbrains/annotations/${project.jetbrains_annotations_version}/",
+				'https://www.javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.2/',
 				'https://javadoc.lwjgl.org/',
 				'https://fastutil.di.unimi.it/docs/',
 				'https://netty.io/4.1/api/',

--- a/mappings/net/minecraft/util/registry/Registry.mapping
+++ b/mappings/net/minecraft/util/registry/Registry.mapping
@@ -112,6 +112,7 @@ CLASS net/minecraft/class_2378 net/minecraft/util/registry/Registry
 	FIELD field_28264 GAME_EVENT Lnet/minecraft/class_2348;
 	FIELD field_28265 POSITION_SOURCE_TYPE Lnet/minecraft/class_2378;
 	FIELD field_28266 GAME_EVENT_KEY Lnet/minecraft/class_5321;
+	FIELD field_29075 FLOAT_PROVIDER_TYPE_KEY Lnet/minecraft/class_5321;
 	FIELD field_29076 FLOAT_PROVIDER_TYPE Lnet/minecraft/class_2378;
 	METHOD <init> (Lnet/minecraft/class_5321;Lcom/mojang/serialization/Lifecycle;)V
 		ARG 1 key


### PR DESCRIPTION
Closes #2217

Fixes some leftover minor stuff from unpick pr
Named `FLOAT_PROVIDER_TYPE_KEY` since the name inferer just infers `FLOAT_PROVIDER_TYPE` name, and it conflicts with the next registry field's name. Like a bug in stitch?
