### PR TITLE
1.17.1-pre2/pre3 stuff

### DIFF
--- a/mappings/net/minecraft/block/TallPlantBlock.mapping
+++ b/mappings/net/minecraft/block/TallPlantBlock.mapping
@@ -1,10 +1,10 @@
 CLASS net/minecraft/class_2320 net/minecraft/block/TallPlantBlock
 	FIELD field_10929 HALF Lnet/minecraft/class_2754;
 	METHOD method_10021 placeAt (Lnet/minecraft/class_1936;Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;I)V
-		ARG 1 world
-		ARG 2 state
-		ARG 3 pos
-		ARG 4 flags
+		ARG 0 world
+		ARG 1 state
+		ARG 2 pos
+		ARG 3 flags
 	METHOD method_30036 onBreakInCreative (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_1657;)V
 		COMMENT Destroys a bottom half of a tall double block (such as a plant or a door)
 		COMMENT without dropping an item when broken in creative.
@@ -14,3 +14,7 @@ CLASS net/minecraft/class_2320 net/minecraft/block/TallPlantBlock
 		ARG 1 pos
 		ARG 2 state
 		ARG 3 player
+	METHOD method_37458 withWaterloggedState (Lnet/minecraft/class_4538;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)Lnet/minecraft/class_2680;
+		ARG 0 world
+		ARG 1 pos
+		ARG 2 state

--- a/mappings/net/minecraft/client/render/MapRenderer.mapping
+++ b/mappings/net/minecraft/client/render/MapRenderer.mapping
@@ -25,9 +25,16 @@ CLASS net/minecraft/class_330 net/minecraft/client/render/MapRenderer
 		FIELD field_2046 state Lnet/minecraft/class_22;
 		FIELD field_2048 texture Lnet/minecraft/class_1043;
 		FIELD field_21689 renderLayer Lnet/minecraft/class_1921;
+		FIELD field_34044 needsUpdate Z
+		METHOD <init> (Lnet/minecraft/class_330;ILnet/minecraft/class_22;)V
+			ARG 2 id
+			ARG 3 state
 		METHOD method_1776 updateTexture ()V
 		METHOD method_1777 draw (Lnet/minecraft/class_4587;Lnet/minecraft/class_4597;ZI)V
 			ARG 1 matrices
 			ARG 2 vertexConsumers
 			ARG 3 hidePlayerIcons
 			ARG 4 light
+		METHOD method_37450 setNeedsUpdate ()V
+		METHOD method_37451 setState (Lnet/minecraft/class_22;)V
+			ARG 1 state

--- a/mappings/net/minecraft/client/util/GlAllocationUtils.mapping
+++ b/mappings/net/minecraft/client/util/GlAllocationUtils.mapping
@@ -1,3 +1,7 @@
 CLASS net/minecraft/class_311 net/minecraft/client/util/GlAllocationUtils
+	FIELD field_34054 ALLOCATOR Lorg/lwjgl/system/MemoryUtil$MemoryAllocator;
 	METHOD method_1596 allocateByteBuffer (I)Ljava/nio/ByteBuffer;
 		ARG 0 size
+	METHOD method_37465 resizeByteBuffer (Ljava/nio/ByteBuffer;I)Ljava/nio/ByteBuffer;
+		ARG 0 source
+		ARG 1 size

--- a/mappings/net/minecraft/client/util/MacWindowUtil.mapping
+++ b/mappings/net/minecraft/client/util/MacWindowUtil.mapping
@@ -1,0 +1,10 @@
+CLASS net/minecraft/class_6417 net/minecraft/client/util/MacWindowUtil
+	FIELD field_34053 FULLSCREEN_MASK I
+	METHOD method_37461 toggleFullscreen (J)V
+		ARG 0 handle
+	METHOD method_37462 isFullscreen (Lca/weblite/objc/NSObject;)Z
+		ARG 0 handle
+	METHOD method_37463 getCocoaWindow (J)Ljava/util/Optional;
+		ARG 0 handle
+	METHOD method_37464 toggleFullscreen (Lca/weblite/objc/NSObject;)V
+		ARG 0 handle

--- a/mappings/net/minecraft/entity/ai/brain/sensor/Sensor.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/sensor/Sensor.mapping
@@ -11,6 +11,10 @@ CLASS net/minecraft/class_4148 net/minecraft/entity/ai/brain/sensor/Sensor
 	FIELD field_26631 TARGET_PREDICATE_IGNORE_DISTANCE_SCALING Lnet/minecraft/class_4051;
 	FIELD field_30258 BASE_MAX_DISTANCE I
 	FIELD field_30259 DEFAULT_RUN_TIME I
+	FIELD field_33762 ATTACKABLE_TARGET_PREDICATE Lnet/minecraft/class_4051;
+	FIELD field_33763 ATTACKABLE_TARGET_PREDICATE_IGNORE_DISTANCE_SCALING Lnet/minecraft/class_4051;
+	FIELD field_34050 ATTACKABLE_TARGET_PREDICATE_IGNORE_VISIBILITY Lnet/minecraft/class_4051;
+	FIELD field_34051 ATTACKABLE_TARGET_PREDICATE_IGNORE_VISIBILITY_OR_DISTANCE_SCALING Lnet/minecraft/class_4051;
 	METHOD <init> (I)V
 		ARG 1 senseInterval
 	METHOD method_19099 getOutputMemoryModules ()Ljava/util/Set;
@@ -21,5 +25,11 @@ CLASS net/minecraft/class_4148 net/minecraft/entity/ai/brain/sensor/Sensor
 		ARG 1 world
 		ARG 2 entity
 	METHOD method_30954 testTargetPredicate (Lnet/minecraft/class_1309;Lnet/minecraft/class_1309;)Z
+		ARG 0 entity
+		ARG 1 target
+	METHOD method_36982 testAttackableTargetPredicate (Lnet/minecraft/class_1309;Lnet/minecraft/class_1309;)Z
+		ARG 0 entity
+		ARG 1 target
+	METHOD method_37456 testAttackableTargetPredicateIgnoreVisibility (Lnet/minecraft/class_1309;Lnet/minecraft/class_1309;)Z
 		ARG 0 entity
 		ARG 1 target

--- a/mappings/net/minecraft/entity/ai/brain/task/AquaticStrollTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/AquaticStrollTask.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_5755 net/minecraft/entity/ai/brain/task/AquaticStrollTask
+	FIELD field_34048 NORMALIZED_POS_MULTIPLIERS [[I

--- a/mappings/net/minecraft/entity/ai/brain/task/GoTowardsLookTarget.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/GoTowardsLookTarget.mapping
@@ -1,6 +1,15 @@
 CLASS net/minecraft/class_4120 net/minecraft/entity/ai/brain/task/GoTowardsLookTarget
 	FIELD field_18378 speed Ljava/util/function/Function;
 	FIELD field_19002 completionRange I
+	FIELD field_34049 predicate Ljava/util/function/Predicate;
 	METHOD <init> (FI)V
 		ARG 1 speed
 		ARG 2 completionRange
+	METHOD <init> (Ljava/util/function/Predicate;Ljava/util/function/Function;I)V
+		ARG 1 predicate
+		ARG 2 speed
+		ARG 3 completionRange
+	METHOD method_33204 (Lnet/minecraft/class_1309;)Z
+		ARG 0 entity
+	METHOD method_37455 (FLnet/minecraft/class_1309;)Ljava/lang/Float;
+		ARG 1 entity

--- a/mappings/net/minecraft/entity/ai/brain/task/HoldTradeOffersTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/HoldTradeOffersTask.mapping
@@ -22,3 +22,8 @@ CLASS net/minecraft/class_4130 net/minecraft/entity/ai/brain/task/HoldTradeOffer
 		ARG 1 villager
 	METHOD method_19603 findPotentialCustomer (Lnet/minecraft/class_1646;)Lnet/minecraft/class_1309;
 		ARG 1 villager
+	METHOD method_37447 holdOffer (Lnet/minecraft/class_1646;Lnet/minecraft/class_1799;)V
+		ARG 0 villager
+		ARG 1 stack
+	METHOD method_37448 holdNothing (Lnet/minecraft/class_1646;)V
+		ARG 0 villager

--- a/mappings/net/minecraft/entity/ai/brain/task/StrollTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/StrollTask.mapping
@@ -4,11 +4,22 @@ CLASS net/minecraft/class_4818 net/minecraft/entity/ai/brain/task/StrollTask
 	FIELD field_22312 verticalRadius I
 	FIELD field_30157 MIN_RUN_TIME I
 	FIELD field_30158 MAX_RUN_TIME I
+	FIELD field_34047 strollInsideWater Z
 	METHOD <init> (F)V
 		ARG 1 speed
 	METHOD <init> (FII)V
 		ARG 1 speed
 		ARG 2 horizontalRadius
 		ARG 3 verticalRadius
+	METHOD <init> (FIIZ)V
+		ARG 1 speed
+		ARG 2 horizontalRadius
+		ARG 3 verticalRadius
+		ARG 4 strollInsideWater
+	METHOD <init> (FZ)V
+		ARG 1 speed
+		ARG 2 strollInsideWater
+	METHOD method_24593 (Lnet/minecraft/class_243;)Lnet/minecraft/class_4142;
+		ARG 1 pos
 	METHOD method_33201 findWalkTarget (Lnet/minecraft/class_1314;)Lnet/minecraft/class_243;
 		ARG 1 entity

--- a/mappings/net/minecraft/entity/mob/MobEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/MobEntity.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/class_1308 net/minecraft/entity/mob/MobEntity
 	FIELD field_30088 AI_DISABLED_FLAG I
 	FIELD field_30089 LEFT_HANDED_FLAG I
 	FIELD field_30090 ATTACKING_FLAG I
+	FIELD field_34043 DEFAULT_DROP_CHANCE F
 	FIELD field_6184 lootTableSeed J
 	FIELD field_6185 targetSelector Lnet/minecraft/class_1355;
 	FIELD field_6186 armorDropChances [F

--- a/mappings/net/minecraft/entity/passive/AxolotlBrain.mapping
+++ b/mappings/net/minecraft/entity/passive/AxolotlBrain.mapping
@@ -70,3 +70,5 @@ CLASS net/minecraft/class_5768 net/minecraft/entity/passive/AxolotlBrain
 		ARG 0 brain
 	METHOD method_33252 addIdleActivities (Lnet/minecraft/class_4095;)V
 		ARG 0 brain
+	METHOD method_37457 canGoToLookTarget (Lnet/minecraft/class_1309;)Z
+		ARG 0 entity

--- a/mappings/net/minecraft/network/PacketByteBuf.mapping
+++ b/mappings/net/minecraft/network/PacketByteBuf.mapping
@@ -702,3 +702,8 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 		COMMENT @return the read optional value
 		COMMENT @see #writeOptional(Optional, BiConsumer)
 		ARG 1 parser
+	METHOD method_37452 (ILjava/util/function/IntFunction;I)Ljava/lang/Object;
+		ARG 2 value
+	METHOD method_37453 getMaxValidator (Ljava/util/function/IntFunction;I)Ljava/util/function/IntFunction;
+		ARG 0 applier
+		ARG 1 max

--- a/mappings/net/minecraft/network/packet/c2s/play/BookUpdateC2SPacket.mapping
+++ b/mappings/net/minecraft/network/packet/c2s/play/BookUpdateC2SPacket.mapping
@@ -4,6 +4,7 @@ CLASS net/minecraft/class_2820 net/minecraft/network/packet/c2s/play/BookUpdateC
 	FIELD field_34040 MAX_PAGE_LENGTH I
 	FIELD field_34041 pages Ljava/util/List;
 	FIELD field_34042 title Ljava/util/Optional;
+	FIELD field_34046 MAX_PAGES I
 	METHOD <init> (ILjava/util/List;Ljava/util/Optional;)V
 		ARG 1 slot
 		ARG 2 pages

--- a/mappings/net/minecraft/network/packet/c2s/play/ClickSlotC2SPacket.mapping
+++ b/mappings/net/minecraft/network/packet/c2s/play/ClickSlotC2SPacket.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/class_2813 net/minecraft/network/packet/c2s/play/ClickSlotC2
 	FIELD field_12819 syncId I
 	FIELD field_29540 modifiedStacks Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
 	FIELD field_34037 revision I
+	FIELD field_34045 MAX_MODIFIED_STACKS I
 	METHOD <init> (IIIILnet/minecraft/class_1713;Lnet/minecraft/class_1799;Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;)V
 		ARG 1 syncId
 		ARG 2 revision
@@ -21,5 +22,7 @@ CLASS net/minecraft/class_2813 net/minecraft/network/packet/c2s/play/ClickSlotC2
 	METHOD method_12193 getButton ()I
 	METHOD method_12194 getSyncId ()I
 	METHOD method_12195 getActionType ()Lnet/minecraft/class_1713;
+	METHOD method_34677 (Lnet/minecraft/class_2540;)Ljava/lang/Integer;
+		ARG 0 buf
 	METHOD method_34678 getModifiedStacks ()Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
 	METHOD method_37440 getRevision ()I

--- a/mappings/net/minecraft/resource/DefaultResourcePack.mapping
+++ b/mappings/net/minecraft/resource/DefaultResourcePack.mapping
@@ -30,5 +30,7 @@ CLASS net/minecraft/class_3268 net/minecraft/resource/DefaultResourcePack
 		ARG 2 path
 	METHOD method_23858 (Ljava/util/function/Predicate;Ljava/nio/file/Path;)Z
 		ARG 1 path
+	METHOD method_37454 getPath (Ljava/net/URI;)Ljava/nio/file/Path;
+		ARG 0 uri
 	CLASS 1
 		FIELD field_29185 stream Ljava/io/InputStream;

--- a/mappings/net/minecraft/screen/ScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/ScreenHandler.mapping
@@ -95,6 +95,9 @@ CLASS net/minecraft/class_1703 net/minecraft/screen/ScreenHandler
 	METHOD method_37420 updateToClient ()V
 	METHOD method_37421 getRevision ()I
 	METHOD method_37422 nextRevision ()I
+	METHOD method_37449 setPreviousTrackedSlotMutable (ILnet/minecraft/class_1799;)V
+		ARG 1 slot
+		ARG 2 stack
 	METHOD method_7591 packQuickCraftData (II)I
 		ARG 0 quickCraftStage
 		ARG 1 buttonId

--- a/mappings/net/minecraft/world/chunk/ChunkNibbleArray.mapping
+++ b/mappings/net/minecraft/world/chunk/ChunkNibbleArray.mapping
@@ -1,11 +1,15 @@
 CLASS net/minecraft/class_2804 net/minecraft/world/chunk/ChunkNibbleArray
 	FIELD field_12783 bytes [B
+	FIELD field_31403 BYTES_LENGTH I
+	FIELD field_31404 COPY_BLOCK_SIZE I
+	FIELD field_34052 COPY_TIMES I
 	METHOD <init> (I)V
 		ARG 1 size
 	METHOD <init> ([B)V
 		ARG 1 bytes
 	METHOD method_12137 asByteArray ()[B
 	METHOD method_12138 divideByTwo (I)I
+		ARG 0 i
 		ARG 1 n
 	METHOD method_12139 get (III)I
 		ARG 1 x
@@ -27,3 +31,5 @@ CLASS net/minecraft/class_2804 net/minecraft/world/chunk/ChunkNibbleArray
 		ARG 3 z
 		ARG 4 value
 	METHOD method_12146 isUninitialized ()Z
+	METHOD method_37459 isOdd (I)I
+		ARG 0 i

--- a/mappings/net/minecraft/world/chunk/light/SkyLightStorage.mapping
+++ b/mappings/net/minecraft/world/chunk/light/SkyLightStorage.mapping
@@ -17,6 +17,8 @@ CLASS net/minecraft/class_3569 net/minecraft/world/chunk/light/SkyLightStorage
 		ARG 1 sectionPos
 	METHOD method_20810 enqueueAddSection (J)V
 		ARG 1 sectionPos
+	METHOD method_37460 copy (Lnet/minecraft/class_2804;)Lnet/minecraft/class_2804;
+		ARG 0 source
 	CLASS class_3570 Data
 		FIELD field_15821 columnToTopSection Lit/unimi/dsi/fastutil/longs/Long2IntOpenHashMap;
 		FIELD field_15822 minSectionY I


### PR DESCRIPTION
Methods related to villager dropping items, some map changes, and validation of integers. Still not quite sure with the naming `setPreviousTrackedSlotMutable`; it's basically `setPreviousTrackedSlot` without `copy()`ing the `stack`.

Update: now has 1.17.1-pre3 mappings, including `placeAt` argument number fix, `TallPlantBlock.withWaterloggedState` (which returns BlockState with waterlogged state if `pos` has water), a util for macOS window handling, `ATTACKABLE_TARGET_PREDICATE_IGNORE_VISIBILITY_OR_DISTANCE_SCALING` and `testAttackableTargetPredicateIgnoreVisibility`, (suggest shorter names please), etc.

Also maps the oddest method of all: `method_37459` (`isOdd`).