### PR TITLE
Loot/JSON serialisation improvements

### DIFF
--- a/mappings/net/minecraft/loot/provider/nbt/ContextLootNbtProvider.mapping
+++ b/mappings/net/minecraft/loot/provider/nbt/ContextLootNbtProvider.mapping
@@ -7,7 +7,7 @@ CLASS net/minecraft/class_5646 net/minecraft/loot/provider/nbt/ContextLootNbtPro
 		ARG 1 target
 	METHOD method_32430 getTarget (Lnet/minecraft/class_47$class_50;)Lnet/minecraft/class_5646$class_5648;
 		ARG 0 entityTarget
-	METHOD method_32431 setTarget (Ljava/lang/String;)Lnet/minecraft/class_5646;
+	METHOD method_32431 fromTarget (Ljava/lang/String;)Lnet/minecraft/class_5646;
 		ARG 0 target
 	METHOD method_35568 fromTarget (Lnet/minecraft/class_47$class_50;)Lnet/minecraft/class_5651;
 		ARG 0 target

--- a/mappings/net/minecraft/loot/provider/nbt/LootNbtProvider.mapping
+++ b/mappings/net/minecraft/loot/provider/nbt/LootNbtProvider.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_5651 net/minecraft/loot/provider/nbt/LootNbtProvider
 	METHOD method_32439 getType ()Lnet/minecraft/class_5650;
-	METHOD method_32440 getNbtTag (Lnet/minecraft/class_47;)Lnet/minecraft/class_2520;
+	METHOD method_32440 getNbt (Lnet/minecraft/class_47;)Lnet/minecraft/class_2520;
 		ARG 1 context
 	METHOD method_32441 getRequiredParameters ()Ljava/util/Set;

--- a/mappings/net/minecraft/loot/provider/nbt/LootNbtProviderTypes.mapping
+++ b/mappings/net/minecraft/loot/provider/nbt/LootNbtProviderTypes.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_5652 net/minecraft/loot/provider/nbt/LootNbtProviderTypes
+	METHOD method_32442 createGsonSerializer ()Ljava/lang/Object;
 	METHOD method_32443 register (Ljava/lang/String;Lnet/minecraft/class_5335;)Lnet/minecraft/class_5650;
 		ARG 0 id
 		ARG 1 jsonSerializer

--- a/mappings/net/minecraft/loot/provider/number/LootNumberProviderTypes.mapping
+++ b/mappings/net/minecraft/loot/provider/number/LootNumberProviderTypes.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_5659 net/minecraft/loot/provider/number/LootNumberProviderTypes
+	METHOD method_32455 createGsonSerializer ()Ljava/lang/Object;
 	METHOD method_32456 register (Ljava/lang/String;Lnet/minecraft/class_5335;)Lnet/minecraft/class_5657;
 		ARG 0 id
 		ARG 1 jsonSerializer

--- a/mappings/net/minecraft/loot/provider/score/LootScoreProviderTypes.mapping
+++ b/mappings/net/minecraft/loot/provider/score/LootScoreProviderTypes.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_5671 net/minecraft/loot/provider/score/LootScoreProviderTypes
+	METHOD method_32478 createGsonSerializer ()Ljava/lang/Object;
 	METHOD method_32479 register (Ljava/lang/String;Lnet/minecraft/class_5335;)Lnet/minecraft/class_5669;
 		ARG 0 id
 		ARG 1 jsonSerializer

--- a/mappings/net/minecraft/util/JsonSerializing.mapping
+++ b/mappings/net/minecraft/util/JsonSerializing.mapping
@@ -1,15 +1,15 @@
 CLASS net/minecraft/class_5330 net/minecraft/util/JsonSerializing
-	METHOD method_29306 createTypeHandler (Lnet/minecraft/class_2378;Ljava/lang/String;Ljava/lang/String;Ljava/util/function/Function;)Lnet/minecraft/class_5330$class_5331;
+	METHOD method_29306 createSerializerBuilder (Lnet/minecraft/class_2378;Ljava/lang/String;Ljava/lang/String;Ljava/util/function/Function;)Lnet/minecraft/class_5330$class_5331;
 		ARG 0 registry
 		ARG 1 rootFieldName
 		ARG 2 idFieldName
 		ARG 3 typeIdentification
-	CLASS class_5331 TypeHandler
-		COMMENT A handler of JSON serializable types that can either obtain a type from
+	CLASS class_5331 SerializerBuilder
+		COMMENT A builder for serializing types to JSON that can either obtain a type from
 		COMMENT a registry to handle JSON conversion or handle with a custom logic bound
 		COMMENT to a type.
 		COMMENT
-		COMMENT <p>When the root element read is an object, the handler obtains the type
+		COMMENT <p>When the root element read is an object, the built serializer obtains the type
 		COMMENT from registry to handle reading; otherwise, it falls back to custom
 		COMMENT logic.
 		FIELD field_25192 registry Lnet/minecraft/class_2378;
@@ -17,13 +17,19 @@ CLASS net/minecraft/class_5330 net/minecraft/util/JsonSerializing
 		FIELD field_25194 idFieldName Ljava/lang/String;
 		FIELD field_25195 typeIdentification Ljava/util/function/Function;
 		FIELD field_25196 customSerializer Lcom/mojang/datafixers/util/Pair;
+		FIELD field_28444 defaultType Lnet/minecraft/class_5336;
 		METHOD <init> (Lnet/minecraft/class_2378;Ljava/lang/String;Ljava/lang/String;Ljava/util/function/Function;)V
 			ARG 1 registry
 			ARG 2 rootFieldName
 			ARG 3 idFieldName
 			ARG 4 typeIdentification
-		METHOD method_29307 createGsonSerializer ()Ljava/lang/Object;
-	CLASS class_5332 CustomSerializer
+		METHOD method_29307 build ()Ljava/lang/Object;
+		METHOD method_32385 customSerializer (Lnet/minecraft/class_5336;Lnet/minecraft/class_5330$class_5332;)Lnet/minecraft/class_5330$class_5331;
+			ARG 1 type
+			ARG 2 serializer
+		METHOD method_33409 defaultType (Lnet/minecraft/class_5336;)Lnet/minecraft/class_5330$class_5331;
+			ARG 1 defaultType
+	CLASS class_5332 type
 		METHOD method_29308 fromJson (Lcom/google/gson/JsonElement;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 			ARG 1 json
 			ARG 2 context
@@ -36,11 +42,13 @@ CLASS net/minecraft/class_5330 net/minecraft/util/JsonSerializing
 		FIELD field_25199 idFieldName Ljava/lang/String;
 		FIELD field_25200 typeIdentification Ljava/util/function/Function;
 		FIELD field_25201 elementSerializer Lcom/mojang/datafixers/util/Pair;
+		FIELD field_28445 defaultType Lnet/minecraft/class_5336;
 		METHOD <init> (Lnet/minecraft/class_2378;Ljava/lang/String;Ljava/lang/String;Ljava/util/function/Function;Lnet/minecraft/class_5336;Lcom/mojang/datafixers/util/Pair;)V
 			ARG 1 registry
 			ARG 2 rootFieldName
 			ARG 3 idFieldName
 			ARG 4 typeIdentification
+			ARG 5 defaultType
 			ARG 6 elementSerializer
 		METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 			ARG 1 json

--- a/mappings/net/minecraft/util/JsonSerializing.mapping
+++ b/mappings/net/minecraft/util/JsonSerializing.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_5330 net/minecraft/util/JsonSerializing
 		ARG 0 registry
 		ARG 1 rootFieldName
 		ARG 2 idFieldName
-		ARG 3 typeIdentification
+		ARG 3 typeGetter
 	CLASS class_5331 SerializerBuilder
 		COMMENT A builder for serializing types to JSON that can either obtain a type from
 		COMMENT a registry to handle JSON conversion or handle with a custom logic bound
@@ -15,8 +15,8 @@ CLASS net/minecraft/class_5330 net/minecraft/util/JsonSerializing
 		FIELD field_25192 registry Lnet/minecraft/class_2378;
 		FIELD field_25193 rootFieldName Ljava/lang/String;
 		FIELD field_25194 idFieldName Ljava/lang/String;
-		FIELD field_25195 typeIdentification Ljava/util/function/Function;
-		FIELD field_25196 customSerializer Lcom/mojang/datafixers/util/Pair;
+		FIELD field_25195 typeGetter Ljava/util/function/Function;
+		FIELD field_25196 elementSerializer Lcom/mojang/datafixers/util/Pair;
 		FIELD field_28444 defaultType Lnet/minecraft/class_5336;
 		METHOD <init> (Lnet/minecraft/class_2378;Ljava/lang/String;Ljava/lang/String;Ljava/util/function/Function;)V
 			ARG 1 registry
@@ -24,12 +24,19 @@ CLASS net/minecraft/class_5330 net/minecraft/util/JsonSerializing
 			ARG 3 idFieldName
 			ARG 4 typeIdentification
 		METHOD method_29307 build ()Ljava/lang/Object;
-		METHOD method_32385 customSerializer (Lnet/minecraft/class_5336;Lnet/minecraft/class_5330$class_5332;)Lnet/minecraft/class_5330$class_5331;
+		METHOD method_32385 elementSerializer (Lnet/minecraft/class_5336;Lnet/minecraft/class_5330$class_5332;)Lnet/minecraft/class_5330$class_5331;
+			COMMENT Sets the element serializer and its target type. It can serialize and
+			COMMENT deserialize instances of one type to non-{@link com.google.gson.JsonObject}
+			COMMENT elements.
 			ARG 1 type
 			ARG 2 serializer
 		METHOD method_33409 defaultType (Lnet/minecraft/class_5336;)Lnet/minecraft/class_5330$class_5331;
+			COMMENT Sets the default type that is used when there's no ID field.
+			COMMENT
+			COMMENT @return this instance
 			ARG 1 defaultType
-	CLASS class_5332 CustomSerializer
+				COMMENT the default type
+	CLASS class_5332 ElementSerializer
 		METHOD method_29308 fromJson (Lcom/google/gson/JsonElement;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 			ARG 1 json
 			ARG 2 context
@@ -40,14 +47,14 @@ CLASS net/minecraft/class_5330 net/minecraft/util/JsonSerializing
 		FIELD field_25197 registry Lnet/minecraft/class_2378;
 		FIELD field_25198 rootFieldName Ljava/lang/String;
 		FIELD field_25199 idFieldName Ljava/lang/String;
-		FIELD field_25200 typeIdentification Ljava/util/function/Function;
+		FIELD field_25200 typeGetter Ljava/util/function/Function;
 		FIELD field_25201 elementSerializer Lcom/mojang/datafixers/util/Pair;
 		FIELD field_28445 defaultType Lnet/minecraft/class_5336;
 		METHOD <init> (Lnet/minecraft/class_2378;Ljava/lang/String;Ljava/lang/String;Ljava/util/function/Function;Lnet/minecraft/class_5336;Lcom/mojang/datafixers/util/Pair;)V
 			ARG 1 registry
 			ARG 2 rootFieldName
 			ARG 3 idFieldName
-			ARG 4 typeIdentification
+			ARG 4 typeGetter
 			ARG 5 defaultType
 			ARG 6 elementSerializer
 		METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;

--- a/mappings/net/minecraft/util/JsonSerializing.mapping
+++ b/mappings/net/minecraft/util/JsonSerializing.mapping
@@ -29,7 +29,7 @@ CLASS net/minecraft/class_5330 net/minecraft/util/JsonSerializing
 			ARG 2 serializer
 		METHOD method_33409 defaultType (Lnet/minecraft/class_5336;)Lnet/minecraft/class_5330$class_5331;
 			ARG 1 defaultType
-	CLASS class_5332 type
+	CLASS class_5332 CustomSerializer
 		METHOD method_29308 fromJson (Lcom/google/gson/JsonElement;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 			ARG 1 json
 			ARG 2 context

--- a/mappings/net/minecraft/util/JsonSerializing.mapping
+++ b/mappings/net/minecraft/util/JsonSerializing.mapping
@@ -28,8 +28,13 @@ CLASS net/minecraft/class_5330 net/minecraft/util/JsonSerializing
 			COMMENT Sets the element serializer and its target type. It can serialize and
 			COMMENT deserialize instances of one type to non-{@link com.google.gson.JsonObject}
 			COMMENT elements.
+			COMMENT
+			COMMENT @apiNote There can only be one element serializer for this builder and
+			COMMENT the built serializer. Calling this method replaces any previous serializer.
 			ARG 1 type
+				COMMENT the target type of the element serializer
 			ARG 2 serializer
+				COMMENT the element serializer
 		METHOD method_33409 defaultType (Lnet/minecraft/class_5336;)Lnet/minecraft/class_5330$class_5331;
 			COMMENT Sets the default type that is used when there's no ID field.
 			COMMENT


### PR DESCRIPTION
- Closes #2552.
- `class_5330$class_5331` (currently called `TypeHandler`) is really just a builder for JSON (de)serializers that are backed by a registry, so I renamed it to `SerializerBuilder`.
  - Also mapped some methods in that class
- Added `createGsonSerializer` mappings where they were missing
- `LootNbtProvider.getNbtTag` -> `getNbt` (self-explanatory, I think)
- Closes #2551