### PR TITLE
Map text methods and params

### DIFF
--- a/mappings/net/minecraft/text/HoverEvent.mapping
+++ b/mappings/net/minecraft/text/HoverEvent.mapping
@@ -35,9 +35,17 @@ CLASS net/minecraft/class_2568 net/minecraft/text/HoverEvent
 			ARG 0 name
 		METHOD method_27671 buildHoverEvent (Lnet/minecraft/class_2561;)Lnet/minecraft/class_2568;
 			ARG 1 value
+		METHOD method_27672 (Lnet/minecraft/class_2568$class_5247;)Lnet/minecraft/class_2568$class_5247;
+			ARG 0 action
 		METHOD method_27674 getName ()Ljava/lang/String;
+		METHOD method_27675 (Lcom/google/gson/JsonElement;)Lnet/minecraft/class_2568$class_5249;
+			ARG 0 json
 		METHOD method_27676 cast (Ljava/lang/Object;)Ljava/lang/Object;
 			ARG 1 o
+		METHOD method_27677 (Lnet/minecraft/class_2561;)Lnet/minecraft/class_2568$class_5249;
+			ARG 0 text
+		METHOD method_27678 (Ljava/lang/Object;)Lcom/google/gson/JsonElement;
+			ARG 0 object
 	CLASS class_5248 EntityContent
 		FIELD field_24351 entityType Lnet/minecraft/class_1299;
 		FIELD field_24352 uuid Ljava/util/UUID;

--- a/mappings/net/minecraft/text/NbtText.mapping
+++ b/mappings/net/minecraft/text/NbtText.mapping
@@ -3,13 +3,16 @@ CLASS net/minecraft/class_2574 net/minecraft/text/NbtText
 	FIELD field_11777 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_11778 interpret Z
 	FIELD field_11779 path Lnet/minecraft/class_2203$class_2209;
+	FIELD field_33539 separator Ljava/util/Optional;
 	METHOD <init> (Ljava/lang/String;Lnet/minecraft/class_2203$class_2209;ZLjava/util/Optional;)V
 		ARG 1 rawPath
 		ARG 2 path
 		ARG 3 interpret
+		ARG 4 separator
 	METHOD <init> (Ljava/lang/String;ZLjava/util/Optional;)V
 		ARG 1 rawPath
 		ARG 2 interpret
+		ARG 3 separator
 	METHOD method_10916 toNbt (Lnet/minecraft/class_2168;)Ljava/util/stream/Stream;
 		ARG 1 source
 	METHOD method_10917 (Lnet/minecraft/class_2168;Lnet/minecraft/class_1297;ILjava/lang/String;)Ljava/util/stream/Stream;
@@ -20,6 +23,16 @@ CLASS net/minecraft/class_2574 net/minecraft/text/NbtText
 		ARG 0 rawPath
 	METHOD method_10920 getPath ()Ljava/lang/String;
 	METHOD method_10921 shouldInterpret ()Z
+	METHOD method_15880 (Lnet/minecraft/class_2561;Lnet/minecraft/class_5250;Lnet/minecraft/class_5250;)Lnet/minecraft/class_5250;
+		ARG 1 accumulator
+		ARG 2 current
+	METHOD method_36334 (Ljava/util/stream/Stream;Lnet/minecraft/class_5250;)Lnet/minecraft/class_5250;
+		ARG 1 text
+	METHOD method_36335 (Lnet/minecraft/class_5250;Lnet/minecraft/class_5250;Lnet/minecraft/class_5250;)Lnet/minecraft/class_5250;
+		ARG 1 accumulator
+		ARG 2 current
+	METHOD method_36336 (Ljava/lang/String;)Lnet/minecraft/class_5250;
+		ARG 0 string
 	CLASS class_2575 BlockNbtText
 		FIELD field_11780 rawPos Ljava/lang/String;
 		FIELD field_16408 pos Lnet/minecraft/class_2267;
@@ -29,10 +42,12 @@ CLASS net/minecraft/class_2574 net/minecraft/text/NbtText
 			ARG 3 interpret
 			ARG 4 rawPos
 			ARG 5 pos
+			ARG 6 separator
 		METHOD <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/util/Optional;)V
 			ARG 1 rawPath
 			ARG 2 rawJson
 			ARG 3 rawPos
+			ARG 4 separator
 		METHOD method_10922 getPos ()Ljava/lang/String;
 		METHOD method_16121 parsePos (Ljava/lang/String;)Lnet/minecraft/class_2267;
 			ARG 1 rawPos
@@ -45,10 +60,12 @@ CLASS net/minecraft/class_2574 net/minecraft/text/NbtText
 			ARG 3 interpret
 			ARG 4 rawSelector
 			ARG 5 selector
+			ARG 6 separator
 		METHOD <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/util/Optional;)V
 			ARG 1 rawPath
 			ARG 2 interpret
 			ARG 3 rawSelector
+			ARG 4 separator
 		METHOD method_10923 parseSelector (Ljava/lang/String;)Lnet/minecraft/class_2300;
 			ARG 0 rawSelector
 		METHOD method_10924 getSelector ()Ljava/lang/String;
@@ -59,8 +76,10 @@ CLASS net/minecraft/class_2574 net/minecraft/text/NbtText
 			ARG 2 path
 			ARG 3 interpret
 			ARG 4 id
+			ARG 5 separator
 		METHOD <init> (Ljava/lang/String;ZLnet/minecraft/class_2960;Ljava/util/Optional;)V
 			ARG 1 rawPath
 			ARG 2 interpret
 			ARG 3 id
+			ARG 4 separator
 		METHOD method_23728 getId ()Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/text/OrderedText.mapping
+++ b/mappings/net/minecraft/text/OrderedText.mapping
@@ -20,7 +20,7 @@ CLASS net/minecraft/class_5481 net/minecraft/text/OrderedText
 		ARG 2 charIndex
 		ARG 3 style
 		ARG 4 charPoint
-	METHOD method_30747 styledString (Ljava/lang/String;Lnet/minecraft/class_2583;)Lnet/minecraft/class_5481;
+	METHOD method_30747 styledForwardsVisitedString (Ljava/lang/String;Lnet/minecraft/class_2583;)Lnet/minecraft/class_5481;
 		ARG 0 string
 		ARG 1 style
 	METHOD method_30748 (Ljava/lang/String;Lnet/minecraft/class_2583;Lit/unimi/dsi/fastutil/ints/Int2IntFunction;Lnet/minecraft/class_5224;)Z
@@ -36,7 +36,7 @@ CLASS net/minecraft/class_5481 net/minecraft/text/OrderedText
 		ARG 1 text2
 	METHOD method_30753 (Ljava/lang/String;Lnet/minecraft/class_2583;Lnet/minecraft/class_5224;)Z
 		ARG 2 visitor
-	METHOD method_30754 styledStringMapped (Ljava/lang/String;Lnet/minecraft/class_2583;Lit/unimi/dsi/fastutil/ints/Int2IntFunction;)Lnet/minecraft/class_5481;
+	METHOD method_30754 styledBackwardsVisitedString (Ljava/lang/String;Lnet/minecraft/class_2583;Lit/unimi/dsi/fastutil/ints/Int2IntFunction;)Lnet/minecraft/class_5481;
 		ARG 0 string
 		ARG 1 style
 		ARG 2 codePointMapper
@@ -45,5 +45,16 @@ CLASS net/minecraft/class_5481 net/minecraft/text/OrderedText
 	METHOD method_34905 empty ()Lnet/minecraft/class_5481;
 	METHOD method_34906 of (Lnet/minecraft/class_5481;)Lnet/minecraft/class_5481;
 		ARG 0 text
+	METHOD method_34907 (Ljava/lang/String;Lnet/minecraft/class_2583;Lnet/minecraft/class_5224;)Z
+		ARG 2 visitor
+	METHOD method_34908 styledForwardsVisitedString (Ljava/lang/String;Lnet/minecraft/class_2583;Lit/unimi/dsi/fastutil/ints/Int2IntFunction;)Lnet/minecraft/class_5481;
+		ARG 0 string
+		ARG 1 style
+		ARG 2 codePointMapper
 	METHOD method_34909 concat ([Lnet/minecraft/class_5481;)Lnet/minecraft/class_5481;
 		ARG 0 texts
+	METHOD method_34910 styledBackwardsVisitedString (Ljava/lang/String;Lnet/minecraft/class_2583;)Lnet/minecraft/class_5481;
+		ARG 0 string
+		ARG 1 style
+	METHOD method_34911 (Ljava/lang/String;Lnet/minecraft/class_2583;Lit/unimi/dsi/fastutil/ints/Int2IntFunction;Lnet/minecraft/class_5224;)Z
+		ARG 3 visitor

--- a/mappings/net/minecraft/text/ScoreText.mapping
+++ b/mappings/net/minecraft/text/ScoreText.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_2578 net/minecraft/text/ScoreText
 	FIELD field_11785 objective Ljava/lang/String;
 	FIELD field_11786 selector Lnet/minecraft/class_2300;
 	FIELD field_11787 name Ljava/lang/String;
-	FIELD field_33290 EVERYTHING Ljava/lang/String;
+	FIELD field_33290 SENDER_PLACEHOLDER Ljava/lang/String;
 	METHOD <init> (Ljava/lang/String;Ljava/lang/String;)V
 		ARG 1 name
 		ARG 2 objective

--- a/mappings/net/minecraft/text/ScoreText.mapping
+++ b/mappings/net/minecraft/text/ScoreText.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/class_2578 net/minecraft/text/ScoreText
 	FIELD field_11785 objective Ljava/lang/String;
 	FIELD field_11786 selector Lnet/minecraft/class_2300;
 	FIELD field_11787 name Ljava/lang/String;
+	FIELD field_33290 EVERYTHING Ljava/lang/String;
 	METHOD <init> (Ljava/lang/String;Ljava/lang/String;)V
 		ARG 1 name
 		ARG 2 objective

--- a/mappings/net/minecraft/text/SelectorText.mapping
+++ b/mappings/net/minecraft/text/SelectorText.mapping
@@ -2,7 +2,10 @@ CLASS net/minecraft/class_2579 net/minecraft/text/SelectorText
 	FIELD field_11789 pattern Ljava/lang/String;
 	FIELD field_11790 selector Lnet/minecraft/class_2300;
 	FIELD field_11791 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_33540 separator Ljava/util/Optional;
 	METHOD <init> (Ljava/lang/String;Ljava/util/Optional;)V
 		ARG 1 pattern
+		ARG 2 separator
 	METHOD method_10932 getPattern ()Ljava/lang/String;
 	METHOD method_36138 getSelector ()Lnet/minecraft/class_2300;
+	METHOD method_36339 getSeparator ()Ljava/util/Optional;

--- a/mappings/net/minecraft/text/StringVisitable.mapping
+++ b/mappings/net/minecraft/text/StringVisitable.mapping
@@ -40,6 +40,8 @@ CLASS net/minecraft/class_5348 net/minecraft/text/StringVisitable
 		COMMENT Concats multiple string visitables by the order they appear in the array.
 		ARG 0 visitables
 			COMMENT an array or varargs of visitables
+	METHOD method_30067 (Ljava/lang/StringBuilder;Ljava/lang/String;)Ljava/util/Optional;
+		ARG 1 string
 	CLASS class_5245 Visitor
 		COMMENT A visitor for string content.
 		METHOD accept (Ljava/lang/String;)Ljava/util/Optional;

--- a/mappings/net/minecraft/text/Text.mapping
+++ b/mappings/net/minecraft/text/Text.mapping
@@ -20,6 +20,8 @@ CLASS net/minecraft/class_2561 net/minecraft/text/Text
 			COMMENT the max length allowed for the string representation of the text
 	METHOD method_10866 getStyle ()Lnet/minecraft/class_2583;
 		COMMENT Returns the style of this text.
+	METHOD method_27655 (ILjava/lang/StringBuilder;Ljava/lang/String;)Ljava/util/Optional;
+		ARG 2 string
 	METHOD method_27659 visitSelf (Lnet/minecraft/class_5348$class_5245;)Ljava/util/Optional;
 		COMMENT Visits the text itself.
 		COMMENT
@@ -78,6 +80,16 @@ CLASS net/minecraft/class_2561 net/minecraft/text/Text
 			ARG 0 reader
 		METHOD method_10880 getPosition (Lcom/google/gson/stream/JsonReader;)I
 			ARG 0 reader
+		METHOD method_36327 (Lcom/google/gson/JsonObject;Lcom/google/gson/JsonSerializationContext;Lnet/minecraft/class_2561;)V
+			ARG 3 separator
+		METHOD method_36328 addSeparator (Lcom/google/gson/JsonSerializationContext;Lcom/google/gson/JsonObject;Ljava/util/Optional;)V
+			ARG 1 context
+			ARG 2 json
+			ARG 3 separator
+		METHOD method_36329 getSeparator (Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;Lcom/google/gson/JsonObject;)Ljava/util/Optional;
+			ARG 1 type
+			ARG 2 context
+			ARG 3 json
 		METHOD serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 			ARG 1 text
 			ARG 2 type

--- a/mappings/net/minecraft/text/TextColor.mapping
+++ b/mappings/net/minecraft/text/TextColor.mapping
@@ -31,6 +31,10 @@ CLASS net/minecraft/class_5251 net/minecraft/text/TextColor
 		COMMENT Parses a color by its name.
 		ARG 0 name
 			COMMENT the name
+	METHOD method_27720 (Lnet/minecraft/class_5251;)Ljava/lang/String;
+		ARG 0 textColor
 	METHOD method_27721 getName ()Ljava/lang/String;
 		COMMENT Gets the name of this color, used for converting the color to JSON format.
+	METHOD method_27722 (Lnet/minecraft/class_124;)Lnet/minecraft/class_5251;
+		ARG 0 formatting
 	METHOD method_27723 getHexCode ()Ljava/lang/String;

--- a/mappings/net/minecraft/text/Texts.mapping
+++ b/mappings/net/minecraft/text/Texts.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_2564 net/minecraft/text/Texts
 	FIELD field_33536 DEFAULT_SEPARATOR Ljava/lang/String;
-	FIELD field_33537 GRAY_SEPARATOR_TEXT Lnet/minecraft/class_2561;
-	FIELD field_33538 SEPARATOR_TEXT Lnet/minecraft/class_2561;
+	FIELD field_33537 GRAY_DEFAULT_SEPARATOR_TEXT Lnet/minecraft/class_2561;
+	FIELD field_33538 DEFAULT_SEPARATOR_TEXT Lnet/minecraft/class_2561;
 	METHOD method_10881 parse (Lnet/minecraft/class_2168;Lnet/minecraft/class_2561;Lnet/minecraft/class_1297;I)Lnet/minecraft/class_5250;
 		ARG 0 source
 		ARG 1 text


### PR DESCRIPTION
This includes separator changes from 21w15a, and OrderedText renames (to better explain new methods.)

Fixes #2353 