### PR TITLE
Update toolchain and fix minor javadoc problems

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -703,7 +703,6 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 }
 
 // Only build jars for package infos if we need to actually expose stuff like annotation in the future.
-// Also need to downgrade java in that case!
 
 build.dependsOn constantsJar
 
@@ -812,15 +811,13 @@ task genFakeSource(type: JavaExec, dependsOn: ["mergeV2", "mapNamedJar"]) {
 }
 
 task decompileCFR(type: JavaExec, dependsOn: [mapNamedJar]) {
-	doFirst {
-		classpath = configurations.decompileClasspath
-	}
 	mainClass.set "org.benf.cfr.reader.Main"
 
 	args namedJar.getAbsolutePath(), "--outputdir", file("namedSrc").absolutePath
 
 	doFirst {
 		file("namedSrc").deleteDir()
+		classpath = configurations.decompileClasspath
 	}
 }
 
@@ -875,7 +872,6 @@ javadoc {
 				'https://commons.apache.org/proper/commons-compress/javadocs/api-1.8.1/',
 				"https://maven.fabricmc.net/docs/fabric-loader-${project.fabric_loader_version}/",
 				"https://docs.oracle.com/en/java/javase/16/docs/api/"
-				// Need to add loader jd publication for env annotations!
 		)
 		// https://docs.oracle.com/en/java/javase/16/docs/specs/man/javadoc.html#additional-options-provided-by-the-standard-doclet
 		addBooleanOption 'Xdoclint:html', true

--- a/build.gradle
+++ b/build.gradle
@@ -659,7 +659,7 @@ task unpickIntermediaryJar(type: JavaExec, dependsOn: [mapIntermediaryJar, "cons
 	outputs.upToDateWhen { false }
 	group "unpick"
 
-	mainClass.set "daomephsta.unpick.cli.Main"
+	mainClass = "daomephsta.unpick.cli.Main"
 	systemProperty "java.util.logging.config.file", file('unpick-logging.properties')
 	classpath configurations.unpick
 
@@ -800,7 +800,7 @@ task genFakeSource(type: JavaExec, dependsOn: ["mergeV2", "mapNamedJar"]) {
 	group = "javadoc generation"
 	outputs.upToDateWhen { false }
 
-	mainClass.set "net.fabricmc.mappingpoet.Main"
+	mainClass = "net.fabricmc.mappingpoet.Main"
 	classpath configurations.mappingPoet
 	// use merged v2 so we have all namespaces in jd
 	args mergeV2.output.getAbsolutePath(), namedJar.getAbsolutePath(), fakeSourceDir.getAbsolutePath(), libraries.getAbsolutePath()
@@ -811,7 +811,7 @@ task genFakeSource(type: JavaExec, dependsOn: ["mergeV2", "mapNamedJar"]) {
 }
 
 task decompileCFR(type: JavaExec, dependsOn: [mapNamedJar]) {
-	mainClass.set "org.benf.cfr.reader.Main"
+	mainClass = "org.benf.cfr.reader.Main"
 
 	args namedJar.getAbsolutePath(), "--outputdir", file("namedSrc").absolutePath
 

--- a/build.gradle
+++ b/build.gradle
@@ -877,7 +877,7 @@ javadoc {
 				"https://docs.oracle.com/en/java/javase/16/docs/api/"
 				// Need to add loader jd publication for env annotations!
 		)
-		// https://docs.oracle.com/en/java/javase/15/docs/specs/man/javadoc.html#additional-options-provided-by-the-standard-doclet
+		// https://docs.oracle.com/en/java/javase/16/docs/specs/man/javadoc.html#additional-options-provided-by-the-standard-doclet
 		addBooleanOption 'Xdoclint:html', true
 		addBooleanOption 'Xdoclint:syntax', true
 		addBooleanOption 'Xdoclint:reference', true

--- a/build.gradle
+++ b/build.gradle
@@ -837,6 +837,7 @@ javadoc {
 	def mappingPoetJar = project.provider { zipTree configurations.mappingPoetJar.singleFile }
 
 	failOnError = false
+	maxMemory = '2G'
 
 	// verbose = true // enable to debug
 	options {

--- a/build.gradle
+++ b/build.gradle
@@ -894,7 +894,7 @@ javadoc {
 		// lazy setting
 		options {
 			tagletPath configurations.mappingPoet.files.toList()
-			header mappingPoetJar.get().filter { it.name == 'javadoc_header.txt' }.singleFile.readLines()[0] // cannot include line breaks
+			header mappingPoetJar.get().filter { it.name == 'javadoc_header.txt' }.singleFile.text.trim() // cannot include line breaks
 			addFileOption "-add-stylesheet", mappingPoetJar.get().filter { it.name == 'forms.css' }.singleFile
 		}
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -12,18 +12,17 @@ buildscript {
 		classpath "net.fabricmc:stitch:${project.stitch_version}"
 		classpath "commons-io:commons-io:2.8.0"
 		classpath 'de.undercouch:gradle-download-task:4.1.1'
-		classpath 'net.fabricmc:tiny-remapper:0.3.2'
+		classpath 'net.fabricmc:tiny-remapper:0.4.2'
 		classpath "net.fabricmc.unpick:unpick:${project.unpick_version}"
 		classpath "net.fabricmc.unpick:unpick-format-utils:${project.unpick_version}"
 	}
 }
 
 plugins {
+	id 'java' // for constants, packages, javadoc
 	id 'de.undercouch.download' version '4.1.1'
-	id 'base'
 	id 'maven-publish'
-	id 'java' // for jd gen
-	id 'org.cadixdev.licenser' version '0.5.1'
+	id 'org.cadixdev.licenser' version '0.6.1'
 	id 'net.fabricmc.filament' version '0.3.0'
 }
 
@@ -145,11 +144,11 @@ task downloadVersionsManifest {
 	group = setupGroup
 	//inputs.property "mc_ver", minecraft_version
 	inputs.property "currenttime", new Date()
-	def manifestFile = new File(cacheFilesMinecraft, "version_manifest.json")
+	def manifestFile = new File(cacheFilesMinecraft, "version_manifest_v2.json")
 	outputs.file(manifestFile)
 	doLast {
 		logger.lifecycle(":downloading minecraft versions manifest")
-		FileUtils.copyURLToFile(new URL("https://launchermeta.mojang.com/mc/game/version_manifest.json"), manifestFile)
+		FileUtils.copyURLToFile(new URL("https://launchermeta.mojang.com/mc/game/version_manifest_v2.json"), manifestFile)
 	}
 }
 
@@ -232,15 +231,20 @@ task downloadIntermediaryV2(type: Download) {
 	def url = "https://maven.fabricmc.net/net/fabricmc/intermediary/${minecraft_version}/intermediary-${minecraft_version}-v2.jar"
 	src com.google.common.net.UrlEscapers.urlFragmentEscaper().escape(url)
 	dest new File(cacheFilesMinecraft, "${minecraft_version}-intermediary-v2.jar")
-}
 
-task extractIntermediaryV2(dependsOn: downloadIntermediaryV2, type: Copy) {
 	def output = new File(cacheFilesMinecraft, "${minecraft_version}-intermediary-v2.tiny")
-	from({ zipTree(downloadIntermediaryV2.dest) }) {
-		include 'mappings/mappings.tiny'
-		rename 'mappings.tiny', "../${output.name}"
+	outputs.file output
+
+	doLast {
+		copy {
+			from({ zipTree(downloadIntermediaryV2.dest) }) {
+				from 'mappings/mappings.tiny'
+				rename 'mappings.tiny', "../${output.name}"
+			}
+
+			into output.parentFile
+		}
 	}
-	into output.parentFile
 }
 
 task mergeJars(dependsOn: downloadMcJars) {
@@ -322,7 +326,7 @@ task invertIntermediary(dependsOn: downloadIntermediary, type: FileOutput) {
 	}
 }
 
-task invertIntermediaryv2(dependsOn: extractIntermediaryV2, type: FileOutput) {
+task invertIntermediaryv2(dependsOn: downloadIntermediaryV2, type: FileOutput) {
 	group = buildMappingGroup
 	def v2Input = new File(cacheFilesMinecraft, "${minecraft_version}-intermediary-v2.tiny")
 
@@ -655,7 +659,7 @@ task unpickIntermediaryJar(type: JavaExec, dependsOn: [mapIntermediaryJar, "cons
 	outputs.upToDateWhen { false }
 	group "unpick"
 
-	main "daomephsta.unpick.cli.Main"
+	mainClass.set "daomephsta.unpick.cli.Main"
 	systemProperty "java.util.logging.config.file", file('unpick-logging.properties')
 	classpath configurations.unpick
 
@@ -670,14 +674,12 @@ task unpickIntermediaryJar(type: JavaExec, dependsOn: [mapIntermediaryJar, "cons
 
 // Setup the build for the unpicked constants
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_16
+targetCompatibility = JavaVersion.VERSION_16
 
 tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
-	if (JavaVersion.current().isJava9Compatible()) {
-		it.options.release = 8
-	}
+	it.options.release = 16
 }
 
 sourceSets {
@@ -687,7 +689,6 @@ sourceSets {
 
 license {
 	header file("HEADER")
-	sourceSets = [sourceSets.constants, sourceSets.packageDocs]
 	include '**/*.java'
 }
 
@@ -699,11 +700,6 @@ task constantsJar(type: Jar) {
 task sourcesJar(type: Jar, dependsOn: classes) {
 	archiveClassifier = "sources"
 	from sourceSets.constants.allSource
-}
-
-compilePackageDocsJava {
-	it.options.encoding = "UTF-8"
-	it.options.release = 16
 }
 
 // Only build jars for package infos if we need to actually expose stuff like annotation in the future.
@@ -805,7 +801,7 @@ task genFakeSource(type: JavaExec, dependsOn: ["mergeV2", "mapNamedJar"]) {
 	group = "javadoc generation"
 	outputs.upToDateWhen { false }
 
-	main "net.fabricmc.mappingpoet.Main"
+	mainClass.set "net.fabricmc.mappingpoet.Main"
 	classpath configurations.mappingPoet
 	// use merged v2 so we have all namespaces in jd
 	args mergeV2.output.getAbsolutePath(), namedJar.getAbsolutePath(), fakeSourceDir.getAbsolutePath(), libraries.getAbsolutePath()
@@ -819,7 +815,7 @@ task decompileCFR(type: JavaExec, dependsOn: [mapNamedJar]) {
 	doFirst {
 		classpath = configurations.decompileClasspath
 	}
-	main = "org.benf.cfr.reader.Main"
+	mainClass.set "org.benf.cfr.reader.Main"
 
 	args namedJar.getAbsolutePath(), "--outputdir", file("namedSrc").absolutePath
 
@@ -890,8 +886,8 @@ javadoc {
 	source fileTree(fakeSourceDir) + sourceSets.constants.allJava + sourceSets.packageDocs.allJava
 	classpath = configurations.javadocClasspath.plus downloadMcLibs.outputs.files.asFileTree
 
-	finalizedBy {
-		task copyCopyOnClickScript(type: Copy) {
+	doLast {
+		project.copy {
 			from mappingPoetJar
 			include "copy_on_click.js"
 			into javadoc.outputDirectory

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx4G
+org.gradle.jvmargs=-Xmx1G
 
 enigma_version=1.3.4
 stitch_version=0.6.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.jvmargs=-Xmx4G
 enigma_version=1.3.4
 stitch_version=0.6.1
 unpick_version=2.2.0
-cfr_version=0.0.3
+cfr_version=0.0.6
 
 # Javadoc generation/linking
-fabric_loader_version=0.11.3
+fabric_loader_version=0.11.6
 jetbrains_annotations_version=21.0.1
 mappingpoet_version=0.2.8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/mappings/net/minecraft/entity/ai/brain/sensor/Sensor.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/sensor/Sensor.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_4148 net/minecraft/entity/ai/brain/sensor/Sensor
 	COMMENT replaces that of individual tasks, so that it is more efficient than the goal
 	COMMENT system.
 	COMMENT
-	COMMENT @see Brain#sensors
+	COMMENT @see net.minecraft.entity.ai.brain.Brain#sensors
 	FIELD field_18463 lastSenseTime J
 	FIELD field_18464 senseInterval I
 	FIELD field_19294 RANDOM Ljava/util/Random;

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -263,7 +263,7 @@ CLASS net/minecraft/class_1792 net/minecraft/item/Item
 		METHOD method_7894 rarity (Lnet/minecraft/class_1814;)Lnet/minecraft/class_1792$class_1793;
 			COMMENT Sets the {@link Rarity} of any item configured with this Settings instance, which changes the color of its name.
 			COMMENT
-			COMMENT <p>An item's rarity defaults to {@link Rarity.COMMON}.
+			COMMENT <p>An item's rarity defaults to {@link Rarity#COMMON}.
 			COMMENT
 			COMMENT @return this instance
 			ARG 1 rarity

--- a/mappings/net/minecraft/server/function/CommandFunction.mapping
+++ b/mappings/net/minecraft/server/function/CommandFunction.mapping
@@ -53,7 +53,7 @@ CLASS net/minecraft/class_2158 net/minecraft/server/function/CommandFunction
 	CLASS class_2162 FunctionElement
 		COMMENT A synthetic element to be stored in a {@link CommandFunctionManager.Entry}.
 		COMMENT This is not present as parts of command functions, but created by {@link
-		COMMENT CommandFunctionManager.Execution#recursiveRun}.
+		COMMENT net.minecraft.server.function.CommandFunctionManager.Execution#recursiveRun}.
 		FIELD field_9812 function Lnet/minecraft/class_2158$class_2159;
 		METHOD <init> (Lnet/minecraft/class_2158;)V
 			ARG 1 function


### PR DESCRIPTION
Fixes #2518 and resolves gradle warnings, including "Execution optimizations have been disabled" and "Deprecated Gradle features were used in this build". Updated tiny remapper to get rid of the indy string concat spam as well.

Also simplifies the intermediary v2 extraction by merging it with download and the javadoc final mapping click to copy script copying.

Signed-off-by: liach <liach@users.noreply.github.com>