### PR TITLE
Remove java < 11 support for yarns buildscript.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [8-jdk, 11-jdk, 15-jdk]
+        java: [11-jdk, 15-jdk]
     runs-on: ubuntu-20.04
     container:
       image: openjdk:${{ matrix.java }}

--- a/build.gradle
+++ b/build.gradle
@@ -777,12 +777,6 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 
 compilePackageDocsJava {
 	it.options.encoding = "UTF-8"
-	// use java 11 as the package info files aren't consumed by downstream java 8 mods etc.
-	if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
-		javaCompiler = javaToolchains.compilerFor {
-			languageVersion = JavaLanguageVersion.of(11)
-		}
-	}
 	it.options.release = 11
 }
 
@@ -885,12 +879,6 @@ task genFakeSource(type: JavaExec, dependsOn: ["mergeV2", "mapNamedJar"]) {
 	group = "javadoc generation"
 	outputs.upToDateWhen { false }
 
-	if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
-		javaLauncher = javaToolchains.launcherFor {
-			languageVersion = JavaLanguageVersion.of(11)
-		}
-	}
-
 	main "net.fabricmc.mappingpoet.Main"
 	classpath configurations.mappingPoet
 	// use merged v2 so we have all namespaces in jd
@@ -924,11 +912,6 @@ javadoc {
 
 	failOnError = false
 
-	if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
-		javadocTool = javaToolchains.javadocToolFor {
-			languageVersion = JavaLanguageVersion.of(11)
-		}
-	}
 	// verbose = true // enable to debug
 	options {
 		// verbose() // enable to debug

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,8 @@
+// This check is done here before any plugins that may require java 11 are able to load.
+if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11)) {
+    throw new UnsupportedOperationException("Yarn's buildscript requires Java 11 or higher.")
+}
+
 rootProject.name = "yarn"
 
 includeBuild 'build-logic'


### PR DESCRIPTION
This PR is more of a warning or possibly discussion about yarn's buildscript requiring java 11.

For a while yarn's buildscript has been downloading J11 to run some tasks (such as javadoc generation) however it has now got to the stage where we would like to write the build script using java 11.

- Overtime some of the build logic is going to be moving out of the massive build.gradle file and into [fabric-filament](https://github.com/FabricMC/fabric-filament) and we would like to use java 11 features here.
- This allows engima to also update to java 11.

This of course does not change the fact that yarn can be used by loom on Java 8.

I dont see any issues with this, but if you have a conern please make it heard ASAP.