### PR TITLE
Fix swapped names in Matrix3f and Matrix4f

### DIFF
--- a/mappings/net/minecraft/util/math/Matrix3f.mapping
+++ b/mappings/net/minecraft/util/math/Matrix3f.mapping
@@ -56,50 +56,50 @@ CLASS net/minecraft/class_4581 net/minecraft/util/math/Matrix3f
 	METHOD method_35260 (Lnet/minecraft/class_4581;Lnet/minecraft/class_1158;)V
 		ARG 0 matrix
 		ARG 1 quaternion
-	METHOD method_35261 readColumnFirst (Ljava/nio/FloatBuffer;)V
+	METHOD method_35261 readColumnMajor (Ljava/nio/FloatBuffer;)V
 		COMMENT Reads a matrix from the buffer in column-major order.
 		COMMENT
-		COMMENT @see #readRowFirst(FloatBuffer)
+		COMMENT @see #readRowMajor(FloatBuffer)
 		COMMENT @see #read(FloatBuffer, boolean)
 		ARG 1 buf
 	METHOD method_35262 read (Ljava/nio/FloatBuffer;Z)V
 		COMMENT Reads a matrix from the buffer.
 		COMMENT
-		COMMENT @see #readRowFirst(FloatBuffer)
-		COMMENT @see #readColumnFirst(FloatBuffer)
+		COMMENT @see #readRowMajor(FloatBuffer)
+		COMMENT @see #readColumnMajor(FloatBuffer)
 		ARG 1 buf
-		ARG 2 rowFirst
+		ARG 2 rowMajor
 			COMMENT {@code true} to read in row-major order; {@code false} to read in
 			COMMENT column-major order
-	METHOD method_35263 readRowFirst (Ljava/nio/FloatBuffer;)V
+	METHOD method_35263 readRowMajor (Ljava/nio/FloatBuffer;)V
 		COMMENT Reads a matrix from the buffer in row-major order.
 		COMMENT
-		COMMENT @see #readColumnFirst(FloatBuffer)
+		COMMENT @see #readColumnMajor(FloatBuffer)
 		COMMENT @see #read(FloatBuffer, boolean)
 		ARG 1 buf
 	METHOD method_35264 write (Ljava/nio/FloatBuffer;Z)V
 		COMMENT Writes this matrix to the buffer.
 		COMMENT
-		COMMENT @see #writeRowFirst(FloatBuffer)
-		COMMENT @see #writeColumnFirst(FloatBuffer)
+		COMMENT @see #writeRowMajor(FloatBuffer)
+		COMMENT @see #writeColumnMajor(FloatBuffer)
 		ARG 1 buf
-		ARG 2 rowFirst
+		ARG 2 rowMajor
 			COMMENT {@code true} to write in row-major order; {@code false} to write in
 			COMMENT column-major order
 	METHOD method_35265 add (Lnet/minecraft/class_4581;)V
 		ARG 1 matrix
-	METHOD method_35266 writeColumnFirst (Ljava/nio/FloatBuffer;)V
+	METHOD method_35266 writeColumnMajor (Ljava/nio/FloatBuffer;)V
 		COMMENT Writes this matrix to the buffer in column-major order.
 		COMMENT
-		COMMENT @see #writeRowFirst(FloatBuffer)
+		COMMENT @see #writeRowMajor(FloatBuffer)
 		COMMENT @see #write(FloatBuffer, boolean)
 		ARG 1 buf
 	METHOD method_35267 subtract (Lnet/minecraft/class_4581;)V
 		ARG 1 matrix
-	METHOD method_35268 writeRowFirst (Ljava/nio/FloatBuffer;)V
+	METHOD method_35268 writeRowMajor (Ljava/nio/FloatBuffer;)V
 		COMMENT Writes this matrix to the buffer in row-major order.
 		COMMENT
-		COMMENT @see #writeColumnFirst(FloatBuffer)
+		COMMENT @see #writeColumnMajor(FloatBuffer)
 		COMMENT @see #write(FloatBuffer, boolean)
 		ARG 1 buf
 	METHOD method_35269 determinant ()F

--- a/mappings/net/minecraft/util/math/Matrix3f.mapping
+++ b/mappings/net/minecraft/util/math/Matrix3f.mapping
@@ -56,10 +56,10 @@ CLASS net/minecraft/class_4581 net/minecraft/util/math/Matrix3f
 	METHOD method_35260 (Lnet/minecraft/class_4581;Lnet/minecraft/class_1158;)V
 		ARG 0 matrix
 		ARG 1 quaternion
-	METHOD method_35261 readRowFirst (Ljava/nio/FloatBuffer;)V
-		COMMENT Reads a matrix from the buffer in row-major order.
+	METHOD method_35261 readColumnFirst (Ljava/nio/FloatBuffer;)V
+		COMMENT Reads a matrix from the buffer in column-major order.
 		COMMENT
-		COMMENT @see #readColumnFirst(FloatBuffer)
+		COMMENT @see #readRowFirst(FloatBuffer)
 		COMMENT @see #read(FloatBuffer, boolean)
 		ARG 1 buf
 	METHOD method_35262 read (Ljava/nio/FloatBuffer;Z)V
@@ -68,13 +68,13 @@ CLASS net/minecraft/class_4581 net/minecraft/util/math/Matrix3f
 		COMMENT @see #readRowFirst(FloatBuffer)
 		COMMENT @see #readColumnFirst(FloatBuffer)
 		ARG 1 buf
-		ARG 2 columnFirst
-			COMMENT {@code true} to read in column-major order; {@code false} to read in
-			COMMENT row-major order
-	METHOD method_35263 readColumnFirst (Ljava/nio/FloatBuffer;)V
-		COMMENT Reads a matrix from the buffer in column-major order.
+		ARG 2 rowFirst
+			COMMENT {@code true} to read in row-major order; {@code false} to read in
+			COMMENT column-major order
+	METHOD method_35263 readRowFirst (Ljava/nio/FloatBuffer;)V
+		COMMENT Reads a matrix from the buffer in row-major order.
 		COMMENT
-		COMMENT @see #readRowFirst(FloatBuffer)
+		COMMENT @see #readColumnFirst(FloatBuffer)
 		COMMENT @see #read(FloatBuffer, boolean)
 		ARG 1 buf
 	METHOD method_35264 write (Ljava/nio/FloatBuffer;Z)V
@@ -83,23 +83,23 @@ CLASS net/minecraft/class_4581 net/minecraft/util/math/Matrix3f
 		COMMENT @see #writeRowFirst(FloatBuffer)
 		COMMENT @see #writeColumnFirst(FloatBuffer)
 		ARG 1 buf
-		ARG 2 columnFirst
-			COMMENT {@code true} to write in column-major order; {@code false} to write in
-			COMMENT row-major order
+		ARG 2 rowFirst
+			COMMENT {@code true} to write in row-major order; {@code false} to write in
+			COMMENT column-major order
 	METHOD method_35265 add (Lnet/minecraft/class_4581;)V
 		ARG 1 matrix
-	METHOD method_35266 writeRowFirst (Ljava/nio/FloatBuffer;)V
-		COMMENT Writes this matrix to the buffer in row-major order.
+	METHOD method_35266 writeColumnFirst (Ljava/nio/FloatBuffer;)V
+		COMMENT Writes this matrix to the buffer in column-major order.
 		COMMENT
-		COMMENT @see #writeColumnFirst(FloatBuffer)
+		COMMENT @see #writeRowFirst(FloatBuffer)
 		COMMENT @see #write(FloatBuffer, boolean)
 		ARG 1 buf
 	METHOD method_35267 subtract (Lnet/minecraft/class_4581;)V
 		ARG 1 matrix
-	METHOD method_35268 writeColumnFirst (Ljava/nio/FloatBuffer;)V
-		COMMENT Writes this matrix to the buffer in column-major order.
+	METHOD method_35268 writeRowFirst (Ljava/nio/FloatBuffer;)V
+		COMMENT Writes this matrix to the buffer in row-major order.
 		COMMENT
-		COMMENT @see #writeRowFirst(FloatBuffer)
+		COMMENT @see #writeColumnFirst(FloatBuffer)
 		COMMENT @see #write(FloatBuffer, boolean)
 		ARG 1 buf
 	METHOD method_35269 determinant ()F

--- a/mappings/net/minecraft/util/math/Matrix4f.mapping
+++ b/mappings/net/minecraft/util/math/Matrix4f.mapping
@@ -63,36 +63,36 @@ CLASS net/minecraft/class_1159 net/minecraft/util/math/Matrix4f
 		ARG 5 farPlane
 	METHOD method_35434 load (Lnet/minecraft/class_1159;)V
 		ARG 1 source
-	METHOD method_35435 readColumnFirst (Ljava/nio/FloatBuffer;)V
+	METHOD method_35435 readColumnMajor (Ljava/nio/FloatBuffer;)V
 		COMMENT Reads a matrix from the buffer in column-major order.
 		COMMENT
-		COMMENT @see #readRowFirst(FloatBuffer)
+		COMMENT @see #readRowMajor(FloatBuffer)
 		COMMENT @see #read(FloatBuffer, boolean)
 		ARG 1 buf
 	METHOD method_35436 read (Ljava/nio/FloatBuffer;Z)V
 		COMMENT Reads a matrix from the buffer.
 		COMMENT
-		COMMENT @see #readRowFirst(FloatBuffer)
-		COMMENT @see #readColumnFirst(FloatBuffer)
+		COMMENT @see #readRowMajor(FloatBuffer)
+		COMMENT @see #readColumnMajor(FloatBuffer)
 		ARG 1 buf
-		ARG 2 rowFirst
+		ARG 2 rowMajor
 			COMMENT {@code true} to read in row-major order; {@code false} to read in
 			COMMENT column-major order
 	METHOD method_35437 isInteger (F)Z
 		ARG 0 value
-	METHOD method_35438 readRowFirst (Ljava/nio/FloatBuffer;)V
+	METHOD method_35438 readRowMajor (Ljava/nio/FloatBuffer;)V
 		COMMENT Reads a matrix from the buffer in row-major order.
 		COMMENT
-		COMMENT @see #readColumnFirst(FloatBuffer)
+		COMMENT @see #readColumnMajor(FloatBuffer)
 		COMMENT @see #read(FloatBuffer, boolean)
 		ARG 1 buf
 	METHOD method_35439 write (Ljava/nio/FloatBuffer;Z)V
 		COMMENT Writes this matrix to the buffer.
 		COMMENT
-		COMMENT @see #writeRowFirst(FloatBuffer)
-		COMMENT @see #writeColumnFirst(FloatBuffer)
+		COMMENT @see #writeRowMajor(FloatBuffer)
+		COMMENT @see #writeColumnMajor(FloatBuffer)
 		ARG 1 buf
-		ARG 2 rowFirst
+		ARG 2 rowMajor
 			COMMENT {@code true} to write in row-major order; {@code false} to write in
 			COMMENT column-major order
 	METHOD method_35440 add (Lnet/minecraft/class_1159;)V
@@ -100,10 +100,10 @@ CLASS net/minecraft/class_1159 net/minecraft/util/math/Matrix4f
 	METHOD method_35441 determinant ()F
 	METHOD method_35442 subtract (Lnet/minecraft/class_1159;)V
 		ARG 1 matrix
-	METHOD method_35443 writeRowFirst (Ljava/nio/FloatBuffer;)V
+	METHOD method_35443 writeRowMajor (Ljava/nio/FloatBuffer;)V
 		COMMENT Writes this matrix to the buffer in row-major order.
 		COMMENT
-		COMMENT @see #writeColumnFirst(FloatBuffer)
+		COMMENT @see #writeColumnMajor(FloatBuffer)
 		COMMENT @see #write(FloatBuffer, boolean)
 		ARG 1 buf
 	METHOD method_35444 trace ()F
@@ -113,10 +113,10 @@ CLASS net/minecraft/class_1159 net/minecraft/util/math/Matrix4f
 		ARG 2 aspectRatio
 		ARG 3 cameraDepth
 		ARG 4 viewDistance
-	METHOD method_4932 writeColumnFirst (Ljava/nio/FloatBuffer;)V
+	METHOD method_4932 writeColumnMajor (Ljava/nio/FloatBuffer;)V
 		COMMENT Writes this matrix to the buffer in column-major order.
 		COMMENT
-		COMMENT @see #writeRowFirst(FloatBuffer)
+		COMMENT @see #writeRowMajor(FloatBuffer)
 		COMMENT @see #write(FloatBuffer, boolean)
 		ARG 1 buf
 	METHOD method_4933 projectionMatrix (FFFF)Lnet/minecraft/class_1159;

--- a/mappings/net/minecraft/util/math/Matrix4f.mapping
+++ b/mappings/net/minecraft/util/math/Matrix4f.mapping
@@ -63,10 +63,10 @@ CLASS net/minecraft/class_1159 net/minecraft/util/math/Matrix4f
 		ARG 5 farPlane
 	METHOD method_35434 load (Lnet/minecraft/class_1159;)V
 		ARG 1 source
-	METHOD method_35435 readRowFirst (Ljava/nio/FloatBuffer;)V
-		COMMENT Reads a matrix from the buffer in row-major order.
+	METHOD method_35435 readColumnFirst (Ljava/nio/FloatBuffer;)V
+		COMMENT Reads a matrix from the buffer in column-major order.
 		COMMENT
-		COMMENT @see #readColumnFirst(FloatBuffer)
+		COMMENT @see #readRowFirst(FloatBuffer)
 		COMMENT @see #read(FloatBuffer, boolean)
 		ARG 1 buf
 	METHOD method_35436 read (Ljava/nio/FloatBuffer;Z)V
@@ -75,15 +75,15 @@ CLASS net/minecraft/class_1159 net/minecraft/util/math/Matrix4f
 		COMMENT @see #readRowFirst(FloatBuffer)
 		COMMENT @see #readColumnFirst(FloatBuffer)
 		ARG 1 buf
-		ARG 2 columnFirst
-			COMMENT {@code true} to read in column-major order; {@code false} to read in
-			COMMENT row-major order
+		ARG 2 rowFirst
+			COMMENT {@code true} to read in row-major order; {@code false} to read in
+			COMMENT column-major order
 	METHOD method_35437 isInteger (F)Z
 		ARG 0 value
-	METHOD method_35438 readColumnFirst (Ljava/nio/FloatBuffer;)V
-		COMMENT Reads a matrix from the buffer in column-major order.
+	METHOD method_35438 readRowFirst (Ljava/nio/FloatBuffer;)V
+		COMMENT Reads a matrix from the buffer in row-major order.
 		COMMENT
-		COMMENT @see #readRowFirst(FloatBuffer)
+		COMMENT @see #readColumnFirst(FloatBuffer)
 		COMMENT @see #read(FloatBuffer, boolean)
 		ARG 1 buf
 	METHOD method_35439 write (Ljava/nio/FloatBuffer;Z)V
@@ -92,18 +92,18 @@ CLASS net/minecraft/class_1159 net/minecraft/util/math/Matrix4f
 		COMMENT @see #writeRowFirst(FloatBuffer)
 		COMMENT @see #writeColumnFirst(FloatBuffer)
 		ARG 1 buf
-		ARG 2 columnFirst
-			COMMENT {@code true} to write in column-major order; {@code false} to write in
-			COMMENT row-major order
+		ARG 2 rowFirst
+			COMMENT {@code true} to write in row-major order; {@code false} to write in
+			COMMENT column-major order
 	METHOD method_35440 add (Lnet/minecraft/class_1159;)V
 		ARG 1 matrix
 	METHOD method_35441 determinant ()F
 	METHOD method_35442 subtract (Lnet/minecraft/class_1159;)V
 		ARG 1 matrix
-	METHOD method_35443 writeColumnFirst (Ljava/nio/FloatBuffer;)V
-		COMMENT Writes this matrix to the buffer in column-major order.
+	METHOD method_35443 writeRowFirst (Ljava/nio/FloatBuffer;)V
+		COMMENT Writes this matrix to the buffer in row-major order.
 		COMMENT
-		COMMENT @see #writeRowFirst(FloatBuffer)
+		COMMENT @see #writeColumnFirst(FloatBuffer)
 		COMMENT @see #write(FloatBuffer, boolean)
 		ARG 1 buf
 	METHOD method_35444 trace ()F
@@ -113,10 +113,10 @@ CLASS net/minecraft/class_1159 net/minecraft/util/math/Matrix4f
 		ARG 2 aspectRatio
 		ARG 3 cameraDepth
 		ARG 4 viewDistance
-	METHOD method_4932 writeRowFirst (Ljava/nio/FloatBuffer;)V
-		COMMENT Writes this matrix to the buffer in row-major order.
+	METHOD method_4932 writeColumnFirst (Ljava/nio/FloatBuffer;)V
+		COMMENT Writes this matrix to the buffer in column-major order.
 		COMMENT
-		COMMENT @see #writeColumnFirst(FloatBuffer)
+		COMMENT @see #writeRowFirst(FloatBuffer)
 		COMMENT @see #write(FloatBuffer, boolean)
 		ARG 1 buf
 	METHOD method_4933 projectionMatrix (FFFF)Lnet/minecraft/class_1159;


### PR DESCRIPTION
It has been incorrect since the first commit that introduced these names. I have confirmed that it's human error.

... I'm the one who introduced these names. Sorry!