### PR TITLE
field_32657 -> MAX_PARTICLE_COUNT

### DIFF
--- a/mappings/net/minecraft/client/particle/ParticleManager.mapping
+++ b/mappings/net/minecraft/client/particle/ParticleManager.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/class_702 net/minecraft/client/particle/ParticleManager
 	FIELD field_18300 spriteAwareFactories Ljava/util/Map;
 	FIELD field_18301 particleAtlasTexture Lnet/minecraft/class_1059;
 	FIELD field_29072 groupCounts Lit/unimi/dsi/fastutil/objects/Object2IntOpenHashMap;
+	FIELD field_32657 MAX_PARTICLE_COUNT I
 	FIELD field_3830 particles Ljava/util/Map;
 	FIELD field_3831 textureManager Lnet/minecraft/class_1060;
 	FIELD field_3832 random Ljava/util/Random;


### PR DESCRIPTION
This is a constant used to set the size of the queue containing particles on the client.

I don't know how to do unpick stuff, but this probably should be unpicked too. :/