### PR TITLE
21w17a stuff

### DIFF
--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -127,6 +127,10 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 	METHOD method_9543 hasDynamicBounds ()Z
 	METHOD method_9554 onLandedUpon (Lnet/minecraft/class_1937;Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;Lnet/minecraft/class_1297;F)V
 		ARG 1 world
+		ARG 2 state
+		ARG 3 pos
+		ARG 4 entity
+		ARG 5 fallDistance
 	METHOD method_9556 afterBreak (Lnet/minecraft/class_1937;Lnet/minecraft/class_1657;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2586;Lnet/minecraft/class_1799;)V
 		ARG 1 world
 		ARG 2 player
@@ -201,6 +205,8 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 		COMMENT Called when an entity steps on this block.
 		ARG 1 world
 		ARG 2 pos
+		ARG 3 state
+		ARG 4 entity
 	METHOD method_9595 getStateManager ()Lnet/minecraft/class_2689;
 	METHOD method_9596 (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;Lnet/minecraft/class_1799;)V
 		ARG 2 stack

--- a/mappings/net/minecraft/block/HangingRootsBlock.mapping
+++ b/mappings/net/minecraft/block/HangingRootsBlock.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/class_5806 net/minecraft/block/HangingRootsBlock
 	FIELD field_28689 SHAPE Lnet/minecraft/class_265;
+	FIELD field_33642 WATERLOGGED Lnet/minecraft/class_2746;

--- a/mappings/net/minecraft/block/TurtleEggBlock.mapping
+++ b/mappings/net/minecraft/block/TurtleEggBlock.mapping
@@ -14,6 +14,10 @@ CLASS net/minecraft/class_2542 net/minecraft/block/TurtleEggBlock
 		ARG 3 state
 	METHOD method_10834 tryBreakEgg (Lnet/minecraft/class_1937;Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;Lnet/minecraft/class_1297;I)V
 		ARG 1 world
+		ARG 2 state
+		ARG 3 pos
+		ARG 4 entity
+		ARG 5 inverseChance
 	METHOD method_10835 breaksEgg (Lnet/minecraft/class_1937;Lnet/minecraft/class_1297;)Z
 		ARG 1 world
 		ARG 2 entity

--- a/mappings/net/minecraft/data/server/RecipesProvider.mapping
+++ b/mappings/net/minecraft/data/server/RecipesProvider.mapping
@@ -278,9 +278,9 @@ CLASS net/minecraft/class_2446 net/minecraft/data/server/RecipesProvider
 		COMMENT <p>The shapeless recipe converts the compacted form to 9 of the normal form.
 		ARG 0 exporter
 		ARG 1 compacted
-			COMMENT compacted output item, e.g. block of copper.
+			COMMENT compacted output item, e.g. block of copper
 		ARG 2 input
-			COMMENT input item used to craft compacted item, e.g. copper ingot.
+			COMMENT input item used to craft compacted item, e.g. copper ingot
 	METHOD method_36444 offerSingleOutputShapelessRecipe (Ljava/util/function/Consumer;Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;Ljava/lang/String;)V
 		ARG 0 exporter
 		ARG 1 output

--- a/mappings/net/minecraft/data/server/RecipesProvider.mapping
+++ b/mappings/net/minecraft/data/server/RecipesProvider.mapping
@@ -145,6 +145,9 @@ CLASS net/minecraft/class_2446 net/minecraft/data/server/RecipesProvider
 	METHOD method_33531 getWallRecipe (Lnet/minecraft/class_1935;Lnet/minecraft/class_1856;)Lnet/minecraft/class_5797;
 		ARG 0 output
 		ARG 1 input
+	METHOD method_33532 (Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;)Lnet/minecraft/class_5797;
+		ARG 0 output
+		ARG 1 input
 	METHOD method_33533 getVariantRecipeInput (Lnet/minecraft/class_5794;Lnet/minecraft/class_5794$class_5796;)Lnet/minecraft/class_2248;
 		COMMENT Gets the block used to craft a certain {@linkplain net.minecraft.data.family.BlockFamily.Variant variant} of a base block.
 		COMMENT
@@ -165,24 +168,57 @@ CLASS net/minecraft/class_2446 net/minecraft/data/server/RecipesProvider
 	METHOD method_33537 createCondensingRecipe (Lnet/minecraft/class_1935;Lnet/minecraft/class_1856;)Lnet/minecraft/class_5797;
 		ARG 0 output
 		ARG 1 input
+	METHOD method_33538 (Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;)Lnet/minecraft/class_5797;
+		ARG 0 output
+		ARG 1 input
 	METHOD method_33539 (Ljava/util/function/Consumer;Lnet/minecraft/class_5794;)V
 		ARG 1 family
+	METHOD method_33541 (Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;)Lnet/minecraft/class_5797;
+		ARG 0 output
+		ARG 1 input
 	METHOD method_33542 createTransmutationRecipe (Lnet/minecraft/class_1935;Lnet/minecraft/class_1856;)Lnet/minecraft/class_5797;
+		ARG 0 output
+		ARG 1 input
+	METHOD method_33543 (Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;)Lnet/minecraft/class_5797;
 		ARG 0 output
 		ARG 1 input
 	METHOD method_33544 createDoorRecipe (Lnet/minecraft/class_1935;Lnet/minecraft/class_1856;)Lnet/minecraft/class_5797;
 		ARG 0 output
 		ARG 1 input
+	METHOD method_33545 (Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;)Lnet/minecraft/class_5797;
+		ARG 0 output
+		ARG 1 input
 	METHOD method_33546 createFenceRecipe (Lnet/minecraft/class_1935;Lnet/minecraft/class_1856;)Lnet/minecraft/class_5797;
+		ARG 0 output
+		ARG 1 input
+	METHOD method_33547 (Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;)Lnet/minecraft/class_5797;
 		ARG 0 output
 		ARG 1 input
 	METHOD method_33548 createFenceGateRecipe (Lnet/minecraft/class_1935;Lnet/minecraft/class_1856;)Lnet/minecraft/class_5797;
 		ARG 0 output
 		ARG 1 input
+	METHOD method_33549 (Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;)Lnet/minecraft/class_5797;
+		ARG 0 output
+		ARG 1 input
+	METHOD method_33550 (Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;)Lnet/minecraft/class_5797;
+		ARG 0 output
+		ARG 1 input
+	METHOD method_33551 (Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;)Lnet/minecraft/class_5797;
+		ARG 0 output
+		ARG 1 input
+	METHOD method_33552 (Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;)Lnet/minecraft/class_5797;
+		ARG 0 output
+		ARG 1 input
 	METHOD method_33553 createTrapdoorRecipe (Lnet/minecraft/class_1935;Lnet/minecraft/class_1856;)Lnet/minecraft/class_5797;
 		ARG 0 output
 		ARG 1 input
+	METHOD method_33554 (Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;)Lnet/minecraft/class_5797;
+		ARG 0 output
+		ARG 1 input
 	METHOD method_33555 createSignRecipe (Lnet/minecraft/class_1935;Lnet/minecraft/class_1856;)Lnet/minecraft/class_5797;
+		ARG 0 output
+		ARG 1 input
+	METHOD method_33556 (Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;)Lnet/minecraft/class_5797;
 		ARG 0 output
 		ARG 1 input
 	METHOD method_33714 convertBetween (Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;)Ljava/lang/String;
@@ -219,21 +255,80 @@ CLASS net/minecraft/class_2446 net/minecraft/data/server/RecipesProvider
 		ARG 3 output
 		ARG 4 experience
 		ARG 5 cookingTime
+		ARG 6 group
+		ARG 7 baseIdString
 	METHOD method_36233 offerSmelting (Ljava/util/function/Consumer;Ljava/util/List;Lnet/minecraft/class_1935;FILjava/lang/String;)V
 		ARG 0 exporter
 		ARG 1 inputs
 		ARG 2 output
 		ARG 3 experience
 		ARG 4 cookingTime
+		ARG 5 group
 	METHOD method_36234 offerBlasting (Ljava/util/function/Consumer;Ljava/util/List;Lnet/minecraft/class_1935;FILjava/lang/String;)V
 		ARG 0 exporter
 		ARG 1 inputs
 		ARG 2 output
 		ARG 3 experience
 		ARG 4 cookingTime
+		ARG 5 group
 	METHOD method_36325 offerReversibleCompactingRecipes (Ljava/util/function/Consumer;Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;)V
 		COMMENT Offers two recipes to convert between a normal and compacted form of an item.
 		COMMENT
 		COMMENT <p>The shaped recipe converts 9 items in a square to a compacted form of the item.
 		COMMENT <p>The shapeless recipe converts the compacted form to 9 of the normal form.
 		ARG 0 exporter
+		ARG 1 compacted
+			COMMENT compacted output item, e.g. block of copper.
+		ARG 2 input
+			COMMENT input item used to craft compacted item, e.g. copper ingot.
+	METHOD method_36444 offerSingleOutputShapelessRecipe (Ljava/util/function/Consumer;Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;Ljava/lang/String;)V
+		ARG 0 exporter
+		ARG 1 output
+		ARG 2 input
+		ARG 3 group
+	METHOD method_36445 offerShapelessRecipe (Ljava/util/function/Consumer;Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;Ljava/lang/String;I)V
+		ARG 0 exporter
+		ARG 1 output
+		ARG 2 input
+		ARG 3 group
+		ARG 4 outputCount
+	METHOD method_36446 offerReversibleCompactingRecipesWithCompactedItemGroup (Ljava/util/function/Consumer;Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;Ljava/lang/String;Ljava/lang/String;)V
+		ARG 0 exporter
+		ARG 1 compacted
+		ARG 2 input
+		ARG 3 compactedItemId
+		ARG 4 compactedItemGroup
+	METHOD method_36447 offerReversibleCompactingRecipes (Ljava/util/function/Consumer;Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+		ARG 0 exporter
+		ARG 1 input
+		ARG 2 compacted
+		ARG 3 compactedItemId
+		ARG 4 compactedItemGroup
+		ARG 5 inputItemId
+		ARG 6 inputItemGroup
+	METHOD method_36448 offerCookingRecipe (Ljava/util/function/Consumer;Ljava/lang/String;Lnet/minecraft/class_3957;ILnet/minecraft/class_1935;Lnet/minecraft/class_1935;F)V
+		ARG 0 exporter
+		ARG 1 cooker
+		ARG 2 serializer
+		ARG 3 cookingTime
+		ARG 4 input
+		ARG 5 output
+		ARG 6 experience
+	METHOD method_36449 offerReversibleCompactingRecipesWithInputItemGroup (Ljava/util/function/Consumer;Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;Ljava/lang/String;Ljava/lang/String;)V
+		ARG 0 exporter
+		ARG 1 input
+		ARG 2 compacted
+		ARG 3 inputItemId
+		ARG 4 inputItemGroup
+	METHOD method_36450 (Lnet/minecraft/class_1935;)Ljava/lang/String;
+		ARG 0 item
+	METHOD method_36451 getSmeltingItemPath (Lnet/minecraft/class_1935;)Ljava/lang/String;
+		ARG 0 item
+	METHOD method_36452 getBlastingItemPath (Lnet/minecraft/class_1935;)Ljava/lang/String;
+		ARG 0 item
+	METHOD method_36546 (Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;)Lnet/minecraft/class_5797;
+		ARG 0 output
+		ARG 1 input
+	METHOD method_36547 createCutCopperRecipe (Lnet/minecraft/class_1935;Lnet/minecraft/class_1856;)Lnet/minecraft/class_2447;
+		ARG 0 output
+		ARG 1 input

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -376,6 +376,12 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT axis-aligned integer box is fully loaded in the world.
 	METHOD method_35049 getRemovalReason ()Lnet/minecraft/class_1297$class_5529;
 	METHOD method_36209 onRemoved ()V
+	METHOD method_36454 getYaw ()F
+	METHOD method_36455 getPitch ()F
+	METHOD method_36456 validateAndSetYaw (F)V
+		ARG 1 yaw
+	METHOD method_36457 validateAndSetPitch (F)V
+		ARG 1 pitch
 	METHOD method_5621 getMountedHeightOffset ()D
 	METHOD method_5622 onBlockCollision (Lnet/minecraft/class_2680;)V
 		ARG 1 state

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -378,9 +378,9 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_36209 onRemoved ()V
 	METHOD method_36454 getYaw ()F
 	METHOD method_36455 getPitch ()F
-	METHOD method_36456 validateAndSetYaw (F)V
+	METHOD method_36456 setYaw (F)V
 		ARG 1 yaw
-	METHOD method_36457 validateAndSetPitch (F)V
+	METHOD method_36457 setPitch (F)V
 		ARG 1 pitch
 	METHOD method_5621 getMountedHeightOffset ()D
 	METHOD method_5622 onBlockCollision (Lnet/minecraft/class_2680;)V
@@ -407,8 +407,8 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		ARG 3 y
 		ARG 5 z
 	METHOD method_5634 getSoundCategory ()Lnet/minecraft/class_3419;
-	METHOD method_5636 setYaw (F)V
-		ARG 1 yaw
+	METHOD method_5636 setBodyYaw (F)V
+		ARG 1 bodyYaw
 	METHOD method_5637 isWet ()Z
 		COMMENT Returns whether this entity is touching water, or is being rained on, or is inside a bubble column...
 		COMMENT

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -267,6 +267,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_35053 hasNoDrag ()Z
 	METHOD method_35054 setNoDrag (Z)V
 		ARG 1 noDrag
+	METHOD method_36362 updateGlowing ()V
 	METHOD method_5973 canTarget (Lnet/minecraft/class_1299;)Z
 		ARG 1 type
 	METHOD method_5989 getLootTable ()Lnet/minecraft/class_2960;
@@ -348,6 +349,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 1 stack
 		ARG 2 count
 	METHOD method_6038 onDismounted (Lnet/minecraft/class_1297;)V
+		ARG 1 vehicle
 	METHOD method_6039 isBlocking ()Z
 	METHOD method_6040 consumeItem ()V
 	METHOD method_6041 getFallSound (I)Lnet/minecraft/class_3414;

--- a/mappings/net/minecraft/network/listener/ClientPlayPacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ClientPlayPacketListener.mapping
@@ -36,7 +36,7 @@ CLASS net/minecraft/class_2602 net/minecraft/network/listener/ClientPlayPacketLi
 		ARG 1 packet
 	METHOD method_11094 onBlockEntityUpdate (Lnet/minecraft/class_2622;)V
 		ARG 1 packet
-	METHOD method_11095 onEntitiesDestroy (Lnet/minecraft/class_2716;)V
+	METHOD method_11095 onEntityDestroy (Lnet/minecraft/class_2716;)V
 		ARG 1 packet
 	METHOD method_11097 onPlayerSpawn (Lnet/minecraft/class_2613;)V
 		ARG 1 packet

--- a/mappings/net/minecraft/network/packet/s2c/play/EntitiesDestroyS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/EntitiesDestroyS2CPacket.mapping
@@ -1,3 +1,0 @@
-CLASS net/minecraft/class_2716 net/minecraft/network/packet/s2c/play/EntitiesDestroyS2CPacket
-	METHOD <init> (Lnet/minecraft/class_2540;)V
-		ARG 1 buf

--- a/mappings/net/minecraft/network/packet/s2c/play/EntityDestroyS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/EntityDestroyS2CPacket.mapping
@@ -1,0 +1,7 @@
+CLASS net/minecraft/class_2716 net/minecraft/network/packet/s2c/play/EntityDestroyS2CPacket
+	FIELD field_33690 entityId I
+	METHOD <init> (I)V
+		ARG 1 entityId
+	METHOD <init> (Lnet/minecraft/class_2540;)V
+		ARG 1 buf
+	METHOD method_36548 getEntityId ()I


### PR DESCRIPTION
Maps new recipe methods, some params, yaw/pitch setters and `EntityDestroyS2CPacket` (apparently Mojang made it singular)

Any better names for `validateAndSetX`/`offerReversibleCompactingRecipesWithXItemGroup`? Couldn't overload because param types are the same.