### PR TITLE
Screen handler updates

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/ingame/HandledScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/HandledScreen.mapping
@@ -60,8 +60,8 @@ CLASS net/minecraft/class_465 net/minecraft/client/gui/screen/ingame/HandledScre
 	METHOD method_2383 onMouseClick (Lnet/minecraft/class_1735;IILnet/minecraft/class_1713;)V
 		COMMENT @see net.minecraft.screen.ScreenHandler#onSlotClick(int, int, net.minecraft.screen.slot.SlotActionType, net.minecraft.entity.player.PlayerEntity)
 		ARG 1 slot
-		ARG 2 invSlot
-		ARG 3 clickData
+		ARG 2 slotId
+		ARG 3 button
 		ARG 4 actionType
 	METHOD method_2384 handleHotbarKeyPressed (II)Z
 		ARG 1 keyCode

--- a/mappings/net/minecraft/client/network/ClientPlayerInteractionManager.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerInteractionManager.mapping
@@ -59,7 +59,7 @@ CLASS net/minecraft/class_636 net/minecraft/client/network/ClientPlayerInteracti
 		COMMENT @see net.minecraft.screen.ScreenHandler#onSlotClick(int, int, net.minecraft.screen.slot.SlotActionType, net.minecraft.entity.player.PlayerEntity)
 		ARG 1 syncId
 		ARG 2 slotId
-		ARG 3 clickData
+		ARG 3 button
 		ARG 4 actionType
 	METHOD method_2907 setGameMode (Lnet/minecraft/class_1934;)V
 		ARG 1 gameMode

--- a/mappings/net/minecraft/network/packet/c2s/play/ClickSlotC2SPacket.mapping
+++ b/mappings/net/minecraft/network/packet/c2s/play/ClickSlotC2SPacket.mapping
@@ -1,14 +1,14 @@
 CLASS net/minecraft/class_2813 net/minecraft/network/packet/c2s/play/ClickSlotC2SPacket
 	FIELD field_12815 actionType Lnet/minecraft/class_1713;
 	FIELD field_12816 stack Lnet/minecraft/class_1799;
-	FIELD field_12817 clickData I
+	FIELD field_12817 button I
 	FIELD field_12818 slot I
 	FIELD field_12819 syncId I
 	FIELD field_29540 modifiedStacks Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
 	METHOD <init> (IIILnet/minecraft/class_1713;Lnet/minecraft/class_1799;Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;)V
 		ARG 1 syncId
 		ARG 2 slot
-		ARG 3 clickData
+		ARG 3 button
 		ARG 4 actionType
 		ARG 5 stack
 		ARG 6 modifiedStacks
@@ -16,7 +16,7 @@ CLASS net/minecraft/class_2813 net/minecraft/network/packet/c2s/play/ClickSlotC2
 		ARG 1 buf
 	METHOD method_12190 getStack ()Lnet/minecraft/class_1799;
 	METHOD method_12192 getSlot ()I
-	METHOD method_12193 getClickData ()I
+	METHOD method_12193 getButton ()I
 	METHOD method_12194 getSyncId ()I
 	METHOD method_12195 getActionType ()Lnet/minecraft/class_1713;
 	METHOD method_34678 getModifiedStacks ()Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;

--- a/mappings/net/minecraft/screen/CartographyTableScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/CartographyTableScreenHandler.mapping
@@ -1,8 +1,11 @@
 CLASS net/minecraft/class_3910 net/minecraft/screen/CartographyTableScreenHandler
 	FIELD field_17293 inventory Lnet/minecraft/class_1263;
 	FIELD field_17294 context Lnet/minecraft/class_3914;
-	FIELD field_19272 resultSlot Lnet/minecraft/class_1731;
+	FIELD field_19272 resultInventory Lnet/minecraft/class_1731;
 	FIELD field_20382 lastTakeResultTime J
+	FIELD field_30773 MAP_SLOT_INDEX I
+	FIELD field_30774 MATERIAL_SLOT_INDEX I
+	FIELD field_30775 RESULT_SLOT_INDEX I
 	METHOD <init> (ILnet/minecraft/class_1661;)V
 		ARG 1 syncId
 		ARG 2 inventory

--- a/mappings/net/minecraft/screen/ForgingScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/ForgingScreenHandler.mapping
@@ -3,6 +3,11 @@ CLASS net/minecraft/class_4861 net/minecraft/screen/ForgingScreenHandler
 	FIELD field_22480 input Lnet/minecraft/class_1263;
 	FIELD field_22481 context Lnet/minecraft/class_3914;
 	FIELD field_22482 player Lnet/minecraft/class_1657;
+	FIELD field_30813 PLAYER_INVENTORY_START_INDEX I
+	FIELD field_30814 FIRST_INPUT_SLOT_INDEX I
+	FIELD field_30815 SECOND_INPUT_SLOT_INDEX I
+	FIELD field_30816 OUTPUT_SLOT_INDEX I
+	FIELD field_30819 PLAYER_INVENTORY_END_INDEX I
 	METHOD <init> (Lnet/minecraft/class_3917;ILnet/minecraft/class_1661;Lnet/minecraft/class_3914;)V
 		ARG 1 type
 		ARG 2 syncId

--- a/mappings/net/minecraft/screen/HopperScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/HopperScreenHandler.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_1722 net/minecraft/screen/HopperScreenHandler
+	FIELD field_30801 SLOT_COUNT I
 	FIELD field_7826 inventory Lnet/minecraft/class_1263;
 	METHOD <init> (ILnet/minecraft/class_1661;)V
 		ARG 1 syncId

--- a/mappings/net/minecraft/screen/ScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/ScreenHandler.mapping
@@ -6,6 +6,10 @@ CLASS net/minecraft/class_1703 net/minecraft/screen/ScreenHandler
 	FIELD field_29207 previousCursorStack Lnet/minecraft/class_1799;
 	FIELD field_29208 syncHandler Lnet/minecraft/class_5916;
 	FIELD field_29209 disableSync Z
+	FIELD field_29559 trackedPropertyValues Lit/unimi/dsi/fastutil/ints/IntList;
+	FIELD field_30730 EMPTY_SPACE_SLOT_INDEX I
+		COMMENT A special slot index value ({@value}) indicating that the player has clicked outside the main panel
+		COMMENT of a screen. Used for dropping the cursor stack.
 	FIELD field_7757 quickCraftSlots Ljava/util/Set;
 	FIELD field_7759 quickCraftStage I
 	FIELD field_7761 slots Lnet/minecraft/class_2371;
@@ -46,7 +50,7 @@ CLASS net/minecraft/class_1703 net/minecraft/screen/ScreenHandler
 		COMMENT (int, int, SlotActionType, PlayerEntity)} in a try-catch block that wraps
 		COMMENT exceptions from this method into a crash report.
 		ARG 1 slotIndex
-		ARG 2 clickData
+		ARG 2 button
 		ARG 3 actionType
 		ARG 4 player
 	METHOD method_34245 setPreviousTrackedSlot (ILnet/minecraft/class_1799;)V
@@ -63,7 +67,7 @@ CLASS net/minecraft/class_1703 net/minecraft/screen/ScreenHandler
 	METHOD method_34250 setPreviousCursorStack (Lnet/minecraft/class_1799;)V
 		ARG 1 stack
 	METHOD method_34252 syncState ()V
-	METHOD method_34253 updateSlot (ILnet/minecraft/class_1799;Ljava/util/function/Supplier;)V
+	METHOD method_34253 checkSlotUpdates (ILnet/minecraft/class_1799;Ljava/util/function/Supplier;)V
 		ARG 1 slot
 		ARG 2 stack
 		ARG 3 copySupplier
@@ -72,8 +76,11 @@ CLASS net/minecraft/class_1703 net/minecraft/screen/ScreenHandler
 	METHOD method_34255 getCursorStack ()Lnet/minecraft/class_1799;
 	METHOD method_34256 disableSyncing ()V
 	METHOD method_34257 enableSyncing ()V
-	METHOD method_34258 updateCursorStack ()V
+	METHOD method_34258 checkCursorStackUpdates ()V
 	METHOD method_34259 getCursorCommandItemSlot ()Lnet/minecraft/class_5630;
+	METHOD method_34715 checkPropertyUpdates (II)V
+		ARG 1 id
+		ARG 2 value
 	METHOD method_7591 packQuickCraftData (II)I
 		ARG 0 quickCraftStage
 		ARG 1 buttonId
@@ -84,7 +91,7 @@ CLASS net/minecraft/class_1703 net/minecraft/screen/ScreenHandler
 	METHOD method_7593 onSlotClick (IILnet/minecraft/class_1713;Lnet/minecraft/class_1657;)V
 		COMMENT Performs a slot click. This can behave in many different ways depending mainly on the action type.
 		ARG 1 slotIndex
-		ARG 2 clickData
+		ARG 2 button
 		ARG 3 actionType
 			COMMENT The type of slot click. Check the docs for each SlotActionType value for details
 		ARG 4 player

--- a/unpick-definitions/screen_handler_slot_ids.unpick
+++ b/unpick-definitions/screen_handler_slot_ids.unpick
@@ -1,0 +1,6 @@
+v2
+
+constant screen_handler_slot_ids net/minecraft/screen/ScreenHandler EMPTY_SPACE_SLOT_INDEX
+
+target_method net/minecraft/screen/ScreenHandler internalOnSlotClick (IILnet/minecraft/screen/slot/SlotActionType;Lnet/minecraft/entity/player/PlayerEntity;)V
+	param 0 screen_handler_slot_ids


### PR DESCRIPTION
- Slot clicks: `invSlot` changed to `slotId` in screens and `clickData` changed to `button` (comes from exception message and is more specific)
- Mapped some simple constant values, but there are many more left
- Mapped `ScreenHandler.trackedSlotValues` (like `trackedStacks` etc)
- Renamed `update*` methods to `check*Updates` in `ScreenHandler`, they check for changed values of items/properties
- Unpicked the special empty space slot index (-999), not sure how useful but helps with reading that one specific (large) method.
  - I would've unpicked it for `HandledScreen.onMouseClick`, but it seems that Unpick doesn't work on it in `HandledScreen.mouseClicked` where it would have been useful.