### PR TITLE
Fix the parameter of SliderWidget.setValue

### DIFF
--- a/mappings/net/minecraft/client/gui/widget/SliderWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/SliderWidget.mapping
@@ -9,7 +9,14 @@ CLASS net/minecraft/class_357 net/minecraft/client/gui/widget/SliderWidget
 		ARG 6 value
 	METHOD method_25344 applyValue ()V
 	METHOD method_25345 setValueFromMouse (D)V
+		COMMENT Sets the value from mouse position.
+		COMMENT
+		COMMENT <p>The value will be calculated from the position and the width of this
+		COMMENT slider.
+		COMMENT
+		COMMENT @see #setValue
 		ARG 1 mouseX
 	METHOD method_25346 updateMessage ()V
 	METHOD method_25347 setValue (D)V
-		ARG 1 mouseX
+		ARG 1 value
+			COMMENT the new value; will be clamped to {@code [0, 1]}.

--- a/mappings/net/minecraft/client/gui/widget/SliderWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/SliderWidget.mapping
@@ -19,4 +19,4 @@ CLASS net/minecraft/class_357 net/minecraft/client/gui/widget/SliderWidget
 	METHOD method_25346 updateMessage ()V
 	METHOD method_25347 setValue (D)V
 		ARG 1 value
-			COMMENT the new value; will be clamped to {@code [0, 1]}.
+			COMMENT the new value; will be clamped to {@code [0, 1]}


### PR DESCRIPTION
The parameter of `SliderWidget.setValue` is not mouse position.