### PR TITLE
Refactor coordinate names to follow conventions

### DIFF
--- a/mappings/net/minecraft/advancement/AdvancementDisplay.mapping
+++ b/mappings/net/minecraft/advancement/AdvancementDisplay.mapping
@@ -7,8 +7,8 @@ CLASS net/minecraft/class_185 net/minecraft/advancement/AdvancementDisplay
 	FIELD field_1241 icon Lnet/minecraft/class_1799;
 	FIELD field_1242 description Lnet/minecraft/class_2561;
 	FIELD field_1243 background Lnet/minecraft/class_2960;
-	FIELD field_1244 yPos F
-	FIELD field_1245 xPos F
+	FIELD field_1244 y F
+	FIELD field_1245 x F
 	METHOD <init> (Lnet/minecraft/class_1799;Lnet/minecraft/class_2561;Lnet/minecraft/class_2561;Lnet/minecraft/class_2960;Lnet/minecraft/class_189;ZZZ)V
 		ARG 1 icon
 		ARG 2 title
@@ -28,9 +28,9 @@ CLASS net/minecraft/class_185 net/minecraft/advancement/AdvancementDisplay
 		ARG 1 buf
 	METHOD method_814 toJson ()Lcom/google/gson/JsonElement;
 	METHOD method_815 getFrame ()Lnet/minecraft/class_189;
-	METHOD method_816 setPosition (FF)V
-		ARG 1 xPos
-		ARG 2 yPos
+	METHOD method_816 setPos (FF)V
+		ARG 1 x
+		ARG 2 y
 	METHOD method_817 getDescription ()Lnet/minecraft/class_2561;
 	METHOD method_818 getX ()F
 	METHOD method_819 getY ()F

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -116,12 +116,12 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 	METHOD method_9538 canMobSpawnInside ()Z
 	METHOD method_9539 getTranslationKey ()Ljava/lang/String;
 	METHOD method_9541 createCuboidShape (DDDDDD)Lnet/minecraft/class_265;
-		ARG 0 xMin
-		ARG 2 yMin
-		ARG 4 zMin
-		ARG 6 xMax
-		ARG 8 yMax
-		ARG 10 zMax
+		ARG 0 minX
+		ARG 2 minY
+		ARG 4 minZ
+		ARG 6 maxX
+		ARG 8 maxY
+		ARG 10 maxZ
 	METHOD method_9542 hasRandomTicks (Lnet/minecraft/class_2680;)Z
 		ARG 1 state
 	METHOD method_9543 hasDynamicBounds ()Z

--- a/mappings/net/minecraft/client/Mouse.mapping
+++ b/mappings/net/minecraft/client/Mouse.mapping
@@ -53,8 +53,8 @@ CLASS net/minecraft/class_312 net/minecraft/client/Mouse
 		ARG 5 modifiers
 	METHOD method_22685 (JDD)V
 		ARG 1 window
-		ARG 3 xOffset
-		ARG 5 yOffset
+		ARG 3 offsetX
+		ARG 5 offsetY
 	METHOD method_22688 (JDD)V
 		ARG 1 window
 		ARG 3 x

--- a/mappings/net/minecraft/client/font/GlyphRenderer.mapping
+++ b/mappings/net/minecraft/client/font/GlyphRenderer.mapping
@@ -1,25 +1,25 @@
 CLASS net/minecraft/class_382 net/minecraft/client/font/GlyphRenderer
 	FIELD field_21692 textLayer Lnet/minecraft/class_1921;
 	FIELD field_21693 seeThroughTextLayer Lnet/minecraft/class_1921;
-	FIELD field_2272 xMin F
-	FIELD field_2273 vMax F
-	FIELD field_2274 vMin F
-	FIELD field_2275 uMax F
-	FIELD field_2276 uMin F
-	FIELD field_2278 yMax F
-	FIELD field_2279 yMin F
-	FIELD field_2280 xMax F
+	FIELD field_2272 minX F
+	FIELD field_2273 maxV F
+	FIELD field_2274 minV F
+	FIELD field_2275 maxU F
+	FIELD field_2276 minU F
+	FIELD field_2278 maxY F
+	FIELD field_2279 minY F
+	FIELD field_2280 maxX F
 	METHOD <init> (Lnet/minecraft/class_1921;Lnet/minecraft/class_1921;FFFFFFFF)V
 		ARG 1 textLayer
 		ARG 2 seeThroughTextLayer
-		ARG 3 uMin
-		ARG 4 uMax
-		ARG 5 vMin
-		ARG 6 vMax
-		ARG 7 xMin
-		ARG 8 xMax
-		ARG 9 yMin
-		ARG 10 yMax
+		ARG 3 minU
+		ARG 4 maxU
+		ARG 5 minV
+		ARG 6 maxV
+		ARG 7 minX
+		ARG 8 maxX
+		ARG 9 minY
+		ARG 10 maxY
 	METHOD method_2025 draw (ZFFLnet/minecraft/class_1159;Lnet/minecraft/class_4588;FFFFI)V
 		ARG 1 italic
 		ARG 2 x
@@ -41,18 +41,18 @@ CLASS net/minecraft/class_382 net/minecraft/client/font/GlyphRenderer
 	CLASS class_328 Rectangle
 		FIELD field_2003 green F
 		FIELD field_2004 red F
-		FIELD field_2005 yMax F
-		FIELD field_2006 xMax F
-		FIELD field_2007 yMin F
-		FIELD field_2008 xMin F
+		FIELD field_2005 maxY F
+		FIELD field_2006 maxX F
+		FIELD field_2007 minY F
+		FIELD field_2008 minX F
 		FIELD field_2009 alpha F
 		FIELD field_2010 blue F
 		FIELD field_20911 zIndex F
 		METHOD <init> (FFFFFFFFF)V
-			ARG 1 xMin
-			ARG 2 yMin
-			ARG 3 xMax
-			ARG 4 yMax
+			ARG 1 minX
+			ARG 2 minY
+			ARG 3 maxX
+			ARG 4 maxY
 			ARG 5 zIndex
 			ARG 6 red
 			ARG 7 green

--- a/mappings/net/minecraft/client/font/TrueTypeFont.mapping
+++ b/mappings/net/minecraft/client/font/TrueTypeFont.mapping
@@ -18,10 +18,10 @@ CLASS net/minecraft/class_395 net/minecraft/client/font/TrueTypeFont
 		FIELD field_2338 width I
 		METHOD <init> (Lnet/minecraft/class_395;IIIIFFI)V
 			ARG 1 outerClass
-			ARG 2 xMin
-			ARG 3 xMax
-			ARG 4 yMax
-			ARG 5 yMin
+			ARG 2 minX
+			ARG 3 maxX
+			ARG 4 maxY
+			ARG 5 minY
 			ARG 6 advance
 			ARG 7 bearing
 			ARG 8 index

--- a/mappings/net/minecraft/client/gui/DrawableHelper.mapping
+++ b/mappings/net/minecraft/client/gui/DrawableHelper.mapping
@@ -105,10 +105,10 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawableHelper
 		ARG 9 v1
 	METHOD method_25296 fillGradient (Lnet/minecraft/class_4587;IIIIII)V
 		ARG 1 matrices
-		ARG 2 xStart
-		ARG 3 yStart
-		ARG 4 xEnd
-		ARG 5 yEnd
+		ARG 2 startX
+		ARG 3 startY
+		ARG 4 endX
+		ARG 5 endY
 		ARG 6 colorStart
 		ARG 7 colorEnd
 	METHOD method_25297 drawTexture (Lnet/minecraft/class_4587;IIIIIIIFFII)V
@@ -185,10 +185,10 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawableHelper
 	METHOD method_25305 getZOffset ()I
 	METHOD method_27533 fillGradient (Lnet/minecraft/class_1159;Lnet/minecraft/class_287;IIIIIII)V
 		ARG 0 matrix
-		ARG 2 xStart
-		ARG 3 yStart
-		ARG 4 xEnd
-		ARG 5 yEnd
+		ARG 2 startX
+		ARG 3 startY
+		ARG 4 endX
+		ARG 5 endY
 		ARG 6 z
 		ARG 7 colorStart
 		ARG 8 colorEnd

--- a/mappings/net/minecraft/client/gui/screen/advancement/AdvancementWidget.mapping
+++ b/mappings/net/minecraft/client/gui/screen/advancement/AdvancementWidget.mapping
@@ -6,8 +6,8 @@ CLASS net/minecraft/class_456 net/minecraft/client/gui/screen/advancement/Advanc
 	FIELD field_2706 parent Lnet/minecraft/class_456;
 	FIELD field_2707 children Ljava/util/List;
 	FIELD field_2709 WIDGETS_TEXTURE Lnet/minecraft/class_2960;
-	FIELD field_2710 yPos I
-	FIELD field_2711 xPos I
+	FIELD field_2710 y I
+	FIELD field_2711 x I
 	FIELD field_2712 display Lnet/minecraft/class_185;
 	FIELD field_2713 title Lnet/minecraft/class_5481;
 	FIELD field_2714 progress Lnet/minecraft/class_167;

--- a/mappings/net/minecraft/client/gui/screen/ingame/HandledScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/HandledScreen.mapping
@@ -35,8 +35,8 @@ CLASS net/minecraft/class_465 net/minecraft/client/gui/screen/ingame/HandledScre
 		ARG 2 inventory
 		ARG 3 title
 	METHOD method_2378 isPointWithinBounds (IIIIDD)Z
-		ARG 1 xPosition
-		ARG 2 yPosition
+		ARG 1 x
+		ARG 2 y
 		ARG 3 width
 		ARG 4 height
 		ARG 5 pointX
@@ -54,8 +54,8 @@ CLASS net/minecraft/class_465 net/minecraft/client/gui/screen/ingame/HandledScre
 		ARG 7 button
 	METHOD method_2382 drawItem (Lnet/minecraft/class_1799;IILjava/lang/String;)V
 		ARG 1 stack
-		ARG 2 xPosition
-		ARG 3 yPosition
+		ARG 2 x
+		ARG 3 y
 		ARG 4 amountText
 	METHOD method_2383 onMouseClick (Lnet/minecraft/class_1735;IILnet/minecraft/class_1713;)V
 		COMMENT @see net.minecraft.screen.ScreenHandler#onSlotClick(int, int, net.minecraft.screen.slot.SlotActionType, net.minecraft.entity.player.PlayerEntity)
@@ -70,8 +70,8 @@ CLASS net/minecraft/class_465 net/minecraft/client/gui/screen/ingame/HandledScre
 		ARG 1 matrices
 		ARG 2 slot
 	METHOD method_2386 getSlotAt (DD)Lnet/minecraft/class_1735;
-		ARG 1 xPosition
-		ARG 3 yPosition
+		ARG 1 x
+		ARG 3 y
 	METHOD method_2387 isPointOverSlot (Lnet/minecraft/class_1735;DD)Z
 		ARG 1 slot
 		ARG 2 pointX

--- a/mappings/net/minecraft/client/render/chunk/ChunkRendererRegion.mapping
+++ b/mappings/net/minecraft/client/render/chunk/ChunkRendererRegion.mapping
@@ -1,10 +1,10 @@
 CLASS net/minecraft/class_853 net/minecraft/client/render/chunk/ChunkRendererRegion
 	FIELD field_4481 offset Lnet/minecraft/class_2338;
-	FIELD field_4482 zSize I
+	FIELD field_4482 sizeZ I
 	FIELD field_4483 chunks [[Lnet/minecraft/class_2818;
-	FIELD field_4484 ySize I
+	FIELD field_4484 sizeY I
 	FIELD field_4485 fluidStates [Lnet/minecraft/class_3610;
-	FIELD field_4486 xSize I
+	FIELD field_4486 sizeX I
 	FIELD field_4487 chunkZOffset I
 	FIELD field_4488 chunkXOffset I
 	FIELD field_4489 blockStates [Lnet/minecraft/class_2680;

--- a/mappings/net/minecraft/client/texture/NativeImage.mapping
+++ b/mappings/net/minecraft/client/texture/NativeImage.mapping
@@ -128,8 +128,8 @@ CLASS net/minecraft/class_1011 net/minecraft/client/texture/NativeImage
 	METHOD method_4320 checkAllocated ()V
 	METHOD method_4321 uploadInternal (IIIIIIIZZZZ)V
 		ARG 1 level
-		ARG 2 xOffset
-		ARG 3 yOffset
+		ARG 2 offsetX
+		ARG 3 offsetY
 		ARG 4 unpackSkipPixels
 		ARG 5 unpackSkipRows
 		ARG 6 width

--- a/mappings/net/minecraft/client/world/ClientWorld.mapping
+++ b/mappings/net/minecraft/client/world/ClientWorld.mapping
@@ -78,16 +78,16 @@ CLASS net/minecraft/class_638 net/minecraft/client/world/ClientWorld
 		ARG 2 state
 		ARG 3 parameters
 	METHOD method_2941 doRandomBlockDisplayTicks (III)V
-		ARG 1 xCenter
-		ARG 2 yCenter
-		ARG 3 zCenter
+		ARG 1 centerX
+		ARG 2 centerY
+		ARG 3 centerZ
 	METHOD method_2942 addEntity (ILnet/minecraft/class_1297;)V
 		ARG 1 id
 		ARG 2 entity
 	METHOD method_2943 randomBlockDisplayTick (IIIILjava/util/Random;Lnet/minecraft/class_638$class_6234;Lnet/minecraft/class_2338$class_2339;)V
-		ARG 1 xCenter
-		ARG 2 yCenter
-		ARG 3 zCenter
+		ARG 1 centerX
+		ARG 2 centerY
+		ARG 3 centerZ
 		ARG 4 radius
 		ARG 5 random
 		ARG 6 blockParticle

--- a/mappings/net/minecraft/datafixer/fix/ChunkPalettedStorageFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/ChunkPalettedStorageFix.mapping
@@ -84,8 +84,8 @@ CLASS net/minecraft/class_3582 net/minecraft/datafixer/fix/ChunkPalettedStorageF
 		METHOD method_15652 visit (I)I
 			ARG 1 sidesToUpgrade
 	CLASS class_3588 Level
-		FIELD field_15883 yPos I
-		FIELD field_15884 xPos I
+		FIELD field_15883 z I
+		FIELD field_15884 x I
 		FIELD field_15885 sidesToUpgrade I
 		FIELD field_15886 level Lcom/mojang/serialization/Dynamic;
 		FIELD field_15887 blockEntities Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;

--- a/mappings/net/minecraft/entity/ai/FuzzyPositions.mapping
+++ b/mappings/net/minecraft/entity/ai/FuzzyPositions.mapping
@@ -41,8 +41,8 @@ CLASS net/minecraft/class_5535 net/minecraft/entity/ai/FuzzyPositions
 		ARG 1 horizontalRange
 		ARG 2 verticalRange
 		ARG 3 startHeight
-		ARG 4 xDirection
-		ARG 6 zDirection
+		ARG 4 directionX
+		ARG 6 directionZ
 		ARG 8 angleRange
 	METHOD method_31543 guessBest (Ljava/util/function/Supplier;Ljava/util/function/ToDoubleFunction;)Lnet/minecraft/class_243;
 		COMMENT Returns the {@link Vec3d#ofBottomCenter(BlockPos) bottom center} of a highest scoring

--- a/mappings/net/minecraft/entity/ai/NoPenaltySolidTargeting.mapping
+++ b/mappings/net/minecraft/entity/ai/NoPenaltySolidTargeting.mapping
@@ -6,16 +6,16 @@ CLASS net/minecraft/class_5530 net/minecraft/entity/ai/NoPenaltySolidTargeting
 		ARG 1 horizontalRange
 		ARG 2 verticalRange
 		ARG 3 startHeight
-		ARG 4 xDirection
-		ARG 6 zDirection
+		ARG 4 directionX
+		ARG 6 directionZ
 		ARG 8 rangeAngle
 	METHOD method_31505 tryMake (Lnet/minecraft/class_1314;IIIDDDZ)Lnet/minecraft/class_2338;
 		ARG 0 entity
 		ARG 1 horizontalRange
 		ARG 2 verticalRange
 		ARG 3 startHeight
-		ARG 4 xDirection
-		ARG 6 zDirection
+		ARG 4 directionX
+		ARG 6 directionZ
 		ARG 8 rangeAngle
 		ARG 10 posTargetInRange
 	METHOD method_31506 (Lnet/minecraft/class_1314;Lnet/minecraft/class_2338;)Z

--- a/mappings/net/minecraft/entity/ai/goal/DolphinJumpGoal.mapping
+++ b/mappings/net/minecraft/entity/ai/goal/DolphinJumpGoal.mapping
@@ -8,11 +8,11 @@ CLASS net/minecraft/class_1357 net/minecraft/entity/ai/goal/DolphinJumpGoal
 		ARG 2 chance
 	METHOD method_6282 isAirAbove (Lnet/minecraft/class_2338;III)Z
 		ARG 1 pos
-		ARG 2 xOffset
-		ARG 3 zOffset
+		ARG 2 offsetX
+		ARG 3 offsetZ
 		ARG 4 multiplier
 	METHOD method_6284 isWater (Lnet/minecraft/class_2338;III)Z
 		ARG 1 pos
-		ARG 2 xOffset
-		ARG 3 zOffset
+		ARG 2 offsetX
+		ARG 3 offsetZ
 		ARG 4 multiplier

--- a/mappings/net/minecraft/entity/ai/goal/DoorInteractGoal.mapping
+++ b/mappings/net/minecraft/entity/ai/goal/DoorInteractGoal.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_1343 net/minecraft/entity/ai/goal/DoorInteractGoal
-	FIELD field_6409 zOffset F
-	FIELD field_6410 xOffset F
+	FIELD field_6409 offsetZ F
+	FIELD field_6410 offsetX F
 	FIELD field_6411 shouldStop Z
 	FIELD field_6412 doorValid Z
 	FIELD field_6413 mob Lnet/minecraft/class_1308;

--- a/mappings/net/minecraft/entity/ai/pathing/MobNavigation.mapping
+++ b/mappings/net/minecraft/entity/ai/pathing/MobNavigation.mapping
@@ -14,9 +14,9 @@ CLASS net/minecraft/class_1409 net/minecraft/entity/ai/pathing/MobNavigation
 		ARG 1 centerX
 		ARG 2 centerY
 		ARG 3 centerZ
-		ARG 4 xSize
-		ARG 5 ySize
-		ARG 6 zSize
+		ARG 4 sizeX
+		ARG 5 sizeY
+		ARG 6 sizeZ
 		ARG 7 entityPos
 		ARG 8 lookVecX
 		ARG 10 lookVecZ
@@ -26,9 +26,9 @@ CLASS net/minecraft/class_1409 net/minecraft/entity/ai/pathing/MobNavigation
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
-		ARG 4 xSize
-		ARG 5 ySize
-		ARG 6 zSize
+		ARG 4 sizeX
+		ARG 5 sizeY
+		ARG 6 sizeZ
 		ARG 7 entityPos
 		ARG 8 lookVecX
 		ARG 10 lookVecZ

--- a/mappings/net/minecraft/item/map/MapState.mapping
+++ b/mappings/net/minecraft/item/map/MapState.mapping
@@ -2,11 +2,11 @@ CLASS net/minecraft/class_22 net/minecraft/item/map/MapState
 	FIELD field_112 updateTrackers Ljava/util/List;
 	FIELD field_113 unlimitedTracking Z
 	FIELD field_114 showIcons Z
-	FIELD field_115 zCenter I
+	FIELD field_115 centerZ I
 		COMMENT The scaled center coordinate of the map state on the Z axis.
 		COMMENT <p>
 		COMMENT Always {@code 0} for the client.
-	FIELD field_116 xCenter I
+	FIELD field_116 centerX I
 		COMMENT The scaled center coordinate of the map state on the X axis.
 		COMMENT <p>
 		COMMENT Always {@code 0} for the client.
@@ -22,8 +22,8 @@ CLASS net/minecraft/class_22 net/minecraft/item/map/MapState
 		COMMENT Empty for the client.
 	FIELD field_17403 locked Z
 	METHOD <init> (IIBZZZLnet/minecraft/class_5321;)V
-		ARG 1 xCenter
-		ARG 2 zCenter
+		ARG 1 centerX
+		ARG 2 centerZ
 		ARG 3 scale
 		ARG 4 showIcons
 		ARG 5 unlimitedTracking
@@ -73,9 +73,9 @@ CLASS net/minecraft/class_22 net/minecraft/item/map/MapState
 		ARG 2 dimension
 	METHOD method_32363 of (DDBZZLnet/minecraft/class_5321;)Lnet/minecraft/class_22;
 		COMMENT Creates a new map state instance.
-		ARG 0 xCenter
+		ARG 0 centerX
 			COMMENT the absolute center X-coordinate
-		ARG 2 zCenter
+		ARG 2 centerZ
 			COMMENT the absolute center Z-coordinate
 		ARG 4 scale
 		ARG 5 showIcons

--- a/mappings/net/minecraft/util/math/BlockPos.mapping
+++ b/mappings/net/minecraft/util/math/BlockPos.mapping
@@ -112,11 +112,11 @@ CLASS net/minecraft/class_2338 net/minecraft/util/math/BlockPos
 		COMMENT negative z offset.
 		ARG 0 center
 			COMMENT the center of iteration
-		ARG 1 xRange
+		ARG 1 rangeX
 			COMMENT the maximum x difference from the center
-		ARG 2 yRange
+		ARG 2 rangeY
 			COMMENT the maximum y difference from the center
-		ARG 3 zRange
+		ARG 3 rangeZ
 			COMMENT the maximum z difference from the center
 	METHOD method_25997 findClosest (Lnet/minecraft/class_2338;IILjava/util/function/Predicate;)Ljava/util/Optional;
 		ARG 0 pos
@@ -195,9 +195,9 @@ CLASS net/minecraft/class_2338 net/minecraft/util/math/BlockPos
 		FIELD field_23946 remaining I
 	CLASS 2
 		FIELD field_23094 maxDistance I
-		FIELD field_23095 xRange I
-		FIELD field_23096 yRange I
-		FIELD field_23097 zRange I
+		FIELD field_23095 rangeX I
+		FIELD field_23096 rangeY I
+		FIELD field_23097 rangeZ I
 		FIELD field_23099 manhattanDistance I
 		FIELD field_23100 limitX I
 		FIELD field_23101 limitY I

--- a/mappings/net/minecraft/util/math/Box.mapping
+++ b/mappings/net/minecraft/util/math/Box.mapping
@@ -58,9 +58,9 @@ CLASS net/minecraft/class_238 net/minecraft/util/math/Box
 		ARG 1 intersectingVector
 		ARG 2 traceDistanceResult
 		ARG 3 approachDirection
-		ARG 4 xDelta
-		ARG 6 yDelta
-		ARG 8 zDelta
+		ARG 4 deltaX
+		ARG 6 deltaY
+		ARG 8 deltaZ
 	METHOD method_1008 contains (DDD)Z
 		COMMENT Checks if the given position is in this box.
 		ARG 1 x
@@ -170,9 +170,9 @@ CLASS net/minecraft/class_238 net/minecraft/util/math/Box
 	METHOD method_998 traceCollisionSide ([DLnet/minecraft/class_2350;DDDDDDDDLnet/minecraft/class_2350;DDD)Lnet/minecraft/class_2350;
 		ARG 0 traceDistanceResult
 		ARG 1 approachDirection
-		ARG 2 xDelta
-		ARG 4 yDelta
-		ARG 6 zDelta
+		ARG 2 deltaX
+		ARG 4 deltaY
+		ARG 6 deltaZ
 		ARG 8 begin
 		ARG 10 minX
 		ARG 12 maxX

--- a/mappings/net/minecraft/util/shape/BitSetVoxelSet.mapping
+++ b/mappings/net/minecraft/util/shape/BitSetVoxelSet.mapping
@@ -1,11 +1,11 @@
 CLASS net/minecraft/class_244 net/minecraft/util/shape/BitSetVoxelSet
-	FIELD field_1354 yMax I
-	FIELD field_1355 xMax I
-	FIELD field_1356 zMin I
-	FIELD field_1357 yMin I
-	FIELD field_1358 xMin I
+	FIELD field_1354 maxY I
+	FIELD field_1355 maxX I
+	FIELD field_1356 minZ I
+	FIELD field_1357 minY I
+	FIELD field_1358 minX I
 	FIELD field_1359 storage Ljava/util/BitSet;
-	FIELD field_1360 zMax I
+	FIELD field_1360 maxZ I
 	METHOD <init> (Lnet/minecraft/class_251;)V
 		ARG 1 other
 	METHOD method_1039 getIndex (III)I
@@ -21,15 +21,15 @@ CLASS net/minecraft/class_244 net/minecraft/util/shape/BitSetVoxelSet
 		ARG 5 function
 	METHOD method_1059 isColumnFull (IIII)Z
 	METHOD method_31939 (IIIIIIIII)Lnet/minecraft/class_244;
-		ARG 0 xSize
-		ARG 1 ySize
-		ARG 2 zSize
-		ARG 3 xMin
-		ARG 4 yMin
-		ARG 5 zMin
-		ARG 6 xMax
-		ARG 7 yMax
-		ARG 8 zMax
+		ARG 0 sizeX
+		ARG 1 sizeY
+		ARG 2 sizeZ
+		ARG 3 minX
+		ARG 4 minY
+		ARG 5 minZ
+		ARG 6 maxX
+		ARG 7 maxY
+		ARG 8 maxZ
 	METHOD method_31940 (IIIZ)V
 		ARG 1 x
 		ARG 2 y

--- a/mappings/net/minecraft/util/shape/CroppedVoxelSet.mapping
+++ b/mappings/net/minecraft/util/shape/CroppedVoxelSet.mapping
@@ -1,19 +1,19 @@
 CLASS net/minecraft/class_262 net/minecraft/util/shape/CroppedVoxelSet
-	FIELD field_1388 yMax I
-	FIELD field_1389 xMax I
-	FIELD field_1390 zMin I
-	FIELD field_1391 yMin I
-	FIELD field_1392 xMin I
+	FIELD field_1388 maxY I
+	FIELD field_1389 maxX I
+	FIELD field_1390 minZ I
+	FIELD field_1391 minY I
+	FIELD field_1392 minX I
 	FIELD field_1393 parent Lnet/minecraft/class_251;
-	FIELD field_1394 zMax I
+	FIELD field_1394 maxZ I
 	METHOD <init> (Lnet/minecraft/class_251;IIIIII)V
 		ARG 1 parent
-		ARG 2 xMin
-		ARG 3 yMin
-		ARG 4 zMin
-		ARG 5 xMax
-		ARG 6 yMax
-		ARG 7 zMax
+		ARG 2 minX
+		ARG 3 minY
+		ARG 4 minZ
+		ARG 5 maxX
+		ARG 6 maxY
+		ARG 7 maxZ
 	METHOD method_31944 clamp (Lnet/minecraft/class_2350$class_2351;I)I
 		ARG 1 axis
 		ARG 2 value

--- a/mappings/net/minecraft/util/shape/VoxelSet.mapping
+++ b/mappings/net/minecraft/util/shape/VoxelSet.mapping
@@ -1,12 +1,12 @@
 CLASS net/minecraft/class_251 net/minecraft/util/shape/VoxelSet
-	FIELD field_1372 zSize I
-	FIELD field_1373 ySize I
-	FIELD field_1374 xSize I
+	FIELD field_1372 sizeZ I
+	FIELD field_1373 sizeY I
+	FIELD field_1374 sizeX I
 	FIELD field_1375 AXES [Lnet/minecraft/class_2350$class_2351;
 	METHOD <init> (III)V
-		ARG 1 xSize
-		ARG 2 ySize
-		ARG 3 zSize
+		ARG 1 sizeX
+		ARG 2 sizeY
+		ARG 3 sizeZ
 	METHOD method_1044 inBoundsAndContains (III)Z
 		ARG 1 x
 		ARG 2 y

--- a/mappings/net/minecraft/util/shape/VoxelShape.mapping
+++ b/mappings/net/minecraft/util/shape/VoxelShape.mapping
@@ -12,12 +12,12 @@ CLASS net/minecraft/class_265 net/minecraft/util/shape/VoxelShape
 		ARG 2 end
 		ARG 3 pos
 	METHOD method_1094 ([Lnet/minecraft/class_265;DDDDDD)V
-		ARG 1 xMin
-		ARG 3 yMin
-		ARG 5 zMin
-		ARG 7 xMax
-		ARG 9 yMax
-		ARG 11 zMax
+		ARG 1 minX
+		ARG 3 minY
+		ARG 5 minZ
+		ARG 7 maxX
+		ARG 9 maxY
+		ARG 11 maxZ
 	METHOD method_1096 offset (DDD)Lnet/minecraft/class_265;
 		ARG 1 x
 		ARG 3 y

--- a/mappings/net/minecraft/util/shape/VoxelShapes.mapping
+++ b/mappings/net/minecraft/util/shape/VoxelShapes.mapping
@@ -47,12 +47,12 @@ CLASS net/minecraft/class_259 net/minecraft/util/shape/VoxelShapes
 		ARG 1 two
 		ARG 2 direction
 	METHOD method_1081 cuboid (DDDDDD)Lnet/minecraft/class_265;
-		ARG 0 xMin
-		ARG 2 yMin
-		ARG 4 zMin
-		ARG 6 xMax
-		ARG 8 yMax
-		ARG 10 zMax
+		ARG 0 minX
+		ARG 2 minY
+		ARG 4 minZ
+		ARG 6 maxX
+		ARG 8 maxY
+		ARG 10 maxZ
 	METHOD method_1082 combine (Lnet/minecraft/class_265;Lnet/minecraft/class_265;Lnet/minecraft/class_247;)Lnet/minecraft/class_265;
 		ARG 0 one
 		ARG 1 two


### PR DESCRIPTION
This PR makes them follow the convention:
> Coordinates can be named `x`, `y`, and `z` when it's clear what they represent. If clarification is needed, add a word in
front of the coordinate (`velocityX`, not `xVelocity`).

https://github.com/FabricMC/yarn/blob/daabbb8bff164ccac9adbddb54a66d020bac5669/CONVENTIONS.md