### PR TITLE
Map some shared constants

### DIFF
--- a/mappings/net/minecraft/SharedConstants.mapping
+++ b/mappings/net/minecraft/SharedConstants.mapping
@@ -5,7 +5,12 @@ CLASS net/minecraft/class_155 net/minecraft/SharedConstants
 	FIELD field_16742 gameVersion Lcom/mojang/bridge/game/GameVersion;
 	FIELD field_25135 useChoiceTypeRegistrations Z
 		COMMENT Specifies whether Minecraft should use choice type registrations from the game's schema when entity types or block entity types are created.
+	FIELD field_29702 TICKS_PER_SECOND I
+	FIELD field_29703 TICKS_PER_MINUTE I
+	FIELD field_29704 TICKS_PER_INGAME_DAY I
 	FIELD field_29719 DEFAULT_PORT I
+	FIELD field_29729 CHUNK_WIDTH I
+	FIELD field_29730 DEFAULT_WORLD_HEIGHT I
 	FIELD field_29731 COMMAND_MAX_LENGTH I
 	FIELD field_29732 WORLD_VERSION I
 	FIELD field_29733 VERSION_NAME Ljava/lang/String;

--- a/mappings/net/minecraft/SharedConstants.mapping
+++ b/mappings/net/minecraft/SharedConstants.mapping
@@ -7,7 +7,7 @@ CLASS net/minecraft/class_155 net/minecraft/SharedConstants
 		COMMENT Specifies whether Minecraft should use choice type registrations from the game's schema when entity types or block entity types are created.
 	FIELD field_29702 TICKS_PER_SECOND I
 	FIELD field_29703 TICKS_PER_MINUTE I
-	FIELD field_29704 TICKS_PER_INGAME_DAY I
+	FIELD field_29704 TICKS_PER_IN_GAME_DAY I
 	FIELD field_29719 DEFAULT_PORT I
 	FIELD field_29729 CHUNK_WIDTH I
 	FIELD field_29730 DEFAULT_WORLD_HEIGHT I


### PR DESCRIPTION
Once 1.17 is out I'll be able to check if `field_29709` is whether the version is a development one, and if `field_29735` is the target release protocol version