### PR TITLE
Misc structure gen mappings

### DIFF
--- a/mappings/net/minecraft/structure/pool/StructurePoolBasedGenerator.mapping
+++ b/mappings/net/minecraft/structure/pool/StructurePoolBasedGenerator.mapping
@@ -1,5 +1,14 @@
 CLASS net/minecraft/class_3778 net/minecraft/structure/pool/StructurePoolBasedGenerator
 	FIELD field_16665 LOGGER Lorg/apache/logging/log4j/Logger;
+	METHOD method_30419 generate (Lnet/minecraft/class_5455;Lnet/minecraft/class_3812;Lnet/minecraft/class_3778$class_3779;Lnet/minecraft/class_2794;Lnet/minecraft/class_3485;Lnet/minecraft/class_2338;Lnet/minecraft/class_6130;Ljava/util/Random;ZZLnet/minecraft/class_5539;)V
+		ARG 0 dynamicRegistries
+		ARG 1 config
+		ARG 2 pieceFactory
+		ARG 5 pos
+		ARG 6 children
+		ARG 8 modifyBoundingBox
+		ARG 9 surface
+		ARG 10 world
 	CLASS class_3779 PieceFactory
 		METHOD create (Lnet/minecraft/class_3485;Lnet/minecraft/class_3784;Lnet/minecraft/class_2338;ILnet/minecraft/class_2470;Lnet/minecraft/class_3341;)Lnet/minecraft/class_3790;
 			ARG 1 structureManager
@@ -39,4 +48,5 @@ CLASS net/minecraft/class_3778 net/minecraft/structure/pool/StructurePoolBasedGe
 			ARG 2 pieceShape
 			ARG 3 minY
 			ARG 4 currentSize
+			ARG 5 modifyBoundingBox
 			ARG 6 world

--- a/mappings/net/minecraft/world/gen/feature/JigsawFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/JigsawFeature.mapping
@@ -1,13 +1,21 @@
 CLASS net/minecraft/class_5434 net/minecraft/world/gen/feature/JigsawFeature
 	FIELD field_25835 structureStartY I
+	FIELD field_25836 modifyBoundingBox Z
 	FIELD field_25837 surface Z
 	METHOD <init> (Lcom/mojang/serialization/Codec;IZZ)V
 		ARG 1 codec
 		ARG 2 structureStartY
+		ARG 3 modifyBoundingBox
 		ARG 4 surface
 	METHOD method_30386 (Lnet/minecraft/class_3195;Lnet/minecraft/class_1923;IJ)Lnet/minecraft/class_3449;
 		ARG 1 feature
+		ARG 2 pos
+		ARG 3 references
+		ARG 4 seed
 	CLASS class_5435 Start
 		FIELD field_25838 jigsawFeature Lnet/minecraft/class_5434;
 		METHOD <init> (Lnet/minecraft/class_5434;Lnet/minecraft/class_1923;IJ)V
 			ARG 1 feature
+			ARG 2 pos
+			ARG 3 references
+			ARG 4 seed

--- a/mappings/net/minecraft/world/gen/feature/StructureFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/StructureFeature.mapping
@@ -2,9 +2,10 @@ CLASS net/minecraft/class_3195 net/minecraft/world/gen/feature/StructureFeature
 	FIELD field_13879 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_24842 STRUCTURES Lcom/google/common/collect/BiMap;
 	FIELD field_24851 SWAMP_HUT Lnet/minecraft/class_3197;
-	FIELD field_24861 JIGSAW_STRUCTURES Ljava/util/List;
+	FIELD field_24861 LAND_MODIFYING_STRUCTURES Ljava/util/List;
 	FIELD field_24862 STRUCTURE_TO_GENERATION_STEP Ljava/util/Map;
 	FIELD field_24863 codec Lcom/mojang/serialization/Codec;
+	FIELD field_25839 JIGSAW_STRUCTURE_PIECES Ljava/util/Map;
 	FIELD field_26362 JIGSAW_ID Lnet/minecraft/class_2960;
 	METHOD <init> (Lcom/mojang/serialization/Codec;)V
 		ARG 1 codec
@@ -97,3 +98,5 @@ CLASS net/minecraft/class_3195 net/minecraft/world/gen/feature/StructureFeature
 		METHOD create (Lnet/minecraft/class_3195;Lnet/minecraft/class_1923;IJ)Lnet/minecraft/class_3449;
 			ARG 1 feature
 			ARG 2 pos
+			ARG 3 references
+			ARG 4 seed

--- a/mappings/net/minecraft/world/gen/feature/StructurePoolFeatureConfig.mapping
+++ b/mappings/net/minecraft/world/gen/feature/StructurePoolFeatureConfig.mapping
@@ -1,7 +1,6 @@
 CLASS net/minecraft/class_3812 net/minecraft/world/gen/feature/StructurePoolFeatureConfig
 	COMMENT A feature config that specifies a starting pool and a size for {@linkplain
-	COMMENT net.minecraft.structure.pool.StructurePoolBasedGenerator#method_30419
-	COMMENT method_30419}.
+	COMMENT net.minecraft.structure.pool.StructurePoolBasedGenerator#generate}.
 	FIELD field_16860 size I
 	FIELD field_16861 startPool Ljava/util/function/Supplier;
 	FIELD field_24886 CODEC Lcom/mojang/serialization/Codec;


### PR DESCRIPTION
Some mappings around Structure Gen and Jigsaw Structure.

The one that took me the most time to figure out was modifyBoundingBox. What it seems to do is shift the bounding box  of structure pool elements. I don't get why, but I do want to point out that it may affect jigsaw connecting. If it's too vague for triage's liking I can just take it out. 

Also notable that StructurePoolBasedGenerator#generate basically iterates through and calls generatePiece, so I'm welcome to changing it to something like generatePieces. 

the field JIGSAW_STRUCTURES was inaccurate- it also included Strongholds which are not jigsaws. This field is for those that modify the land like villages. Maybe it could be LAND_ADJUSTING_STRUCTURES if you guys think that'd fit better. 