### PR TITLE
Rename gamemode to gameMode

### DIFF
--- a/mappings/net/minecraft/predicate/PlayerPredicate.mapping
+++ b/mappings/net/minecraft/predicate/PlayerPredicate.mapping
@@ -46,7 +46,7 @@ CLASS net/minecraft/class_4553 net/minecraft/predicate/PlayerPredicate
 		METHOD method_22506 toJson ()Lcom/google/gson/JsonElement;
 	CLASS class_4557 Builder
 		FIELD field_20730 experienceLevel Lnet/minecraft/class_2096$class_2100;
-		FIELD field_20731 gamemode Lnet/minecraft/class_1934;
+		FIELD field_20731 gameMode Lnet/minecraft/class_1934;
 		FIELD field_20732 stats Ljava/util/Map;
 		FIELD field_20733 recipes Lit/unimi/dsi/fastutil/objects/Object2BooleanMap;
 		FIELD field_20734 advancements Ljava/util/Map;
@@ -56,7 +56,7 @@ CLASS net/minecraft/class_4553 net/minecraft/predicate/PlayerPredicate
 			ARG 1 stat
 			ARG 2 value
 		METHOD method_35312 gameMode (Lnet/minecraft/class_1934;)Lnet/minecraft/class_4553$class_4557;
-			ARG 1 gamemode
+			ARG 1 gameMode
 		METHOD method_35313 experienceLevel (Lnet/minecraft/class_2096$class_2100;)Lnet/minecraft/class_4553$class_4557;
 			ARG 1 experienceLevel
 		METHOD method_35314 advancement (Lnet/minecraft/class_2960;Ljava/util/Map;)Lnet/minecraft/class_4553$class_4557;


### PR DESCRIPTION
This PR renames all occurrences of `gamemode` in yarn mappings.