### PR TITLE
Use automapped names for documented fields

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ plugins {
 	id 'maven-publish'
 	id 'java' // for jd gen
 	id 'org.cadixdev.licenser' version '0.5.1'
-	id 'net.fabricmc.filament' version '0.3.0'
+	id 'net.fabricmc.filament' version '0.3.1'
 }
 
 def minecraft_version = "1.17.1"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx4G
 
-enigma_version=1.3.4
+enigma_version=1.4.1
 stitch_version=0.6.1
 unpick_version=2.2.0
 cfr_version=0.0.3

--- a/mappings/net/minecraft/item/ArmorMaterials.mapping
+++ b/mappings/net/minecraft/item/ArmorMaterials.mapping
@@ -4,7 +4,6 @@ CLASS net/minecraft/class_1740 net/minecraft/item/ArmorMaterials
 	FIELD field_7884 name Ljava/lang/String;
 	FIELD field_7885 repairIngredientSupplier Lnet/minecraft/class_3528;
 	FIELD field_7886 equipSound Lnet/minecraft/class_3414;
-	FIELD field_7887 CHAIN Lnet/minecraft/class_1740;
 	FIELD field_7891 BASE_DURABILITY [I
 	FIELD field_7893 protectionAmounts [I
 	FIELD field_7894 toughness F

--- a/mappings/net/minecraft/screen/slot/SlotActionType.mapping
+++ b/mappings/net/minecraft/screen/slot/SlotActionType.mapping
@@ -1,23 +1,23 @@
 CLASS net/minecraft/class_1713 net/minecraft/screen/slot/SlotActionType
-	FIELD field_7789 QUICK_CRAFT Lnet/minecraft/class_1713;
+	FIELD field_7789 Lnet/minecraft/class_1713;
 		COMMENT Drags items between multiple slots. This is usually triggered by the player clicking and dragging between slots.
 		COMMENT
 		COMMENT <p>This action happens in 3 stages. Stage 0 signals that the drag has begun, and stage 2 signals that the drag has ended. In between multiple stage 1s signal which slots were dragged on.
 		COMMENT
 		COMMENT <p>The stage is packed into the click data along with the mouse button that was clicked. See {@link net.minecraft.screen.ScreenHandler#packQuickCraftData(int, int) ScreenHandler.packQuickCraftData(int, int)} for details.
-	FIELD field_7790 PICKUP Lnet/minecraft/class_1713;
+	FIELD field_7790 Lnet/minecraft/class_1713;
 		COMMENT Performs a normal slot click. This can pickup or place items in the slot, possibly merging the cursor stack into the slot, or swapping the slot stack with the cursor stack if they can't be merged.
-	FIELD field_7791 SWAP Lnet/minecraft/class_1713;
+	FIELD field_7791 Lnet/minecraft/class_1713;
 		COMMENT Exchanges items between a slot and a hotbar slot. This is usually triggered by the player pressing a 1-9 number key while hovering over a slot.
 		COMMENT
 		COMMENT <p>When the action type is swap, the click data is the hotbar slot to swap with (0-8).
-	FIELD field_7793 PICKUP_ALL Lnet/minecraft/class_1713;
+	FIELD field_7793 Lnet/minecraft/class_1713;
 		COMMENT Replenishes the cursor stack with items from the screen handler. This is usually triggered by the player double clicking.
-	FIELD field_7794 QUICK_MOVE Lnet/minecraft/class_1713;
+	FIELD field_7794 Lnet/minecraft/class_1713;
 		COMMENT Performs a shift-click. This usually quickly moves items between the player's inventory and the open screen handler.
-	FIELD field_7795 THROW Lnet/minecraft/class_1713;
+	FIELD field_7795 Lnet/minecraft/class_1713;
 		COMMENT Throws the item out of the inventory. This is usually triggered by the player pressing Q while hovering over a slot, or clicking outside the window.
 		COMMENT
 		COMMENT <p>When the action type is throw, the click data determines whether to throw a whole stack (1) or a single item from that stack (0).
-	FIELD field_7796 CLONE Lnet/minecraft/class_1713;
+	FIELD field_7796 Lnet/minecraft/class_1713;
 		COMMENT Clones the item in the slot. Usually triggered by middle clicking an item in creative mode.

--- a/mappings/net/minecraft/util/ActionResult.mapping
+++ b/mappings/net/minecraft/util/ActionResult.mapping
@@ -1,14 +1,14 @@
 CLASS net/minecraft/class_1269 net/minecraft/util/ActionResult
-	FIELD field_21466 CONSUME Lnet/minecraft/class_1269;
+	FIELD field_21466 Lnet/minecraft/class_1269;
 		COMMENT Indicates an action is performed but no animation should accompany the
 		COMMENT performance.
-	FIELD field_5811 PASS Lnet/minecraft/class_1269;
+	FIELD field_5811 Lnet/minecraft/class_1269;
 		COMMENT Indicates an action is not performed but allows other actions to
 		COMMENT perform.
-	FIELD field_5812 SUCCESS Lnet/minecraft/class_1269;
+	FIELD field_5812 Lnet/minecraft/class_1269;
 		COMMENT Indicates an action is performed and the actor's hand should swing to
 		COMMENT indicate the performance.
-	FIELD field_5814 FAIL Lnet/minecraft/class_1269;
+	FIELD field_5814 Lnet/minecraft/class_1269;
 		COMMENT Indicates that an action is not performed and prevents other actions
 		COMMENT from performing.
 	METHOD method_23665 isAccepted ()Z

--- a/mappings/net/minecraft/world/GameRules.mapping
+++ b/mappings/net/minecraft/world/GameRules.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_1928 net/minecraft/world/GameRules
-	FIELD field_19388 DO_MOB_GRIEFING Lnet/minecraft/class_1928$class_4313;
+	FIELD field_19388 Lnet/minecraft/class_1928$class_4313;
 		COMMENT A {@linkplain Rule game rule} which regulates whether mobs can modify the world.
 		COMMENT
 		COMMENT <p>Generally one is expected to test this rule before an entity modifies the world.
@@ -10,29 +10,29 @@ CLASS net/minecraft/class_1928 net/minecraft/world/GameRules
 		COMMENT <li>Whether a zombie can break down a door
 		COMMENT <li>Whether a wither killing an entity will place or drop a wither rose
 		COMMENT </ul>
-	FIELD field_19389 KEEP_INVENTORY Lnet/minecraft/class_1928$class_4313;
+	FIELD field_19389 Lnet/minecraft/class_1928$class_4313;
 		COMMENT A {@linkplain Rule game rule} which regulates whether player inventories should be persist through respawning.
-	FIELD field_19390 DO_MOB_SPAWNING Lnet/minecraft/class_1928$class_4313;
+	FIELD field_19390 Lnet/minecraft/class_1928$class_4313;
 		COMMENT A {@linkplain Rule game rule} which regulates whether mobs can spawn naturally.
-	FIELD field_19391 DO_MOB_LOOT Lnet/minecraft/class_1928$class_4313;
+	FIELD field_19391 Lnet/minecraft/class_1928$class_4313;
 		COMMENT A {@linkplain Rule game rule} which regulates whether mobs should drop loot on death.
-	FIELD field_19392 DO_TILE_DROPS Lnet/minecraft/class_1928$class_4313;
+	FIELD field_19392 Lnet/minecraft/class_1928$class_4313;
 		COMMENT A {@linkplain Rule game rule} which regulates whether blocks should drop their items when broken.
-	FIELD field_19401 REDUCED_DEBUG_INFO Lnet/minecraft/class_1928$class_4313;
+	FIELD field_19401 Lnet/minecraft/class_1928$class_4313;
 		COMMENT A {@linkplain Rule game rule} which regulates whether clients' {@linkplain net.minecraft.client.gui.hud.DebugHud debug HUD}s show reduced information.
 		COMMENT
 		COMMENT <p>When the value of this rule is changed, all connected clients will be notified to update their display.
 		COMMENT In vanilla, this includes the visibility of coordinates on the clients' debug HUDs.
-	FIELD field_19405 MAX_ENTITY_CRAMMING Lnet/minecraft/class_1928$class_4313;
+	FIELD field_19405 Lnet/minecraft/class_1928$class_4313;
 		COMMENT A {@linkplain Rule game rule} which regulates the number of entities that can be crammed into a block space before they incur cramming damage.
-	FIELD field_19409 ANNOUNCE_ADVANCEMENTS Lnet/minecraft/class_1928$class_4313;
+	FIELD field_19409 Lnet/minecraft/class_1928$class_4313;
 		COMMENT A {@linkplain Rule game rule} which regulates whether a player's advancements should be announced in chat.
 	FIELD field_19410 LOGGER Lorg/apache/logging/log4j/Logger;
-	FIELD field_19422 DISABLE_RAIDS Lnet/minecraft/class_1928$class_4313;
+	FIELD field_19422 Lnet/minecraft/class_1928$class_4313;
 		COMMENT A {@linkplain Rule game rule} which regulates whether raids should occur.
 		COMMENT
 		COMMENT <p>If this rule is set to {@code true} while raids are occurring, the raids will be stopped.
-	FIELD field_20638 DO_IMMEDIATE_RESPAWN Lnet/minecraft/class_1928$class_4313;
+	FIELD field_20638 Lnet/minecraft/class_1928$class_4313;
 		COMMENT A {@linkplain Rule game rule} which regulates whether a player should immediately respawn upon death.
 	FIELD field_30963 DEFAULT_RANDOM_TICK_SPEED I
 	FIELD field_9196 rules Ljava/util/Map;

--- a/mappings/net/minecraft/world/chunk/ChunkStatus.mapping
+++ b/mappings/net/minecraft/world/chunk/ChunkStatus.mapping
@@ -114,9 +114,9 @@ CLASS net/minecraft/class_2806 net/minecraft/world/chunk/ChunkStatus
 			ARG 6 lightingProvider
 	CLASS class_2808 ChunkType
 		COMMENT Specifies the type of a chunk
-		FIELD field_12807 LEVELCHUNK Lnet/minecraft/class_2806$class_2808;
+		FIELD field_12807 Lnet/minecraft/class_2806$class_2808;
 			COMMENT A chunk which is complete and bound to a world.
-		FIELD field_12808 PROTOCHUNK Lnet/minecraft/class_2806$class_2808;
+		FIELD field_12808 Lnet/minecraft/class_2806$class_2808;
 			COMMENT A chunk which is incomplete and not loaded to the world yet.
 	CLASS class_3768 SimpleGenerationTask
 		METHOD doWork (Lnet/minecraft/class_2806;Lnet/minecraft/class_3218;Lnet/minecraft/class_2794;Ljava/util/List;Lnet/minecraft/class_2791;)V


### PR DESCRIPTION
The latest version of Enigma fixes javadocs on automapped fields (thanks 2xsaiko)
Closes #1493