### PR TITLE
Correct visibleOnly method name -> ignoreVisibility

### DIFF
--- a/mappings/net/minecraft/entity/ai/TargetPredicate.mapping
+++ b/mappings/net/minecraft/entity/ai/TargetPredicate.mapping
@@ -19,4 +19,4 @@ CLASS net/minecraft/class_4051 net/minecraft/entity/ai/TargetPredicate
 	METHOD method_33335 copy ()Lnet/minecraft/class_4051;
 	METHOD method_36625 createAttackable ()Lnet/minecraft/class_4051;
 	METHOD method_36626 createNonAttackable ()Lnet/minecraft/class_4051;
-	METHOD method_36627 visibleOnly ()Lnet/minecraft/class_4051;
+	METHOD method_36627 ignoreVisibility ()Lnet/minecraft/class_4051;


### PR DESCRIPTION
`visibleOnly` actually sets `respectsVisibility` to `false`
```java
    public TargetPredicate visibleOnly() {
        this.respectsVisibility = false;
        return this;
    }
```
later in `test`, you can see that `respectsVisibility` is correctly named, as it precedes the visibility check:
```java
                if (this.respectsVisibility && baseEntity instanceof MobEntity && !((MobEntity)baseEntity).getVisibilityCache().canSee(targetEntity)) {
                    return false;
                }
```
so `visibleOnly`'s name implies it does the inverse of what it actually does. 