### PR TITLE
Add mappings to StructurePoolElement

### DIFF
--- a/mappings/net/minecraft/structure/pool/StructurePoolElement.mapping
+++ b/mappings/net/minecraft/structure/pool/StructurePoolElement.mapping
@@ -30,3 +30,30 @@ CLASS net/minecraft/class_3784 net/minecraft/structure/pool/StructurePoolElement
 		ARG 3 rotation
 	METHOD method_16757 getType ()Lnet/minecraft/class_3816;
 	METHOD method_19308 getGroundLevelDelta ()I
+	METHOD method_30421 newFeaturePoolElement (Lnet/minecraft/class_2975;)Ljava/util/function/Function;
+		ARG 0 processors
+	METHOD method_30422 (Lnet/minecraft/class_2975;Lnet/minecraft/class_3785$class_3786;)Lnet/minecraft/class_3776;
+		ARG 1 projection
+	METHOD method_30425 newLegacySinglePoolElement (Ljava/lang/String;)Ljava/util/function/Function;
+		ARG 0 id
+	METHOD method_30426 newProcessedLegacySinglePoolElement (Ljava/lang/String;Lnet/minecraft/class_5497;)Ljava/util/function/Function;
+		ARG 0 id
+		ARG 1 processors
+	METHOD method_30427 (Ljava/lang/String;Lnet/minecraft/class_5497;Lnet/minecraft/class_3785$class_3786;)Lnet/minecraft/class_3781;
+		ARG 2 projection
+	METHOD method_30428 (Ljava/lang/String;Lnet/minecraft/class_3785$class_3786;)Lnet/minecraft/class_3781;
+		ARG 1 projection
+	METHOD method_30429 newListPoolElement (Ljava/util/List;)Ljava/util/function/Function;
+	METHOD method_30430 (Ljava/util/List;Lnet/minecraft/class_3785$class_3786;)Lnet/minecraft/class_3782;
+		ARG 1 projection
+	METHOD method_30433 (Lnet/minecraft/class_3785$class_3786;)Lnet/minecraft/class_3777;
+		ARG 0 projection
+	METHOD method_30434 newSinglePoolElement (Ljava/lang/String;)Ljava/util/function/Function;
+		ARG 0 id
+	METHOD method_30435 newProcessedSinglePoolElement (Ljava/lang/String;Lnet/minecraft/class_5497;)Ljava/util/function/Function;
+		ARG 0 id
+		ARG 1 processors
+	METHOD method_30436 (Ljava/lang/String;Lnet/minecraft/class_5497;Lnet/minecraft/class_3785$class_3786;)Lnet/minecraft/class_5188;
+		ARG 2 projection
+	METHOD method_30437 (Ljava/lang/String;Lnet/minecraft/class_3785$class_3786;)Lnet/minecraft/class_5188;
+		ARG 1 projection

--- a/mappings/net/minecraft/structure/pool/StructurePoolElement.mapping
+++ b/mappings/net/minecraft/structure/pool/StructurePoolElement.mapping
@@ -30,27 +30,27 @@ CLASS net/minecraft/class_3784 net/minecraft/structure/pool/StructurePoolElement
 		ARG 3 rotation
 	METHOD method_16757 getType ()Lnet/minecraft/class_3816;
 	METHOD method_19308 getGroundLevelDelta ()I
-	METHOD method_30421 newFeaturePoolElement (Lnet/minecraft/class_2975;)Ljava/util/function/Function;
+	METHOD method_30421 ofFeature (Lnet/minecraft/class_2975;)Ljava/util/function/Function;
 		ARG 0 processors
 	METHOD method_30422 (Lnet/minecraft/class_2975;Lnet/minecraft/class_3785$class_3786;)Lnet/minecraft/class_3776;
 		ARG 1 projection
-	METHOD method_30425 newLegacySinglePoolElement (Ljava/lang/String;)Ljava/util/function/Function;
+	METHOD method_30425 ofLegacySingle (Ljava/lang/String;)Ljava/util/function/Function;
 		ARG 0 id
-	METHOD method_30426 newProcessedLegacySinglePoolElement (Ljava/lang/String;Lnet/minecraft/class_5497;)Ljava/util/function/Function;
+	METHOD method_30426 ofProcessedLegacySingle (Ljava/lang/String;Lnet/minecraft/class_5497;)Ljava/util/function/Function;
 		ARG 0 id
 		ARG 1 processors
 	METHOD method_30427 (Ljava/lang/String;Lnet/minecraft/class_5497;Lnet/minecraft/class_3785$class_3786;)Lnet/minecraft/class_3781;
 		ARG 2 projection
 	METHOD method_30428 (Ljava/lang/String;Lnet/minecraft/class_3785$class_3786;)Lnet/minecraft/class_3781;
 		ARG 1 projection
-	METHOD method_30429 newListPoolElement (Ljava/util/List;)Ljava/util/function/Function;
+	METHOD method_30429 ofList (Ljava/util/List;)Ljava/util/function/Function;
 	METHOD method_30430 (Ljava/util/List;Lnet/minecraft/class_3785$class_3786;)Lnet/minecraft/class_3782;
 		ARG 1 projection
 	METHOD method_30433 (Lnet/minecraft/class_3785$class_3786;)Lnet/minecraft/class_3777;
 		ARG 0 projection
-	METHOD method_30434 newSinglePoolElement (Ljava/lang/String;)Ljava/util/function/Function;
+	METHOD method_30434 ofSingle (Ljava/lang/String;)Ljava/util/function/Function;
 		ARG 0 id
-	METHOD method_30435 newProcessedSinglePoolElement (Ljava/lang/String;Lnet/minecraft/class_5497;)Ljava/util/function/Function;
+	METHOD method_30435 ofProcessedSingle (Ljava/lang/String;Lnet/minecraft/class_5497;)Ljava/util/function/Function;
 		ARG 0 id
 		ARG 1 processors
 	METHOD method_30436 (Ljava/lang/String;Lnet/minecraft/class_5497;Lnet/minecraft/class_3785$class_3786;)Lnet/minecraft/class_5188;

--- a/mappings/net/minecraft/structure/pool/StructurePoolElement.mapping
+++ b/mappings/net/minecraft/structure/pool/StructurePoolElement.mapping
@@ -57,3 +57,4 @@ CLASS net/minecraft/class_3784 net/minecraft/structure/pool/StructurePoolElement
 		ARG 2 projection
 	METHOD method_30437 (Ljava/lang/String;Lnet/minecraft/class_3785$class_3786;)Lnet/minecraft/class_5188;
 		ARG 1 projection
+	METHOD method_30438 ofEmpty ()Ljava/util/function/Function;


### PR DESCRIPTION
This class is used in Data and Generator classes in net.minecraft.structure in order to make structure pools via code. Mapping it will allow modders to understand what these methods do, instead of having to dig around vanilla Data and Generator classes for which ones to use.

The naming follows names like Lists#newArrayList. 