### PR TITLE
Rename the NbtCompoundTagArgumentType class to NbtCompoundArgumentType

### DIFF
--- a/mappings/net/minecraft/command/argument/NbtCompoundArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/NbtCompoundArgumentType.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2179 net/minecraft/command/argument/NbtCompoundTagArgumentType
+CLASS net/minecraft/class_2179 net/minecraft/command/argument/NbtCompoundArgumentType
 	FIELD field_9843 EXAMPLES Ljava/util/Collection;
 	METHOD method_9284 nbtCompound ()Lnet/minecraft/class_2179;
 	METHOD method_9285 getNbtCompound (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lnet/minecraft/class_2487;


### PR DESCRIPTION
Fixes #2359