### PR TITLE
Two package info mappings from generatePackageInfoMappings

### DIFF
--- a/mappings/net/minecraft/unused/packageinfo/PackageInfo6389.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfo6389.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_6389 net/minecraft/unused/packageinfo/PackageInfo6389

--- a/mappings/net/minecraft/unused/packageinfo/PackageInfo6391.mapping
+++ b/mappings/net/minecraft/unused/packageinfo/PackageInfo6391.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_6391 net/minecraft/unused/packageinfo/PackageInfo6391


### PR DESCRIPTION
Just fyi to @sfPlayer1 or modmuss: You can probably run `generatePackageInfoMappings` before publishing yarn next time