### PR TITLE
Rename BakedModel#getSprite to more intuitive name

### DIFF
--- a/mappings/net/minecraft/client/render/block/BlockModels.mapping
+++ b/mappings/net/minecraft/client/render/block/BlockModels.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/class_773 net/minecraft/client/render/block/BlockModels
 	METHOD method_3337 (Lnet/minecraft/class_2680;)V
 		ARG 1 state
 	METHOD method_3338 propertyMapToString (Ljava/util/Map;)Ljava/lang/String;
-	METHOD method_3339 getSprite (Lnet/minecraft/class_2680;)Lnet/minecraft/class_1058;
+	METHOD method_3339 getModelIcon (Lnet/minecraft/class_2680;)Lnet/minecraft/class_1058;
 		ARG 1 state
 	METHOD method_3340 getModelId (Lnet/minecraft/class_2680;)Lnet/minecraft/class_1091;
 		ARG 0 state

--- a/mappings/net/minecraft/client/render/block/BlockModels.mapping
+++ b/mappings/net/minecraft/client/render/block/BlockModels.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/class_773 net/minecraft/client/render/block/BlockModels
 	METHOD method_3337 (Lnet/minecraft/class_2680;)V
 		ARG 1 state
 	METHOD method_3338 propertyMapToString (Ljava/util/Map;)Ljava/lang/String;
-	METHOD method_3339 getModelIcon (Lnet/minecraft/class_2680;)Lnet/minecraft/class_1058;
+	METHOD method_3339 getModelParticleSprite (Lnet/minecraft/class_2680;)Lnet/minecraft/class_1058;
 		ARG 1 state
 	METHOD method_3340 getModelId (Lnet/minecraft/class_2680;)Lnet/minecraft/class_1091;
 		ARG 0 state

--- a/mappings/net/minecraft/client/render/item/ItemModels.mapping
+++ b/mappings/net/minecraft/client/render/item/ItemModels.mapping
@@ -7,11 +7,11 @@ CLASS net/minecraft/class_763 net/minecraft/client/render/item/ItemModels
 	METHOD method_3303 getModelManager ()Lnet/minecraft/class_1092;
 	METHOD method_3304 getModel (Lnet/minecraft/class_1792;)Lnet/minecraft/class_1087;
 		ARG 1 item
-	METHOD method_3305 getModelIcon (Lnet/minecraft/class_1799;)Lnet/minecraft/class_1058;
+	METHOD method_3305 getModelParticleSprite (Lnet/minecraft/class_1799;)Lnet/minecraft/class_1058;
 		ARG 1 stack
 	METHOD method_3306 getModelId (Lnet/minecraft/class_1792;)I
 		ARG 0 item
-	METHOD method_3307 getModelIcon (Lnet/minecraft/class_1935;)Lnet/minecraft/class_1058;
+	METHOD method_3307 getModelParticleSprite (Lnet/minecraft/class_1935;)Lnet/minecraft/class_1058;
 		ARG 1 item
 	METHOD method_3308 getModel (Lnet/minecraft/class_1799;)Lnet/minecraft/class_1087;
 		ARG 1 stack

--- a/mappings/net/minecraft/client/render/item/ItemModels.mapping
+++ b/mappings/net/minecraft/client/render/item/ItemModels.mapping
@@ -7,11 +7,11 @@ CLASS net/minecraft/class_763 net/minecraft/client/render/item/ItemModels
 	METHOD method_3303 getModelManager ()Lnet/minecraft/class_1092;
 	METHOD method_3304 getModel (Lnet/minecraft/class_1792;)Lnet/minecraft/class_1087;
 		ARG 1 item
-	METHOD method_3305 getSprite (Lnet/minecraft/class_1799;)Lnet/minecraft/class_1058;
+	METHOD method_3305 getModelIcon (Lnet/minecraft/class_1799;)Lnet/minecraft/class_1058;
 		ARG 1 stack
 	METHOD method_3306 getModelId (Lnet/minecraft/class_1792;)I
 		ARG 0 item
-	METHOD method_3307 getSprite (Lnet/minecraft/class_1935;)Lnet/minecraft/class_1058;
+	METHOD method_3307 getModelIcon (Lnet/minecraft/class_1935;)Lnet/minecraft/class_1058;
 		ARG 1 item
 	METHOD method_3308 getModel (Lnet/minecraft/class_1799;)Lnet/minecraft/class_1087;
 		ARG 1 stack

--- a/mappings/net/minecraft/client/render/model/BakedModel.mapping
+++ b/mappings/net/minecraft/client/render/model/BakedModel.mapping
@@ -12,7 +12,7 @@ CLASS net/minecraft/class_1087 net/minecraft/client/render/model/BakedModel
 	METHOD method_4708 useAmbientOcclusion ()Z
 	METHOD method_4709 getTransformation ()Lnet/minecraft/class_809;
 	METHOD method_4710 getOverrides ()Lnet/minecraft/class_806;
-	METHOD method_4711 getSprite ()Lnet/minecraft/class_1058;
+	METHOD method_4711 getModelIcon ()Lnet/minecraft/class_1058;
 		COMMENT {@return a texture that represents the model}
 		COMMENT <p>
 		COMMENT For example, this is used for the block break particles.

--- a/mappings/net/minecraft/client/render/model/BakedModel.mapping
+++ b/mappings/net/minecraft/client/render/model/BakedModel.mapping
@@ -12,9 +12,9 @@ CLASS net/minecraft/class_1087 net/minecraft/client/render/model/BakedModel
 	METHOD method_4708 useAmbientOcclusion ()Z
 	METHOD method_4709 getTransformation ()Lnet/minecraft/class_809;
 	METHOD method_4710 getOverrides ()Lnet/minecraft/class_806;
-	METHOD method_4711 getModelIcon ()Lnet/minecraft/class_1058;
+	METHOD method_4711 getParticleSprite ()Lnet/minecraft/class_1058;
 		COMMENT {@return a texture that represents the model}
 		COMMENT <p>
-		COMMENT For example, this is used for the block break particles.
+		COMMENT This is primarily used in particles. For example, block break particles use this sprite.
 	METHOD method_4712 hasDepth ()Z
 	METHOD method_4713 isBuiltin ()Z

--- a/mappings/net/minecraft/client/render/model/BakedModel.mapping
+++ b/mappings/net/minecraft/client/render/model/BakedModel.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/class_1087 net/minecraft/client/render/model/BakedModel
 	METHOD method_4709 getTransformation ()Lnet/minecraft/class_809;
 	METHOD method_4710 getOverrides ()Lnet/minecraft/class_806;
 	METHOD method_4711 getSprite ()Lnet/minecraft/class_1058;
-		COMMENT A texture that represents the model.
+		COMMENT {@return a texture that represents the model}
 		COMMENT <p>
 		COMMENT For example, this is used for the block break particles.
 	METHOD method_4712 hasDepth ()Z

--- a/mappings/net/minecraft/client/render/model/BakedModel.mapping
+++ b/mappings/net/minecraft/client/render/model/BakedModel.mapping
@@ -13,5 +13,8 @@ CLASS net/minecraft/class_1087 net/minecraft/client/render/model/BakedModel
 	METHOD method_4709 getTransformation ()Lnet/minecraft/class_809;
 	METHOD method_4710 getOverrides ()Lnet/minecraft/class_806;
 	METHOD method_4711 getSprite ()Lnet/minecraft/class_1058;
+		COMMENT A texture that represents the model.
+		COMMENT <p>
+		COMMENT For example, this is used for the block break particles.
 	METHOD method_4712 hasDepth ()Z
 	METHOD method_4713 isBuiltin ()Z


### PR DESCRIPTION
getSprite is a somewhat confusing name, it's used for block break particles, some fluid stuff, and the "ItemBillboardParticle" (the particle effect used to show barrier blocks & now light blocks).