### PR TITLE
Remove all instances of  'ZERO WIDTH NON-JOINER' (U+200C) present in mappings.

### DIFF
--- a/mappings/net/minecraft/state/property/Properties.mapping
+++ b/mappings/net/minecraft/state/property/Properties.mapping
@@ -35,7 +35,7 @@ CLASS net/minecraft/class_2741 net/minecraft/state/property/Properties
 	FIELD field_12494 DELAY Lnet/minecraft/class_2758;
 		COMMENT A property that specifies the delay a repeater will apply.
 	FIELD field_12495 NORTH_WIRE_CONNECTION Lnet/minecraft/class_2754;
-		COMMENT A property that specifies how redstone wire attaches to the north.‌
+		COMMENT A property that specifies how redstone wire attaches to the north.
 	FIELD field_12496 AXIS Lnet/minecraft/class_2754;
 		COMMENT A property that specifies the axis a block is oriented to.
 	FIELD field_12497 AGE_3 Lnet/minecraft/class_2758;
@@ -53,7 +53,7 @@ CLASS net/minecraft/class_2741 net/minecraft/state/property/Properties
 	FIELD field_12503 STAIR_SHAPE Lnet/minecraft/class_2754;
 		COMMENT A property that specifies the shape of a stair block.
 	FIELD field_12504 WEST_WIRE_CONNECTION Lnet/minecraft/class_2754;
-		COMMENT A property that specifies how redstone wire attaches to the west.‌
+		COMMENT A property that specifies how redstone wire attaches to the west.
 	FIELD field_12505 BITES Lnet/minecraft/class_2758;
 		COMMENT A property that specifies the bites taken out of a cake.
 	FIELD field_12506 CHEST_TYPE Lnet/minecraft/class_2754;
@@ -93,7 +93,7 @@ CLASS net/minecraft/class_2741 net/minecraft/state/property/Properties
 	FIELD field_12522 TRIGGERED Lnet/minecraft/class_2746;
 		COMMENT A property that specifies if a dispenser is activated.
 	FIELD field_12523 EAST_WIRE_CONNECTION Lnet/minecraft/class_2754;
-		COMMENT A property that specifies how redstone wire attaches to the east.‌
+		COMMENT A property that specifies how redstone wire attaches to the east.
 	FIELD field_12524 NOTE Lnet/minecraft/class_2758;
 		COMMENT A property that specifies the pitch of a note block.
 	FIELD field_12525 FACING Lnet/minecraft/class_2753;
@@ -160,7 +160,7 @@ CLASS net/minecraft/class_2741 net/minecraft/state/property/Properties
 	FIELD field_12550 AGE_7 Lnet/minecraft/class_2758;
 		COMMENT A property that specifies the age of a block on a scale of 0 to 7.
 	FIELD field_12551 SOUTH_WIRE_CONNECTION Lnet/minecraft/class_2754;
-		COMMENT A property that specifies how redstone wire attaches to the south.‌
+		COMMENT A property that specifies how redstone wire attaches to the south.
 	FIELD field_12552 EXTENDED Lnet/minecraft/class_2746;
 		COMMENT A property that specifies if a piston is extended.
 	FIELD field_12553 DISARMED Lnet/minecraft/class_2746;
@@ -190,13 +190,13 @@ CLASS net/minecraft/class_2741 net/minecraft/state/property/Properties
 	FIELD field_20432 HONEY_LEVEL Lnet/minecraft/class_2758;
 		COMMENT A property that specifies the honey level of a beehive.
 	FIELD field_22174 EAST_WALL_SHAPE Lnet/minecraft/class_2754;
-		COMMENT A property that specifies how a wall extends from the center post to the east.‌
+		COMMENT A property that specifies how a wall extends from the center post to the east.
 	FIELD field_22175 NORTH_WALL_SHAPE Lnet/minecraft/class_2754;
-		COMMENT A property that specifies how a wall extends from the center post to the north.‌
+		COMMENT A property that specifies how a wall extends from the center post to the north.
 	FIELD field_22176 SOUTH_WALL_SHAPE Lnet/minecraft/class_2754;
-		COMMENT A property that specifies how a wall extends from the center post to the south.‌
+		COMMENT A property that specifies how a wall extends from the center post to the south.
 	FIELD field_22177 WEST_WALL_SHAPE Lnet/minecraft/class_2754;
-		COMMENT A property that specifies how a wall extends from the center post to the west.‌
+		COMMENT A property that specifies how a wall extends from the center post to the west.
 	FIELD field_23084 VINE_END Lnet/minecraft/class_2746;
 	FIELD field_23187 CHARGES Lnet/minecraft/class_2758;
 		COMMENT A property that specifies the amount of charges a respawn anchor has.


### PR DESCRIPTION
Please no invisible unicode characters.

For reference, other non-ASCII characters in Yarn are:

- One “§” U+00A7 Section Sign
https://github.com/FabricMC/yarn/blob/fd85633178de1fb3c2b82654f868f6f1370f0277/mappings/net/minecraft/client/font/TextVisitFactory.mapping#L38
- Four “×” U+00D7 Multiplication Sign
https://github.com/FabricMC/yarn/blob/fd85633178de1fb3c2b82654f868f6f1370f0277/mappings/net/minecraft/world/biome/source/BiomeCoords.mapping#L8-L9