### PR TITLE
Map bootstrap methods and fields

### DIFF
--- a/mappings/net/minecraft/Bootstrap.mapping
+++ b/mappings/net/minecraft/Bootstrap.mapping
@@ -5,11 +5,22 @@ CLASS net/minecraft/class_2966 net/minecraft/Bootstrap
 	METHOD method_12847 println (Ljava/lang/String;)V
 		ARG 0 str
 	METHOD method_12848 collectMissingTranslations (Ljava/lang/Iterable;Ljava/util/function/Function;Ljava/util/Set;)V
+		ARG 0 registry
 		ARG 1 keyExtractor
 		ARG 2 translationKeys
+	METHOD method_12850 (Ljava/util/function/Function;Lnet/minecraft/class_2477;Ljava/util/Set;Ljava/lang/Object;)V
+		ARG 3 object
 	METHOD method_12851 initialize ()V
 	METHOD method_12852 setOutputStreams ()V
+	METHOD method_17595 (Lnet/minecraft/class_2960;)Ljava/lang/String;
+		ARG 0 stat
 	METHOD method_17597 getMissingTranslations ()Ljava/util/Set;
 	METHOD method_17598 logMissing ()V
 	METHOD method_27732 collectMissingGameRuleTranslations (Ljava/util/Set;)V
 		ARG 0 translations
+	METHOD method_36235 ensureBootstrapped (Ljava/util/function/Supplier;)V
+		ARG 0 callerGetter
+	METHOD method_36236 (Ljava/lang/String;)V
+		ARG 0 key
+	METHOD method_36237 createNotBootstrappedException (Ljava/util/function/Supplier;)Ljava/lang/RuntimeException;
+		ARG 0 callerGetter

--- a/mappings/net/minecraft/MinecraftVersion.mapping
+++ b/mappings/net/minecraft/MinecraftVersion.mapping
@@ -10,6 +10,8 @@ CLASS net/minecraft/class_3797 net/minecraft/MinecraftVersion
 	FIELD field_16741 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_25319 GAME_VERSION Lcom/mojang/bridge/game/GameVersion;
 	FIELD field_27843 resourcePackVersion I
+	METHOD <init> (Lcom/google/gson/JsonObject;)V
+		ARG 1 json
 	METHOD getPackVersion (Lcom/mojang/bridge/game/PackType;)I
 		ARG 1 packType
 	METHOD method_16672 create ()Lcom/mojang/bridge/game/GameVersion;

--- a/mappings/net/minecraft/SharedConstants.mapping
+++ b/mappings/net/minecraft/SharedConstants.mapping
@@ -5,6 +5,13 @@ CLASS net/minecraft/class_155 net/minecraft/SharedConstants
 	FIELD field_16742 gameVersion Lcom/mojang/bridge/game/GameVersion;
 	FIELD field_25135 useChoiceTypeRegistrations Z
 		COMMENT Specifies whether Minecraft should use choice type registrations from the game's schema when entity types or block entity types are created.
+	FIELD field_29719 DEFAULT_PORT I
+	FIELD field_29731 COMMAND_MAX_LENGTH I
+	FIELD field_29732 WORLD_VERSION I
+	FIELD field_29733 VERSION_NAME Ljava/lang/String;
+	FIELD field_29734 RELEASE_TARGET Ljava/lang/String;
+	FIELD field_29737 SNBT_TOO_OLD_THRESHOLD I
+	FIELD field_29740 DATA_VERSION_KEY Ljava/lang/String;
 	METHOD method_16673 getGameVersion ()Lcom/mojang/bridge/game/GameVersion;
 	METHOD method_31372 getProtocolVersion ()I
 	METHOD method_34872 setGameVersion (Lcom/mojang/bridge/game/GameVersion;)V


### PR DESCRIPTION
Still many left in `SharedConstants` but we don't know what they mean if it's just `false` 😛 

`COMMAND_MAX_LENGTH` constant was named because the value is used in AbstractCommandBlockScreen` and packet reading related to commands. `SNBT_TOO_OLD_THRESHOLD` is used to warn if a SNBT is "too old" and needs update. (I suspect SNBT_TOO_OLD_THRESHOLD is internally "the first world version of the release target, including ones for Mojangesta")