### PR TITLE
Document `SpawnEggItem.getColor`

### DIFF
--- a/mappings/net/minecraft/item/SpawnEggItem.mapping
+++ b/mappings/net/minecraft/item/SpawnEggItem.mapping
@@ -18,7 +18,11 @@ CLASS net/minecraft/class_1826 net/minecraft/item/SpawnEggItem
 	METHOD method_8015 getEntityType (Lnet/minecraft/class_2487;)Lnet/minecraft/class_1299;
 		ARG 1 nbt
 	METHOD method_8016 getColor (I)I
-		ARG 1 num
+		COMMENT {@return the color of the specified tint index}
+		COMMENT
+		COMMENT @implSpec If the tint index is 0, returns {@link #primaryColor}. Otherwise, returns {@link #secondaryColor}.
+		ARG 1 tintIndex
+			COMMENT the tint index
 	METHOD method_8017 getAll ()Ljava/lang/Iterable;
 	METHOD method_8018 isOfSameEntityType (Lnet/minecraft/class_2487;Lnet/minecraft/class_1299;)Z
 		ARG 1 nbt


### PR DESCRIPTION
Also renamed the awful parameter name `num` to `tintIndex` (passed from an item colour provider).