### PR TITLE
Fill in the missing classes!

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/ingame/BeaconScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/BeaconScreen.mapping
@@ -53,7 +53,7 @@ CLASS net/minecraft/class_466 net/minecraft/client/gui/screen/ingame/BeaconScree
 			ARG 4 u
 			ARG 5 v
 			ARG 6 message
-	CLASS class_6392 ButtonWidget
+	CLASS class_6392 HoverableButtonWidget
 		METHOD method_25352 renderTooltip (Lnet/minecraft/class_4587;II)V
 			ARG 1 matrices
 			ARG 2 mouseX

--- a/mappings/net/minecraft/client/gui/screen/ingame/BeaconScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/BeaconScreen.mapping
@@ -53,7 +53,7 @@ CLASS net/minecraft/class_466 net/minecraft/client/gui/screen/ingame/BeaconScree
 			ARG 4 u
 			ARG 5 v
 			ARG 6 message
-	CLASS class_6392
+	CLASS class_6392 ButtonWidget
 		METHOD method_25352 renderTooltip (Lnet/minecraft/class_4587;II)V
 			ARG 1 matrices
 			ARG 2 mouseX

--- a/mappings/net/minecraft/client/render/Camera.mapping
+++ b/mappings/net/minecraft/client/render/Camera.mapping
@@ -48,7 +48,7 @@ CLASS net/minecraft/class_4184 net/minecraft/client/render/Camera
 	METHOD method_19337 reset ()V
 	METHOD method_23767 getRotation ()Lnet/minecraft/class_1158;
 	METHOD method_35689 getDiagonalPlane ()Lnet/minecraft/class_1160;
-	METHOD method_36425 getMathHelper ()Lnet/minecraft/class_4184$class_6355;
+	METHOD method_36425 getPlaneHelper ()Lnet/minecraft/class_4184$class_6355;
 	CLASS class_6355 PlaneHelper
 		FIELD field_33622 horizontalPlane Lnet/minecraft/class_243;
 		FIELD field_33623 verticalPlane Lnet/minecraft/class_243;

--- a/mappings/net/minecraft/client/render/Camera.mapping
+++ b/mappings/net/minecraft/client/render/Camera.mapping
@@ -48,3 +48,15 @@ CLASS net/minecraft/class_4184 net/minecraft/client/render/Camera
 	METHOD method_19337 reset ()V
 	METHOD method_23767 getRotation ()Lnet/minecraft/class_1158;
 	METHOD method_35689 getDiagonalPlane ()Lnet/minecraft/class_1160;
+	METHOD method_36425 getMathHelper ()Lnet/minecraft/class_4184$class_6355;
+	CLASS class_6355 PlaneHelper
+		FIELD field_33622 horizontalPlane Lnet/minecraft/class_243;
+		FIELD field_33623 verticalPlane Lnet/minecraft/class_243;
+		FIELD field_33624 diagonalPlane Lnet/minecraft/class_243;
+		METHOD <init> (Lnet/minecraft/class_243;Lnet/minecraft/class_243;Lnet/minecraft/class_243;)V
+			ARG 1 horizontalPlane
+			ARG 2 verticalPlane
+			ARG 3 diagonalPlane
+		METHOD method_36427 (FF)Lnet/minecraft/class_243;
+			ARG 1 verticalMultiplier
+			ARG 2 diagonalMultiplier

--- a/mappings/net/minecraft/entity/mob/ShulkerEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/ShulkerEntity.mapping
@@ -50,3 +50,4 @@ CLASS net/minecraft/class_1606 net/minecraft/entity/mob/ShulkerEntity
 			ARG 2 shulker
 	CLASS class_1611 PeekGoal
 		FIELD field_7352 counter I
+	CLASS class_6376 ShulkerLookControl


### PR DESCRIPTION
There are only 4 classes unnamed in Yarn right now. This fills in three of them:
- `ShulkerLookControl` in `ShulkerEntity` (many other entities have the exact same subclass)
- `PlaneHelper` in `Camera` (a math**s** helper for managing planes)
- `HoverableButtonWidget` in `BeaconScreen` (this is a janky name and I'm willing to change it, it just reflects what the subclass does)

Feedback needed, these are janky as hell and could do with refining; I just wanted to get the change moving!