### PR TITLE
Add MONOCHROME_LOGO to Option

### DIFF
--- a/mappings/net/minecraft/client/option/GameOptions.mapping
+++ b/mappings/net/minecraft/client/option/GameOptions.mapping
@@ -109,7 +109,7 @@ CLASS net/minecraft/class_315 net/minecraft/client/option/GameOptions
 	FIELD field_26845 keySocialInteractions Lnet/minecraft/class_304;
 	FIELD field_26926 hideMatchedNames Z
 	FIELD field_28777 hideBundleTutorial Z
-	FIELD field_32156 monochromeBackground Z
+	FIELD field_32156 monochromeLogo Z
 	METHOD <init> (Lnet/minecraft/class_310;Ljava/io/File;)V
 		ARG 1 client
 		ARG 2 optionsFile

--- a/mappings/net/minecraft/client/option/GameOptions.mapping
+++ b/mappings/net/minecraft/client/option/GameOptions.mapping
@@ -109,6 +109,7 @@ CLASS net/minecraft/class_315 net/minecraft/client/option/GameOptions
 	FIELD field_26845 keySocialInteractions Lnet/minecraft/class_304;
 	FIELD field_26926 hideMatchedNames Z
 	FIELD field_28777 hideBundleTutorial Z
+	FIELD field_32156 monochromeBackground Z
 	METHOD <init> (Lnet/minecraft/class_310;Ljava/io/File;)V
 		ARG 1 client
 		ARG 2 optionsFile

--- a/mappings/net/minecraft/client/option/Option.mapping
+++ b/mappings/net/minecraft/client/option/Option.mapping
@@ -59,6 +59,7 @@ CLASS net/minecraft/class_316 net/minecraft/client/option/Option
 	FIELD field_27956 TOGGLE_TEXT Lnet/minecraft/class_2561;
 	FIELD field_27957 HOLD_TEXT Lnet/minecraft/class_2561;
 	FIELD field_32146 MONOCHROME_LOGO Lnet/minecraft/class_4064;
+	FIELD field_32148 MONOCHROME_LOGO_TOOLTIP Lnet/minecraft/class_2561;
 	METHOD <init> (Ljava/lang/String;)V
 		ARG 1 key
 	METHOD method_18513 (Lnet/minecraft/class_315;)Ljava/lang/Double;

--- a/mappings/net/minecraft/client/option/Option.mapping
+++ b/mappings/net/minecraft/client/option/Option.mapping
@@ -58,6 +58,7 @@ CLASS net/minecraft/class_316 net/minecraft/client/option/Option
 	FIELD field_26925 HIDE_MATCHED_NAMES_TOOLTIP Lnet/minecraft/class_2561;
 	FIELD field_27956 TOGGLE_TEXT Lnet/minecraft/class_2561;
 	FIELD field_27957 HOLD_TEXT Lnet/minecraft/class_2561;
+	FIELD field_32146 MONOCHROME_LOGO Lnet/minecraft/class_4064;
 	METHOD <init> (Ljava/lang/String;)V
 		ARG 1 key
 	METHOD method_18513 (Lnet/minecraft/class_315;)Ljava/lang/Double;

--- a/mappings/net/minecraft/client/option/Option.mapping
+++ b/mappings/net/minecraft/client/option/Option.mapping
@@ -447,4 +447,4 @@ CLASS net/minecraft/class_316 net/minecraft/client/option/Option
 	METHOD method_35709 (Lnet/minecraft/class_315;Lnet/minecraft/class_316;Ljava/lang/Boolean;)V
 		ARG 0 gameOptions
 		ARG 1 option
-		ARG 2 value
+		ARG 2 monochromeLogo

--- a/mappings/net/minecraft/client/option/Option.mapping
+++ b/mappings/net/minecraft/client/option/Option.mapping
@@ -442,3 +442,9 @@ CLASS net/minecraft/class_316 net/minecraft/client/option/Option
 		ARG 0 gameOptions
 	METHOD method_32593 (Lnet/minecraft/class_315;)Ljava/lang/Integer;
 		ARG 0 gameOptions
+	METHOD method_35708 (Lnet/minecraft/class_315;)Ljava/lang/Boolean;
+		ARG 0 gameOptions
+	METHOD method_35709 (Lnet/minecraft/class_315;Lnet/minecraft/class_316;Ljava/lang/Boolean;)V
+		ARG 0 gameOptions
+		ARG 1 option
+		ARG 2 value


### PR DESCRIPTION
21w13a added the "Monochrome Logo" toggle in Accessibility settings, which makes the background in the mojang logo turn black instead of red, to reduce strain on the eyes. This change will give the Option for that the name MONOCHROME_LOGO