### PR TITLE
Bump enigma

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
 			url 'https://maven.fabricmc.net'
 		}
 		mavenCentral()
+		mavenLocal()
 	}
 	dependencies {
 		classpath "cuchaz:enigma-cli:${project.enigma_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx4G
 
-enigma_version=1.3.2
+enigma_version=1.3.4
 stitch_version=0.6.1
 unpick_version=2.2.0
 cfr_version=0.0.3


### PR DESCRIPTION
1. Add `mavenLocal()` to buildscript dependencies; this allows testing yarn usage with local builds of enigma, stitch, etc. more easily. A similar `mavenLocal()` already exists for the regular dependencies block, which is for the same purpose.
2. Bump enigma to 1.3.4, which improves cfr usage experience a bit.