### PR TITLE
Map Minecraft logo outline method

### DIFF
--- a/mappings/net/minecraft/client/gui/DrawableHelper.mapping
+++ b/mappings/net/minecraft/client/gui/DrawableHelper.mapping
@@ -206,6 +206,10 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawableHelper
 		ARG 3 x
 		ARG 4 y
 		ARG 5 color
+	METHOD method_29343 drawOutline (IILjava/util/function/BiConsumer;)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 renderCallback
 	METHOD method_33284 fillGradient (Lnet/minecraft/class_4587;IIIIIII)V
 		ARG 0 matrices
 		ARG 1 startX

--- a/mappings/net/minecraft/client/gui/DrawableHelper.mapping
+++ b/mappings/net/minecraft/client/gui/DrawableHelper.mapping
@@ -206,7 +206,7 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawableHelper
 		ARG 3 x
 		ARG 4 y
 		ARG 5 color
-	METHOD method_29343 drawOutline (IILjava/util/function/BiConsumer;)V
+	METHOD method_29343 drawWithOutline (IILjava/util/function/BiConsumer;)V
 		ARG 1 x
 		ARG 2 y
 		ARG 3 renderCallback

--- a/mappings/net/minecraft/client/gui/DrawableHelper.mapping
+++ b/mappings/net/minecraft/client/gui/DrawableHelper.mapping
@@ -209,7 +209,8 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawableHelper
 	METHOD method_29343 drawWithOutline (IILjava/util/function/BiConsumer;)V
 		ARG 1 x
 		ARG 2 y
-		ARG 3 renderCallback
+		ARG 3 renderAction
+			COMMENT the action to render both the content and the outline, taking x and y positions as input
 	METHOD method_33284 fillGradient (Lnet/minecraft/class_4587;IIIIIII)V
 		ARG 0 matrices
 		ARG 1 startX


### PR DESCRIPTION
This was first added in 20w21a as method_29063, but has been method_29343 since 20w22a. It is used on the TitleScreen and the CreditsScreen.