### PR TITLE
Restore lost arguments and map some random stuff

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/ConfirmScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ConfirmScreen.mapping
@@ -10,6 +10,7 @@ CLASS net/minecraft/class_410 net/minecraft/client/gui/screen/ConfirmScreen
 		ARG 2 title
 		ARG 3 message
 	METHOD <init> (Lit/unimi/dsi/fastutil/booleans/BooleanConsumer;Lnet/minecraft/class_2561;Lnet/minecraft/class_2561;Lnet/minecraft/class_2561;Lnet/minecraft/class_2561;)V
+		ARG 1 callback
 		ARG 2 title
 		ARG 3 message
 		ARG 4 yesTranslated

--- a/mappings/net/minecraft/client/gui/screen/DeathScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/DeathScreen.mapping
@@ -4,6 +4,7 @@ CLASS net/minecraft/class_418 net/minecraft/client/gui/screen/DeathScreen
 	FIELD field_2451 ticksSinceDeath I
 	FIELD field_26537 scoreText Lnet/minecraft/class_2561;
 	METHOD <init> (Lnet/minecraft/class_2561;Z)V
+		ARG 1 message
 		ARG 2 isHardcore
 	METHOD method_19808 (Lnet/minecraft/class_4185;)V
 		ARG 1 button

--- a/mappings/net/minecraft/client/option/FullscreenOption.mapping
+++ b/mappings/net/minecraft/client/option/FullscreenOption.mapping
@@ -1,1 +1,16 @@
 CLASS net/minecraft/class_4454 net/minecraft/client/option/FullscreenOption
+	METHOD <init> (Lnet/minecraft/class_1041;)V
+		ARG 1 window
+	METHOD <init> (Lnet/minecraft/class_1041;Lnet/minecraft/class_313;)V
+		ARG 1 window
+		ARG 2 monitor
+	METHOD method_21588 (Lnet/minecraft/class_313;Lnet/minecraft/class_319;)Ljava/lang/Double;
+		ARG 1 videoMode
+	METHOD method_21589 (Lnet/minecraft/class_313;Lnet/minecraft/class_1041;Lnet/minecraft/class_315;)Ljava/lang/Double;
+		ARG 2 options
+	METHOD method_21590 (Lnet/minecraft/class_313;Lnet/minecraft/class_1041;Lnet/minecraft/class_315;Ljava/lang/Double;)V
+		ARG 2 options
+		ARG 3 newValue
+	METHOD method_27464 (Lnet/minecraft/class_313;Lnet/minecraft/class_315;Lnet/minecraft/class_4067;)Lnet/minecraft/class_2561;
+		ARG 1 options
+		ARG 2 option

--- a/mappings/net/minecraft/client/option/ServerList.mapping
+++ b/mappings/net/minecraft/client/option/ServerList.mapping
@@ -9,7 +9,9 @@ CLASS net/minecraft/class_641 net/minecraft/client/option/ServerList
 		ARG 2 serverInfo
 	METHOD method_2981 loadFile ()V
 	METHOD method_2982 get (I)Lnet/minecraft/class_642;
+		ARG 1 index
 	METHOD method_2983 remove (Lnet/minecraft/class_642;)V
+		ARG 1 serverInfo
 	METHOD method_2984 size ()I
 	METHOD method_2985 swapEntries (II)V
 		ARG 1 index1
@@ -18,3 +20,4 @@ CLASS net/minecraft/class_641 net/minecraft/client/option/ServerList
 		ARG 0 e
 	METHOD method_2987 saveFile ()V
 	METHOD method_2988 add (Lnet/minecraft/class_642;)V
+		ARG 1 serverInfo

--- a/mappings/net/minecraft/client/realms/gui/screen/RealmsConfigureWorldScreen.mapping
+++ b/mappings/net/minecraft/client/realms/gui/screen/RealmsConfigureWorldScreen.mapping
@@ -29,6 +29,7 @@ CLASS net/minecraft/class_4388 net/minecraft/client/realms/gui/screen/RealmsConf
 	FIELD field_26485 OPEN_TEXT Lnet/minecraft/class_2561;
 	FIELD field_26486 CLOSED_TEXT Lnet/minecraft/class_2561;
 	METHOD <init> (Lnet/minecraft/class_4325;J)V
+		ARG 1 parent
 		ARG 2 serverId
 	METHOD method_21198 stateChanged ()V
 	METHOD method_21199 addSlotButton (I)Lnet/minecraft/class_4367;

--- a/mappings/net/minecraft/screen/CartographyTableScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/CartographyTableScreenHandler.mapping
@@ -14,4 +14,6 @@ CLASS net/minecraft/class_3910 net/minecraft/screen/CartographyTableScreenHandle
 		ARG 2 inventory
 		ARG 3 context
 	METHOD method_17381 updateResult (Lnet/minecraft/class_1799;Lnet/minecraft/class_1799;Lnet/minecraft/class_1799;)V
+		ARG 1 map
+		ARG 2 item
 		ARG 3 oldResult

--- a/mappings/net/minecraft/structure/StructurePiece.mapping
+++ b/mappings/net/minecraft/structure/StructurePiece.mapping
@@ -17,6 +17,8 @@ CLASS net/minecraft/class_3443 net/minecraft/structure/StructurePiece
 		ARG 1 world
 		ARG 2 boundingBox
 		ARG 3 random
+		ARG 4 x
+		ARG 5 y
 		ARG 6 z
 		ARG 7 lootTableId
 	METHOD method_14916 orientateChest (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)Lnet/minecraft/class_2680;
@@ -70,6 +72,8 @@ CLASS net/minecraft/class_3443 net/minecraft/structure/StructurePiece
 		ARG 2 boundingBox
 		ARG 3 random
 		ARG 4 x
+		ARG 5 y
+		ARG 6 z
 		ARG 7 facing
 		ARG 8 lootTableId
 	METHOD method_14931 generate (Lnet/minecraft/class_5281;Lnet/minecraft/class_5138;Lnet/minecraft/class_2794;Ljava/util/Random;Lnet/minecraft/class_3341;Lnet/minecraft/class_1923;Lnet/minecraft/class_2338;)Z

--- a/mappings/net/minecraft/util/shape/SimplePairList.mapping
+++ b/mappings/net/minecraft/util/shape/SimplePairList.mapping
@@ -4,5 +4,6 @@ CLASS net/minecraft/class_254 net/minecraft/util/shape/SimplePairList
 	FIELD field_1378 maxValues [I
 	METHOD <init> (Lit/unimi/dsi/fastutil/doubles/DoubleList;Lit/unimi/dsi/fastutil/doubles/DoubleList;ZZ)V
 		ARG 1 first
+		ARG 2 second
 		ARG 3 includeFirstOnly
 		ARG 4 includeSecondOnly

--- a/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
+++ b/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
@@ -11,6 +11,7 @@ CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
 	FIELD field_12943 elementDeserializer Ljava/util/function/Function;
 	FIELD field_28812 lockStack Lnet/minecraft/class_5831;
 	METHOD <init> (Lnet/minecraft/class_2837;Lnet/minecraft/class_2361;Ljava/util/function/Function;Ljava/util/function/Function;Ljava/lang/Object;)V
+		ARG 1 fallbackPalette
 		ARG 2 idList
 		ARG 3 elementDeserializer
 		ARG 4 elementSerializer


### PR DESCRIPTION
Most of the arguments here got lost since 1.16.5, I noticed them while I was backporting to 1.16.5 (PR coming soon).

Also mapped `FullscreenOption` because why not.