### PR TITLE
Assorted fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -890,7 +890,9 @@ task genFakeSource(type: JavaExec, dependsOn: ["mergeV2", "mapNamedJar"]) {
 }
 
 task decompileCFR(type: JavaExec, dependsOn: [mapNamedJar]) {
-	classpath = configurations.decompileClasspath
+	doFirst {
+		classpath = configurations.decompileClasspath
+	}
 	main = "org.benf.cfr.reader.Main"
 
 	args namedJar.getAbsolutePath(), "--outputdir", file("namedSrc").absolutePath

--- a/mappings/net/minecraft/util/registry/Registry.mapping
+++ b/mappings/net/minecraft/util/registry/Registry.mapping
@@ -74,7 +74,8 @@ CLASS net/minecraft/class_2378 net/minecraft/util/registry/Registry
 	FIELD field_25096 BIOME_SOURCE Lnet/minecraft/class_2378;
 	FIELD field_25097 CHUNK_GENERATOR Lnet/minecraft/class_2378;
 	FIELD field_25098 registryKey Lnet/minecraft/class_5321;
-		COMMENT The {@linkplain RegistryKey} representing the ID of the actual registry.
+		COMMENT The key representing the type of elements held by this registry. It is also the
+		COMMENT key of this registry within the root registry.
 	FIELD field_25099 lifecycle Lcom/mojang/serialization/Lifecycle;
 	FIELD field_25100 ROOT_KEY Lnet/minecraft/class_2960;
 	FIELD field_25101 ROOT Lnet/minecraft/class_2385;
@@ -100,8 +101,29 @@ CLASS net/minecraft/class_2378 net/minecraft/util/registry/Registry
 	FIELD field_25295 LOOT_POOL_ENTRY_TYPE_KEY Lnet/minecraft/class_5321;
 	FIELD field_25296 LOOT_FUNCTION_TYPE_KEY Lnet/minecraft/class_5321;
 	FIELD field_25297 LOOT_CONDITION_TYPE_KEY Lnet/minecraft/class_5321;
+	FIELD field_25298 WORLD_KEY Lnet/minecraft/class_5321;
+		COMMENT A registry key representing the {@link World} type. Can be used to obtain
+		COMMENT registry keys with the {@link World} type, such as that for the overworld.
+		COMMENT
+		COMMENT <p>Notice that {@code this == Registry.DIMENSION_KEY}.
+		COMMENT
+		COMMENT @see #DIMENSION_KEY
+		COMMENT @see World#OVERWORLD
+		COMMENT @see net.minecraft.server.MinecraftServer#worlds
 	FIELD field_25299 LOOT_CONDITION_TYPE Lnet/minecraft/class_2378;
-	FIELD field_25490 DIMENSION_OPTIONS Lnet/minecraft/class_5321;
+	FIELD field_25490 DIMENSION_KEY Lnet/minecraft/class_5321;
+		COMMENT A registry key representing the {@link DimensionOptions} type.
+		COMMENT
+		COMMENT <p>Notice that {@code this == Registry.WORLD_KEY}.
+		COMMENT
+		COMMENT @see #WORLD_KEY
+	FIELD field_25912 CONFIGURED_SURFACE_BUILDER_KEY Lnet/minecraft/class_5321;
+	FIELD field_25913 CONFIGURED_CARVER_KEY Lnet/minecraft/class_5321;
+	FIELD field_25914 CONFIGURED_FEATURE_KEY Lnet/minecraft/class_5321;
+	FIELD field_25915 CONFIGURED_STRUCTURE_FEATURE_KEY Lnet/minecraft/class_5321;
+	FIELD field_25916 STRUCTURE_PROCESSOR_LIST_KEY Lnet/minecraft/class_5321;
+	FIELD field_25917 STRUCTURE_POOL_KEY Lnet/minecraft/class_5321;
+	FIELD field_26374 CHUNK_GENERATOR_SETTINGS_KEY Lnet/minecraft/class_5321;
 	FIELD field_28005 LOOT_NUMBER_PROVIDER_TYPE_KEY Lnet/minecraft/class_5321;
 	FIELD field_28006 LOOT_NBT_PROVIDER_TYPE_KEY Lnet/minecraft/class_5321;
 	FIELD field_28007 LOOT_SCORE_PROVIDER_TYPE_KEY Lnet/minecraft/class_5321;
@@ -114,7 +136,10 @@ CLASS net/minecraft/class_2378 net/minecraft/util/registry/Registry
 	FIELD field_28266 GAME_EVENT_KEY Lnet/minecraft/class_5321;
 	FIELD field_29075 FLOAT_PROVIDER_TYPE_KEY Lnet/minecraft/class_5321;
 	FIELD field_29076 FLOAT_PROVIDER_TYPE Lnet/minecraft/class_2378;
+	FIELD field_33092 INT_PROVIDER_TYPE_KEY Lnet/minecraft/class_5321;
 	FIELD field_33093 INT_PROVIDER_TYPE Lnet/minecraft/class_2378;
+	FIELD field_33094 HEIGHT_PROVIDER_TYPE_KEY Lnet/minecraft/class_5321;
+	FIELD field_33095 HEIGHT_PROVIDER_TYPE Lnet/minecraft/class_2378;
 	METHOD <init> (Lnet/minecraft/class_5321;Lcom/mojang/serialization/Lifecycle;)V
 		ARG 1 key
 		ARG 2 lifecycle
@@ -147,6 +172,7 @@ CLASS net/minecraft/class_2378 net/minecraft/util/registry/Registry
 		ARG 3 entry
 	METHOD method_10235 getIds ()Ljava/util/Set;
 	METHOD method_10240 getRandom (Ljava/util/Random;)Ljava/lang/Object;
+		ARG 1 random
 	METHOD method_10247 create (Lnet/minecraft/class_5321;Ljava/util/function/Supplier;)Lnet/minecraft/class_2378;
 		ARG 0 key
 		ARG 1 defaultEntry
@@ -183,4 +209,6 @@ CLASS net/minecraft/class_2378 net/minecraft/util/registry/Registry
 		COMMENT @throws IllegalStateException if the entry was not present in the registry
 		ARG 1 key
 	METHOD method_31189 getOrEmpty (Lnet/minecraft/class_5321;)Ljava/util/Optional;
+		ARG 1 key
+	METHOD method_35842 contains (Lnet/minecraft/class_5321;)Z
 		ARG 1 key


### PR DESCRIPTION
Always name registry fields. Otherwise the name inference messes things up.
Javadocs start building again (was nuked by https://github.com/FabricMC/yarn/pull/2221#discussion_r605365434)
Cfr decompile fails because decompileClasspath is resolved too early
and cannot be modified in downloadMcLibs

Signed-off-by: liach <liach@users.noreply.github.com>