### PR TITLE
Recipe docs

### DIFF
--- a/mappings/net/minecraft/recipe/CuttingRecipe.mapping
+++ b/mappings/net/minecraft/recipe/CuttingRecipe.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_3972 net/minecraft/recipe/CuttingRecipe
+	COMMENT A recipe that has only one input ingredient. It can be used by any type
+	COMMENT of recipe as long as its subclass implements the proper interface.
 	FIELD field_17642 input Lnet/minecraft/class_1856;
 	FIELD field_17643 output Lnet/minecraft/class_1799;
 	FIELD field_17644 id Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/recipe/Ingredient.mapping
+++ b/mappings/net/minecraft/recipe/Ingredient.mapping
@@ -28,7 +28,7 @@ CLASS net/minecraft/class_1856 net/minecraft/recipe/Ingredient
 	METHOD method_8102 fromJson (Lcom/google/gson/JsonElement;)Lnet/minecraft/class_1856;
 		ARG 0 json
 	METHOD method_8103 isEmpty ()Z
-	METHOD method_8105 getMatchingStacksClient ()[Lnet/minecraft/class_1799;
+	METHOD method_8105 getMatchingStacks ()[Lnet/minecraft/class_1799;
 	METHOD method_8106 fromTag (Lnet/minecraft/class_3494;)Lnet/minecraft/class_1856;
 		ARG 0 tag
 	METHOD method_8107 entryFromJson (Lcom/google/gson/JsonObject;)Lnet/minecraft/class_1856$class_1859;

--- a/mappings/net/minecraft/recipe/Recipe.mapping
+++ b/mappings/net/minecraft/recipe/Recipe.mapping
@@ -1,43 +1,91 @@
 CLASS net/minecraft/class_1860 net/minecraft/recipe/Recipe
+	COMMENT A recipe is an arrangement of item stacks in an inventory that can
+	COMMENT yield a product item stack.
+	COMMENT
+	COMMENT <p>Recipes are loaded by and stored in the {@link RecipeManager}. They
+	COMMENT are part of the server's data packs and are sent to the client, governed
+	COMMENT by their {@linkplain #getSerializer() serializers}. Hence, recipes
+	COMMENT should not be stored, as they may become obsolete after reloads.
+	COMMENT
+	COMMENT <p>A few of the methods in this class are dedicated to crafting recipes
+	COMMENT or recipe books. Users can have stub implementations if they do not use
+	COMMENT those functionalities.
 	METHOD method_17447 createIcon ()Lnet/minecraft/class_1799;
-		COMMENT Creates the stack that is displayed on the recipe book tab containing this recipe, and on a toast when a recipe of this type is unlocked.
-		COMMENT Used in conjunction with {@link #getGroup()}.
+		COMMENT {@return an item rendered on the top left of the {@linkplain #getOutput()
+		COMMENT output preview} on the recipe toast when a new recipe is unlocked} This
+		COMMENT can be interpreted as a catalyst for the recipe.
 	METHOD method_17716 getType ()Lnet/minecraft/class_3956;
+		COMMENT {@return the type of this recipe}
+		COMMENT
+		COMMENT <p>The {@code type} in the recipe JSON format is the {@linkplain
+		COMMENT #getSerializer() serializer} instead.
 	METHOD method_31583 (Lnet/minecraft/class_1856;)Z
 		ARG 0 ingredient
 	METHOD method_31584 isEmpty ()Z
+		COMMENT {@return whether this recipe has no ingredient or has any empty ingredient}
+		COMMENT The recipe book uses this to ignore recipes for display.
 	METHOD method_8110 getOutput ()Lnet/minecraft/class_1799;
-	METHOD method_8111 getRemainder (Lnet/minecraft/class_1263;)Lnet/minecraft/class_2371;
-		COMMENT Returns the remaining stacks to be left in the crafting grid after crafting is complete.
-		COMMENT Should return the same number of items as the input grid contains in the same order they're expected
-		COMMENT to appear in that grid.
+		COMMENT {@return a preview of the recipe's output}
 		COMMENT
-		COMMENT @implSpec Default implementation simply returns a grid of all empty stacks where all stacks from the
-		COMMENT input grid have been replaced with the result of calling {@link net.minecraft.item.Item#getRecipeRemainder()} on them.
+		COMMENT <p>The returned stack should not be modified. To obtain the actual output,
+		COMMENT call {@link #craft(Inventory)}.
+	METHOD method_8111 getRemainder (Lnet/minecraft/class_1263;)Lnet/minecraft/class_2371;
+		COMMENT {@return the remaining stacks to be left in the {@code inventory} after the recipe is used}
+		COMMENT At each index, the remainder item stack in the list should correspond to the original
+		COMMENT item stack in the {@code inventory}.
+		COMMENT
+		COMMENT @implSpec The default implementation returns a list of the same size as the {@code inventory}.
+		COMMENT At each index, the list contains the {@linkplain net.minecraft.item.Item#getRecipeRemainder()
+		COMMENT remainder} of the item stack at the same index in the {@code inventory}, or is {@linkplain
+		COMMENT ItemStack#EMPTY empty} if the stack has no remainder.
 		ARG 1 inventory
+			COMMENT the input inventory
 	METHOD method_8112 getGroup ()Ljava/lang/String;
-		COMMENT Optional group this recipe belongs in. Used to group recipes into different categories by the recipe book.
+		COMMENT {@return a group this recipe belongs in, or an empty string} This is
+		COMMENT only used by the recipe book.
+		COMMENT
+		COMMENT <p>The group string is arbitrary, and is not rendered anywhere; in
+		COMMENT the recipe book, recipes with the same group will belong to the same
+		COMMENT cell in the grid of recipes. If the string is empty, this recipe will
+		COMMENT belong to its own cell.
 	METHOD method_8113 fits (II)Z
-		COMMENT Determines whether this recipe's pattern will fit into the available crafting area.
+		COMMENT {@return whether this recipe will fit into the given grid size}
+		COMMENT
+		COMMENT <p>This is currently only used by recipe book.
 		ARG 1 width
+			COMMENT the width of the input inventory
 		ARG 2 height
+			COMMENT the height of the input inventory
 	METHOD method_8114 getId ()Lnet/minecraft/class_2960;
+		COMMENT {@return the ID of this recipe}
 	METHOD method_8115 matches (Lnet/minecraft/class_1263;Lnet/minecraft/class_1937;)Z
-		COMMENT Determines whether this recipe matches the contents currently placed inside the available crafting grid.
+		COMMENT {@return whether this recipe matches the contents inside the
+		COMMENT {@code inventory} in the given {@code world}}
+		COMMENT
+		COMMENT <p>The {@code world} currently is only used by the map cloning recipe to
+		COMMENT prevent duplication of explorer maps.
 		ARG 1 inventory
+			COMMENT the input inventory
 		ARG 2 world
+			COMMENT the input world
 	METHOD method_8116 craft (Lnet/minecraft/class_1263;)Lnet/minecraft/class_1799;
 		COMMENT Crafts this recipe.
 		COMMENT
-		COMMENT <p>This method may perform side effects on the {@code inventory} argument.</p>
+		COMMENT <p>This method does not perform side effects on the {@code inventory}.
 		COMMENT
-		COMMENT <p>This method should return a new item stack on each call.</p>
+		COMMENT <p>This method should return a new item stack on each call.
 		COMMENT
 		COMMENT @return the resulting item stack
 		ARG 1 inventory
+			COMMENT the input inventory
 	METHOD method_8117 getIngredients ()Lnet/minecraft/class_2371;
-		COMMENT The ingredients accepted as inputs for this recipe. Used by the recipe book
+		COMMENT {@return the ingredients accepted as inputs for this recipe} Used by the recipe book
 		COMMENT when displaying a ghost form of this recipe on the crafting grid as well as for
 		COMMENT previewing the possible inputs in the book itself.
 	METHOD method_8118 isIgnoredInRecipeBook ()Z
+		COMMENT {@return whether this recipe is ignored by the recipe book} If a recipe
+		COMMENT is ignored by the recipe book, it will be never displayed. In addition,
+		COMMENT it won't be restricted by the {@link net.minecraft.world.GameRules#DO_LIMITED_CRAFTING
+		COMMENT doLimitedCrafting} game rule.
 	METHOD method_8119 getSerializer ()Lnet/minecraft/class_1865;
+		COMMENT {@return the serializer associated with this recipe}

--- a/mappings/net/minecraft/recipe/RecipeManager.mapping
+++ b/mappings/net/minecraft/recipe/RecipeManager.mapping
@@ -1,42 +1,126 @@
 CLASS net/minecraft/class_1863 net/minecraft/recipe/RecipeManager
+	COMMENT A recipe manager allows easier use of recipes, such as finding matches and
+	COMMENT remainders. It is also integrated with a recipe loader, which loads recipes
+	COMMENT from data packs' JSON files.
 	FIELD field_19359 GSON Lcom/google/gson/Gson;
 	FIELD field_9023 recipes Ljava/util/Map;
 	FIELD field_9024 errored Z
+		COMMENT This isn't quite indicating an errored state; its value is only set to
+		COMMENT {@code false} and is never {@code true}, and isn't used anywhere.
 	FIELD field_9027 LOGGER Lorg/apache/logging/log4j/Logger;
 	METHOD method_17717 getAllOfType (Lnet/minecraft/class_3956;)Ljava/util/Map;
 		ARG 1 type
 	METHOD method_17718 (Lnet/minecraft/class_3956;Lnet/minecraft/class_1937;Lnet/minecraft/class_1263;Lnet/minecraft/class_1860;)Ljava/util/stream/Stream;
 		ARG 3 recipe
 	METHOD method_17720 deserialize (Lnet/minecraft/class_2960;Lcom/google/gson/JsonObject;)Lnet/minecraft/class_1860;
+		COMMENT Reads a recipe from a JSON object.
+		COMMENT
+		COMMENT @implNote Even though a recipe's {@linkplain Recipe#getSerializer() serializer}
+		COMMENT is stored in a {@code type} field in the JSON format and referred so in this
+		COMMENT method, its registry has key {@code minecraft:root/minecraft:recipe_serializer}
+		COMMENT and is thus named.
+		COMMENT
+		COMMENT @throws com.google.gson.JsonParseException if the recipe JSON is invalid
+		COMMENT @return the read recipe
+		COMMENT @see RecipeSerializer#read
 		ARG 0 id
+			COMMENT the recipe's ID
 		ARG 1 json
+			COMMENT the recipe JSON
+	METHOD method_17721 (Lnet/minecraft/class_2960;Ljava/util/Map;)Lnet/minecraft/class_1860;
+		ARG 1 map
+	METHOD method_17722 (Ljava/util/Map;)Ljava/util/stream/Stream;
+		ARG 0 map
+	METHOD method_17723 (Ljava/util/Map;)Ljava/util/stream/Stream;
+		ARG 0 map
 	METHOD method_17874 (Lnet/minecraft/class_3956;Lnet/minecraft/class_1937;Lnet/minecraft/class_1263;Lnet/minecraft/class_1860;)Ljava/util/stream/Stream;
 		ARG 3 recipe
 	METHOD method_17876 (Lnet/minecraft/class_1860;)Ljava/lang/String;
 		ARG 0 recipe
 	METHOD method_17877 getAllMatches (Lnet/minecraft/class_3956;Lnet/minecraft/class_1263;Lnet/minecraft/class_1937;)Ljava/util/List;
+		COMMENT Creates a list of all recipes of the given {@code type} that match the
+		COMMENT given {@code inventory} and {@code world}. The list is ordered by the
+		COMMENT translation key of the output item stack of each recipe.
+		COMMENT
+		COMMENT <p>This list does not update with this manager. Modifications to
+		COMMENT the returned list do not affect this manager.
+		COMMENT
+		COMMENT @return the created list of matching recipes
 		ARG 1 type
+			COMMENT the desired recipe type
 		ARG 2 inventory
+			COMMENT the input inventory
 		ARG 3 world
+			COMMENT the input world
 	METHOD method_20702 setRecipes (Ljava/lang/Iterable;)V
+		COMMENT Sets the recipes for this recipe manager. Used by the client to set the server
+		COMMENT side recipes.
 		ARG 1 recipes
+			COMMENT the recipes to set
+	METHOD method_20704 (Ljava/util/Map;Lnet/minecraft/class_1860;)V
+		ARG 1 recipe
+	METHOD method_20706 (Lnet/minecraft/class_3956;)Ljava/util/Map;
+		ARG 0 t
 	METHOD method_20707 (Lnet/minecraft/class_3956;)Lcom/google/common/collect/ImmutableMap$Builder;
 		ARG 0 recipeType
 	METHOD method_30027 listAllOfType (Lnet/minecraft/class_3956;)Ljava/util/List;
-		COMMENT Creates a list of all recipes of the given type.
-		COMMENT Modifications to the returned list do not affect the manager.
-		ARG 1 recipeType
+		COMMENT Creates a list of all recipes of the given {@code type}. The list has an
+		COMMENT arbitrary order.
+		COMMENT
+		COMMENT <p>This list does not update with this manager. Modifications to
+		COMMENT the returned list do not affect this manager.
+		COMMENT
+		COMMENT @return the created list of recipes of the given {@code type}
+		ARG 1 type
+			COMMENT the desired recipe type
 	METHOD method_30028 (Lnet/minecraft/class_1860;)Lnet/minecraft/class_1860;
 		ARG 0 recipe
+	METHOD method_35227 isErrored ()Z
+		COMMENT {@return the {@link #errored} field} This is unused in vanilla and will only
+		COMMENT return {@code false} without mods.
 	METHOD method_8126 values ()Ljava/util/Collection;
+		COMMENT {@return all recipes in this manager}
+		COMMENT
+		COMMENT <p>The returned set does not update with the manager. Modifications to the
+		COMMENT returned set does not affect this manager.
 	METHOD method_8127 keys ()Ljava/util/stream/Stream;
+		COMMENT {@return a stream of IDs of recipes in this manager}
+		COMMENT
+		COMMENT <p>The returned stream does not update after {@link #setRecipes(Iterable)}
+		COMMENT call.
+		COMMENT
+		COMMENT @apiNote This is used by the command sources to suggest recipe IDs for command
+		COMMENT arguments.
 	METHOD method_8128 getRemainingStacks (Lnet/minecraft/class_3956;Lnet/minecraft/class_1263;Lnet/minecraft/class_1937;)Lnet/minecraft/class_2371;
-		ARG 1 recipeType
-		ARG 2 inventory
-		ARG 3 world
-	METHOD method_8130 get (Lnet/minecraft/class_2960;)Ljava/util/Optional;
-		ARG 1 id
-	METHOD method_8132 getFirstMatch (Lnet/minecraft/class_3956;Lnet/minecraft/class_1263;Lnet/minecraft/class_1937;)Ljava/util/Optional;
+		COMMENT {@return the remainder of a recipe of the given {@code type} that match
+		COMMENT the given {@code inventory} and {@code world}, or a shallow copy of the
+		COMMENT {@code inventory}}
+		COMMENT
+		COMMENT <p>This retrieves the {@linkplain Recipe#getRemainders(Inventory)
+		COMMENT remainders} of {@link #getFirstMatch(RecipeType, Inventory, World)
+		COMMENT getFirstMatch(type, inventory, world)} if the match exists.
+		COMMENT
+		COMMENT @see Recipe#getRemainders(Inventory)
 		ARG 1 type
+			COMMENT the desired recipe type
 		ARG 2 inventory
+			COMMENT the input inventory
 		ARG 3 world
+			COMMENT the input world
+	METHOD method_8130 get (Lnet/minecraft/class_2960;)Ljava/util/Optional;
+		COMMENT {@return a recipe with the given {@code id}, or empty if there is no such recipe}
+		ARG 1 id
+			COMMENT the ID of the desired recipe
+	METHOD method_8132 getFirstMatch (Lnet/minecraft/class_3956;Lnet/minecraft/class_1263;Lnet/minecraft/class_1937;)Ljava/util/Optional;
+		COMMENT {@return a recipe of the given {@code type} that match the given
+		COMMENT {@code inventory} and {@code world}}
+		COMMENT
+		COMMENT <p>If there are multiple matching recipes, the result is arbitrary,
+		COMMENT but this method will return the same result unless the recipes in this
+		COMMENT manager are updated.
+		ARG 1 type
+			COMMENT the desired recipe type
+		ARG 2 inventory
+			COMMENT the input inventory
+		ARG 3 world
+			COMMENT the input world

--- a/mappings/net/minecraft/recipe/RecipeManager.mapping
+++ b/mappings/net/minecraft/recipe/RecipeManager.mapping
@@ -96,11 +96,11 @@ CLASS net/minecraft/class_1863 net/minecraft/recipe/RecipeManager
 		COMMENT the given {@code inventory} and {@code world}, or a shallow copy of the
 		COMMENT {@code inventory}}
 		COMMENT
-		COMMENT <p>This retrieves the {@linkplain Recipe#getRemainders(Inventory)
+		COMMENT <p>This retrieves the {@linkplain Recipe#getRemainder(Inventory)
 		COMMENT remainders} of {@link #getFirstMatch(RecipeType, Inventory, World)
 		COMMENT getFirstMatch(type, inventory, world)} if the match exists.
 		COMMENT
-		COMMENT @see Recipe#getRemainders(Inventory)
+		COMMENT @see Recipe#getRemainder(Inventory)
 		ARG 1 type
 			COMMENT the desired recipe type
 		ARG 2 inventory

--- a/mappings/net/minecraft/recipe/RecipeSerializer.mapping
+++ b/mappings/net/minecraft/recipe/RecipeSerializer.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_1865 net/minecraft/recipe/RecipeSerializer
 	COMMENT The recipe serializer controls the serialization and deserialization of
-	COMMENT recipe content. The us the serialization of recipes' IDs.
+	COMMENT recipe content. The caller should handle the serialization of recipes' IDs.
 	COMMENT
 	COMMENT <p>Even though they are referred to by the {@code type} field in recipe
 	COMMENT JSON format, they are stored in a registry with key
@@ -35,7 +35,7 @@ CLASS net/minecraft/class_1865 net/minecraft/recipe/RecipeSerializer
 	METHOD method_8121 read (Lnet/minecraft/class_2960;Lcom/google/gson/JsonObject;)Lnet/minecraft/class_1860;
 		COMMENT Reads a recipe from a JSON object.
 		COMMENT
-		COMMENT @implNote If this throws any excpetion besides {@link com.google.gson.JsonParseException}
+		COMMENT @implNote If this throws any exception besides {@link com.google.gson.JsonParseException}
 		COMMENT and {@link IllegalArgumentException}, it will terminate and affect loading
 		COMMENT of all recipes from data packs beyond the current recipe.
 		COMMENT

--- a/mappings/net/minecraft/recipe/RecipeSerializer.mapping
+++ b/mappings/net/minecraft/recipe/RecipeSerializer.mapping
@@ -1,4 +1,15 @@
 CLASS net/minecraft/class_1865 net/minecraft/recipe/RecipeSerializer
+	COMMENT The recipe serializer controls the serialization and deserialization of
+	COMMENT recipe content. The us the serialization of recipes' IDs.
+	COMMENT
+	COMMENT <p>Even though they are referred to by the {@code type} field in recipe
+	COMMENT JSON format, they are stored in a registry with key
+	COMMENT {@code minecraft:root/minecraft:recipe_serializer}, and is hence named.
+	COMMENT
+	COMMENT <p>If a recipe's serializer exists only on the server but not on the
+	COMMENT client, the client will disconnect upon receiving the recipe; if a
+	COMMENT recipe JSON intended for an absent recipe serializer is read, it is
+	COMMENT skipped.
 	FIELD field_17084 BLASTING Lnet/minecraft/class_3957;
 	FIELD field_17085 SMOKING Lnet/minecraft/class_3957;
 	FIELD field_17347 CAMPFIRE_COOKING Lnet/minecraft/class_3957;
@@ -22,11 +33,37 @@ CLASS net/minecraft/class_1865 net/minecraft/recipe/RecipeSerializer
 		ARG 0 id
 		ARG 1 serializer
 	METHOD method_8121 read (Lnet/minecraft/class_2960;Lcom/google/gson/JsonObject;)Lnet/minecraft/class_1860;
+		COMMENT Reads a recipe from a JSON object.
+		COMMENT
+		COMMENT @implNote If this throws any excpetion besides {@link com.google.gson.JsonParseException}
+		COMMENT and {@link IllegalArgumentException}, it will terminate and affect loading
+		COMMENT of all recipes from data packs beyond the current recipe.
+		COMMENT
+		COMMENT @throws com.google.gson.JsonParseException if the recipe JSON is incorrect
+		COMMENT @return the read recipe
 		ARG 1 id
+			COMMENT the recipe's ID
 		ARG 2 json
+			COMMENT the recipe JSON
 	METHOD method_8122 read (Lnet/minecraft/class_2960;Lnet/minecraft/class_2540;)Lnet/minecraft/class_1860;
+		COMMENT Reads a recipe from a packet byte buf, usually on the client.
+		COMMENT
+		COMMENT <p>This can throw whatever exception the packet byte buf throws. This may be
+		COMMENT called in the netty event loop than the client game engine thread.
+		COMMENT
+		COMMENT @return the read recipe
 		ARG 1 id
+			COMMENT the recipe's ID
 		ARG 2 buf
+			COMMENT the recipe buf
 	METHOD method_8124 write (Lnet/minecraft/class_2540;Lnet/minecraft/class_1860;)V
+		COMMENT Writes a recipe to a packet byte buf, usually on the server.
+		COMMENT
+		COMMENT <p>The recipe's ID is already written into the buf when this is called.
+		COMMENT
+		COMMENT <p>This can throw whatever exception the packet byte buf throws. This may be
+		COMMENT called in the netty event loop than the server game engine thread.
 		ARG 1 buf
+			COMMENT the recipe buf
 		ARG 2 recipe
+			COMMENT the recipe

--- a/mappings/net/minecraft/recipe/RecipeType.mapping
+++ b/mappings/net/minecraft/recipe/RecipeType.mapping
@@ -1,12 +1,18 @@
 CLASS net/minecraft/class_3956 net/minecraft/recipe/RecipeType
-	FIELD field_17545 CRAFTING Lnet/minecraft/class_3956;
-	FIELD field_17546 SMELTING Lnet/minecraft/class_3956;
-	FIELD field_17547 BLASTING Lnet/minecraft/class_3956;
-	FIELD field_17548 SMOKING Lnet/minecraft/class_3956;
-	FIELD field_17549 CAMPFIRE_COOKING Lnet/minecraft/class_3956;
-	METHOD method_17725 get (Lnet/minecraft/class_1860;Lnet/minecraft/class_1937;Lnet/minecraft/class_1263;)Ljava/util/Optional;
+	COMMENT The recipe type allows matching recipes more efficiently by only checking
+	COMMENT recipes under a given type.
+	COMMENT
+	COMMENT @param <T> the common supertype of recipes within a recipe type
+	METHOD method_17725 match (Lnet/minecraft/class_1860;Lnet/minecraft/class_1937;Lnet/minecraft/class_1263;)Ljava/util/Optional;
+		COMMENT {@return the given {@code recipe} if it matches, otherwise empty}
+		COMMENT
+		COMMENT <p>This utility method casts the {@code recipe} from {@code Recipe<C>} to
+		COMMENT {@code T} conveniently.
 		ARG 1 recipe
+			COMMENT the recipe to match and cast
 		ARG 2 world
+			COMMENT the input world
 		ARG 3 inventory
+			COMMENT the input inventory
 	METHOD method_17726 register (Ljava/lang/String;)Lnet/minecraft/class_3956;
 		ARG 0 id

--- a/mappings/net/minecraft/recipe/SpecialRecipeSerializer.mapping
+++ b/mappings/net/minecraft/recipe/SpecialRecipeSerializer.mapping
@@ -1,4 +1,10 @@
 CLASS net/minecraft/class_1866 net/minecraft/recipe/SpecialRecipeSerializer
-	FIELD field_9046 id Ljava/util/function/Function;
+	COMMENT A serializer for hardcoded recipes. The recipes with this serializer don't
+	COMMENT transport any extra data besides their ID when read from JSON or synchronized
+	COMMENT over network.
+	COMMENT
+	COMMENT <p>The name "special" comes from the fact that in vanilla, recipes using this
+	COMMENT serializer have IDs starting with {@code crafting_special_}.
+	FIELD field_9046 factory Ljava/util/function/Function;
 	METHOD <init> (Ljava/util/function/Function;)V
-		ARG 1 id
+		ARG 1 factory

--- a/mappings/net/minecraft/recipe/SpecialRecipeSerializer.mapping
+++ b/mappings/net/minecraft/recipe/SpecialRecipeSerializer.mapping
@@ -4,7 +4,8 @@ CLASS net/minecraft/class_1866 net/minecraft/recipe/SpecialRecipeSerializer
 	COMMENT over network.
 	COMMENT
 	COMMENT <p>The name "special" comes from the fact that in vanilla, recipes using this
-	COMMENT serializer have IDs starting with {@code crafting_special_}.
+	COMMENT serializer have IDs starting with {@code crafting_special_}. All of their logic and ingredients
+	COMMENT are also defined in code, which distinguishes them from "non-special" recipes.
 	FIELD field_9046 factory Ljava/util/function/Function;
 	METHOD <init> (Ljava/util/function/Function;)V
 		ARG 1 factory


### PR DESCRIPTION
Document recipes a bit, and clean up outdated docs. I think a few renames are necessary for later; see #2548.

There is also renames to fix #2544 and a few other less impactful ones (removing `Client` suffix after the getter is now universal)

Signed-off-by: liach <liach@users.noreply.github.com>