### PR TITLE
Rename fontRenderer to textRenderer

### DIFF
--- a/mappings/net/minecraft/client/gui/hud/DebugHud.mapping
+++ b/mappings/net/minecraft/client/gui/hud/DebugHud.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_340 net/minecraft/client/gui/hud/DebugHud
 	FIELD field_19274 HEIGHT_MAP_TYPES Ljava/util/Map;
 	FIELD field_2079 client Lnet/minecraft/class_310;
 	FIELD field_2080 chunkFuture Ljava/util/concurrent/CompletableFuture;
-	FIELD field_2081 fontRenderer Lnet/minecraft/class_327;
+	FIELD field_2081 textRenderer Lnet/minecraft/class_327;
 	FIELD field_2082 blockHit Lnet/minecraft/class_239;
 	FIELD field_2083 fluidHit Lnet/minecraft/class_239;
 	FIELD field_2084 chunk Lnet/minecraft/class_2818;

--- a/mappings/net/minecraft/client/gui/hud/InGameHud.mapping
+++ b/mappings/net/minecraft/client/gui/hud/InGameHud.mapping
@@ -88,7 +88,7 @@ CLASS net/minecraft/class_329 net/minecraft/client/gui/hud/InGameHud
 		ARG 1 type
 		ARG 2 message
 		ARG 3 sender
-	METHOD method_1756 getFontRenderer ()Lnet/minecraft/class_327;
+	METHOD method_1756 getTextRenderer ()Lnet/minecraft/class_327;
 	METHOD method_1757 renderScoreboardSidebar (Lnet/minecraft/class_4587;Lnet/minecraft/class_266;)V
 		ARG 1 matrices
 		ARG 2 objective

--- a/mappings/net/minecraft/client/gui/screen/ingame/EnchantingPhrases.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/EnchantingPhrases.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/class_487 net/minecraft/client/gui/screen/ingame/EnchantingP
 	FIELD field_2917 INSTANCE Lnet/minecraft/class_487;
 	FIELD field_2918 random Ljava/util/Random;
 	METHOD method_2479 generatePhrase (Lnet/minecraft/class_327;I)Lnet/minecraft/class_5348;
-		ARG 1 fontRenderer
+		ARG 1 textRenderer
 		ARG 2 width
 	METHOD method_2480 setSeed (J)V
 		ARG 1 seed


### PR DESCRIPTION
This PR renames all occurrences of `fontRenderer` to `textRenderer`.

Follow up of #466.