### PR TITLE
Fix javadoc errors

### DIFF
--- a/mappings/net/minecraft/recipe/Recipe.mapping
+++ b/mappings/net/minecraft/recipe/Recipe.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/class_1860 net/minecraft/recipe/Recipe
 		COMMENT to appear in that grid.
 		COMMENT
 		COMMENT @implSpec Default implementation simply returns a grid of all empty stacks where all stacks from the
-		COMMENT input grid have been replaced with the result of calling {@link Item#getRecipeRemainder()} on them.
+		COMMENT input grid have been replaced with the result of calling {@link net.minecraft.item.Item#getRecipeRemainder()} on them.
 		ARG 1 inventory
 	METHOD method_8112 getGroup ()Ljava/lang/String;
 		COMMENT Optional group this recipe belongs in. Used to group recipes into different categories by the recipe book.

--- a/mappings/net/minecraft/util/collection/LinkedBlockPosHashSet.mapping
+++ b/mappings/net/minecraft/util/collection/LinkedBlockPosHashSet.mapping
@@ -12,7 +12,7 @@ CLASS net/minecraft/class_6136 net/minecraft/util/collection/LinkedBlockPosHashS
 	COMMENT <li>Positions that are geometrically close together are grouped together in memory. This localises adjacent reads and writes.</li>
 	COMMENT <li>A larger number of positions can be comprised together into one long allowing for a smaller memory footprint.</li>
 	COMMENT </ol>
-	COMMENT @see LevelPropagator
+	COMMENT @see net.minecraft.world.chunk.light.LevelPropagator
 	FIELD field_31715 buffer Lnet/minecraft/class_6136$class_6137;
 	METHOD <init> (IF)V
 		ARG 1 expectedSize
@@ -76,7 +76,7 @@ CLASS net/minecraft/class_6136 net/minecraft/util/collection/LinkedBlockPosHashS
 		METHOD method_35487 add (J)Z
 			COMMENT Ensures that this collection contains the specified element (optional operation).
 			COMMENT
-			COMMENT @see Collection#add(Object)
+			COMMENT @see java.util.Collection#add(Object)
 			ARG 1 posLong
 		METHOD method_35488 rem (J)Z
 			COMMENT Removes a block position from this map.

--- a/mappings/net/minecraft/world/WorldEvents.mapping
+++ b/mappings/net/minecraft/world/WorldEvents.mapping
@@ -269,7 +269,7 @@ CLASS net/minecraft/class_6088 net/minecraft/world/WorldEvents
 		COMMENT A fire block or campfire is extinguished.
 		COMMENT <br>Plays the fire extinguish sound event.
 		COMMENT <p>Called by {@link net.minecraft.block.AbstractFireBlock#onBreak(net.minecraft.world.World, net.minecraft.util.math.BlockPos, net.minecraft.block.BlockState, net.minecraft.entity.player.PlayerEntity) AbstractFireBlock#onBreak},
-		COMMENT {@link net.minecraft.entity.projectile.thrown.PotionEntity#extinguishFire(net.minecraft.util.math.BlockPos, net.minecraft.util.math.Direction) PotionEntity#extinguishFire},
+		COMMENT {@link net.minecraft.entity.projectile.thrown.PotionEntity#extinguishFire(net.minecraft.util.math.BlockPos) PotionEntity#extinguishFire},
 		COMMENT and {@link net.minecraft.item.ShovelItem#useOnBlock(net.minecraft.item.ItemUsageContext) ShovelItem#useOnBlock}
 	FIELD field_31168 MUSIC_DISC_PLAYED I
 		COMMENT A Music Disc is played.


### PR DESCRIPTION
Fixes these errors (https://github.com/FabricMC/yarn/runs/2427135969#step:7:197):
```
> Task :genFakeSource
:Fake source generated
/__w/yarn/yarn/.gradle/temp/fakeSource/net/minecraft/util/collection/LinkedBlockPosHashSet.java:20: error: reference not found

 * @see LevelPropagator
        ^
> Task :javadoc
/__w/yarn/yarn/.gradle/temp/fakeSource/net/minecraft/util/collection/LinkedBlockPosHashSet.java:226: error: reference not found
     * @see Collection#add(Object)
            ^
/__w/yarn/yarn/.gradle/temp/fakeSource/net/minecraft/recipe/Recipe.java:61: error: reference not found
   * input grid have been replaced with the result of calling {@link Item#getRecipeRemainder()} on them.
                                                                     ^
/__w/yarn/yarn/.gradle/temp/fakeSource/net/minecraft/world/WorldEvents.java:121: error: reference not found
   * {@link net.minecraft.entity.projectile.thrown.PotionEntity#extinguishFire(net.minecraft.util.math.BlockPos, net.minecraft.util.math.Direction) PotionEntity#extinguishFire},
            ^
4 errors
```
