### PR TITLE
21w16a stuff

### DIFF
--- a/mappings/net/minecraft/block/AbstractLichenBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractLichenBlock.mapping
@@ -51,7 +51,7 @@ CLASS net/minecraft/class_5778 net/minecraft/block/AbstractLichenBlock
 	METHOD method_33367 mirror (Lnet/minecraft/class_2680;Ljava/util/function/Function;)Lnet/minecraft/class_2680;
 		ARG 1 state
 		ARG 2 mirror
-	METHOD method_33368 withNoDirections (Lnet/minecraft/class_2689;)Lnet/minecraft/class_2680;
+	METHOD method_33368 withAllDirections (Lnet/minecraft/class_2689;)Lnet/minecraft/class_2680;
 		ARG 0 stateManager
 	METHOD method_33369 canHaveDirection (Lnet/minecraft/class_2350;)Z
 		ARG 1 direction
@@ -98,3 +98,8 @@ CLASS net/minecraft/class_5778 net/minecraft/block/AbstractLichenBlock
 		ARG 2 world
 		ARG 3 pos
 		ARG 4 from
+	METHOD method_36292 withNoDirections (Lnet/minecraft/class_2248;)Lnet/minecraft/class_2680;
+		ARG 0 block
+	METHOD method_36293 withAllDirectionsSet (Lnet/minecraft/class_2680;Z)Lnet/minecraft/class_2680;
+		ARG 0 state
+		ARG 1 facing

--- a/mappings/net/minecraft/block/AzaleaBlock.mapping
+++ b/mappings/net/minecraft/block/AzaleaBlock.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/class_5800 net/minecraft/block/AzaleaBlock
 	FIELD field_30996 SHAPE Lnet/minecraft/class_265;
+	FIELD field_33563 generator Lnet/minecraft/class_6349;

--- a/mappings/net/minecraft/block/PillarBlock.mapping
+++ b/mappings/net/minecraft/block/PillarBlock.mapping
@@ -1,2 +1,5 @@
 CLASS net/minecraft/class_2465 net/minecraft/block/PillarBlock
 	FIELD field_11459 AXIS Lnet/minecraft/class_2754;
+	METHOD method_36377 changeRotation (Lnet/minecraft/class_2680;Lnet/minecraft/class_2470;)Lnet/minecraft/class_2680;
+		ARG 0 state
+		ARG 1 rotation

--- a/mappings/net/minecraft/block/PointedDripstoneBlock.mapping
+++ b/mappings/net/minecraft/block/PointedDripstoneBlock.mapping
@@ -8,6 +8,8 @@ CLASS net/minecraft/class_5689 net/minecraft/block/PointedDripstoneBlock
 	FIELD field_28056 FRUSTUM_SHAPE Lnet/minecraft/class_265;
 	FIELD field_28057 MIDDLE_SHAPE Lnet/minecraft/class_265;
 	FIELD field_28058 BASE_SHAPE Lnet/minecraft/class_265;
+	FIELD field_33568 MAX_STALACTITE_GROWTH I
+	FIELD field_33569 STALACTITE_FLOOR_SEARCH_RANGE I
 	METHOD method_32767 getDripPos (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)Lnet/minecraft/class_2338;
 		ARG 0 world
 		ARG 1 pos
@@ -66,10 +68,12 @@ CLASS net/minecraft/class_5689 net/minecraft/block/PointedDripstoneBlock
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 range
+		ARG 4 allowMerged
 	METHOD method_32783 canDrip (Lnet/minecraft/class_2680;)Z
 		ARG 0 state
 	METHOD method_32784 isTip (Lnet/minecraft/class_2680;Z)Z
 		ARG 0 state
+		ARG 1 allowMerged
 	METHOD method_32785 isPointingDown (Lnet/minecraft/class_2680;)Z
 		ARG 0 state
 	METHOD method_32899 createParticle (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)V
@@ -97,13 +101,54 @@ CLASS net/minecraft/class_5689 net/minecraft/block/PointedDripstoneBlock
 		ARG 0 fluid
 	METHOD method_33274 (Lnet/minecraft/class_3611;Lnet/minecraft/class_2680;)Z
 		ARG 1 state
+	METHOD method_33275 (Lnet/minecraft/class_2350;Lnet/minecraft/class_2680;)Z
+		ARG 1 state
 	METHOD method_33276 getFluid (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)Ljava/util/Optional;
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 state
 	METHOD method_33277 (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3611;)V
 		ARG 3 fluid
+	METHOD method_33278 (Lnet/minecraft/class_2350;Lnet/minecraft/class_2680;)Z
+		ARG 1 state
 	METHOD method_33279 (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)Lnet/minecraft/class_3611;
 		ARG 1 pos
 	METHOD method_33280 (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3611;)V
 		ARG 3 fluid
+	METHOD method_33281 (Lnet/minecraft/class_2680;)Z
+		ARG 0 state
+	METHOD method_35283 isPointingUp (Lnet/minecraft/class_2680;)Z
+		ARG 0 state
+	METHOD method_36368 tryGrowStalagmite (Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;)V
+		ARG 0 world
+		ARG 1 pos
+	METHOD method_36369 tryGrow (Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)V
+		ARG 0 world
+		ARG 1 pos
+		ARG 2 direction
+	METHOD method_36370 place (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;Lnet/minecraft/class_5691;)V
+		ARG 0 world
+		ARG 1 pos
+		ARG 2 direction
+		ARG 3 thickness
+	METHOD method_36371 canGrow (Lnet/minecraft/class_2680;Lnet/minecraft/class_2680;)Z
+		ARG 0 dripstoneBlockState
+		ARG 1 waterState
+	METHOD method_36372 isTip (Lnet/minecraft/class_2680;Lnet/minecraft/class_2350;)Z
+		ARG 0 state
+		ARG 1 direction
+	METHOD method_36373 (ZLnet/minecraft/class_2680;)Z
+		ARG 1 state
+	METHOD method_36374 canGrow (Lnet/minecraft/class_2680;Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;)Z
+		ARG 0 state
+		ARG 1 world
+		ARG 2 pos
+	METHOD method_36375 tryGrow (Lnet/minecraft/class_2680;Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;Ljava/util/Random;)V
+		ARG 0 state
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 random
+	METHOD method_36376 growMerged (Lnet/minecraft/class_2680;Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;)V
+		ARG 0 state
+		ARG 1 world
+		ARG 2 pos

--- a/mappings/net/minecraft/block/RotatedInfestedBlock.mapping
+++ b/mappings/net/minecraft/block/RotatedInfestedBlock.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_6348 net/minecraft/block/RotatedInfestedBlock

--- a/mappings/net/minecraft/block/sapling/AzaleaSaplingGenerator.mapping
+++ b/mappings/net/minecraft/block/sapling/AzaleaSaplingGenerator.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_6349 net/minecraft/block/sapling/AzaleaSaplingGenerator

--- a/mappings/net/minecraft/client/gui/screen/ingame/AbstractCommandBlockScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/AbstractCommandBlockScreen.mapping
@@ -15,3 +15,8 @@ CLASS net/minecraft/class_463 net/minecraft/client/gui/screen/ingame/AbstractCom
 	METHOD method_2360 onCommandChanged (Ljava/lang/String;)V
 		ARG 1 text
 	METHOD method_2364 getTrackOutputButtonHeight ()I
+	METHOD method_32641 (Lnet/minecraft/class_5676;Ljava/lang/Boolean;)V
+		ARG 1 button
+		ARG 2 trackOutput
+	METHOD method_32642 setPreviousOutputText (Z)V
+		ARG 1 trackOutput

--- a/mappings/net/minecraft/client/network/ClientPlayNetworkHandler.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayNetworkHandler.mapping
@@ -60,6 +60,8 @@ CLASS net/minecraft/class_634 net/minecraft/client/network/ClientPlayNetworkHand
 	METHOD method_29091 getRegistryManager ()Lnet/minecraft/class_5455;
 	METHOD method_29356 getWorldKeys ()Ljava/util/Set;
 	METHOD method_31363 getPlayerUuids ()Ljava/util/Collection;
+	METHOD method_34014 (Ljava/lang/String;Ljava/lang/String;ZZ)V
+		ARG 4 enabled
 	METHOD method_36322 getServerResourcePackPrompt (Lnet/minecraft/class_2561;Lnet/minecraft/class_2561;)Lnet/minecraft/class_2561;
 		ARG 0 defaultPrompt
 		ARG 1 customPrompt

--- a/mappings/net/minecraft/client/realms/Request.mapping
+++ b/mappings/net/minecraft/client/realms/Request.mapping
@@ -52,6 +52,9 @@ CLASS net/minecraft/class_4346 net/minecraft/client/realms/Request
 	METHOD method_21054 connect ()Lnet/minecraft/class_4346;
 	METHOD method_21055 doConnect ()Lnet/minecraft/class_4346;
 	METHOD method_21056 dispose ()V
+	METHOD method_35685 withHeader (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/class_4346;
+		ARG 1 name
+		ARG 2 value
 	CLASS class_4347 Delete
 	CLASS class_4348 Get
 	CLASS class_4349 Post

--- a/mappings/net/minecraft/data/server/recipe/CraftingRecipeJsonFactory.mapping
+++ b/mappings/net/minecraft/data/server/recipe/CraftingRecipeJsonFactory.mapping
@@ -7,3 +7,4 @@ CLASS net/minecraft/class_5797 net/minecraft/data/server/recipe/CraftingRecipeJs
 	METHOD method_33530 criterion (Ljava/lang/String;Lnet/minecraft/class_184;)Lnet/minecraft/class_5797;
 		ARG 1 name
 		ARG 2 conditions
+	METHOD method_36441 getOutput ()Lnet/minecraft/class_1792;

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -375,6 +375,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT each axis and checks whether the expanded box's smallest enclosing
 		COMMENT axis-aligned integer box is fully loaded in the world.
 	METHOD method_35049 getRemovalReason ()Lnet/minecraft/class_1297$class_5529;
+	METHOD method_36209 onRemoved ()V
 	METHOD method_5621 getMountedHeightOffset ()D
 	METHOD method_5622 onBlockCollision (Lnet/minecraft/class_2680;)V
 		ARG 1 state

--- a/mappings/net/minecraft/entity/projectile/FishingBobberEntity.mapping
+++ b/mappings/net/minecraft/entity/projectile/FishingBobberEntity.mapping
@@ -33,11 +33,14 @@ CLASS net/minecraft/class_1536 net/minecraft/entity/projectile/FishingBobberEnti
 	METHOD method_26342 getPositionType (Lnet/minecraft/class_2338;)Lnet/minecraft/class_1536$class_4984;
 		ARG 1 pos
 	METHOD method_26957 getHookedEntity ()Lnet/minecraft/class_1297;
+	METHOD method_36210 setPlayerFishHook (Lnet/minecraft/class_1536;)V
+		ARG 1 fishingBobber
 	METHOD method_6947 getPlayerOwner ()Lnet/minecraft/class_1657;
 	METHOD method_6949 tickFishingLogic (Lnet/minecraft/class_2338;)V
 		ARG 1 pos
 	METHOD method_6951 updateHookedEntityId (Lnet/minecraft/class_1297;)V
 	METHOD method_6954 pullHookedEntity (Lnet/minecraft/class_1297;)V
+		ARG 1 entity
 	METHOD method_6957 use (Lnet/minecraft/class_1799;)I
 		ARG 1 usedItem
 	METHOD method_6958 checkForCollision ()V

--- a/mappings/net/minecraft/server/command/ServerCommandSource.mapping
+++ b/mappings/net/minecraft/server/command/ServerCommandSource.mapping
@@ -40,6 +40,8 @@ CLASS net/minecraft/class_2168 net/minecraft/server/command/ServerCommandSource
 		ARG 10 silent
 		ARG 11 consumer
 		ARG 12 entityAnchor
+	METHOD method_36321 withOutput (Lnet/minecraft/class_2165;)Lnet/minecraft/class_2168;
+		ARG 1 output
 	METHOD method_9206 withLevel (I)Lnet/minecraft/class_2168;
 		ARG 1 level
 	METHOD method_9207 getPlayer ()Lnet/minecraft/class_3222;

--- a/mappings/net/minecraft/text/Text.mapping
+++ b/mappings/net/minecraft/text/Text.mapping
@@ -46,6 +46,11 @@ CLASS net/minecraft/class_2561 net/minecraft/text/Text
 		COMMENT Creates a literal text with the given string as content.
 		ARG 0 string
 	METHOD method_30937 asOrderedText ()Lnet/minecraft/class_5481;
+	METHOD method_36135 (Ljava/util/List;Lnet/minecraft/class_2583;Ljava/lang/String;)Ljava/util/Optional;
+		ARG 1 styleOverride
+		ARG 2 text
+	METHOD method_36136 getWithStyle (Lnet/minecraft/class_2583;)Ljava/util/List;
+		ARG 1 style
 	CLASS class_2562 Serializer
 		COMMENT A JSON serializer for {@link Text}.
 		FIELD field_11752 JSON_READER_LINE_START Ljava/lang/reflect/Field;

--- a/mappings/net/minecraft/text/Texts.mapping
+++ b/mappings/net/minecraft/text/Texts.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/class_2564 net/minecraft/text/Texts
+	FIELD field_33536 DEFAULT_SEPARATOR Ljava/lang/String;
+	FIELD field_33537 GRAY_SEPARATOR_TEXT Lnet/minecraft/class_2561;
+	FIELD field_33538 SEPARATOR_TEXT Lnet/minecraft/class_2561;
 	METHOD method_10881 parse (Lnet/minecraft/class_2168;Lnet/minecraft/class_2561;Lnet/minecraft/class_1297;I)Lnet/minecraft/class_5250;
 		ARG 0 source
 		ARG 1 text
@@ -28,3 +31,16 @@ CLASS net/minecraft/class_2564 net/minecraft/text/Texts
 		ARG 1 style
 		ARG 2 sender
 		ARG 3 depth
+	METHOD method_36330 parse (Lnet/minecraft/class_2168;Ljava/util/Optional;Lnet/minecraft/class_1297;I)Ljava/util/Optional;
+		ARG 0 source
+		ARG 1 text
+		ARG 2 sender
+		ARG 3 depth
+	METHOD method_36331 join (Ljava/util/Collection;Ljava/util/Optional;Ljava/util/function/Function;)Lnet/minecraft/class_5250;
+		ARG 0 elements
+		ARG 1 separator
+		ARG 2 transformer
+	METHOD method_36332 join (Ljava/util/Collection;Lnet/minecraft/class_2561;Ljava/util/function/Function;)Lnet/minecraft/class_5250;
+		ARG 0 elements
+		ARG 1 separator
+		ARG 2 transformer

--- a/mappings/net/minecraft/util/ChatUtil.mapping
+++ b/mappings/net/minecraft/util/ChatUtil.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_3544 net/minecraft/util/ChatUtil
 	FIELD field_15771 PATTERN Ljava/util/regex/Pattern;
 	FIELD field_29204 LINE_BREAK Ljava/util/regex/Pattern;
+	FIELD field_33559 ENDS_WITH_LINE_BREAK Ljava/util/regex/Pattern;
 	METHOD method_15438 isEmpty (Ljava/lang/String;)Z
 		ARG 0 text
 	METHOD method_15439 ticksToString (I)Ljava/lang/String;
@@ -13,3 +14,5 @@ CLASS net/minecraft/class_3544 net/minecraft/util/ChatUtil
 		ARG 0 text
 		ARG 1 maxLength
 		ARG 2 addEllipsis
+	METHOD method_36358 endsWithLineBreak (Ljava/lang/String;)Z
+		ARG 0 text

--- a/mappings/net/minecraft/util/Identifier.mapping
+++ b/mappings/net/minecraft/util/Identifier.mapping
@@ -51,6 +51,7 @@ CLASS net/minecraft/class_2960 net/minecraft/util/Identifier
 		ARG 0 character
 	METHOD method_29186 validate (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
 		ARG 0 id
+	METHOD method_36181 toUnderscoreSeparatedString ()Ljava/lang/String;
 	CLASS class_2961 Serializer
 		METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 			ARG 1 json

--- a/mappings/net/minecraft/util/crash/CrashReport.mapping
+++ b/mappings/net/minecraft/util/crash/CrashReport.mapping
@@ -11,6 +11,7 @@ CLASS net/minecraft/class_128 net/minecraft/util/crash/CrashReport
 		ARG 1 message
 		ARG 2 cause
 	METHOD method_24305 initCrashReport ()V
+	METHOD method_36147 getStackTrace ()Ljava/lang/String;
 	METHOD method_555 addStackTrace (Ljava/lang/StringBuilder;)V
 		ARG 1 crashReportBuilder
 	METHOD method_556 addElement (Ljava/lang/String;I)Lnet/minecraft/class_129;


### PR DESCRIPTION
Maps dripstone growth, azalea sapling, infested deepslate, text separator change (from 15a) and more.

`AbstractLichenBlock.withNoDirections` was renamed to `withAllDirections` because apparently the behavior of the method completely changed during snapshots.