### PR TITLE
BlockBox mappings

### DIFF
--- a/mappings/net/minecraft/util/math/BlockBox.mapping
+++ b/mappings/net/minecraft/util/math/BlockBox.mapping
@@ -7,18 +7,24 @@ CLASS net/minecraft/class_3341 net/minecraft/util/math/BlockBox
 	COMMENT they are not modified.
 	COMMENT
 	COMMENT @see Box
-	FIELD field_14376 maxZ I
-	FIELD field_14377 maxY I
-	FIELD field_14378 maxX I
-	FIELD field_14379 minZ I
-	FIELD field_14380 minY I
-	FIELD field_14381 minX I
+	FIELD field_14376 maxY I
+	FIELD field_14377 maxX I
+	FIELD field_14378 minZ I
+	FIELD field_14379 minY I
+	FIELD field_14380 minX I
+	FIELD field_14381 maxZ I
 	FIELD field_29325 CODEC Lcom/mojang/serialization/Codec;
 		COMMENT A codec that stores a block box as an int array. In the serialized array,
 		COMMENT the ordered elements are {@link #minX}, {@link #minY}, {@link #minZ},
 		COMMENT {@link #maxX}, {@link #maxY}, {@link #maxZ}.
+	FIELD field_31548 LOGGER Lorg/apache/logging/log4j/Logger;
 	METHOD <init> (IIIIII)V
 		ARG 1 minX
+		ARG 2 minY
+		ARG 3 minZ
+		ARG 4 maxX
+		ARG 5 maxY
+		ARG 6 maxZ
 	METHOD <init> (Lnet/minecraft/class_2338;)V
 		COMMENT Creates a box enclosing only {@code pos}.
 		ARG 1 pos
@@ -27,14 +33,14 @@ CLASS net/minecraft/class_3341 net/minecraft/util/math/BlockBox
 	METHOD method_14657 intersects (Lnet/minecraft/class_3341;)Z
 		ARG 1 other
 	METHOD method_14659 getDimensions ()Lnet/minecraft/class_2382;
-	METHOD method_14660 getBlockCountX ()I
+	METHOD method_14660 getBlockCountY ()I
 	METHOD method_14661 move (III)Lnet/minecraft/class_3341;
 		ARG 1 dx
 		ARG 2 dy
 		ARG 3 dz
 	METHOD method_14662 contains (Lnet/minecraft/class_2382;)Z
 		ARG 1 vec
-	METHOD method_14663 getBlockCountY ()I
+	METHOD method_14663 getBlockCountZ ()I
 	METHOD method_14665 empty ()Lnet/minecraft/class_3341;
 		COMMENT Creates an empty box.
 	METHOD method_14667 rotated (IIIIIIIIILnet/minecraft/class_2350;)Lnet/minecraft/class_3341;
@@ -83,3 +89,14 @@ CLASS net/minecraft/class_3341 net/minecraft/util/math/BlockBox
 		ARG 0 array
 	METHOD method_34394 (Lnet/minecraft/class_3341;)Ljava/util/stream/IntStream;
 		ARG 0 box
+	METHOD method_35410 expand (I)Lnet/minecraft/class_3341;
+		ARG 1 offset
+	METHOD method_35412 intersection (Lnet/minecraft/class_3341;)Lnet/minecraft/class_3341;
+		ARG 1 box
+	METHOD method_35414 getBlockCountX ()I
+	METHOD method_35415 getMinX ()I
+	METHOD method_35416 getMinY ()I
+	METHOD method_35417 getMinZ ()I
+	METHOD method_35418 getMaxX ()I
+	METHOD method_35419 getMaxY ()I
+	METHOD method_35420 getMaxZ ()I


### PR DESCRIPTION
fields and methods in `BlockBox` were incorrectly named (`minX` was `minY`, etc)