### PR TITLE
Map various render buffer / buffer builder internals

### DIFF
--- a/mappings/com/mojang/blaze3d/systems/RenderSystem.mapping
+++ b/mappings/com/mojang/blaze3d/systems/RenderSystem.mapping
@@ -161,7 +161,7 @@ CLASS com/mojang/blaze3d/systems/RenderSystem
 		FIELD field_27333 increment I
 		FIELD field_27334 indexMapper Lcom/mojang/blaze3d/systems/RenderSystem$class_5590$class_5591;
 		FIELD field_27335 id I
-		FIELD field_27336 vertexFormat Lnet/minecraft/class_293$class_5595;
+		FIELD field_27336 elementFormat Lnet/minecraft/class_293$class_5595;
 		FIELD field_27337 size I
 		METHOD <init> (IILcom/mojang/blaze3d/systems/RenderSystem$class_5590$class_5591;)V
 			ARG 1 sizeMultiplier
@@ -172,7 +172,7 @@ CLASS com/mojang/blaze3d/systems/RenderSystem
 			ARG 1 newSize
 		METHOD method_31922 getIndexConsumer (Ljava/nio/ByteBuffer;)Lit/unimi/dsi/fastutil/ints/IntConsumer;
 			ARG 1 indicesBuffer
-		METHOD method_31924 getVertexFormat ()Lnet/minecraft/class_293$class_5595;
+		METHOD method_31924 getElementFormat ()Lnet/minecraft/class_293$class_5595;
 		CLASS class_5591 IndexMapper
 			METHOD accept (Lit/unimi/dsi/fastutil/ints/IntConsumer;I)V
 				ARG 1 indexConsumer

--- a/mappings/net/minecraft/client/gl/JsonEffectGlShader.mapping
+++ b/mappings/net/minecraft/client/gl/JsonEffectGlShader.mapping
@@ -39,3 +39,4 @@ CLASS net/minecraft/class_280 net/minecraft/client/gl/JsonEffectGlShader
 		ARG 0 resourceManager
 		ARG 1 type
 		ARG 2 name
+	METHOD method_35763 getName ()Ljava/lang/String;

--- a/mappings/net/minecraft/client/gl/PostProcessShader.mapping
+++ b/mappings/net/minecraft/client/gl/PostProcessShader.mapping
@@ -16,8 +16,10 @@ CLASS net/minecraft/class_283 net/minecraft/client/gl/PostProcessShader
 		ARG 1 projectionMatrix
 	METHOD method_1292 addAuxTarget (Ljava/lang/String;Ljava/util/function/IntSupplier;II)V
 		ARG 1 name
+		ARG 2 valueSupplier
 		ARG 3 width
 		ARG 4 height
 	METHOD method_1293 render (F)V
 		ARG 1 time
 	METHOD method_1295 getProgram ()Lnet/minecraft/class_280;
+	METHOD method_35777 getName ()Ljava/lang/String;

--- a/mappings/net/minecraft/client/gl/VertexBuffer.mapping
+++ b/mappings/net/minecraft/client/gl/VertexBuffer.mapping
@@ -2,11 +2,37 @@ CLASS net/minecraft/class_291 net/minecraft/client/gl/VertexBuffer
 	FIELD field_1593 vertexCount I
 	FIELD field_1594 vertexBufferId I
 	FIELD field_27366 indexBufferId I
+	FIELD field_27367 vertexFormat Lnet/minecraft/class_293$class_5595;
+	FIELD field_27368 drawMode Lnet/minecraft/class_293$class_5596;
+	FIELD field_27369 usesTexture Z
+	FIELD field_29338 vertexArrayId I
+	FIELD field_29339 elementFormat Lnet/minecraft/class_293;
 	METHOD method_1352 upload (Lnet/minecraft/class_287;)V
 		ARG 1 buffer
 	METHOD method_1353 bind ()V
 	METHOD method_1354 unbind ()V
+	METHOD method_22641 (Ljava/lang/Integer;)V
+		ARG 1 id
 	METHOD method_22643 submitUpload (Lnet/minecraft/class_287;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 buffer
 	METHOD method_22644 uploadInternal (Lnet/minecraft/class_287;)V
 		ARG 1 buffer
+	METHOD method_31968 (Ljava/lang/Integer;)V
+		ARG 1 id
+	METHOD method_34427 setShader (Lnet/minecraft/class_1159;Lnet/minecraft/class_1159;Lnet/minecraft/class_5944;)V
+		ARG 1 viewMatrix
+		ARG 2 projectionMatrix
+		ARG 3 shader
+	METHOD method_34428 (Ljava/lang/Integer;)V
+		ARG 1 id
+	METHOD method_34429 (Ljava/lang/Runnable;)V
+		ARG 0 action
+	METHOD method_34430 unbindVertexArray ()V
+	METHOD method_34431 innerSetShader (Lnet/minecraft/class_1159;Lnet/minecraft/class_1159;Lnet/minecraft/class_5944;)V
+		ARG 1 viewMatrix
+		ARG 2 projectionMatrix
+		ARG 3 shader
+	METHOD method_34432 drawVertices ()V
+	METHOD method_34435 getElementFormat ()Lnet/minecraft/class_293;
+	METHOD method_34437 bindVertexArray ()V
+	METHOD method_35665 drawElements ()V

--- a/mappings/net/minecraft/client/render/BufferBuilder.mapping
+++ b/mappings/net/minecraft/client/render/BufferBuilder.mapping
@@ -12,6 +12,14 @@ CLASS net/minecraft/class_287 net/minecraft/client/render/BufferBuilder
 	FIELD field_20776 buildStart I
 	FIELD field_20777 nextDrawStart I
 	FIELD field_20884 elementOffset I
+	FIELD field_21594 textured Z
+	FIELD field_21595 hasOverlay Z
+	FIELD field_27348 currentParameters [Lnet/minecraft/class_1160;
+	FIELD field_27349 cameraX F
+	FIELD field_27350 cameraY F
+	FIELD field_27351 cameraZ F
+	FIELD field_27352 cameraOffset Z
+	FIELD field_32050 MAX_BUFFER_SIZE I
 	METHOD <init> (I)V
 		ARG 1 initialCapacity
 	METHOD method_1324 restoreState (Lnet/minecraft/class_287$class_5594;)V
@@ -32,17 +40,52 @@ CLASS net/minecraft/class_287 net/minecraft/client/render/BufferBuilder
 	METHOD method_23477 reset ()V
 	METHOD method_23918 setFormat (Lnet/minecraft/class_293;)V
 		ARG 1 format
+	METHOD method_31948 setCameraPosition (FFF)V
+		ARG 1 cameraX
+		ARG 2 cameraY
+		ARG 3 cameraZ
+	METHOD method_31949 createConsumer (Lnet/minecraft/class_293$class_5595;)Lit/unimi/dsi/fastutil/ints/IntConsumer;
+		ARG 1 elementFormat
+	METHOD method_31950 writeCameraOffset (Lnet/minecraft/class_293$class_5595;)V
+		ARG 1 elementFormat
+	METHOD method_31954 buildParameterVector ()[Lnet/minecraft/class_1160;
 	CLASS class_4574 DrawArrayParameters
 		FIELD field_20779 vertexFormat Lnet/minecraft/class_293;
 		FIELD field_20780 count I
 		FIELD field_20781 mode Lnet/minecraft/class_293$class_5596;
+		FIELD field_27354 vertexCount I
+		FIELD field_27355 elementFormat Lnet/minecraft/class_293$class_5595;
+		FIELD field_27356 cameraOffset Z
+		FIELD field_27357 textured Z
 		METHOD <init> (Lnet/minecraft/class_293;IILnet/minecraft/class_293$class_5596;Lnet/minecraft/class_293$class_5595;ZZ)V
 			ARG 1 vertexFormat
 			ARG 2 count
-			ARG 3 mode
+			ARG 3 vertexCount
+			ARG 4 drawMode
+			ARG 5 elementFormat
+			ARG 6 cameraOffset
+			ARG 7 textured
 		METHOD method_22634 getVertexFormat ()Lnet/minecraft/class_293;
 		METHOD method_22635 getCount ()I
 		METHOD method_22636 getMode ()Lnet/minecraft/class_293$class_5596;
+		METHOD method_31955 getVertexCount ()I
+		METHOD method_31956 getElementFormat ()Lnet/minecraft/class_293$class_5595;
+		METHOD method_31957 getLimit ()I
+		METHOD method_31958 getDrawStart ()I
+		METHOD method_31959 isCameraOffset ()Z
+		METHOD method_31960 isTextured ()Z
+		METHOD method_31961 getDrawLength ()I
 	CLASS class_5594 State
 		FIELD field_27358 drawMode Lnet/minecraft/class_293$class_5596;
 		FIELD field_27359 vertexCount I
+		FIELD field_27360 currentParameters [Lnet/minecraft/class_1160;
+		FIELD field_27361 cameraX F
+		FIELD field_27362 cameraY F
+		FIELD field_27363 cameraZ F
+		METHOD <init> (Lnet/minecraft/class_293$class_5596;I[Lnet/minecraft/class_1160;FFF)V
+			ARG 1 drawMode
+			ARG 2 vertexCount
+			ARG 3 currentParameters
+			ARG 4 cameraX
+			ARG 5 cameraY
+			ARG 6 cameraZ

--- a/mappings/net/minecraft/client/render/BufferBuilder.mapping
+++ b/mappings/net/minecraft/client/render/BufferBuilder.mapping
@@ -48,6 +48,12 @@ CLASS net/minecraft/class_287 net/minecraft/client/render/BufferBuilder
 		ARG 1 elementFormat
 	METHOD method_31950 writeCameraOffset (Lnet/minecraft/class_293$class_5595;)V
 		ARG 1 elementFormat
+	METHOD method_31951 (I)V
+		ARG 1 value
+	METHOD method_31952 (I)V
+		ARG 1 value
+	METHOD method_31953 (I)V
+		ARG 1 value
 	METHOD method_31954 buildParameterVector ()[Lnet/minecraft/class_1160;
 	CLASS class_4574 DrawArrayParameters
 		FIELD field_20779 vertexFormat Lnet/minecraft/class_293;

--- a/mappings/net/minecraft/client/render/BufferRenderer.mapping
+++ b/mappings/net/minecraft/client/render/BufferRenderer.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_286 net/minecraft/client/render/BufferRenderer
-	FIELD field_29331 currentVertexArrayObject I
-	FIELD field_29332 currentVertexBufferObject I
-	FIELD field_29333 currentElementBufferObject I
+	FIELD field_29331 currentVertexArray I
+	FIELD field_29332 currentVertexBuffer I
+	FIELD field_29333 currentElementBuffer I
 	FIELD field_29334 vertexFormat Lnet/minecraft/class_293;
 	METHOD method_1309 draw (Lnet/minecraft/class_287;)V
 		ARG 0 bufferBuilder
@@ -17,5 +17,6 @@ CLASS net/minecraft/class_286 net/minecraft/client/render/BufferRenderer
 		ARG 5 vertexCount
 		ARG 6 textured
 	METHOD method_34423 unbindElementBuffer ()V
-	METHOD method_34424 (Lnet/minecraft/class_287;)V
+	METHOD method_34424 postDraw (Lnet/minecraft/class_287;)V
+		COMMENT Similar to a regular draw, however this method will skip rendering shaders.
 		ARG 0 builder

--- a/mappings/net/minecraft/client/render/BufferRenderer.mapping
+++ b/mappings/net/minecraft/client/render/BufferRenderer.mapping
@@ -2,7 +2,20 @@ CLASS net/minecraft/class_286 net/minecraft/client/render/BufferRenderer
 	FIELD field_29331 currentVertexArrayObject I
 	FIELD field_29332 currentVertexBufferObject I
 	FIELD field_29333 currentElementBufferObject I
+	FIELD field_29334 vertexFormat Lnet/minecraft/class_293;
 	METHOD method_1309 draw (Lnet/minecraft/class_287;)V
 		ARG 0 bufferBuilder
 	METHOD method_34420 unbindAll ()V
+	METHOD method_34421 bind (Lnet/minecraft/class_293;)V
+		ARG 0 vertexFormat
+	METHOD method_34422 draw (Ljava/nio/ByteBuffer;Lnet/minecraft/class_293$class_5596;Lnet/minecraft/class_293;ILnet/minecraft/class_293$class_5595;IZ)V
+		ARG 0 buffer
+		ARG 1 drawMode
+		ARG 2 vertexFormat
+		ARG 3 count
+		ARG 4 elementFormat
+		ARG 5 vertexCount
+		ARG 6 textured
 	METHOD method_34423 unbindElementBuffer ()V
+	METHOD method_34424 (Lnet/minecraft/class_287;)V
+		ARG 0 builder

--- a/mappings/net/minecraft/client/render/BufferVertexConsumer.mapping
+++ b/mappings/net/minecraft/client/render/BufferVertexConsumer.mapping
@@ -14,3 +14,4 @@ CLASS net/minecraft/class_4584 net/minecraft/client/render/BufferVertexConsumer
 		ARG 2 v
 		ARG 3 index
 	METHOD method_22900 getCurrentElement ()Lnet/minecraft/class_296;
+	METHOD method_24212 packByte (F)B

--- a/mappings/net/minecraft/client/render/RenderLayer.mapping
+++ b/mappings/net/minecraft/client/render/RenderLayer.mapping
@@ -28,6 +28,7 @@ CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 	METHOD <init> (Ljava/lang/String;Lnet/minecraft/class_293;Lnet/minecraft/class_293$class_5596;IZZLjava/lang/Runnable;Ljava/lang/Runnable;)V
 		ARG 1 name
 		ARG 2 vertexFormat
+		ARG 3 drawMode
 		ARG 4 expectedBufferSize
 		ARG 5 hasCrumbling
 		ARG 6 translucent
@@ -94,11 +95,13 @@ CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 	METHOD method_24048 of (Ljava/lang/String;Lnet/minecraft/class_293;Lnet/minecraft/class_293$class_5596;ILnet/minecraft/class_1921$class_4688;)Lnet/minecraft/class_1921$class_4687;
 		ARG 0 name
 		ARG 1 vertexFormat
+		ARG 2 drawMode
 		ARG 3 expectedBufferSize
 		ARG 4 phaseData
 	METHOD method_24049 of (Ljava/lang/String;Lnet/minecraft/class_293;Lnet/minecraft/class_293$class_5596;IZZLnet/minecraft/class_1921$class_4688;)Lnet/minecraft/class_1921$class_4687;
 		ARG 0 name
 		ARG 1 vertexFormat
+		ARG 2 drawMode
 		ARG 3 expectedBufferSize
 		ARG 4 hasCrumbling
 		ARG 5 translucent
@@ -132,6 +135,8 @@ CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 	METHOD method_29997 getTripwire ()Lnet/minecraft/class_1921;
 	METHOD method_34569 of (Lnet/minecraft/class_4668$class_5942;)Lnet/minecraft/class_1921$class_4688;
 		ARG 0 shader
+	METHOD method_34571 getEndGateway ()Lnet/minecraft/class_1921;
+	METHOD method_34572 getLineStrip ()Lnet/minecraft/class_1921;
 	METHOD method_34822 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
 		ARG 0 texture
 	METHOD method_34823 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
@@ -176,13 +181,21 @@ CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 		FIELD field_21403 phases Lnet/minecraft/class_1921$class_4688;
 		FIELD field_21697 affectedOutline Ljava/util/Optional;
 		FIELD field_21851 outline Z
+		FIELD field_29640 CULLING_LAYERS Ljava/util/function/BiFunction;
 		METHOD <init> (Ljava/lang/String;Lnet/minecraft/class_293;Lnet/minecraft/class_293$class_5596;IZZLnet/minecraft/class_1921$class_4688;)V
 			ARG 1 name
 			ARG 2 vertexFormat
+			ARG 3 drawMode
 			ARG 4 expectedBufferSize
 			ARG 5 hasCrumbling
 			ARG 6 translucent
 			ARG 7 phases
+		METHOD method_34843 (Lnet/minecraft/class_1921$class_4688;Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
+			ARG 1 texture
+		METHOD method_34844 (Lnet/minecraft/class_2960;Lnet/minecraft/class_4668$class_4671;)Lnet/minecraft/class_1921;
+			ARG 0 texture
+			ARG 1 culling
+		METHOD method_35784 getPhases ()Lnet/minecraft/class_1921$class_4688;
 	CLASS class_4688 MultiPhaseParameters
 		FIELD field_21406 texture Lnet/minecraft/class_4668$class_5939;
 		FIELD field_21407 transparency Lnet/minecraft/class_4668$class_4685;
@@ -197,6 +210,21 @@ CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 		FIELD field_21420 lineWidth Lnet/minecraft/class_4668$class_4677;
 		FIELD field_21422 phases Lcom/google/common/collect/ImmutableList;
 		FIELD field_21852 outlineMode Lnet/minecraft/class_1921$class_4750;
+		FIELD field_29461 shader Lnet/minecraft/class_4668$class_5942;
+		METHOD <init> (Lnet/minecraft/class_4668$class_5939;Lnet/minecraft/class_4668$class_5942;Lnet/minecraft/class_4668$class_4685;Lnet/minecraft/class_4668$class_4672;Lnet/minecraft/class_4668$class_4671;Lnet/minecraft/class_4668$class_4676;Lnet/minecraft/class_4668$class_4679;Lnet/minecraft/class_4668$class_4675;Lnet/minecraft/class_4668$class_4678;Lnet/minecraft/class_4668$class_4684;Lnet/minecraft/class_4668$class_4686;Lnet/minecraft/class_4668$class_4677;Lnet/minecraft/class_1921$class_4750;)V
+			ARG 1 texture
+			ARG 2 shader
+			ARG 3 transparency
+			ARG 4 depthTest
+			ARG 5 cull
+			ARG 6 lightmap
+			ARG 7 overlay
+			ARG 8 layering
+			ARG 9 target
+			ARG 10 texturing
+			ARG 11 writeMaskState
+			ARG 12 lineWidth
+			ARG 13 outlineMode
 		METHOD method_23598 builder ()Lnet/minecraft/class_1921$class_4688$class_4689;
 		CLASS class_4689 Builder
 			FIELD field_21424 transparency Lnet/minecraft/class_4668$class_4685;

--- a/mappings/net/minecraft/client/render/VertexConsumer.mapping
+++ b/mappings/net/minecraft/client/render/VertexConsumer.mapping
@@ -7,6 +7,10 @@ CLASS net/minecraft/class_4588 net/minecraft/client/render/VertexConsumer
 		ARG 4 alpha
 	METHOD method_1344 next ()V
 	METHOD method_22901 fixedColor (IIII)V
+		ARG 1 red
+		ARG 2 green
+		ARG 3 blue
+		ARG 4 alpha
 	METHOD method_22912 vertex (DDD)Lnet/minecraft/class_4588;
 		ARG 1 x
 		ARG 3 y
@@ -76,3 +80,4 @@ CLASS net/minecraft/class_4588 net/minecraft/client/render/VertexConsumer
 		ARG 12 normalX
 		ARG 13 normalY
 		ARG 14 normalZ
+	METHOD method_35666 unfixColor ()V

--- a/mappings/net/minecraft/client/render/VertexConsumers.mapping
+++ b/mappings/net/minecraft/client/render/VertexConsumers.mapping
@@ -1,10 +1,43 @@
 CLASS net/minecraft/class_4720 net/minecraft/client/render/VertexConsumers
-	METHOD method_24037 dual (Lnet/minecraft/class_4588;Lnet/minecraft/class_4588;)Lnet/minecraft/class_4588;
+	COMMENT A utility for combining multiple VertexConsumers into one.
+	METHOD method_24037 union (Lnet/minecraft/class_4588;Lnet/minecraft/class_4588;)Lnet/minecraft/class_4588;
 		ARG 0 first
 		ARG 1 second
+	METHOD method_35668 union ()Lnet/minecraft/class_4588;
+		COMMENT Generates a union of zero VertexConsumers.
+		COMMENT <p>
+		COMMENT Obviously this is not possible.
+		COMMENT
+		COMMENT @throws IllegalArgumentException
+	METHOD method_35669 union (Lnet/minecraft/class_4588;)Lnet/minecraft/class_4588;
+		ARG 0 first
+	METHOD method_35670 union ([Lnet/minecraft/class_4588;)Lnet/minecraft/class_4588;
+		ARG 0 delegates
 	CLASS class_4589 Dual
 		FIELD field_21685 first Lnet/minecraft/class_4588;
 		FIELD field_21686 second Lnet/minecraft/class_4588;
 		METHOD <init> (Lnet/minecraft/class_4588;Lnet/minecraft/class_4588;)V
 			ARG 1 first
 			ARG 2 second
+	CLASS class_6189 Union
+		FIELD field_32053 delegates [Lnet/minecraft/class_4588;
+		METHOD <init> ([Lnet/minecraft/class_4588;)V
+			ARG 1 delegates
+		METHOD method_35671 (DDDLnet/minecraft/class_4588;)V
+			ARG 6 i
+		METHOD method_35672 (FFFFFFFFFIIFFFLnet/minecraft/class_4588;)V
+			ARG 14 i
+		METHOD method_35673 (FFFLnet/minecraft/class_4588;)V
+			ARG 3 i
+		METHOD method_35674 (FFLnet/minecraft/class_4588;)V
+			ARG 2 i
+		METHOD method_35675 (IIIILnet/minecraft/class_4588;)V
+			ARG 4 i
+		METHOD method_35676 (IILnet/minecraft/class_4588;)V
+			ARG 2 i
+		METHOD method_35677 delegate (Ljava/util/function/Consumer;)V
+			ARG 1 action
+		METHOD method_35678 (IIIILnet/minecraft/class_4588;)V
+			ARG 4 i
+		METHOD method_35679 (IILnet/minecraft/class_4588;)V
+			ARG 2 i

--- a/mappings/net/minecraft/client/render/VertexFormat.mapping
+++ b/mappings/net/minecraft/client/render/VertexFormat.mapping
@@ -2,12 +2,12 @@ CLASS net/minecraft/class_293 net/minecraft/client/render/VertexFormat
 	FIELD field_1597 offsets Lit/unimi/dsi/fastutil/ints/IntList;
 	FIELD field_1600 size I
 	FIELD field_1602 elements Lcom/google/common/collect/ImmutableList;
-	FIELD field_29340 shaderAttributes Lcom/google/common/collect/ImmutableMap;
-	FIELD field_29341 vertexArrayId I
-	FIELD field_29342 vertexbufferId I
-	FIELD field_29343 textureBufferId I
+	FIELD field_29340 elementMap Lcom/google/common/collect/ImmutableMap;
+	FIELD field_29341 vertexArray I
+	FIELD field_29342 vertexBuffer I
+	FIELD field_29343 elementBuffer I
 	METHOD <init> (Lcom/google/common/collect/ImmutableMap;)V
-		ARG 1 shaderAttributes
+		ARG 1 elementMap
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o
 	METHOD method_1357 getElements ()Lcom/google/common/collect/ImmutableList;
@@ -16,9 +16,9 @@ CLASS net/minecraft/class_293 net/minecraft/client/render/VertexFormat
 	METHOD method_22649 startDrawing ()V
 	METHOD method_22651 endDrawing ()V
 	METHOD method_34445 getShaderAttributes ()Lcom/google/common/collect/ImmutableList;
-	METHOD method_34446 getVertexArrayId ()I
+	METHOD method_34446 getVertexArray ()I
 	METHOD method_34447 getVertexBufferId ()I
-	METHOD method_34448 getTextureBuffer ()I
+	METHOD method_34448 getElementBuffer ()I
 	METHOD method_34449 innerStartDrawing ()V
 	METHOD method_34450 innerEndDrawing ()V
 	CLASS class_5595 IntType
@@ -35,9 +35,11 @@ CLASS net/minecraft/class_293 net/minecraft/client/render/VertexFormat
 				COMMENT a number from 8 to 32 bits of memory
 	CLASS class_5596 DrawMode
 		FIELD field_27383 mode I
+		FIELD field_27384 vertexCount I
 		FIELD field_27385 size I
 		METHOD <init> (Ljava/lang/String;IIII)V
 			ARG 3 mode
+			ARG 4 vertexCount
 			ARG 5 size
 		METHOD method_31973 getSize (I)I
 			ARG 1 vertexCount

--- a/mappings/net/minecraft/client/render/VertexFormat.mapping
+++ b/mappings/net/minecraft/client/render/VertexFormat.mapping
@@ -17,7 +17,7 @@ CLASS net/minecraft/class_293 net/minecraft/client/render/VertexFormat
 	METHOD method_22651 endDrawing ()V
 	METHOD method_34445 getShaderAttributes ()Lcom/google/common/collect/ImmutableList;
 	METHOD method_34446 getVertexArray ()I
-	METHOD method_34447 getVertexBufferId ()I
+	METHOD method_34447 getVertexBuffer ()I
 	METHOD method_34448 getElementBuffer ()I
 	METHOD method_34449 innerStartDrawing ()V
 	METHOD method_34450 innerEndDrawing ()V

--- a/mappings/net/minecraft/client/render/VertexFormat.mapping
+++ b/mappings/net/minecraft/client/render/VertexFormat.mapping
@@ -2,6 +2,12 @@ CLASS net/minecraft/class_293 net/minecraft/client/render/VertexFormat
 	FIELD field_1597 offsets Lit/unimi/dsi/fastutil/ints/IntList;
 	FIELD field_1600 size I
 	FIELD field_1602 elements Lcom/google/common/collect/ImmutableList;
+	FIELD field_29340 shaderAttributes Lcom/google/common/collect/ImmutableMap;
+	FIELD field_29341 vertexArrayId I
+	FIELD field_29342 vertexbufferId I
+	FIELD field_29343 textureBufferId I
+	METHOD <init> (Lcom/google/common/collect/ImmutableMap;)V
+		ARG 1 shaderAttributes
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o
 	METHOD method_1357 getElements ()Lcom/google/common/collect/ImmutableList;
@@ -10,12 +16,16 @@ CLASS net/minecraft/class_293 net/minecraft/client/render/VertexFormat
 	METHOD method_22649 startDrawing ()V
 	METHOD method_22651 endDrawing ()V
 	METHOD method_34445 getShaderAttributes ()Lcom/google/common/collect/ImmutableList;
+	METHOD method_34446 getVertexArrayId ()I
+	METHOD method_34447 getVertexBufferId ()I
+	METHOD method_34448 getTextureBuffer ()I
+	METHOD method_34449 innerStartDrawing ()V
+	METHOD method_34450 innerEndDrawing ()V
 	CLASS class_5595 IntType
-		FIELD field_27371 BYTE Lnet/minecraft/class_293$class_5595;
-		FIELD field_27372 SHORT Lnet/minecraft/class_293$class_5595;
-		FIELD field_27373 INT Lnet/minecraft/class_293$class_5595;
+		FIELD field_27374 count I
 		FIELD field_27375 size I
 		METHOD <init> (Ljava/lang/String;III)V
+			ARG 3 count
 			ARG 4 size
 		METHOD method_31972 getSmallestTypeFor (I)Lnet/minecraft/class_293$class_5595;
 			COMMENT Gets the smallest type in which the given number fits.
@@ -24,14 +34,10 @@ CLASS net/minecraft/class_293 net/minecraft/client/render/VertexFormat
 			ARG 0 number
 				COMMENT a number from 8 to 32 bits of memory
 	CLASS class_5596 DrawMode
-		FIELD field_27377 LINES Lnet/minecraft/class_293$class_5596;
-		FIELD field_27378 LINE_STRIP Lnet/minecraft/class_293$class_5596;
-		FIELD field_27379 TRIANGLES Lnet/minecraft/class_293$class_5596;
-		FIELD field_27380 TRIANGLE_STRIP Lnet/minecraft/class_293$class_5596;
-		FIELD field_27381 TRIANGLE_FAN Lnet/minecraft/class_293$class_5596;
-		FIELD field_27382 QUADS Lnet/minecraft/class_293$class_5596;
 		FIELD field_27383 mode I
+		FIELD field_27385 size I
 		METHOD <init> (Ljava/lang/String;IIII)V
 			ARG 3 mode
+			ARG 5 size
 		METHOD method_31973 getSize (I)I
 			ARG 1 vertexCount

--- a/mappings/net/minecraft/client/render/VertexFormatElement.mapping
+++ b/mappings/net/minecraft/client/render/VertexFormatElement.mapping
@@ -119,8 +119,8 @@ CLASS net/minecraft/class_296 net/minecraft/client/render/VertexFormatElement
 			ARG 5 textureIndex
 			ARG 6 elementIndex
 		METHOD method_34452 (II)V
-			ARG 0 texture_index
-			ARG 1 element_index
+			ARG 0 textureIndex
+			ARG 1 elementIndex
 		CLASS class_4575 Starter
 			METHOD setupBufferState (IIIJII)V
 				ARG 1 size

--- a/mappings/net/minecraft/client/render/VertexFormatElement.mapping
+++ b/mappings/net/minecraft/client/render/VertexFormatElement.mapping
@@ -14,11 +14,18 @@ CLASS net/minecraft/class_296 net/minecraft/client/render/VertexFormatElement
 	METHOD method_1382 getType ()Lnet/minecraft/class_296$class_298;
 	METHOD method_1383 isValidType (ILnet/minecraft/class_296$class_298;)Z
 		ARG 1 index
+		ARG 2 type
 	METHOD method_1385 getIndex ()I
 	METHOD method_1386 getFormat ()Lnet/minecraft/class_296$class_297;
 	METHOD method_1387 getSize ()I
 	METHOD method_22652 startDrawing (IJI)V
+		ARG 1 arrayId
+		ARG 2 pointer
+		ARG 4 stride
 	METHOD method_22653 endDrawing (I)V
+		ARG 1 arrayId
+	METHOD method_34451 getCount ()I
+	METHOD method_35667 isPosition ()Z
 	CLASS class_297 Format
 		FIELD field_1618 size I
 		FIELD field_1626 name Ljava/lang/String;
@@ -36,15 +43,19 @@ CLASS net/minecraft/class_296 net/minecraft/client/render/VertexFormatElement
 		FIELD field_20784 finisher Lnet/minecraft/class_296$class_298$class_5938;
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;Lnet/minecraft/class_296$class_298$class_4575;Lnet/minecraft/class_296$class_298$class_5938;)V
 			ARG 3 name
+			ARG 4 starter
+			ARG 5 finisher
 		METHOD method_1392 getName ()Ljava/lang/String;
 		METHOD method_22654 endDrawing (II)V
 			ARG 1 elementIndex
+			ARG 2 arrayId
 		METHOD method_22655 startDrawing (IIIJII)V
 			ARG 1 count
 			ARG 2 glId
 			ARG 3 stride
 			ARG 4 pointer
 			ARG 6 elementIndex
+			ARG 7 arrayId
 		CLASS class_4575 Starter
 			METHOD setupBufferState (IIIJII)V
 				ARG 1 count
@@ -52,3 +63,8 @@ CLASS net/minecraft/class_296 net/minecraft/client/render/VertexFormatElement
 				ARG 3 stride
 				ARG 4 pointer
 				ARG 6 elementIndex
+				ARG 7 arrayId
+		CLASS class_5938 Finisher
+			METHOD clearBufferState (II)V
+				ARG 1 elementIndex
+				ARG 2 arrayId

--- a/mappings/net/minecraft/client/render/VertexFormatElement.mapping
+++ b/mappings/net/minecraft/client/render/VertexFormatElement.mapping
@@ -1,42 +1,47 @@
 CLASS net/minecraft/class_296 net/minecraft/client/render/VertexFormatElement
-	FIELD field_1612 count I
-	FIELD field_1613 index I
+	COMMENT Represents a singular field within a larger vertex format.
+	COMMENT <p>
+	COMMENT This element comprises a data type, a field length,
+	COMMENT and the corresponding GL element type to which this field corresponds.
+	FIELD field_1612 length I
+	FIELD field_1613 textureIndex I
 	FIELD field_1614 type Lnet/minecraft/class_296$class_298;
-	FIELD field_1615 format Lnet/minecraft/class_296$class_297;
-	FIELD field_21329 size I
+	FIELD field_1615 dataType Lnet/minecraft/class_296$class_297;
+	FIELD field_21329 byteLength I
+		COMMENT The total length of this element (in bytes).
 	METHOD <init> (ILnet/minecraft/class_296$class_297;Lnet/minecraft/class_296$class_298;I)V
-		ARG 1 index
-		ARG 2 format
+		ARG 1 textureIndex
+		ARG 2 dataType
 		ARG 3 type
-		ARG 4 count
+		ARG 4 length
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o
 	METHOD method_1382 getType ()Lnet/minecraft/class_296$class_298;
 	METHOD method_1383 isValidType (ILnet/minecraft/class_296$class_298;)Z
 		ARG 1 index
 		ARG 2 type
-	METHOD method_1385 getIndex ()I
-	METHOD method_1386 getFormat ()Lnet/minecraft/class_296$class_297;
-	METHOD method_1387 getSize ()I
+	METHOD method_1385 getTextureIndex ()I
+	METHOD method_1386 getDataType ()Lnet/minecraft/class_296$class_297;
+	METHOD method_1387 getByteLength ()I
 	METHOD method_22652 startDrawing (IJI)V
-		ARG 1 arrayId
+		ARG 1 elementIndex
 		ARG 2 pointer
 		ARG 4 stride
 	METHOD method_22653 endDrawing (I)V
-		ARG 1 arrayId
-	METHOD method_34451 getCount ()I
+		ARG 1 elementIndex
+	METHOD method_34451 getLength ()I
 	METHOD method_35667 isPosition ()Z
-	CLASS class_297 Format
-		FIELD field_1618 size I
+	CLASS class_297 DataType
+		FIELD field_1618 byteLength I
 		FIELD field_1626 name Ljava/lang/String;
-		FIELD field_1627 glId I
+		FIELD field_1627 id I
 		METHOD <init> (Ljava/lang/String;IILjava/lang/String;I)V
-			ARG 3 size
+			ARG 3 byteCount
 			ARG 4 name
-			ARG 5 glId
+			ARG 5 id
 		METHOD method_1389 getName ()Ljava/lang/String;
-		METHOD method_1390 getGlId ()I
-		METHOD method_1391 getSize ()I
+		METHOD method_1390 getId ()I
+		METHOD method_1391 getByteLength ()I
 	CLASS class_298 Type
 		FIELD field_1630 name Ljava/lang/String;
 		FIELD field_20783 starter Lnet/minecraft/class_296$class_298$class_4575;
@@ -47,24 +52,84 @@ CLASS net/minecraft/class_296 net/minecraft/client/render/VertexFormatElement
 			ARG 5 finisher
 		METHOD method_1392 getName ()Ljava/lang/String;
 		METHOD method_22654 endDrawing (II)V
-			ARG 1 elementIndex
-			ARG 2 arrayId
+			ARG 1 textureIndex
+			ARG 2 elementIndex
 		METHOD method_22655 startDrawing (IIIJII)V
-			ARG 1 count
-			ARG 2 glId
+			ARG 1 size
+			ARG 2 type
 			ARG 3 stride
 			ARG 4 pointer
+			ARG 6 textureIndex
+			ARG 7 elementIndex
+		METHOD method_22657 (II)V
+			ARG 0 textureIndex
+			ARG 1 elementIndex
+		METHOD method_22658 (IIIJII)V
+			ARG 0 size
+			ARG 1 type
+			ARG 2 stride
+			ARG 3 pointer
+			ARG 5 textureIndex
 			ARG 6 elementIndex
-			ARG 7 arrayId
+		METHOD method_22659 (II)V
+			ARG 0 textureIndex
+			ARG 1 elementIndex
+		METHOD method_22660 (IIIJII)V
+			ARG 0 size
+			ARG 1 type
+			ARG 2 stride
+			ARG 3 pointer
+			ARG 5 textureIndex
+			ARG 6 elementIndex
+		METHOD method_22661 (II)V
+			ARG 0 textureIndex
+			ARG 1 elementIndex
+		METHOD method_22662 (IIIJII)V
+			ARG 0 size
+			ARG 1 type
+			ARG 2 stride
+			ARG 3 pointer
+			ARG 5 textureIndex
+			ARG 6 elementIndex
+		METHOD method_22663 (II)V
+			ARG 0 textureIndex
+			ARG 1 elementIndex
+		METHOD method_22664 (IIIJII)V
+			ARG 0 size
+			ARG 1 type
+			ARG 2 stride
+			ARG 3 pointer
+			ARG 5 textureIndex
+			ARG 6 elementIndex
+		METHOD method_22665 (II)V
+			ARG 0 textureIndex
+			ARG 1 elementIndex
+		METHOD method_22666 (IIIJII)V
+			ARG 0 size
+			ARG 1 type
+			ARG 2 stride
+			ARG 3 pointer
+			ARG 5 textureIndex
+			ARG 6 elementIndex
+		METHOD method_22667 (IIIJII)V
+			ARG 0 size
+			ARG 1 type
+			ARG 2 stride
+			ARG 3 pointer
+			ARG 5 textureIndex
+			ARG 6 elementIndex
+		METHOD method_34452 (II)V
+			ARG 0 texture_index
+			ARG 1 element_index
 		CLASS class_4575 Starter
 			METHOD setupBufferState (IIIJII)V
-				ARG 1 count
-				ARG 2 glId
+				ARG 1 size
+				ARG 2 type
 				ARG 3 stride
 				ARG 4 pointer
-				ARG 6 elementIndex
-				ARG 7 arrayId
+				ARG 6 textureIndex
+				ARG 7 elementIndex
 		CLASS class_5938 Finisher
 			METHOD clearBufferState (II)V
-				ARG 1 elementIndex
-				ARG 2 arrayId
+				ARG 1 textureIndex
+				ARG 2 elementIndex

--- a/mappings/net/minecraft/client/render/VertexFormats.mapping
+++ b/mappings/net/minecraft/client/render/VertexFormats.mapping
@@ -12,11 +12,12 @@ CLASS net/minecraft/class_290 net/minecraft/client/render/VertexFormats
 	FIELD field_1586 POSITION_TEXTURE_LIGHT_COLOR Lnet/minecraft/class_293;
 	FIELD field_1587 POSITION_ELEMENT Lnet/minecraft/class_296;
 	FIELD field_1590 POSITION_COLOR_TEXTURE_LIGHT_NORMAL Lnet/minecraft/class_293;
-	FIELD field_1591 TEXTURE_ELEMENT Lnet/minecraft/class_296;
+	FIELD field_1591 TEXTURE_0_ELEMENT Lnet/minecraft/class_296;
 	FIELD field_1592 POSITION Lnet/minecraft/class_293;
 	FIELD field_20886 LIGHT_ELEMENT Lnet/minecraft/class_296;
 	FIELD field_20887 POSITION_COLOR_TEXTURE Lnet/minecraft/class_293;
 	FIELD field_20888 POSITION_COLOR_TEXTURE_LIGHT Lnet/minecraft/class_293;
 	FIELD field_21468 POSITION_COLOR_LIGHT Lnet/minecraft/class_293;
+	FIELD field_29335 TEXTURE_ELEMENT Lnet/minecraft/class_296;
 	FIELD field_29336 BLIT_SCREEN Lnet/minecraft/class_293;
 	FIELD field_29337 LINES Lnet/minecraft/class_293;

--- a/mappings/net/minecraft/client/render/entity/FishingBobberEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/FishingBobberEntityRenderer.mapping
@@ -1,3 +1,21 @@
 CLASS net/minecraft/class_906 net/minecraft/client/render/entity/FishingBobberEntityRenderer
 	FIELD field_21742 LAYER Lnet/minecraft/class_1921;
 	FIELD field_4707 TEXTURE Lnet/minecraft/class_2960;
+	METHOD method_23172 (FFFLnet/minecraft/class_4588;Lnet/minecraft/class_4587$class_4665;FF)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 z
+		ARG 3 buffer
+		ARG 4 mormal
+	METHOD method_23840 vertex (Lnet/minecraft/class_4588;Lnet/minecraft/class_1159;Lnet/minecraft/class_4581;IFIII)V
+		ARG 0 buffer
+		ARG 1 matrix
+		ARG 2 normalMatrix
+		ARG 3 light
+		ARG 4 x
+		ARG 5 y
+		ARG 6 u
+		ARG 7 v
+	METHOD method_23954 percentage (II)F
+		ARG 0 value
+		ARG 1 max

--- a/mappings/net/minecraft/client/render/entity/FishingBobberEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/FishingBobberEntityRenderer.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/class_906 net/minecraft/client/render/entity/FishingBobberEn
 		ARG 1 y
 		ARG 2 z
 		ARG 3 buffer
-		ARG 4 mormal
+		ARG 4 normal
 	METHOD method_23840 vertex (Lnet/minecraft/class_4588;Lnet/minecraft/class_1159;Lnet/minecraft/class_4581;IFIII)V
 		ARG 0 buffer
 		ARG 1 matrix

--- a/mappings/net/minecraft/client/render/entity/LightningEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/LightningEntityRenderer.mapping
@@ -1,1 +1,7 @@
 CLASS net/minecraft/class_919 net/minecraft/client/render/entity/LightningEntityRenderer
+	METHOD method_23183 drawBranch (Lnet/minecraft/class_1159;Lnet/minecraft/class_4588;FFIFFFFFFFZZZZ)V
+		ARG 0 matrix
+		ARG 1 buffer
+		ARG 7 red
+		ARG 8 green
+		ARG 9 blue


### PR DESCRIPTION
I'm sure some of this was already mapped with my PR for RenderPhase, but I guess they were corrupted by the move to 21w14a.