### PR TITLE
Rename the createTreeFeature and createLargeTreeFeature methods to indicate that they return a constant reference to a configured feature

### DIFF
--- a/mappings/net/minecraft/block/sapling/LargeTreeSaplingGenerator.mapping
+++ b/mappings/net/minecraft/block/sapling/LargeTreeSaplingGenerator.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/class_2650 net/minecraft/block/sapling/LargeTreeSaplingGener
 		ARG 2 pos
 		ARG 3 x
 		ARG 4 z
-	METHOD method_11443 createLargeTreeFeature (Ljava/util/Random;)Lnet/minecraft/class_2975;
+	METHOD method_11443 getLargeTreeFeature (Ljava/util/Random;)Lnet/minecraft/class_2975;
 		ARG 1 random
 	METHOD method_11444 generateLargeTree (Lnet/minecraft/class_3218;Lnet/minecraft/class_2794;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Ljava/util/Random;II)Z
 		ARG 1 world

--- a/mappings/net/minecraft/block/sapling/SaplingGenerator.mapping
+++ b/mappings/net/minecraft/block/sapling/SaplingGenerator.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_2647 net/minecraft/block/sapling/SaplingGenerator
-	METHOD method_11430 createTreeFeature (Ljava/util/Random;Z)Lnet/minecraft/class_2975;
+	METHOD method_11430 getTreeFeature (Ljava/util/Random;Z)Lnet/minecraft/class_2975;
 		ARG 1 random
 		ARG 2 bees
 	METHOD method_11431 generate (Lnet/minecraft/class_3218;Lnet/minecraft/class_2794;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Ljava/util/Random;)Z


### PR DESCRIPTION
Fixes #2506