### PR TITLE
1.18-es1 JFR stuff

### DIFF
--- a/mappings/net/minecraft/server/command/JfrCommand.mapping
+++ b/mappings/net/minecraft/server/command/JfrCommand.mapping
@@ -1,0 +1,18 @@
+CLASS net/minecraft/class_6478 net/minecraft/server/command/JfrCommand
+	FIELD field_34279 LOGGER Lorg/apache/logging/log4j/Logger;
+	METHOD method_37810 register (Lcom/mojang/brigadier/CommandDispatcher;)V
+		ARG 0 dispatcher
+	METHOD method_37811 (Lcom/mojang/brigadier/context/CommandContext;)I
+		ARG 0 context
+	METHOD method_37812 executeStart (Lnet/minecraft/class_2168;)I
+		ARG 0 source
+	METHOD method_37813 (Lnet/minecraft/class_2168;Ljava/lang/IllegalStateException;)Ljava/lang/Integer;
+		ARG 1 exception
+	METHOD method_37814 (Lnet/minecraft/class_2168;Ljava/nio/file/Path;)Ljava/lang/Integer;
+		ARG 1 path
+	METHOD method_37815 (Lcom/mojang/brigadier/context/CommandContext;)I
+		ARG 0 context
+	METHOD method_37816 executeStop (Lnet/minecraft/class_2168;)I
+		ARG 0 source
+	METHOD method_37817 (Lnet/minecraft/class_2168;)Z
+		ARG 0 source

--- a/mappings/net/minecraft/server/command/ResetChunksCommand.mapping
+++ b/mappings/net/minecraft/server/command/ResetChunksCommand.mapping
@@ -1,0 +1,12 @@
+CLASS net/minecraft/class_6479 net/minecraft/server/command/ResetChunksCommand
+	METHOD method_37819 (Lnet/minecraft/class_2791;)Ljava/util/concurrent/CompletableFuture;
+		ARG 0 chunk
+	METHOD method_37821 register (Lcom/mojang/brigadier/CommandDispatcher;)V
+		ARG 0 dispatcher
+	METHOD method_37822 (Lcom/mojang/brigadier/context/CommandContext;)I
+		ARG 0 context
+	METHOD method_37824 (Lnet/minecraft/class_2168;)Z
+		ARG 0 source
+	METHOD method_37825 executeResetChunks (Lnet/minecraft/class_2168;I)I
+		ARG 0 source
+		ARG 1 radius

--- a/mappings/net/minecraft/util/math/Quantiles.mapping
+++ b/mappings/net/minecraft/util/math/Quantiles.mapping
@@ -1,0 +1,8 @@
+CLASS net/minecraft/class_6421 net/minecraft/util/math/Quantiles
+	FIELD field_34075 QUANTILE_POINTS Lcom/google/common/math/Quantiles$ScaleAndIndexes;
+	METHOD method_37501 reverseMap (Ljava/util/Map;)Ljava/util/Map;
+		ARG 0 map
+	METHOD method_37502 create ([D)Ljava/util/Map;
+		ARG 0 values
+	METHOD method_37503 create ([J)Ljava/util/Map;
+		ARG 0 values

--- a/mappings/net/minecraft/util/profiling/jfr/JfrJsonReport.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/JfrJsonReport.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_6432 net/minecraft/util/profiling/jfr/JfrJsonReport

--- a/mappings/net/minecraft/util/profiling/jfr/JfrJsonReport.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/JfrJsonReport.mapping
@@ -1,1 +1,63 @@
 CLASS net/minecraft/class_6432 net/minecraft/util/profiling/jfr/JfrJsonReport
+	FIELD field_34104 gson Lcom/google/gson/Gson;
+	FIELD field_34105 BYTES_PER_SECOND Ljava/lang/String;
+	FIELD field_34106 COUNT Ljava/lang/String;
+	FIELD field_34107 DURATION_NANOS_TOTAL Ljava/lang/String;
+	FIELD field_34108 TOTAL_BYTES Ljava/lang/String;
+	FIELD field_34109 COUNT_PER_SECOND Ljava/lang/String;
+	METHOD method_37530 (Lnet/minecraft/class_6436;)Lcom/google/gson/JsonElement;
+		ARG 0 sample
+	METHOD method_37531 (Lnet/minecraft/class_6437;)D
+		ARG 0 sample
+	METHOD method_37532 collectFileIoSection (Lnet/minecraft/class_6438$class_6439;)Lcom/google/gson/JsonElement;
+		ARG 1 statistics
+	METHOD method_37533 collectHeapSection (Lnet/minecraft/class_6440$class_6441;)Lcom/google/gson/JsonElement;
+		ARG 1 statistics
+	METHOD method_37534 collectPacketSection (Lnet/minecraft/class_6443$class_6444;)Lcom/google/gson/JsonElement;
+		ARG 1 statistics
+	METHOD method_37535 collectThreadAllocationSection (Lnet/minecraft/class_6445$class_6446;)Lcom/google/gson/JsonElement;
+		ARG 1 allocationMap
+	METHOD method_37536 (Lnet/minecraft/class_6447;)D
+		ARG 0 sample
+	METHOD method_37537 (Lcom/google/gson/JsonArray;Lcom/mojang/datafixers/util/Pair;)V
+		ARG 1 entry
+	METHOD method_37538 (Lcom/google/gson/JsonArray;Ljava/lang/String;Ljava/lang/Long;)V
+		ARG 1 threadName
+		ARG 2 allocatedBytesPerSecond
+	METHOD method_37539 (Lcom/google/gson/JsonArray;Lorg/apache/commons/lang3/tuple/Pair;)V
+		ARG 1 entry
+	METHOD method_37540 (Lcom/google/gson/JsonObject;Lcom/google/gson/JsonArray;)V
+		ARG 1 json
+	METHOD method_37541 (Lcom/google/gson/JsonObject;Lcom/google/gson/JsonObject;)V
+		ARG 1 json
+	METHOD method_37542 (Lcom/google/gson/JsonObject;Ljava/lang/Integer;Ljava/lang/Double;)V
+		ARG 1 quantile
+		ARG 2 averageTickMs
+	METHOD method_37543 (Lcom/google/gson/JsonObject;Ljava/time/Duration;)V
+		ARG 1 duration
+	METHOD method_37544 (Lcom/mojang/datafixers/util/Pair;)D
+		ARG 0 pair
+	METHOD method_37545 (Ljava/lang/String;Ljava/lang/Long;Lcom/google/gson/JsonObject;)V
+		ARG 2 json
+	METHOD method_37546 collectChunkGenSection (Ljava/util/List;)Lcom/google/gson/JsonElement;
+		ARG 1 statistics
+	METHOD method_37547 (Ljava/util/List;Ljava/util/function/ToDoubleFunction;)Lcom/google/gson/JsonObject;
+		ARG 0 samples
+		ARG 1 valueGetter
+	METHOD method_37548 collectFileIoSection (Lnet/minecraft/class_6429;)Lcom/google/gson/JsonElement;
+		ARG 1 profile
+	METHOD method_37549 (Lnet/minecraft/class_6437;)D
+		ARG 0 sample
+	METHOD method_37550 (Lnet/minecraft/class_6447;)D
+		ARG 0 sample
+	METHOD method_37551 (Lcom/google/gson/JsonObject;Ljava/lang/Integer;Ljava/lang/Double;)V
+		ARG 1 quantile
+		ARG 2 duration
+	METHOD method_37552 collectServerTickSection (Ljava/util/List;)Lcom/google/gson/JsonElement;
+		ARG 1 samples
+	METHOD method_37553 collectNetworkSection (Lnet/minecraft/class_6429;)Lcom/google/gson/JsonElement;
+		ARG 1 profile
+	METHOD method_37554 (Lnet/minecraft/class_6437;)D
+		ARG 0 sample
+	METHOD method_37555 collectCpuPercentSection (Ljava/util/List;)Lcom/google/gson/JsonElement;
+		ARG 1 samples

--- a/mappings/net/minecraft/util/profiling/jfr/JfrProfile.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/JfrProfile.mapping
@@ -1,0 +1,52 @@
+CLASS net/minecraft/class_6429 net/minecraft/util/profiling/jfr/JfrProfile
+	FIELD field_34091 startTime Ljava/time/Instant;
+	FIELD field_34092 endTime Ljava/time/Instant;
+	FIELD field_34093 worldGenDuration Lnet/minecraft/class_6429$class_6430;
+	FIELD field_34094 serverTickTimeSamples Ljava/util/List;
+	FIELD field_34095 cpuLoadSamples Ljava/util/List;
+	FIELD field_34096 gcHeapSummaryStatistics Lnet/minecraft/class_6440$class_6441;
+	FIELD field_34097 threadAllocationMap Lnet/minecraft/class_6445$class_6446;
+	FIELD field_34098 packetReadStatistics Lnet/minecraft/class_6443$class_6444;
+	FIELD field_34099 packetSentStatistics Lnet/minecraft/class_6443$class_6444;
+	FIELD field_34100 fileWriteStatistics Lnet/minecraft/class_6438$class_6439;
+	FIELD field_34101 fileReadStatistics Lnet/minecraft/class_6438$class_6439;
+	FIELD field_34102 chunkGenerationSamples Ljava/util/List;
+	METHOD <init> (Ljava/time/Instant;Ljava/time/Instant;Lnet/minecraft/class_6429$class_6430;Ljava/util/List;Ljava/util/List;Lnet/minecraft/class_6440$class_6441;Lnet/minecraft/class_6445$class_6446;Lnet/minecraft/class_6443$class_6444;Lnet/minecraft/class_6443$class_6444;Lnet/minecraft/class_6438$class_6439;Lnet/minecraft/class_6438$class_6439;Ljava/util/List;)V
+		ARG 1 startTime
+		ARG 2 endTime
+		ARG 3 worldGenDuration
+		ARG 4 serverTickTimeSamples
+		ARG 5 cpuLoadSamples
+		ARG 6 gcHeapSummaryStatistics
+		ARG 7 threadAllocationMap
+		ARG 8 packetReadStatistics
+		ARG 9 packetSentStatistics
+		ARG 10 fileWriteStatistics
+		ARG 11 fileReadStatistics
+		ARG 12 chunkGenerationSamples
+	METHOD method_37510 getStartTime ()Ljava/time/Instant;
+	METHOD method_37511 (Lnet/minecraft/class_6436;)Lnet/minecraft/class_2806;
+		ARG 0 sample
+	METHOD method_37512 (Lcom/mojang/datafixers/util/Pair;)Ljava/time/Duration;
+		ARG 0 entry
+	METHOD method_37513 (Ljava/util/Map$Entry;)Lcom/mojang/datafixers/util/Pair;
+		ARG 0 entry
+	METHOD method_37514 getEndTime ()Ljava/time/Instant;
+	METHOD method_37515 getDuration ()Ljava/time/Duration;
+	METHOD method_37516 getWorldGenDuration ()Ljava/util/Optional;
+	METHOD method_37517 getServerTickTimeSamples ()Ljava/util/List;
+	METHOD method_37518 getGcHeapSummaryStatistics ()Lnet/minecraft/class_6440$class_6441;
+	METHOD method_37519 getThreadAllocationMap ()Lnet/minecraft/class_6445$class_6446;
+	METHOD method_37520 getPacketReadStatistics ()Lnet/minecraft/class_6443$class_6444;
+	METHOD method_37521 getPacketSentStatistics ()Lnet/minecraft/class_6443$class_6444;
+	METHOD method_37522 getFileWriteStatistics ()Lnet/minecraft/class_6438$class_6439;
+	METHOD method_37523 getFileReadStatistics ()Lnet/minecraft/class_6438$class_6439;
+	METHOD method_37524 getChunkGenerationSampleStatistics ()Ljava/util/List;
+	METHOD method_37525 getCpuLoadSamples ()Ljava/util/List;
+	METHOD method_37526 collect ()Ljava/lang/String;
+	METHOD method_37527 collectJson ()Ljava/lang/String;
+	CLASS class_6430 OptionalDuration
+		FIELD field_34103 duration Ljava/time/Duration;
+		METHOD <init> (Ljava/time/Duration;)V
+			ARG 1 duration
+		METHOD method_37528 toOptional ()Ljava/util/Optional;

--- a/mappings/net/minecraft/util/profiling/jfr/JfrProfileRecorder.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/JfrProfileRecorder.mapping
@@ -1,1 +1,28 @@
 CLASS net/minecraft/class_6428 net/minecraft/util/profiling/jfr/JfrProfileRecorder
+	FIELD field_34076 startTime Ljava/time/Instant;
+	FIELD field_34077 endTime Ljava/time/Instant;
+	FIELD field_34078 chunkGenerationSamples Ljava/util/List;
+	FIELD field_34079 cpuLoadSamples Ljava/util/List;
+	FIELD field_34080 packetReadSamples Ljava/util/List;
+	FIELD field_34081 packetSentSamples Ljava/util/List;
+	FIELD field_34082 fileWriteSamples Ljava/util/List;
+	FIELD field_34083 fileReadSamples Ljava/util/List;
+	FIELD field_34084 gcCount I
+	FIELD field_34085 gcDuration Ljava/time/Duration;
+	FIELD field_34086 gcHeapSummarySamples Ljava/util/List;
+	FIELD field_34087 threadAllocationStatisticsSamples Ljava/util/List;
+	FIELD field_34088 serverTickTimeSamples Ljava/util/List;
+	FIELD field_34089 worldGenDuration Ljava/time/Duration;
+	METHOD <init> (Ljava/util/stream/Stream;)V
+		ARG 1 events
+	METHOD method_37504 createProfile ()Lnet/minecraft/class_6429;
+	METHOD method_37505 readProfile (Ljava/nio/file/Path;)Lnet/minecraft/class_6429;
+		ARG 0 path
+	METHOD method_37506 handleEvents (Ljava/util/stream/Stream;)V
+		ARG 1 events
+	METHOD method_37507 (Ljdk/jfr/consumer/RecordedEvent;)V
+		ARG 1 event
+	METHOD method_37508 addFileIoSample (Ljdk/jfr/consumer/RecordedEvent;Ljava/util/List;Ljava/lang/String;)V
+		ARG 1 event
+		ARG 2 samples
+		ARG 3 bytesKey

--- a/mappings/net/minecraft/util/profiling/jfr/JfrProfileRecorder.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/JfrProfileRecorder.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_6428 net/minecraft/util/profiling/jfr/JfrProfileRecorder

--- a/mappings/net/minecraft/util/profiling/jfr/JfrProfiler.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/JfrProfiler.mapping
@@ -23,5 +23,5 @@ CLASS net/minecraft/class_6419 net/minecraft/util/profiling/jfr/JfrProfiler
 		METHOD recordingStateChanged (Ljdk/jfr/Recording;)V
 			ARG 1 recording
 	CLASS class_6420 InstanceType
-		METHOD method_37500 getInstanceType (Lnet/minecraft/server/MinecraftServer;)Lnet/minecraft/class_6419$class_6420;
+		METHOD method_37500 get (Lnet/minecraft/server/MinecraftServer;)Lnet/minecraft/class_6419$class_6420;
 			ARG 0 server

--- a/mappings/net/minecraft/util/profiling/jfr/JfrProfiler.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/JfrProfiler.mapping
@@ -1,0 +1,27 @@
+CLASS net/minecraft/class_6419 net/minecraft/util/profiling/jfr/JfrProfiler
+	FIELD field_34063 MINECRAFT Ljava/lang/String;
+	FIELD field_34064 WORLD_GENERATION Ljava/lang/String;
+	FIELD field_34065 TICKING Ljava/lang/String;
+	FIELD field_34066 NETWORK Ljava/lang/String;
+	FIELD field_34067 EVENTS Lcom/google/common/collect/ImmutableList;
+	FIELD field_34068 DATE_TIME_FORMAT Ljava/lang/String;
+	FIELD field_34069 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_34070 CONFIG_PATH Ljava/lang/String;
+	FIELD field_34071 currentRecording Ljdk/jfr/Recording;
+	METHOD method_37492 stop ()Lcom/mojang/datafixers/util/Either;
+	METHOD method_37493 start (Lnet/minecraft/class_6419$class_6420;)Z
+		ARG 0 instanceType
+	METHOD method_37494 (Lnet/minecraft/class_6419$class_6420;Ljava/lang/String;Ljdk/jfr/Recording;)V
+		ARG 2 recording
+	METHOD method_37495 start (Ljava/nio/file/Path;Lnet/minecraft/class_6419$class_6420;)Z
+		ARG 0 path
+		ARG 1 instanceType
+	METHOD method_37496 (Ljdk/jfr/Recording;)Z
+		ARG 0 recording
+	METHOD method_37498 isProfiling ()Z
+	CLASS 1
+		METHOD recordingStateChanged (Ljdk/jfr/Recording;)V
+			ARG 1 recording
+	CLASS class_6420 InstanceType
+		METHOD method_37500 getInstanceType (Lnet/minecraft/server/MinecraftServer;)Lnet/minecraft/class_6419$class_6420;
+			ARG 0 server

--- a/mappings/net/minecraft/util/profiling/jfr/JfrRecord.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/JfrRecord.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_6429 net/minecraft/util/profiling/jfr/JfrRecord
+	METHOD method_37526 toTextReport ()Ljava/lang/String;
+	METHOD method_37527 toJson ()Ljava/lang/String;

--- a/mappings/net/minecraft/util/profiling/jfr/JfrRecord.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/JfrRecord.mapping
@@ -1,3 +1,0 @@
-CLASS net/minecraft/class_6429 net/minecraft/util/profiling/jfr/JfrRecord
-	METHOD method_37526 toTextReport ()Ljava/lang/String;
-	METHOD method_37527 toJson ()Ljava/lang/String;

--- a/mappings/net/minecraft/util/profiling/jfr/JfrReport.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/JfrReport.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_6433 net/minecraft/util/profiling/jfr/JfrReport
+	METHOD method_37529 toString (Lnet/minecraft/class_6429;)Ljava/lang/String;

--- a/mappings/net/minecraft/util/profiling/jfr/JfrReport.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/JfrReport.mapping
@@ -1,2 +1,3 @@
 CLASS net/minecraft/class_6433 net/minecraft/util/profiling/jfr/JfrReport
 	METHOD method_37529 toString (Lnet/minecraft/class_6429;)Ljava/lang/String;
+		ARG 1 profile

--- a/mappings/net/minecraft/util/profiling/jfr/JfrTextReport.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/JfrTextReport.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_6434 net/minecraft/util/profiling/jfr/JfrTextReport
+	FIELD field_34110 LINE_SEPARATOR Ljava/lang/String;
+	FIELD field_34111 MIN_AVERAGE_MAX_FORMAT Ljava/lang/String;

--- a/mappings/net/minecraft/util/profiling/jfr/JfrTextReport.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/JfrTextReport.mapping
@@ -1,3 +1,59 @@
 CLASS net/minecraft/class_6434 net/minecraft/util/profiling/jfr/JfrTextReport
 	FIELD field_34110 LINE_SEPARATOR Ljava/lang/String;
 	FIELD field_34111 MIN_AVERAGE_MAX_FORMAT Ljava/lang/String;
+	METHOD method_37556 toMegabytes (D)D
+		ARG 0 bytes
+	METHOD method_37557 (ILnet/minecraft/class_6437;)D
+		ARG 1 sample
+	METHOD method_37558 toMegabytes (J)D
+		ARG 0 bytes
+	METHOD method_37559 format (Lnet/minecraft/class_6436;)Ljava/lang/String;
+		ARG 1 sample
+	METHOD method_37560 (Lnet/minecraft/class_6447;)D
+		ARG 0 sample
+	METHOD method_37561 format (Lnet/minecraft/class_6450;)Ljava/lang/String;
+		ARG 1 statistics
+	METHOD method_37562 (Lnet/minecraft/class_6450;I)Ljava/lang/String;
+		ARG 1 quantile
+	METHOD method_37563 (Lcom/mojang/datafixers/util/Pair;)I
+		ARG 0 pair
+	METHOD method_37564 addFileIoSections (Ljava/lang/StringBuilder;Lnet/minecraft/class_6438$class_6439;Lnet/minecraft/class_6438$class_6439;)V
+		ARG 1 builder
+		ARG 2 writeStatistics
+		ARG 3 readStatistics
+	METHOD method_37565 addGcSection (Ljava/lang/StringBuilder;Lnet/minecraft/class_6440$class_6441;)V
+		ARG 1 builder
+		ARG 2 statistics
+	METHOD method_37566 addPacketSection (Ljava/lang/StringBuilder;Lnet/minecraft/class_6443$class_6444;Ljava/lang/String;)V
+		ARG 1 builder
+		ARG 2 statistics
+		ARG 3 type
+	METHOD method_37567 addThreadAllocationSection (Ljava/lang/StringBuilder;Lnet/minecraft/class_6445$class_6446;)V
+		ARG 1 builder
+		ARG 2 allocationMap
+	METHOD method_37568 (Ljava/lang/StringBuilder;Ljava/lang/String;Ljava/lang/Long;)V
+		ARG 1 threadName
+		ARG 2 allocatedBytesPerSecond
+	METHOD method_37569 (Ljava/lang/StringBuilder;Ljava/time/Duration;)V
+		ARG 1 duration
+	METHOD method_37570 addServerTicksSection (Ljava/lang/StringBuilder;Ljava/util/List;)V
+		ARG 1 builder
+		ARG 2 samples
+	METHOD method_37571 (Ljava/lang/StringBuilder;Lorg/apache/commons/lang3/tuple/Pair;)V
+		ARG 1 entry
+	METHOD method_37572 toKilobytes (D)D
+		ARG 0 bytes
+	METHOD method_37573 (ILnet/minecraft/class_6437;)D
+		ARG 1 sample
+	METHOD method_37574 toKilobytes (J)D
+		ARG 0 bytes
+	METHOD method_37575 addCpuUsageSection (Ljava/lang/StringBuilder;Ljava/util/List;)V
+		ARG 1 builder
+		ARG 2 samples
+	METHOD method_37576 (Ljava/lang/StringBuilder;Lorg/apache/commons/lang3/tuple/Pair;)V
+		ARG 1 entry
+	METHOD method_37577 (ILnet/minecraft/class_6437;)D
+		ARG 1 sample
+	METHOD method_37578 addChunkGenSection (Ljava/lang/StringBuilder;Ljava/util/List;)V
+		ARG 1 builder
+		ARG 2 statistics

--- a/mappings/net/minecraft/util/profiling/jfr/event/StackTracelessEvent.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/event/StackTracelessEvent.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_6422 net/minecraft/util/profiling/jfr/event/StackTracelessEvent

--- a/mappings/net/minecraft/util/profiling/jfr/sample/ChunkGenerationSample.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/sample/ChunkGenerationSample.mapping
@@ -1,0 +1,9 @@
+CLASS net/minecraft/class_6436 net/minecraft/util/profiling/jfr/sample/ChunkGenerationSample
+	FIELD field_34112 duration Ljava/time/Duration;
+	FIELD field_34113 chunkPos Lnet/minecraft/class_1923;
+	FIELD field_34114 centerPos Lnet/minecraft/class_2338;
+	FIELD field_34115 chunkStatus Lnet/minecraft/class_2806;
+	FIELD field_34116 successful Z
+	FIELD field_34117 worldKey Ljava/lang/String;
+	METHOD <init> (Ljdk/jfr/consumer/RecordedEvent;)V
+		ARG 1 event

--- a/mappings/net/minecraft/util/profiling/jfr/sample/CpuLoadSample.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/sample/CpuLoadSample.mapping
@@ -1,0 +1,6 @@
+CLASS net/minecraft/class_6437 net/minecraft/util/profiling/jfr/sample/CpuLoadSample
+	FIELD field_34118 jvm D
+	FIELD field_34119 userJvm D
+	FIELD field_34120 system D
+	METHOD <init> (Ljdk/jfr/consumer/RecordedEvent;)V
+		ARG 1 event

--- a/mappings/net/minecraft/util/profiling/jfr/sample/FileIoSample.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/sample/FileIoSample.mapping
@@ -1,0 +1,36 @@
+CLASS net/minecraft/class_6438 net/minecraft/util/profiling/jfr/sample/FileIoSample
+	FIELD field_34121 time Ljava/time/Instant;
+	FIELD field_34122 duration Ljava/time/Duration;
+	FIELD field_34123 path Ljava/lang/String;
+	FIELD field_34124 bytes J
+	METHOD <init> (Ljava/time/Instant;Ljava/time/Duration;Ljava/lang/String;J)V
+		ARG 1 time
+		ARG 2 duration
+		ARG 3 path
+		ARG 4 bytes
+	CLASS class_6439 Statistics
+		FIELD field_34125 totalBytes J
+		FIELD field_34126 count I
+		FIELD field_34127 duration Ljava/time/Duration;
+		FIELD field_34128 samples Ljava/util/List;
+		METHOD <init> (Ljava/time/Duration;Ljava/util/List;)V
+			ARG 1 duration
+			ARG 2 samples
+		METHOD method_37580 getTotalBytes ()J
+		METHOD method_37581 (Lnet/minecraft/class_6438;)J
+			ARG 0 sample
+		METHOD method_37582 (Ljava/util/Map$Entry;)Lorg/apache/commons/lang3/tuple/Pair;
+			ARG 0 entry
+		METHOD method_37583 getCount ()I
+		METHOD method_37584 (Lnet/minecraft/class_6438;)Ljava/lang/String;
+			ARG 0 sample
+		METHOD method_37585 getBytesPerSecond ()D
+		METHOD method_37586 (Lnet/minecraft/class_6438;)Z
+			ARG 0 sample
+		METHOD method_37587 getCountPerSecond ()D
+		METHOD method_37588 (Lnet/minecraft/class_6438;)Ljava/time/Duration;
+			ARG 0 sample
+		METHOD method_37589 getTotalDuration ()Ljava/time/Duration;
+		METHOD method_37590 (Lnet/minecraft/class_6438;)J
+			ARG 0 sample
+		METHOD method_37591 getTopContributors ()Ljava/util/stream/Stream;

--- a/mappings/net/minecraft/util/profiling/jfr/sample/GcHeapSummarySample.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/sample/GcHeapSummarySample.mapping
@@ -1,0 +1,21 @@
+CLASS net/minecraft/class_6440 net/minecraft/util/profiling/jfr/sample/GcHeapSummarySample
+	FIELD field_34129 time Ljava/time/Instant;
+	FIELD field_34130 gcId I
+	FIELD field_34131 heapUsed J
+	FIELD field_34132 summaryType Lnet/minecraft/class_6440$class_6442;
+	METHOD <init> (Ljdk/jfr/consumer/RecordedEvent;)V
+		ARG 1 event
+	CLASS class_6441 Statistics
+		FIELD field_34133 allocatedBytesPerSecond D
+		FIELD field_34134 count I
+		FIELD field_34135 gcDuration Ljava/time/Duration;
+		FIELD field_34136 duration Ljava/time/Duration;
+		METHOD <init> (Ljava/time/Duration;Ljava/util/List;Ljava/time/Duration;I)V
+			ARG 1 duration
+			ARG 2 samples
+			ARG 3 gcDuration
+			ARG 4 count
+		METHOD method_37592 gcDurationRatio ()F
+		METHOD method_37594 getAllocatedBytesPerSecond (Ljava/util/List;)D
+			ARG 0 samples
+	CLASS class_6442 SummaryType

--- a/mappings/net/minecraft/util/profiling/jfr/sample/LongRunningSample.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/sample/LongRunningSample.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_6449 net/minecraft/util/profiling/jfr/sample/LongRunningSample
+	METHOD method_37579 getDuration ()Ljava/time/Duration;

--- a/mappings/net/minecraft/util/profiling/jfr/sample/LongRunningSampleStatistics.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/sample/LongRunningSampleStatistics.mapping
@@ -1,0 +1,12 @@
+CLASS net/minecraft/class_6450 net/minecraft/util/profiling/jfr/sample/LongRunningSampleStatistics
+	FIELD field_34154 QUANTILES [I
+	FIELD field_34155 fastestSample Lnet/minecraft/class_6449;
+	FIELD field_34156 slowestSample Lnet/minecraft/class_6449;
+	FIELD field_34157 secondSlowestSample Ljava/util/Optional;
+	FIELD field_34158 count I
+	FIELD field_34159 quantiles Ljava/util/Map;
+	FIELD field_34160 totalDuration Ljava/time/Duration;
+	METHOD <init> (Ljava/util/List;)V
+		ARG 1 samples
+	METHOD method_37609 (Lnet/minecraft/class_6449;)J
+		ARG 0 sample

--- a/mappings/net/minecraft/util/profiling/jfr/sample/PacketSample.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/sample/PacketSample.mapping
@@ -1,0 +1,28 @@
+CLASS net/minecraft/class_6443 net/minecraft/util/profiling/jfr/sample/PacketSample
+	FIELD field_34140 time Ljava/time/Instant;
+	FIELD field_34141 packetName Ljava/lang/String;
+	FIELD field_34142 bytes I
+	METHOD <init> (Ljdk/jfr/consumer/RecordedEvent;)V
+		ARG 1 event
+	CLASS class_6444 Statistics
+		FIELD field_34143 count J
+		FIELD field_34144 totalBytes J
+		FIELD field_34145 topContributors Ljava/util/List;
+		FIELD field_34146 duration Ljava/time/Duration;
+		METHOD <init> (Ljava/time/Duration;Ljava/util/List;)V
+			ARG 1 duration
+			ARG 2 samples
+		METHOD method_37597 getCount ()J
+		METHOD method_37598 (Lnet/minecraft/class_6443;)J
+			ARG 0 sample
+		METHOD method_37599 (Ljava/util/Map$Entry;)Lcom/mojang/datafixers/util/Pair;
+			ARG 0 entry
+		METHOD method_37600 getCountPerSecond ()D
+		METHOD method_37601 (Lnet/minecraft/class_6443;)Ljava/lang/String;
+			ARG 0 sample
+		METHOD method_37602 getBytesPerSecond ()D
+		METHOD method_37603 (Lnet/minecraft/class_6443;)I
+			ARG 0 sample
+		METHOD method_37604 getTotalBytes ()J
+		METHOD method_37605 getTopContributors ()Ljava/util/List;
+		METHOD method_37606 getDuration ()Ljava/time/Duration;

--- a/mappings/net/minecraft/util/profiling/jfr/sample/ServerTickTimeSample.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/sample/ServerTickTimeSample.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_6447 net/minecraft/util/profiling/jfr/sample/ServerTickTimeSample
+	FIELD field_34152 time Ljava/time/Instant;
+	FIELD field_34153 averageTickMs F
+	METHOD <init> (Ljdk/jfr/consumer/RecordedEvent;)V
+		ARG 1 event

--- a/mappings/net/minecraft/util/profiling/jfr/sample/ThreadAllocationStatisticsSample.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/sample/ThreadAllocationStatisticsSample.mapping
@@ -1,0 +1,16 @@
+CLASS net/minecraft/class_6445 net/minecraft/util/profiling/jfr/sample/ThreadAllocationStatisticsSample
+	FIELD field_34147 UNKNOWN Ljava/lang/String;
+	FIELD field_34148 time Ljava/time/Instant;
+	FIELD field_34149 threadName Ljava/lang/String;
+	FIELD field_34150 allocated J
+	METHOD <init> (Ljdk/jfr/consumer/RecordedEvent;)V
+		ARG 1 event
+	CLASS class_6446 AllocationMap
+		FIELD field_34151 allocations Ljava/util/Map;
+		METHOD <init> (Ljava/util/List;)V
+			ARG 1 samples
+		METHOD method_37607 (Lnet/minecraft/class_6445;)Ljava/lang/String;
+			ARG 0 sample
+		METHOD method_37608 (Ljava/lang/String;Ljava/util/List;)V
+			ARG 1 threadName
+			ARG 2 groupedSamples

--- a/mappings/net/minecraft/util/profiling/jfr/sample/TimedSample.mapping
+++ b/mappings/net/minecraft/util/profiling/jfr/sample/TimedSample.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_6448 net/minecraft/util/profiling/jfr/sample/TimedSample
+	METHOD method_37596 getTime ()Ljava/time/Instant;


### PR DESCRIPTION
~~Still wip.~~ Should be ready for review.

Notes 1: JfrCommand is definitely available on both dedicated and integrated. Not sure about ResetChunksCommand, but is probably available on integrated too.

Notes 2: JFR packages use `/util/profiling/jfr` since there are already several deobfscuated classes related to JFR under this. Should we move them to be consistent with `/util/profiler` naming?

Notes 3: ResetChunksCommand has a strange code that assigns a variable but never uses. Unfortunately that's also the only place that constructs class_6469 (subclass of ProtoChunk). Naming ideas anyone?