### PR TITLE
Map some BeeEntity constants

### DIFF
--- a/mappings/net/minecraft/entity/passive/BeeEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/BeeEntity.mapping
@@ -32,7 +32,7 @@ CLASS net/minecraft/class_4466 net/minecraft/entity/passive/BeeEntity
 	FIELD field_30286 POLLINATION_FAIL_TICKS I
 		COMMENT The duration in ticks when a bee's pollination is considered failed.
 	FIELD field_30288 MAX_POLLINATED_CROPS I
-	FIELD field_30289 STING_POSION_DURATION_NORMAL_DIFFICULTY I
+	FIELD field_30289 STING_POISON_DURATION_NORMAL_DIFFICULTY I
 	FIELD field_30290 STING_POISON_DURATION_HARD_DIFFICULTY I
 	FIELD field_30291 MAX_REACH_DISTANCE I
 		COMMENT The maximum distance a bee will wander from the hive before getting lost.

--- a/mappings/net/minecraft/entity/passive/BeeEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/BeeEntity.mapping
@@ -34,11 +34,9 @@ CLASS net/minecraft/class_4466 net/minecraft/entity/passive/BeeEntity
 	FIELD field_30288 MAX_POLLINATED_CROPS I
 	FIELD field_30289 NORMAL_DIFFICULTY_STING_POISON_DURATION I
 	FIELD field_30290 HARD_DIFFICULTY_STING_POISON_DURATION I
-	FIELD field_30291 MAX_REACH_DISTANCE I
-		COMMENT The maximum distance a bee will wander from the hive before getting lost.
-		COMMENT Also the maximum distance to a flower.
-	FIELD field_30293 MAX_DISTANCE_FROM_HIVE I
-		COMMENT The maximum distance a bee should reach before having to return to the hive.
+	FIELD field_30291 FLOWER_SCAN_RANGE I
+		COMMENT The range of scan for flowers that can be navigated to.
+	FIELD field_30293 HIVE_SCAN_RANGE I
 	METHOD method_21769 addParticle (Lnet/minecraft/class_1937;DDDDDLnet/minecraft/class_2394;)V
 		ARG 1 world
 		ARG 2 lastX

--- a/mappings/net/minecraft/entity/passive/BeeEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/BeeEntity.mapping
@@ -32,8 +32,8 @@ CLASS net/minecraft/class_4466 net/minecraft/entity/passive/BeeEntity
 	FIELD field_30286 POLLINATION_FAIL_TICKS I
 		COMMENT The duration in ticks when a bee's pollination is considered failed.
 	FIELD field_30288 MAX_POLLINATED_CROPS I
-	FIELD field_30289 STING_POISON_DURATION_NORMAL_DIFFICULTY I
-	FIELD field_30290 STING_POISON_DURATION_HARD_DIFFICULTY I
+	FIELD field_30289 NORMAL_DIFFICULTY_STING_POISON_DURATION I
+	FIELD field_30290 HARD_DIFFICULTY_STING_POISON_DURATION I
 	FIELD field_30291 MAX_REACH_DISTANCE I
 		COMMENT The maximum distance a bee will wander from the hive before getting lost.
 		COMMENT Also the maximum distance to a flower.

--- a/mappings/net/minecraft/entity/passive/BeeEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/BeeEntity.mapping
@@ -34,9 +34,10 @@ CLASS net/minecraft/class_4466 net/minecraft/entity/passive/BeeEntity
 	FIELD field_30288 MAX_POLLINATED_CROPS I
 	FIELD field_30289 NORMAL_DIFFICULTY_STING_POISON_DURATION I
 	FIELD field_30290 HARD_DIFFICULTY_STING_POISON_DURATION I
-	FIELD field_30291 FLOWER_SCAN_RANGE I
-		COMMENT The range of scan for flowers that can be navigated to.
-	FIELD field_30293 HIVE_SCAN_RANGE I
+	FIELD field_30291 TOO_FAR_DISTANCE I
+		COMMENT The minimum distance that bees lose their hive or flower position at.
+	FIELD field_30293 MIN_HIVE_RETURN_DISTANCE I
+		COMMENT The minimum distance that bees will immediately return to their hive at.
 	METHOD method_21769 addParticle (Lnet/minecraft/class_1937;DDDDDLnet/minecraft/class_2394;)V
 		ARG 1 world
 		ARG 2 lastX

--- a/mappings/net/minecraft/entity/passive/BeeEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/BeeEntity.mapping
@@ -31,6 +31,14 @@ CLASS net/minecraft/class_4466 net/minecraft/entity/passive/BeeEntity
 		COMMENT A bee will start moving to a flower once this time in ticks has passed from a pollination.
 	FIELD field_30286 POLLINATION_FAIL_TICKS I
 		COMMENT The duration in ticks when a bee's pollination is considered failed.
+	FIELD field_30288 MAX_POLLINATED_CROPS I
+	FIELD field_30289 STING_POSION_DURATION_NORMAL_DIFFICULTY I
+	FIELD field_30290 STING_POISON_DURATION_HARD_DIFFICULTY I
+	FIELD field_30291 MAX_REACH_DISTANCE I
+		COMMENT The maximum distance a bee will wander from the hive before getting lost.
+		COMMENT Also the maximum distance to a flower.
+	FIELD field_30293 MAX_DISTANCE_FROM_HIVE I
+		COMMENT The maximum distance a bee should reach before having to return to the hive.
 	METHOD method_21769 addParticle (Lnet/minecraft/class_1937;DDDDDLnet/minecraft/class_2394;)V
 		ARG 1 world
 		ARG 2 lastX


### PR DESCRIPTION
`field_30284` is related to the minimum chance of being hurt because the bee has stung (`this.random.nextInt(MathHelper.clamp(1200 - this.ticksSinceSting, 1, 1200)) == 0` in `#mobTick`, 1200 is the field), but I can't think of a good name for it.

One of either `field_30274` and `field_30275` is the pollination delay and the find hive (`FindHiveGoal`) delay, but we won't be able to know which is which until a value changes.

The names of 30291 and 30293 don't convince me, open to suggestions