### PR TITLE
Fix regression and map recipe datagen.

### DIFF
--- a/mappings/net/minecraft/data/server/recipe/CraftingRecipeJsonFactory.mapping
+++ b/mappings/net/minecraft/data/server/recipe/CraftingRecipeJsonFactory.mapping
@@ -2,8 +2,16 @@ CLASS net/minecraft/class_5797 net/minecraft/data/server/recipe/CraftingRecipeJs
 	METHOD method_10431 offerTo (Ljava/util/function/Consumer;)V
 		ARG 1 exporter
 	METHOD method_17972 offerTo (Ljava/util/function/Consumer;Lnet/minecraft/class_2960;)V
+		ARG 1 exporter
+		ARG 2 recipeId
 	METHOD method_33529 group (Ljava/lang/String;)Lnet/minecraft/class_5797;
 		ARG 1 group
 	METHOD method_33530 criterion (Ljava/lang/String;Lnet/minecraft/class_184;)Lnet/minecraft/class_5797;
 		ARG 1 name
 		ARG 2 conditions
+	METHOD method_36441 getOutputItem ()Lnet/minecraft/class_1792;
+	METHOD method_36442 getItemId (Lnet/minecraft/class_1935;)Lnet/minecraft/class_2960;
+		ARG 0 item
+	METHOD method_36443 offerTo (Ljava/util/function/Consumer;Ljava/lang/String;)V
+		ARG 1 exporter
+		ARG 2 recipeIdStr

--- a/mappings/net/minecraft/data/server/recipe/CraftingRecipeJsonFactory.mapping
+++ b/mappings/net/minecraft/data/server/recipe/CraftingRecipeJsonFactory.mapping
@@ -14,4 +14,4 @@ CLASS net/minecraft/class_5797 net/minecraft/data/server/recipe/CraftingRecipeJs
 		ARG 0 item
 	METHOD method_36443 offerTo (Ljava/util/function/Consumer;Ljava/lang/String;)V
 		ARG 1 exporter
-		ARG 2 recipeIdStr
+		ARG 2 recipePath

--- a/mappings/net/minecraft/data/server/recipe/ShapedRecipeJsonFactory.mapping
+++ b/mappings/net/minecraft/data/server/recipe/ShapedRecipeJsonFactory.mapping
@@ -38,3 +38,12 @@ CLASS net/minecraft/class_2447 net/minecraft/data/server/recipe/ShapedRecipeJson
 		FIELD field_11388 inputs Ljava/util/Map;
 		FIELD field_11389 builder Lnet/minecraft/class_161$class_162;
 		FIELD field_11390 advancementId Lnet/minecraft/class_2960;
+		METHOD <init> (Lnet/minecraft/class_2960;Lnet/minecraft/class_1792;ILjava/lang/String;Ljava/util/List;Ljava/util/Map;Lnet/minecraft/class_161$class_162;Lnet/minecraft/class_2960;)V
+			ARG 1 recipeId
+			ARG 2 output
+			ARG 3 resultCount
+			ARG 4 group
+			ARG 5 pattern
+			ARG 6 inputs
+			ARG 7 builder
+			ARG 8 advancementId


### PR DESCRIPTION
Regression specifics: params got dropped in the constructor of `ShapedRecipeJsonProvider` due to the class becoming static thus loosing a synthetic param.