### PR TITLE
Generate use page for javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -929,6 +929,7 @@ javadoc {
 		)
 		taglets "net.fabricmc.mappingpoet.jd.MappingTaglet"
 		// taglet path, header, extra stylesheet settings deferred
+		it.use()
 
 		addBooleanOption "-allow-script-in-comments", true
 		links(


### PR DESCRIPTION
Closes #2093

I have decided to act now since the use page is a good way to look at annotations (see https://github.com/FabricMC/yarn/pull/2241#discussion_r605530446), which are now shipped by mojang. Also it's good for learning the usage of types as any part of signatures.

Notice that

> The built javadoc jar size grows in size by about 40% after generating use pages.

so this may need some deliberation.