### PR TITLE
Map new methods added to the AbstractBlock.Settings class in 21w18a

### DIFF
--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -310,6 +310,10 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 			ARG 1 color
 		METHOD method_31711 (Lnet/minecraft/class_3620;Lnet/minecraft/class_2680;)Lnet/minecraft/class_3620;
 			ARG 1 state
+		METHOD method_36557 hardness (F)Lnet/minecraft/class_4970$class_2251;
+			ARG 1 hardness
+		METHOD method_36558 resistance (F)Lnet/minecraft/class_4970$class_2251;
+			ARG 1 resistance
 		METHOD method_9617 of (Lnet/minecraft/class_3614;Lnet/minecraft/class_1767;)Lnet/minecraft/class_4970$class_2251;
 			ARG 0 material
 			ARG 1 color


### PR DESCRIPTION
This pull request should be confirmed to not break Fabric API's [`FabricBlockSettings` methods](https://github.com/FabricMC/fabric/blob/daa367217679ffae237a7216154255bd840edc47/fabric-object-builder-api-v1/src/main/java/net/fabricmc/fabric/api/object/builder/v1/block/FabricBlockSettings.java#L249-L257) which have the same names.