### PR TITLE
Map stuff in LightmapTextureManager.

### DIFF
--- a/mappings/net/minecraft/client/render/LightmapTextureManager.mapping
+++ b/mappings/net/minecraft/client/render/LightmapTextureManager.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_765 net/minecraft/client/render/LightmapTextureManager
-	COMMENT Represents the lightmap texture manager.
+	COMMENT The lightmap texture manager maintains a texture containing the RGBA overlay for each of the 16&times;16 sky and block light combinations.
 	COMMENT <p>
 	COMMENT Also contains some utilities to pack and unpack lightmap coordinates from sky and block light values,
 	COMMENT and some lightmap coordinates constants.

--- a/mappings/net/minecraft/client/render/LightmapTextureManager.mapping
+++ b/mappings/net/minecraft/client/render/LightmapTextureManager.mapping
@@ -1,4 +1,18 @@
 CLASS net/minecraft/class_765 net/minecraft/client/render/LightmapTextureManager
+	COMMENT Represents the lightmap texture manager.
+	COMMENT <p>
+	COMMENT Also contains some utilities to pack and unpack lightmap coordinates from sky and block light values,
+	COMMENT and some lightmap coordinates constants.
+	FIELD field_21528 flickerIntensity F
+	FIELD field_32767 MAX_LIGHT_COORDINATE I
+		COMMENT Represents the maximum lightmap coordinate, where both sky light and block light equals {@code 15}.
+		COMMENT The value of this maximum lightmap coordinate is {@value}.
+	FIELD field_32768 MAX_SKY_LIGHT_COORDINATE I
+		COMMENT Represents the maximum sky-light-wise lightmap coordinate whose value is {@value}.
+		COMMENT This is equivalent to a {@code 15} sky light and {@code 0} block light.
+	FIELD field_32769 MAX_BLOCK_LIGHT_COORDINATE I
+		COMMENT Represents the maximum block-light-wise lightmap coordinate whose value is {@value}.
+		COMMENT This is equivalent to a {@code 0} sky light and {@code 15} block light.
 	FIELD field_4133 image Lnet/minecraft/class_1011;
 	FIELD field_4134 renderer Lnet/minecraft/class_757;
 	FIELD field_4135 dirty Z
@@ -14,6 +28,16 @@ CLASS net/minecraft/class_765 net/minecraft/client/render/LightmapTextureManager
 	METHOD method_23687 pack (II)I
 		ARG 0 block
 		ARG 1 sky
+	METHOD method_23795 easeOutQuart (F)F
+		COMMENT Represents an easing function.
+		COMMENT <p>
+		COMMENT In this class, it's also used to brighten colors,
+		COMMENT then the result is used to lerp between the normal and brightened color
+		COMMENT with the gamma value.
+		COMMENT
+		COMMENT @see <a href="https://easings.net/#easeOutQuart">https://easings.net/#easeOutQuart</a>
+		ARG 1 x
+			COMMENT represents the absolute progress of the animation in the bounds of 0 (beginning of the animation) and 1 (end of animation)
 	METHOD method_24186 getBlockLightCoordinates (I)I
 		ARG 0 light
 	METHOD method_24187 getSkyLightCoordinates (I)I


### PR DESCRIPTION
Especially the constants as I'm a bit annoyed to use the unmapped names when modding.

What would be cool is also to unpick those in the code base, but I have no idea how to write unpick definitions.