### PR TITLE
Change Slot.onStackChanged -> Slot.onQuickTransfer

### DIFF
--- a/mappings/net/minecraft/screen/slot/Slot.mapping
+++ b/mappings/net/minecraft/screen/slot/Slot.mapping
@@ -33,9 +33,9 @@ CLASS net/minecraft/class_1735 net/minecraft/screen/slot/Slot
 	METHOD method_7668 markDirty ()V
 	METHOD method_7669 onCrafted (Lnet/minecraft/class_1799;)V
 		ARG 1 stack
-	METHOD method_7670 onStackChanged (Lnet/minecraft/class_1799;Lnet/minecraft/class_1799;)V
-		ARG 1 originalItem
-		ARG 2 newItem
+	METHOD method_7670 onQuickTransfer (Lnet/minecraft/class_1799;Lnet/minecraft/class_1799;)V
+		ARG 1 newItem
+		ARG 2 original
 	METHOD method_7671 takeStack (I)Lnet/minecraft/class_1799;
 		ARG 1 amount
 	METHOD method_7672 onTake (I)V


### PR DESCRIPTION
Fixes misleading name and switched parameters in this method https://github.com/FabricMC/yarn/issues/1656