### PR TITLE
Two annotations. They write cursed annotations

### DIFF
--- a/mappings/net/minecraft/obfuscate/DontObfuscate.mapping
+++ b/mappings/net/minecraft/obfuscate/DontObfuscate.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/obfuscate/DontObfuscate net/minecraft/obfuscate/DontObfuscate
+CLASS net/minecraft/obfuscate/DontObfuscate
 	COMMENT This annotation applies to some unobfuscated elements within the Minecraft
 	COMMENT source code.
 	COMMENT

--- a/mappings/net/minecraft/obfuscate/DontObfuscate.mapping
+++ b/mappings/net/minecraft/obfuscate/DontObfuscate.mapping
@@ -5,21 +5,19 @@ CLASS net/minecraft/obfuscate/DontObfuscate net/minecraft/obfuscate/DontObfuscat
 	COMMENT <p>Its behavior appears as follows:
 	COMMENT <ul>
 	COMMENT <li>The annotation itself is not obfuscated.</li>
-	COMMENT <li>If a class is annotated, it is not obfuscated.</li>
+	COMMENT <li>If a class is annotated, it is not obfuscated. It's not yet clear if its
+	COMMENT members will always become deobfuscated as well.</li>
 	COMMENT <li>If a member is annotated, it and its containing class is not obfuscated,
 	COMMENT but other members in the same class may stay obfuscated.</li>
 	COMMENT </ul>
 	COMMENT
+	COMMENT <p>Visit the use page for the usage of this annotation.
+	COMMENT
 	COMMENT <p>In addition, single-abstract-method interfaces used as lambda expressions
-	COMMENT have their single abstract method unobfuscated without this annotation.
+	COMMENT always have their single abstract method unobfuscated per proguard behavior.
 	COMMENT
 	COMMENT <p>This annotation is not {@link java.lang.annotation.Documented}, and hence
 	COMMENT will not appear in the generated javadoc for annotated elements.
 	COMMENT
-	COMMENT @see net.minecraft.client.Main#main(String[])
-	COMMENT @see net.minecraft.data.Main#main(String[])
-	COMMENT @see net.minecraft.server.Main#main(String[])
-	COMMENT @see net.minecraft.client.ClientBrandRetriever#getClientModName()
-	COMMENT @see net.minecraft.server.MinecraftServer#getServerModName()
 	COMMENT @see net.minecraft.util.CubicSampler.RgbFetcher
-	COMMENT @see net.minecraft.world.level.ColorResolver#getColor()
+	COMMENT @see net.minecraft.world.level.ColorResolver#getColor

--- a/mappings/net/minecraft/obfuscate/DontObfuscate.mapping
+++ b/mappings/net/minecraft/obfuscate/DontObfuscate.mapping
@@ -1,0 +1,25 @@
+CLASS net/minecraft/obfuscate/DontObfuscate net/minecraft/obfuscate/DontObfuscate
+	COMMENT This annotation applies to some unobfuscated elements within the Minecraft
+	COMMENT source code.
+	COMMENT
+	COMMENT <p>Its behavior appears as follows:
+	COMMENT <ul>
+	COMMENT <li>The annotation itself is not obfuscated.</li>
+	COMMENT <li>If a class is annotated, it is not obfuscated.</li>
+	COMMENT <li>If a member is annotated, it and its containing class is not obfuscated,
+	COMMENT but other members in the same class may stay obfuscated.</li>
+	COMMENT </ul>
+	COMMENT
+	COMMENT <p>In addition, single-abstract-method interfaces used as lambda expressions
+	COMMENT have their single abstract method unobfuscated without this annotation.
+	COMMENT
+	COMMENT <p>This annotation is not {@link java.lang.annotation.Documented}, and hence
+	COMMENT will not appear in the generated javadoc for annotated elements.
+	COMMENT
+	COMMENT @see net.minecraft.client.Main#main(String[])
+	COMMENT @see net.minecraft.data.Main#main(String[])
+	COMMENT @see net.minecraft.server.Main#main(String[])
+	COMMENT @see net.minecraft.client.ClientBrandRetriever#getClientModName()
+	COMMENT @see net.minecraft.server.MinecraftServer#getServerModName()
+	COMMENT @see net.minecraft.util.CubicSampler.RgbFetcher
+	COMMENT @see net.minecraft.world.level.ColorResolver#getColor()

--- a/mappings/net/minecraft/util/annotation/Debug.mapping
+++ b/mappings/net/minecraft/util/annotation/Debug.mapping
@@ -1,0 +1,15 @@
+CLASS net/minecraft/class_5996 net/minecraft/util/annotation/Debug
+	COMMENT An annotation, mostly on side-effect-free methods.
+	COMMENT
+	COMMENT <p>Most methods annotated are getters that don't cause side-effects. Some of
+	COMMENT those methods also may execute dry-runs.
+	COMMENT
+	COMMENT <p>However, it is present on {@link
+	COMMENT net.minecraft.entity.passive.BeeEntity.MoveToHiveGoal}, and its purpose in that
+	COMMENT case is not yet clear.
+	COMMENT
+	COMMENT <p>This annotation has class retention and can be applied to a wide range of
+	COMMENT targets.
+	COMMENT
+	COMMENT <p>This annotation is not {@link java.lang.annotation.Documented}, and hence
+	COMMENT will not appear in the generated javadoc for annotated elements.


### PR DESCRIPTION
Depends on #2238 for proper javadocs.

The `Debug` name is presumptive and most likely is something else. Feel free to suggest.