### PR TITLE
Rename ShapedRecipe#getItemStack to getItem

### DIFF
--- a/mappings/net/minecraft/recipe/ShapedRecipe.mapping
+++ b/mappings/net/minecraft/recipe/ShapedRecipe.mapping
@@ -53,7 +53,7 @@ CLASS net/minecraft/class_1869 net/minecraft/recipe/ShapedRecipe
 		ARG 0 line
 	METHOD method_8153 findLastSymbol (Ljava/lang/String;)I
 		ARG 0 pattern
-	METHOD method_8155 getItemStack (Lcom/google/gson/JsonObject;)Lnet/minecraft/class_1792;
+	METHOD method_8155 getItem (Lcom/google/gson/JsonObject;)Lnet/minecraft/class_1792;
 		ARG 0 json
 	METHOD method_8157 readSymbols (Lcom/google/gson/JsonObject;)Ljava/util/Map;
 		COMMENT Reads the pattern symbols.


### PR DESCRIPTION
As `ShapedRecipe#getItemStack` returns an `Item` rather than an `ItemStack` in 1.17