### PR TITLE
Ensure that releases are not ran in parallel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,16 @@ jobs:
       - uses: actions/checkout@v1
       - uses: gradle/wrapper-validation-action@v1
 
+      # Ensure that releases are not ran in parallel, this ensures that the latest commit is the latest release
+      # See https://github.com/softprops/turnstyle
+      - name: Turnstyle
+        uses: softprops/turnstyle@v1
+        with:
+          continue-after-seconds: 900
+          same-branch-only: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # Generate the build number based on tags to allow per branch build numbers, not something github provides by default.
       - name: Generate build number
         id: buildnumber


### PR DESCRIPTION
This resolves builds beign pushed to maven in the wrong order: see the final few 13a builds here: https://meta.fabricmc.net/v2/versions/yarn/

This happens when PRs are merged all at once and its a race to release.