### PR TITLE
Map the gray map color used for deepslate

### DIFF
--- a/mappings/net/minecraft/block/MapColor.mapping
+++ b/mappings/net/minecraft/block/MapColor.mapping
@@ -64,6 +64,7 @@ CLASS net/minecraft/class_3620 net/minecraft/block/MapColor
 	FIELD field_25706 DARK_AQUA Lnet/minecraft/class_3620;
 	FIELD field_25707 DARK_DULL_PINK Lnet/minecraft/class_3620;
 	FIELD field_25708 BRIGHT_TEAL Lnet/minecraft/class_3620;
+	FIELD field_33532 DEEPSLATE_GRAY Lnet/minecraft/class_3620;
 	METHOD <init> (II)V
 		ARG 1 id
 		ARG 2 color


### PR DESCRIPTION
This pull request maps the `#646464` map color that is used for deepslate.