### PR TITLE
Add javadoc linting task using Filament

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ plugins {
 	id 'maven-publish'
 	id 'java' // for jd gen
 	id 'org.cadixdev.licenser' version '0.5.1'
-	id 'net.fabricmc.filament' version '0.1.0'
+	id 'net.fabricmc.filament' version '0.2.0'
 }
 
 def minecraft_version = "21w14a"
@@ -990,6 +990,13 @@ generatePackageInfoMappings {
 	packageName = "net/minecraft/unused/packageinfo/"
 	outputDir = file("mappings/net/minecraft/unused/packageinfo")
 }
+
+javadocLint {
+	group = "javadoc generation"
+	mappingDirectory = file("mappings")
+}
+
+check.dependsOn javadocLint
 
 publishing {
 	publications {

--- a/mappings/net/minecraft/entity/EyeOfEnderEntity.mapping
+++ b/mappings/net/minecraft/entity/EyeOfEnderEntity.mapping
@@ -18,6 +18,5 @@ CLASS net/minecraft/class_1672 net/minecraft/entity/EyeOfEnderEntity
 	METHOD method_7478 initTargetPos (Lnet/minecraft/class_2338;)V
 		COMMENT Sets where the eye will fly towards.
 		COMMENT If close enough, it will fly directly towards it, otherwise, it will fly upwards, in the direction of the BlockPos.
-		COMMENT
-		COMMENT @param pos the block the eye of ender is drawn towards
 		ARG 1 pos
+			COMMENT the block the eye of ender is drawn towards

--- a/mappings/net/minecraft/entity/ai/brain/Brain.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/Brain.mapping
@@ -74,7 +74,7 @@ CLASS net/minecraft/class_4095 net/minecraft/entity/ai/brain/Brain
 		ARG 1 value
 	METHOD method_24524 indexTaskList (ILcom/google/common/collect/ImmutableList;)Lcom/google/common/collect/ImmutableList;
 		ARG 1 begin
-			COMMENT The beginning of the index of tasks, exclusive
+			COMMENT the beginning of the index of tasks, exclusive
 		ARG 2 tasks
 	METHOD method_24525 remember (Lnet/minecraft/class_4140;Ljava/lang/Object;J)V
 		ARG 1 type

--- a/mappings/net/minecraft/entity/passive/WolfEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/WolfEntity.mapping
@@ -22,10 +22,10 @@ CLASS net/minecraft/class_1493 net/minecraft/entity/passive/WolfEntity
 		COMMENT <p>
 		COMMENT The brightness multiplier represents how much darker the wolf gets while its fur is wet. The multiplier changes (from 0.75 to 1.0 incrementally) when a wolf shakes.
 		COMMENT
-		COMMENT @param tickDelta Progress for linearly interpolating between the previous and current game state.
 		COMMENT @return Brightness as a float value between 0.75 and 1.0.
 		COMMENT @see net.minecraft.client.render.entity.model.TintableAnimalModel#setColorMultiplier(float, float, float)
 		ARG 1 tickDelta
+			COMMENT progress for linearly interpolating between the previous and current game state
 	METHOD method_6708 setCollarColor (Lnet/minecraft/class_1767;)V
 		ARG 1 color
 	METHOD method_6710 isBegging ()Z

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -221,7 +221,7 @@ CLASS net/minecraft/class_1657 net/minecraft/entity/player/PlayerEntity
 	METHOD method_7329 dropItem (Lnet/minecraft/class_1799;ZZ)Lnet/minecraft/class_1542;
 		ARG 1 stack
 		ARG 2 throwRandomly
-			COMMENT If true, the item will be thrown in a random direction from the entity regardless of which direction the entity is facing
+			COMMENT if true, the item will be thrown in a random direction from the entity regardless of which direction the entity is facing
 		ARG 3 retainOwnership
 	METHOD method_7330 updateTurtleHelmet ()V
 	METHOD method_7331 requestRespawn ()V

--- a/mappings/net/minecraft/screen/ScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/ScreenHandler.mapping
@@ -93,7 +93,7 @@ CLASS net/minecraft/class_1703 net/minecraft/screen/ScreenHandler
 		ARG 1 slotIndex
 		ARG 2 button
 		ARG 3 actionType
-			COMMENT The type of slot click. Check the docs for each SlotActionType value for details
+			COMMENT the type of slot click, check the docs for each {@link SlotActionType} value for details
 		ARG 4 player
 	METHOD method_7594 unpackQuickCraftStage (I)I
 		ARG 0 quickCraftData

--- a/mappings/net/minecraft/util/math/BlockPos.mapping
+++ b/mappings/net/minecraft/util/math/BlockPos.mapping
@@ -166,16 +166,15 @@ CLASS net/minecraft/class_2338 net/minecraft/util/math/BlockPos
 		COMMENT a block towards the first direction, followed by moving along
 		COMMENT the second direction.
 		COMMENT
-		COMMENT @param center the center of iteration
-		COMMENT @param radius the maximum chebychev distance
-		COMMENT @param firstDirection the direction the iterator moves first
-		COMMENT @param secondDirection the direction the iterator moves after the first
-		COMMENT
 		COMMENT @throws IllegalStateException when the 2 directions lie on the same axis
 		ARG 0 center
+			COMMENT the center of iteration
 		ARG 1 radius
+			COMMENT the maximum chebychev distance
 		ARG 2 firstDirection
+			COMMENT the direction the iterator moves first
 		ARG 3 secondDirection
+			COMMENT the direction the iterator moves after the first
 	METHOD method_33096 withY (I)Lnet/minecraft/class_2338;
 		ARG 1 y
 	METHOD method_34848 iterateRandomly (Ljava/util/Random;ILnet/minecraft/class_2338;I)Ljava/lang/Iterable;

--- a/mappings/net/minecraft/util/math/MathHelper.mapping
+++ b/mappings/net/minecraft/util/math/MathHelper.mapping
@@ -93,11 +93,11 @@ CLASS net/minecraft/class_3532 net/minecraft/util/math/MathHelper
 		COMMENT This is the delta value needed to lerp between {@code start} and {@code end} to get {@code value}.
 		COMMENT In other words, {@code getLerpProgress(lerp(delta, start, end), start, end) == delta}.
 		ARG 0 value
-			COMMENT The result of the lerp function
+			COMMENT the result of the lerp function
 		ARG 2 start
-			COMMENT The value interpolated from
+			COMMENT the value interpolated from
 		ARG 4 end
-			COMMENT The value interpolated to
+			COMMENT the value interpolated to
 	METHOD method_15371 hashCode (III)J
 		ARG 0 x
 		ARG 1 y
@@ -168,41 +168,41 @@ CLASS net/minecraft/class_3532 net/minecraft/util/math/MathHelper
 	METHOD method_16437 lerp2 (DDDDDD)D
 		COMMENT A two-dimensional lerp between values on the 4 corners of the unit square. Arbitrary values are specified for the corners and the output is interpolated between them.
 		ARG 0 deltaX
-			COMMENT The x-coordinate on the unit square
+			COMMENT the x-coordinate on the unit square
 		ARG 2 deltaY
-			COMMENT The y-coordinate on the unit square
+			COMMENT the y-coordinate on the unit square
 		ARG 4 x0y0
-			COMMENT The output if {@code deltaX} is 0 and {@code deltaY} is 0
+			COMMENT the output if {@code deltaX} is 0 and {@code deltaY} is 0
 		ARG 6 x1y0
-			COMMENT The output if {@code deltaX} is 1 and {@code deltaY} is 0
+			COMMENT the output if {@code deltaX} is 1 and {@code deltaY} is 0
 		ARG 8 x0y1
-			COMMENT The output if {@code deltaX} is 0 and {@code deltaY} is 1
+			COMMENT the output if {@code deltaX} is 0 and {@code deltaY} is 1
 		ARG 10 x1y1
-			COMMENT The output if {@code deltaX} is 1 and {@code deltaY} is 1
+			COMMENT the output if {@code deltaX} is 1 and {@code deltaY} is 1
 	METHOD method_16438 lerp3 (DDDDDDDDDDD)D
 		COMMENT A three-dimensional lerp between values on the 8 corners of the unit cube. Arbitrary values are specified for the corners and the output is interpolated between them.
 		ARG 0 deltaX
-			COMMENT The x-coordinate on the unit cube
+			COMMENT the x-coordinate on the unit cube
 		ARG 2 deltaY
-			COMMENT The y-coordinate on the unit cube
+			COMMENT the y-coordinate on the unit cube
 		ARG 4 deltaZ
-			COMMENT The z-coordinate on the unit cube
+			COMMENT the z-coordinate on the unit cube
 		ARG 6 x0y0z0
-			COMMENT The output if {@code deltaX} is 0, {@code deltaY} is 0 and {@code deltaZ} is 0
+			COMMENT the output if {@code deltaX} is 0, {@code deltaY} is 0 and {@code deltaZ} is 0
 		ARG 8 x1y0z0
-			COMMENT The output if {@code deltaX} is 1, {@code deltaY} is 0 and {@code deltaZ} is 0
+			COMMENT the output if {@code deltaX} is 1, {@code deltaY} is 0 and {@code deltaZ} is 0
 		ARG 10 x0y1z0
-			COMMENT The output if {@code deltaX} is 0, {@code deltaY} is 1 and {@code deltaZ} is 0
+			COMMENT the output if {@code deltaX} is 0, {@code deltaY} is 1 and {@code deltaZ} is 0
 		ARG 12 x1y1z0
-			COMMENT The output if {@code deltaX} is 1, {@code deltaY} is 1 and {@code deltaZ} is 0
+			COMMENT the output if {@code deltaX} is 1, {@code deltaY} is 1 and {@code deltaZ} is 0
 		ARG 14 x0y0z1
-			COMMENT The output if {@code deltaX} is 0, {@code deltaY} is 0 and {@code deltaZ} is 1
+			COMMENT the output if {@code deltaX} is 0, {@code deltaY} is 0 and {@code deltaZ} is 1
 		ARG 16 x1y0z1
-			COMMENT The output if {@code deltaX} is 1, {@code deltaY} is 0 and {@code deltaZ} is 1
+			COMMENT the output if {@code deltaX} is 1, {@code deltaY} is 0 and {@code deltaZ} is 1
 		ARG 18 x0y1z1
-			COMMENT The output if {@code deltaX} is 0, {@code deltaY} is 1 and {@code deltaZ} is 1
+			COMMENT the output if {@code deltaX} is 0, {@code deltaY} is 1 and {@code deltaZ} is 1
 		ARG 20 x1y1z1
-			COMMENT The output if {@code deltaX} is 1, {@code deltaY} is 1 and {@code deltaZ} is 1
+			COMMENT the output if {@code deltaX} is 1, {@code deltaY} is 1 and {@code deltaZ} is 1
 	METHOD method_16439 lerp (FFF)F
 		ARG 0 delta
 		ARG 1 start

--- a/mappings/net/minecraft/world/EntityView.mapping
+++ b/mappings/net/minecraft/world/EntityView.mapping
@@ -70,11 +70,11 @@ CLASS net/minecraft/class_1924 net/minecraft/world/EntityView
 		COMMENT
 		COMMENT @return a list of entities within a box, excluding the given entity, all satisfying the given predicate
 		ARG 1 except
-			COMMENT the entity the box logically surrounds. This entity is ignored if it is inside the box.
+			COMMENT the entity the box logically surrounds; this entity is ignored if it is inside the box
 		ARG 2 box
 			COMMENT the box in which to search for entities
 		ARG 3 predicate
-			COMMENT a predicate which entities must satisfy in order to be included in the returned list.
+			COMMENT a predicate which entities must satisfy in order to be included in the returned list
 	METHOD method_8335 getOtherEntities (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;)Ljava/util/List;
 		COMMENT Computes a list of entities within some box, excluding the given entity, that are not spectators.
 		COMMENT
@@ -82,7 +82,7 @@ CLASS net/minecraft/class_1924 net/minecraft/world/EntityView
 		COMMENT @see #getOtherEntities(Entity, Box, Predicate)
 		COMMENT @see Entity#isSpectator()
 		ARG 1 except
-			COMMENT the entity the box logically surrounds. This entity is ignored if it is inside the box.
+			COMMENT the entity the box logically surrounds; this entity is ignored if it is inside the box
 		ARG 2 box
 			COMMENT the box in which to search for entities
 	METHOD method_8338 (Lnet/minecraft/class_238;Lnet/minecraft/class_1297;Lnet/minecraft/class_1297;)Z

--- a/mappings/net/minecraft/world/gen/ChunkRandom.mapping
+++ b/mappings/net/minecraft/world/gen/ChunkRandom.mapping
@@ -47,11 +47,11 @@ CLASS net/minecraft/class_2919 net/minecraft/world/gen/ChunkRandom
 		COMMENT at doing so, many entropy issues arise from the salt being so small and result in
 		COMMENT weird alignments between features that have an index close apart.
 		ARG 1 populationSeed
-			COMMENT The population seed computed in setPopulationSeed().
+			COMMENT the population seed computed in {@link #setPopulationSeed(long, int, int)}
 		ARG 3 index
-			COMMENT The index of the feature in the feature list.
+			COMMENT the index of the feature in the feature list
 		ARG 4 step
-			COMMENT The generation step's ordinal for this feature.
+			COMMENT the generation step's ordinal for this feature
 	METHOD method_12665 setRegionSeed (JIII)J
 		COMMENT Seeds the randomizer to determine the start position of structure features such as
 		COMMENT temples, monuments and buried treasures within a region.

--- a/mappings/net/minecraft/world/gen/chunk/ChunkGenerator.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/ChunkGenerator.mapping
@@ -33,14 +33,15 @@ CLASS net/minecraft/class_2794 net/minecraft/world/gen/chunk/ChunkGenerator
 		COMMENT Tries to find the closest structure of a given type near a given block.
 		COMMENT <p>
 		COMMENT New chunks will only be generated up to the {@link net.minecraft.world.chunk.ChunkStatus#STRUCTURE_STARTS} phase by this method.
+		COMMENT <p>
+		COMMENT The radius is ignored for strongholds.
 		COMMENT
 		COMMENT @return {@code null} if no structure could be found within the given search radius
 		ARG 1 world
 		ARG 2 feature
 		ARG 3 center
 		ARG 4 radius
-			COMMENT The search radius in chunks around the chunk the given block position is in. A radius of 0 will only search in the given chunk.
-			COMMENT This is ignored for strongholds.
+			COMMENT the search radius in chunks around the chunk the given block position is in; a radius of 0 will only search in the given chunk
 		ARG 5 skipExistingChunks
 			COMMENT whether only structures that are not referenced by generated chunks (chunks past the STRUCTURE_STARTS stage) are returned, excluding strongholds
 	METHOD method_12104 getWorldHeight ()I

--- a/mappings/net/minecraft/world/gen/feature/StructureFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/StructureFeature.mapping
@@ -22,7 +22,7 @@ CLASS net/minecraft/class_3195 net/minecraft/world/gen/feature/StructureFeature
 		ARG 2 structureAccessor
 		ARG 3 searchStartPos
 		ARG 4 searchRadius
-			COMMENT The search radius in chunks around the chunk the given block position is in. A radius of 0 will only search in the given chunk.
+			COMMENT the search radius in chunks around the chunk the given block position is in; a radius of 0 will only search in the given chunk
 		ARG 5 skipExistingChunks
 		ARG 6 worldSeed
 		ARG 8 config

--- a/mappings/net/minecraft/world/gen/surfacebuilder/SurfaceBuilder.mapping
+++ b/mappings/net/minecraft/world/gen/surfacebuilder/SurfaceBuilder.mapping
@@ -58,7 +58,7 @@ CLASS net/minecraft/class_3523 net/minecraft/world/gen/surfacebuilder/SurfaceBui
 		ARG 9 defaultBlock
 			COMMENT default block of the chunk generator, used to know which block to replace with the surface blocks
 		ARG 10 defaultFluid
-			COMMENT Default fluid of the chunk generator
+			COMMENT default fluid of the chunk generator
 		ARG 11 seaLevel
 			COMMENT the sea level of the chunk generator
 	METHOD method_15306 initSeed (J)V

--- a/mappings/net/minecraft/world/poi/PointOfInterestStorage.mapping
+++ b/mappings/net/minecraft/world/poi/PointOfInterestStorage.mapping
@@ -85,7 +85,7 @@ CLASS net/minecraft/class_4153 net/minecraft/world/poi/PointOfInterestStorage
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 radius
-			COMMENT The radius in blocks
+			COMMENT the radius in blocks
 	METHOD method_26339 hasTypeAt (Lnet/minecraft/class_4158;Lnet/minecraft/class_2338;)Z
 		ARG 1 type
 		ARG 2 pos


### PR DESCRIPTION
Basically #2289 but using Filament. Filament's `javadocLint` is also better and supports incremental running so it'll run faster and skip unmodified files :^)

Adds a `javadocLint` task that ensures the current javadoc comments follow Yarn's guidelines for javadocs, namely:

> Write quick descriptions for parameter javadocs as well as `@return` tags, with no uppercase or period. Add parameter docs to the parameter itself instead of using the `@param` tag.

(The `@return` tags are not currently checked, nor are some other guidelines defined in `CONVENTIONS.md`. The parameter style seems to be broken most often.)

All javadoc comments are also fixed here to follow the conventions.

<details><summary>Example output of <code>javadocLint</code> when there are errors:</summary>
<pre>
lint: net/minecraft/world/gen/chunk/ChunkGenerator.locateStructure.radius: parameter javadoc ends with '.'
lint: net/minecraft/world/gen/chunk/ChunkGenerator.locateStructure.radius: parameter javadoc starts with uppercase word 'The'
lint: net/minecraft/entity/player/PlayerEntity.dropItem.throwRandomly: parameter javadoc starts with uppercase word 'If'
lint: net/minecraft/entity/EyeOfEnderEntity.initTargetPos: method contains parameter docs, which should be on the parameter itself
lint: net/minecraft/screen/ScreenHandler.onSlotClick.actionType: parameter javadoc starts with uppercase word 'The'
</pre>
</details>