### PR TITLE
Map SplashOverlay.renderProgressBar

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/SplashOverlay.mapping
+++ b/mappings/net/minecraft/client/gui/screen/SplashOverlay.mapping
@@ -8,6 +8,8 @@ CLASS net/minecraft/class_425 net/minecraft/client/gui/screen/SplashOverlay
 	FIELD field_18220 reloadStartTime J
 	FIELD field_2483 LOGO Lnet/minecraft/class_2960;
 	FIELD field_25041 BRAND_ARGB Ljava/util/function/IntSupplier;
+	FIELD field_32247 RELOAD_COMPLETE_FADE_DURATION J
+	FIELD field_32248 RELOAD_START_FADE_DURATION J
 	FIELD field_32249 MOJANG_RED I
 	FIELD field_32250 MONOCHROME_BLACK I
 	METHOD <init> (Lnet/minecraft/class_310;Lnet/minecraft/class_4011;Ljava/util/function/Consumer;Z)V
@@ -17,6 +19,10 @@ CLASS net/minecraft/class_425 net/minecraft/client/gui/screen/SplashOverlay
 		ARG 4 reloading
 	METHOD method_18103 renderProgressBar (Lnet/minecraft/class_4587;IIIIF)V
 		ARG 1 matrices
+		ARG 2 x1
+		ARG 3 y1
+		ARG 4 x2
+		ARG 5 y2
 		ARG 6 opacity
 	METHOD method_18819 init (Lnet/minecraft/class_310;)V
 		ARG 0 client

--- a/mappings/net/minecraft/client/gui/screen/SplashOverlay.mapping
+++ b/mappings/net/minecraft/client/gui/screen/SplashOverlay.mapping
@@ -19,10 +19,10 @@ CLASS net/minecraft/class_425 net/minecraft/client/gui/screen/SplashOverlay
 		ARG 4 reloading
 	METHOD method_18103 renderProgressBar (Lnet/minecraft/class_4587;IIIIF)V
 		ARG 1 matrices
-		ARG 2 x1
-		ARG 3 y1
-		ARG 4 x2
-		ARG 5 y2
+		ARG 2 minX
+		ARG 3 minY
+		ARG 4 maxX
+		ARG 5 maxY
 		ARG 6 opacity
 	METHOD method_18819 init (Lnet/minecraft/class_310;)V
 		ARG 0 client


### PR DESCRIPTION
`x1` and `y1` could also be called `topLeftX` and `topLeftY`, `x2` and `y2` could be `bottomRightX` and `bottomRightY`.
Or instead of `x1` `y1` `x2` `y2` it could be `left` `top` `right` `bottom` but the order didn't feel right.

The fields were intended to be unpicked but unpicker doesn't support fields yet.