### PR TITLE
Map raw metal blocks

### DIFF
--- a/mappings/net/minecraft/block/MapColor.mapping
+++ b/mappings/net/minecraft/block/MapColor.mapping
@@ -64,7 +64,7 @@ CLASS net/minecraft/class_3620 net/minecraft/block/MapColor
 	FIELD field_25706 DARK_AQUA Lnet/minecraft/class_3620;
 	FIELD field_25707 DARK_DULL_PINK Lnet/minecraft/class_3620;
 	FIELD field_25708 BRIGHT_TEAL Lnet/minecraft/class_3620;
-	FIELD field_33533 IRON Lnet/minecraft/class_3620;
+	FIELD field_33533 RAW_IRON_PINK Lnet/minecraft/class_3620;
 	METHOD <init> (II)V
 		ARG 1 id
 		ARG 2 color

--- a/mappings/net/minecraft/block/MapColor.mapping
+++ b/mappings/net/minecraft/block/MapColor.mapping
@@ -64,6 +64,7 @@ CLASS net/minecraft/class_3620 net/minecraft/block/MapColor
 	FIELD field_25706 DARK_AQUA Lnet/minecraft/class_3620;
 	FIELD field_25707 DARK_DULL_PINK Lnet/minecraft/class_3620;
 	FIELD field_25708 BRIGHT_TEAL Lnet/minecraft/class_3620;
+	FIELD field_33533 IRON Lnet/minecraft/class_3620;
 	METHOD <init> (II)V
 		ARG 1 id
 		ARG 2 color

--- a/mappings/net/minecraft/data/server/RecipesProvider.mapping
+++ b/mappings/net/minecraft/data/server/RecipesProvider.mapping
@@ -232,3 +232,11 @@ CLASS net/minecraft/class_2446 net/minecraft/data/server/RecipesProvider
 		ARG 2 output
 		ARG 3 experience
 		ARG 4 cookingTime
+	METHOD method_36325 offerReversibleCompactingRecipes (Ljava/util/function/Consumer;Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;)V
+		COMMENT Offers two recipes to convert between a normal and compacted form of an item.
+		COMMENT
+		COMMENT <p>The shaped recipe converts 9 items in a square to a compacted form of the item.
+		COMMENT <p>The shapeless recipe converts the compacted form to 9 of the normal form.
+		ARG 0 exporter
+		ARG 1 normal
+		ARG 2 compact

--- a/mappings/net/minecraft/item/Items.mapping
+++ b/mappings/net/minecraft/item/Items.mapping
@@ -287,6 +287,9 @@ CLASS net/minecraft/class_1802 net/minecraft/item/Items
 	FIELD field_33404 WAXED_OXIDIZED_CUT_COPPER Lnet/minecraft/class_1792;
 	FIELD field_33405 WAXED_OXIDIZED_CUT_COPPER_STAIRS Lnet/minecraft/class_1792;
 	FIELD field_33406 WAXED_OXIDIZED_CUT_COPPER_SLAB Lnet/minecraft/class_1792;
+	FIELD field_33505 RAW_IRON_BLOCK Lnet/minecraft/class_1792;
+	FIELD field_33506 RAW_COPPER_BLOCK Lnet/minecraft/class_1792;
+	FIELD field_33507 RAW_GOLD_BLOCK Lnet/minecraft/class_1792;
 	FIELD field_8043 ORANGE_TERRACOTTA Lnet/minecraft/class_1792;
 	FIELD field_8047 JUNGLE_PRESSURE_PLATE Lnet/minecraft/class_1792;
 	FIELD field_8048 SPRUCE_BUTTON Lnet/minecraft/class_1792;


### PR DESCRIPTION
This pull request maps the item fields of raw metal blocks, a recipe exporter for the compacting and decompacting recipes, and a map color (`#D8AF93`) used for raw iron blocks.