### PR TITLE
Fixes #2399

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ dependencies {
 	javadocClasspath "org.jetbrains:annotations:${project.jetbrains_annotations_version}"
 	javadocClasspath "com.google.code.findbugs:jsr305:3.0.2" // for some other jsr annotations
 	decompileClasspath "net.fabricmc:cfr:${project.cfr_version}"
-	mappingPoetJar 'net.fabricmc:mappingpoet:0.2.7'
+	mappingPoetJar 'net.fabricmc:mappingpoet:0.2.8'
 	unpick "net.fabricmc.unpick:unpick-cli:${project.unpick_version}"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx1G
+org.gradle.jvmargs=-Xmx4G
 
 enigma_version=0.27.1
 stitch_version=0.5.1+build.77


### PR DESCRIPTION
Increases ram because otherwise javadoc will stall.

Also due to javadoc tool's bug, the summary table for overriding method entries are currently broken. Will investigate that separately later.

Signed-off-by: liach <liach@users.noreply.github.com>