### PR TITLE
Shorten set_block_state_flags

### DIFF
--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -7,8 +7,8 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 	FIELD field_10651 STATE_IDS Lnet/minecraft/class_2361;
 	FIELD field_17562 cachedItem Lnet/minecraft/class_1792;
 	FIELD field_19312 FULL_CUBE_SHAPE_CACHE Lcom/google/common/cache/LoadingCache;
-	FIELD field_31027 PROPAGATE_CHANGE I
-		COMMENT Propagates a change event to surrounding blocks.
+	FIELD field_31027 NOTIFY_NEIGHBORS I
+		COMMENT Sends a neighbor update event to surrounding blocks.
 	FIELD field_31028 NOTIFY_LISTENERS I
 		COMMENT Notifies listeners and clients who need to react when the block changes.
 	FIELD field_31029 NO_REDRAW I
@@ -23,8 +23,8 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 		COMMENT Signals that the current block is being moved to a different location, usually because of a piston.
 	FIELD field_31034 SKIP_LIGHTING_UPDATES I
 		COMMENT Signals that lighting updates should be skipped.
-	FIELD field_31036 DEFAULT_SET_BLOCK_STATE_FLAG I
-		COMMENT The default setBlockState behavior. Same as {@code PROPAGATE_CHANGE | NOTIFY_LISTENERS}.
+	FIELD field_31036 NOTIFY_ALL I
+		COMMENT The default setBlockState behavior. Same as {@code NOTIFY_NEIGHBORS | NOTIFY_LISTENERS}.
 	METHOD method_16361 hasTopRim (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z
 		ARG 0 world
 		ARG 1 pos

--- a/mappings/net/minecraft/world/ModifiableWorld.mapping
+++ b/mappings/net/minecraft/world/ModifiableWorld.mapping
@@ -11,9 +11,7 @@ CLASS net/minecraft/class_1945 net/minecraft/world/ModifiableWorld
 		COMMENT change persisted across loads. It's recommended to check whether this world is client before
 		COMMENT interacting with the world in this way.</p>
 		COMMENT
-		COMMENT <p>For the accepted values of the flags, see {@link net.fabricmc.yarn.constants.SetBlockStateFlags}.
-		COMMENT
-		COMMENT @see net.fabricmc.yarn.constants.SetBlockStateFlags
+		COMMENT <p>See {@link #setBlockState(BlockPos, BlockState, int)} for a list of accepted flags.
 		ARG 1 pos
 			COMMENT the target position
 		ARG 2 state
@@ -44,10 +42,20 @@ CLASS net/minecraft/class_1945 net/minecraft/world/ModifiableWorld
 		COMMENT change persisted across loads. It's recommended to check whether this world is client before
 		COMMENT interacting with the world in this way.</p>
 		COMMENT
-		COMMENT <p>For the accepted values of the flags, see {@link net.fabricmc.yarn.constants.SetBlockStateFlags}.
+		COMMENT <p>The accepted values of these flags are:
+		COMMENT <ul>
+		COMMENT <li>{@link net.minecraft.block.Block#NOTIFY_ALL Block.NOTIFY_ALL}</li>
+		COMMENT <li>{@link net.minecraft.block.Block#NOTIFY_NEIGHBORS Block.NOTIFY_NEIGHBORS}</li>
+		COMMENT <li>{@link net.minecraft.block.Block#NOTIFY_LISTENERS Block.NOTIFY_LISTENERS}</li>
+		COMMENT <li>{@link net.minecraft.block.Block#NO_REDRAW Block.NO_REDRAW}</li>
+		COMMENT <li>{@link net.minecraft.block.Block#REDRAW_ON_MAIN_THREAD Block.REDRAW_ON_MAIN_THREAD}</li>
+		COMMENT <li>{@link net.minecraft.block.Block#FORCE_STATE Block.FORCE_STATE}</li>
+		COMMENT <li>{@link net.minecraft.block.Block#SKIP_DROPS Block.SKIP_DROPS}</li>
+		COMMENT <li>{@link net.minecraft.block.Block#MOVED Block.MOVED}</li>
+		COMMENT <li>{@link net.minecraft.block.Block#SKIP_LIGHTING_UPDATES Block.SKIP_LIGHTING_UPDATES}</li>
+		COMMENT </ul>
 		COMMENT
 		COMMENT @see #setBlockState(BlockPos, BlockState, int, int)
-		COMMENT @see net.fabricmc.yarn.constants.SetBlockStateFlags
 		ARG 1 pos
 			COMMENT the target position
 		ARG 2 state

--- a/unpick-definitions/set_block_state_flags.unpick
+++ b/unpick-definitions/set_block_state_flags.unpick
@@ -1,7 +1,7 @@
 v2
 
-flag set_block_state_flags net/minecraft/block/Block DEFAULT_SET_BLOCK_STATE_FLAG
-flag set_block_state_flags net/minecraft/block/Block PROPAGATE_CHANGE
+flag set_block_state_flags net/minecraft/block/Block NOTIFY_ALL
+flag set_block_state_flags net/minecraft/block/Block NOTIFY_NEIGHBORS
 flag set_block_state_flags net/minecraft/block/Block NOTIFY_LISTENERS
 flag set_block_state_flags net/minecraft/block/Block NO_REDRAW
 flag set_block_state_flags net/minecraft/block/Block REDRAW_ON_MAIN_THREAD


### PR DESCRIPTION
Renamed `PROPAGATE_CHANGE` to `NOTIFY_NEIGHBORS`, which allows for `NOTIFY_ALL` to encompass both that and `NOTIFY_LISTENERS`.
Given that `NOTIFY_ALL` is really commonly used, it's important that it shouldn't be as long as it was.