### PR TITLE
Rename *Criterion.test methods to trigger

### DIFF
--- a/mappings/net/minecraft/advancement/Advancement.mapping
+++ b/mappings/net/minecraft/advancement/Advancement.mapping
@@ -53,6 +53,8 @@ CLASS net/minecraft/class_161 net/minecraft/advancement/Advancement
 			ARG 6 showToast
 			ARG 7 announceToChat
 			ARG 8 hidden
+		METHOD method_34884 requirements ([[Ljava/lang/String;)Lnet/minecraft/class_161$class_162;
+			ARG 1 requirements
 		METHOD method_692 fromJson (Lcom/google/gson/JsonObject;Lnet/minecraft/class_5257;)Lnet/minecraft/class_161$class_162;
 			ARG 0 obj
 			ARG 1 predicateDeserializer

--- a/mappings/net/minecraft/advancement/PlayerAdvancementTracker.mapping
+++ b/mappings/net/minecraft/advancement/PlayerAdvancementTracker.mapping
@@ -12,6 +12,7 @@ CLASS net/minecraft/class_2985 net/minecraft/advancement/PlayerAdvancementTracke
 	FIELD field_13396 dirty Z
 	FIELD field_25324 dataFixer Lcom/mojang/datafixers/DataFixer;
 	FIELD field_25325 playerManager Lnet/minecraft/class_3324;
+	FIELD field_33383 MAX_VISIBLE_CHILDREN I
 	METHOD <init> (Lcom/mojang/datafixers/DataFixer;Lnet/minecraft/class_3324;Lnet/minecraft/class_2989;Ljava/io/File;Lnet/minecraft/class_3222;)V
 		ARG 1 dataFixer
 		ARG 2 playerManager

--- a/mappings/net/minecraft/advancement/criterion/AbstractCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/AbstractCriterion.mapping
@@ -1,8 +1,8 @@
 CLASS net/minecraft/class_4558 net/minecraft/advancement/criterion/AbstractCriterion
 	FIELD field_20735 progressions Ljava/util/Map;
-	METHOD method_22510 test (Lnet/minecraft/class_3222;Ljava/util/function/Predicate;)V
+	METHOD method_22510 trigger (Lnet/minecraft/class_3222;Ljava/util/function/Predicate;)V
 		ARG 1 player
-		ARG 2 tester
+		ARG 2 predicate
 	METHOD method_22512 (Lnet/minecraft/class_2985;)Ljava/util/Set;
 		ARG 0 manager
 	METHOD method_27854 conditionsFromJson (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2048$class_5258;Lnet/minecraft/class_5257;)Lnet/minecraft/class_195;

--- a/mappings/net/minecraft/advancement/criterion/BeeNestDestroyedCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/BeeNestDestroyedCriterion.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_4708 net/minecraft/advancement/criterion/BeeNestDestro
 		ARG 3 conditions
 	METHOD method_23873 getBlock (Lcom/google/gson/JsonObject;)Lnet/minecraft/class_2248;
 		ARG 0 root
-	METHOD method_23875 test (Lnet/minecraft/class_3222;Lnet/minecraft/class_2680;Lnet/minecraft/class_1799;I)V
+	METHOD method_23875 trigger (Lnet/minecraft/class_3222;Lnet/minecraft/class_2680;Lnet/minecraft/class_1799;I)V
 		ARG 1 player
 		ARG 2 state
 		ARG 3 stack

--- a/mappings/net/minecraft/advancement/criterion/CriterionProgress.mapping
+++ b/mappings/net/minecraft/advancement/criterion/CriterionProgress.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/class_178 net/minecraft/advancement/criterion/CriterionProgr
 	METHOD method_784 isObtained ()Z
 	METHOD method_785 fromPacket (Lnet/minecraft/class_2540;)Lnet/minecraft/class_178;
 		ARG 0 buf
-	METHOD method_786 getObtainedDate ()Ljava/util/Date;
+	METHOD method_786 getObtained ()Ljava/util/Date;
 	METHOD method_787 toPacket (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD method_788 obtainedAt (Ljava/lang/String;)Lnet/minecraft/class_178;

--- a/mappings/net/minecraft/advancement/criterion/CriterionProgress.mapping
+++ b/mappings/net/minecraft/advancement/criterion/CriterionProgress.mapping
@@ -1,11 +1,11 @@
 CLASS net/minecraft/class_178 net/minecraft/advancement/criterion/CriterionProgress
-	FIELD field_1219 obtained Ljava/util/Date;
+	FIELD field_1219 obtainedDate Ljava/util/Date;
 	FIELD field_1220 FORMAT Ljava/text/SimpleDateFormat;
 	METHOD method_783 toJson ()Lcom/google/gson/JsonElement;
 	METHOD method_784 isObtained ()Z
 	METHOD method_785 fromPacket (Lnet/minecraft/class_2540;)Lnet/minecraft/class_178;
 		ARG 0 buf
-	METHOD method_786 getObtained ()Ljava/util/Date;
+	METHOD method_786 getObtainedDate ()Ljava/util/Date;
 	METHOD method_787 toPacket (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD method_788 obtainedAt (Ljava/lang/String;)Lnet/minecraft/class_178;

--- a/mappings/net/minecraft/advancement/criterion/InventoryChangedCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/InventoryChangedCriterion.mapping
@@ -24,6 +24,8 @@ CLASS net/minecraft/class_2066 net/minecraft/advancement/criterion/InventoryChan
 			ARG 3 full
 			ARG 4 empty
 			ARG 5 items
+		METHOD method_24363 (Lnet/minecraft/class_1799;Lnet/minecraft/class_2073;)Z
+			ARG 1 item
 		METHOD method_8957 items ([Lnet/minecraft/class_2073;)Lnet/minecraft/class_2066$class_2068;
 			ARG 0 items
 		METHOD method_8958 matches (Lnet/minecraft/class_1661;Lnet/minecraft/class_1799;III)Z

--- a/mappings/net/minecraft/advancement/criterion/ItemUsedOnBlockCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/ItemUsedOnBlockCriterion.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_4711 net/minecraft/advancement/criterion/ItemUsedOnBlo
 	FIELD field_21576 ID Lnet/minecraft/class_2960;
 	METHOD method_23888 (Lnet/minecraft/class_2680;Lnet/minecraft/class_3222;Lnet/minecraft/class_2338;Lnet/minecraft/class_1799;Lnet/minecraft/class_4711$class_4712;)Z
 		ARG 4 conditions
-	METHOD method_23889 test (Lnet/minecraft/class_3222;Lnet/minecraft/class_2338;Lnet/minecraft/class_1799;)V
+	METHOD method_23889 trigger (Lnet/minecraft/class_3222;Lnet/minecraft/class_2338;Lnet/minecraft/class_1799;)V
 		ARG 1 player
 		ARG 2 pos
 		ARG 3 stack

--- a/mappings/net/minecraft/advancement/criterion/LightningStrikeCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/LightningStrikeCriterion.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_6405 net/minecraft/advancement/criterion/LightningStri
 	FIELD field_33925 ID Lnet/minecraft/class_2960;
 	METHOD method_37239 (Lnet/minecraft/class_3222;Lnet/minecraft/class_1297;)Lnet/minecraft/class_47;
 		ARG 1 bystander
-	METHOD method_37240 test (Lnet/minecraft/class_3222;Lnet/minecraft/class_1538;Ljava/util/List;)V
+	METHOD method_37240 trigger (Lnet/minecraft/class_3222;Lnet/minecraft/class_1538;Ljava/util/List;)V
 		ARG 1 player
 		ARG 2 lightning
 		ARG 3 bystanders

--- a/mappings/net/minecraft/advancement/criterion/PlayerGeneratesContainerLootCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/PlayerGeneratesContainerLootCriterion.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_5282 net/minecraft/advancement/criterion/PlayerGenerat
 	FIELD field_24502 ID Lnet/minecraft/class_2960;
 	METHOD method_27992 (Lnet/minecraft/class_2960;Lnet/minecraft/class_5282$class_5283;)Z
 		ARG 1 conditions
-	METHOD method_27993 test (Lnet/minecraft/class_3222;Lnet/minecraft/class_2960;)V
+	METHOD method_27993 trigger (Lnet/minecraft/class_3222;Lnet/minecraft/class_2960;)V
 		ARG 1 player
 		ARG 2 id
 	CLASS class_5283 Conditions

--- a/mappings/net/minecraft/advancement/criterion/PlayerInteractedWithEntityCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/PlayerInteractedWithEntityCriterion.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_5409 net/minecraft/advancement/criterion/PlayerInterac
 	FIELD field_25699 ID Lnet/minecraft/class_2960;
 	METHOD method_30095 (Lnet/minecraft/class_1799;Lnet/minecraft/class_47;Lnet/minecraft/class_5409$class_5410;)Z
 		ARG 2 conditions
-	METHOD method_30097 test (Lnet/minecraft/class_3222;Lnet/minecraft/class_1799;Lnet/minecraft/class_1297;)V
+	METHOD method_30097 trigger (Lnet/minecraft/class_3222;Lnet/minecraft/class_1799;Lnet/minecraft/class_1297;)V
 		ARG 1 player
 		ARG 2 stack
 		ARG 3 entity

--- a/mappings/net/minecraft/advancement/criterion/SlideDownBlockCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/SlideDownBlockCriterion.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/class_4713 net/minecraft/advancement/criterion/SlideDownBloc
 		ARG 1 conditions
 	METHOD method_23907 getBlock (Lcom/google/gson/JsonObject;)Lnet/minecraft/class_2248;
 		ARG 0 root
-	METHOD method_23909 test (Lnet/minecraft/class_3222;Lnet/minecraft/class_2680;)V
+	METHOD method_23909 trigger (Lnet/minecraft/class_3222;Lnet/minecraft/class_2680;)V
 		ARG 1 player
 		ARG 2 state
 	CLASS class_4714 Conditions

--- a/mappings/net/minecraft/advancement/criterion/StartedRidingCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/StartedRidingCriterion.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_6407 net/minecraft/advancement/criterion/StartedRidingCriterion
 	FIELD field_33932 ID Lnet/minecraft/class_2960;
-	METHOD method_37257 test (Lnet/minecraft/class_3222;)V
+	METHOD method_37257 trigger (Lnet/minecraft/class_3222;)V
 		ARG 1 player
 	METHOD method_37259 (Lnet/minecraft/class_6407$class_6408;)Z
 		ARG 0 conditions

--- a/mappings/net/minecraft/advancement/criterion/UsingItemCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/UsingItemCriterion.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_6409 net/minecraft/advancement/criterion/UsingItemCriterion
 	FIELD field_33937 ID Lnet/minecraft/class_2960;
-	METHOD method_37262 test (Lnet/minecraft/class_3222;Lnet/minecraft/class_1799;)V
+	METHOD method_37262 trigger (Lnet/minecraft/class_3222;Lnet/minecraft/class_1799;)V
 		ARG 1 player
 		ARG 2 stack
 	METHOD method_37263 (Lnet/minecraft/class_1799;Lnet/minecraft/class_6409$class_6410;)Z

--- a/mappings/net/minecraft/advancement/criterion/VillagerTradeCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/VillagerTradeCriterion.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_2140 net/minecraft/advancement/criterion/VillagerTrade
 	FIELD field_9762 ID Lnet/minecraft/class_2960;
 	METHOD method_22539 (Lnet/minecraft/class_47;Lnet/minecraft/class_1799;Lnet/minecraft/class_2140$class_2142;)Z
 		ARG 2 conditions
-	METHOD method_9146 handle (Lnet/minecraft/class_3222;Lnet/minecraft/class_3988;Lnet/minecraft/class_1799;)V
+	METHOD method_9146 trigger (Lnet/minecraft/class_3222;Lnet/minecraft/class_3988;Lnet/minecraft/class_1799;)V
 		ARG 1 player
 		ARG 2 merchant
 		ARG 3 stack


### PR DESCRIPTION
As [liach said](https://github.com/FabricMC/yarn/issues/2269#issuecomment-813069618), these methods actually handle everything that should happen when a criterion is trigged. They do not return booleans, so it doesn't make sense to name them `test`.

Closes #2269 