### PR TITLE
Rename optional tag provider builder

### DIFF
--- a/mappings/net/minecraft/data/server/AbstractTagProvider.mapping
+++ b/mappings/net/minecraft/data/server/AbstractTagProvider.mapping
@@ -35,7 +35,7 @@ CLASS net/minecraft/class_2474 net/minecraft/data/server/AbstractTagProvider
 			ARG 1 elements
 		METHOD method_27171 (Lnet/minecraft/class_2960;)V
 			ARG 1 id
-		METHOD method_35922 add (Lnet/minecraft/class_2960;)Lnet/minecraft/class_2474$class_5124;
+		METHOD method_35922 addOptional (Lnet/minecraft/class_2960;)Lnet/minecraft/class_2474$class_5124;
 			ARG 1 id
-		METHOD method_35923 addTag (Lnet/minecraft/class_2960;)Lnet/minecraft/class_2474$class_5124;
+		METHOD method_35923 addOptionalTag (Lnet/minecraft/class_2960;)Lnet/minecraft/class_2474$class_5124;
 			ARG 1 id


### PR DESCRIPTION
Rename methods from `AbstractTagProvider.ObjectBuilder` that accepts `Identifier` from `add` to `addOptional`.