### PR TITLE
Mapped class_6461 (vanilla biome parameters)

### DIFF
--- a/mappings/net/minecraft/SharedConstants.mapping
+++ b/mappings/net/minecraft/SharedConstants.mapping
@@ -19,11 +19,15 @@ CLASS net/minecraft/class_155 net/minecraft/SharedConstants
 	FIELD field_29735 RELEASE_TARGET_PROTOCOL_VERSION I
 	FIELD field_29737 SNBT_TOO_OLD_THRESHOLD I
 	FIELD field_29740 DATA_VERSION_KEY Ljava/lang/String;
+	FIELD field_34061 DEBUG_BIOME_SOURCE Z
 	METHOD method_16673 getGameVersion ()Lnet/minecraft/class_6418;
 	METHOD method_31372 getProtocolVersion ()I
 	METHOD method_34872 setGameVersion (Lnet/minecraft/class_6418;)V
 		ARG 0 gameVersion
 	METHOD method_36208 createGameVersion ()V
+	METHOD method_37481 (II)Z
+		ARG 0 x
+		ARG 1 z
 	METHOD method_643 isValidChar (C)Z
 		ARG 0 chr
 	METHOD method_644 stripInvalidChars (Ljava/lang/String;)Ljava/lang/String;

--- a/mappings/net/minecraft/class_6461.mapping
+++ b/mappings/net/minecraft/class_6461.mapping
@@ -1,3 +1,0 @@
-CLASS net/minecraft/class_6461
-	FIELD field_34212 OCEAN_BIOMES [[Lnet/minecraft/class_5321;
-	FIELD field_34215 MOUNTAIN_BIOMES [[Lnet/minecraft/class_5321;

--- a/mappings/net/minecraft/world/biome/source/util/VanillaBiomeParameters.mapping
+++ b/mappings/net/minecraft/world/biome/source/util/VanillaBiomeParameters.mapping
@@ -1,0 +1,87 @@
+CLASS net/minecraft/class_6461 net/minecraft/world/biome/source/util/VanillaBiomeParameters
+	FIELD field_34198 DEFAULT_PARAMETER Lnet/minecraft/class_6452$class_6454;
+	FIELD field_34199 TEMPERATURE_PARAMETERS [Lnet/minecraft/class_6452$class_6454;
+	FIELD field_34200 HUMIDITY_PARAMETERS [Lnet/minecraft/class_6452$class_6454;
+	FIELD field_34201 EROSION_PARAMETERS [Lnet/minecraft/class_6452$class_6454;
+	FIELD field_34202 FROZEN_TEMPERATURE Lnet/minecraft/class_6452$class_6454;
+	FIELD field_34203 NON_FROZEN_TEMPERATURE_PARAMETERS Lnet/minecraft/class_6452$class_6454;
+	FIELD field_34204 MUSHROOM_FIELDS_CONTINENTALNESS Lnet/minecraft/class_6452$class_6454;
+	FIELD field_34205 DEEP_OCEAN_CONTINENTALNESS Lnet/minecraft/class_6452$class_6454;
+	FIELD field_34206 OCEAN_CONTINENTALNESS Lnet/minecraft/class_6452$class_6454;
+	FIELD field_34207 SHORE_CONTINENTALNESS Lnet/minecraft/class_6452$class_6454;
+	FIELD field_34208 RIVER_CONTINENTALNESS Lnet/minecraft/class_6452$class_6454;
+	FIELD field_34209 NEXT_TO_SHORE_CONTINENTALNESS Lnet/minecraft/class_6452$class_6454;
+	FIELD field_34210 NEAR_SHORE_CONTINENTALNESS Lnet/minecraft/class_6452$class_6454;
+	FIELD field_34211 FAR_FROM_SHORE_CONTINENTALNESS Lnet/minecraft/class_6452$class_6454;
+	FIELD field_34212 OCEAN_BIOMES [[Lnet/minecraft/class_5321;
+	FIELD field_34213 COMMON_BIOMES [[Lnet/minecraft/class_5321;
+	FIELD field_34214 SPECIAL_BIOMES [[Lnet/minecraft/class_5321;
+	FIELD field_34215 HILL_BIOMES [[Lnet/minecraft/class_5321;
+	FIELD field_34282 PLATEAU_BIOMES [[Lnet/minecraft/class_5321;
+	METHOD method_37702 getHillBiome (II)Lnet/minecraft/class_5321;
+		ARG 1 temperature
+		ARG 2 humidity
+	METHOD method_37703 getRegularBiome (IILnet/minecraft/class_6452$class_6454;)Lnet/minecraft/class_5321;
+		ARG 1 temperature
+		ARG 2 humidity
+		ARG 3 weirdness
+	METHOD method_37704 getBiomeOrShatteredSavanna (ILnet/minecraft/class_5321;)Lnet/minecraft/class_5321;
+		ARG 1 temperature
+		ARG 2 biome
+	METHOD method_37705 writeVanillaBiomeParameters (Lcom/google/common/collect/ImmutableList$Builder;)V
+		ARG 1 parameters
+	METHOD method_37706 writeMountainousBiomes (Lcom/google/common/collect/ImmutableList$Builder;Lnet/minecraft/class_6452$class_6454;)V
+		ARG 1 parameters
+		ARG 2 weirdness
+	METHOD method_37707 writeBiomeParameters (Lcom/google/common/collect/ImmutableList$Builder;Lnet/minecraft/class_6452$class_6454;Lnet/minecraft/class_6452$class_6454;Lnet/minecraft/class_6452$class_6454;Lnet/minecraft/class_6452$class_6454;Lnet/minecraft/class_6452$class_6454;FLnet/minecraft/class_5321;)V
+		ARG 1 parameters
+		ARG 2 temperature
+		ARG 3 humidity
+		ARG 4 continentalness
+		ARG 5 erosion
+		ARG 6 weirdness
+		ARG 7 offset
+		ARG 8 biome
+	METHOD method_37708 getPlateauOrFrozenBiome (IILnet/minecraft/class_6452$class_6454;)Lnet/minecraft/class_5321;
+		ARG 1 temperature
+		ARG 2 humidity
+		ARG 3 weirdness
+	METHOD method_37709 writeOceanBiomes (Lcom/google/common/collect/ImmutableList$Builder;)V
+		ARG 1 parameters
+	METHOD method_37710 writePlainBiomes (Lcom/google/common/collect/ImmutableList$Builder;Lnet/minecraft/class_6452$class_6454;)V
+		ARG 1 parameters
+		ARG 2 weirdness
+	METHOD method_37711 writeCaveBiomeParameters (Lcom/google/common/collect/ImmutableList$Builder;Lnet/minecraft/class_6452$class_6454;Lnet/minecraft/class_6452$class_6454;Lnet/minecraft/class_6452$class_6454;Lnet/minecraft/class_6452$class_6454;Lnet/minecraft/class_6452$class_6454;FLnet/minecraft/class_5321;)V
+		ARG 1 parameters
+		ARG 2 temperature
+		ARG 3 humidity
+		ARG 4 continentalness
+		ARG 5 erosion
+		ARG 6 weirdness
+		ARG 7 offset
+		ARG 8 biome
+	METHOD method_37712 getMountainSlopesOrRegularBiome (IILnet/minecraft/class_6452$class_6454;)Lnet/minecraft/class_5321;
+		ARG 1 temperature
+		ARG 2 humidity
+		ARG 3 weirdness
+	METHOD method_37713 writeLandBiomes (Lcom/google/common/collect/ImmutableList$Builder;)V
+		ARG 1 parameters
+	METHOD method_37714 writeMixedBiomes (Lcom/google/common/collect/ImmutableList$Builder;Lnet/minecraft/class_6452$class_6454;)V
+		ARG 1 parameters
+		ARG 2 weirdness
+	METHOD method_37715 writeCaveBiomes (Lcom/google/common/collect/ImmutableList$Builder;)V
+		ARG 1 parameters
+	METHOD method_37716 writeBiomesNearRivers (Lcom/google/common/collect/ImmutableList$Builder;Lnet/minecraft/class_6452$class_6454;)V
+		ARG 1 parameters
+		ARG 2 weirdness
+	METHOD method_37717 writeDebugBiomeParameters (Lcom/google/common/collect/ImmutableList$Builder;)V
+		ARG 1 parameters
+	METHOD method_37718 writeRiverBiomes (Lcom/google/common/collect/ImmutableList$Builder;Lnet/minecraft/class_6452$class_6454;)V
+		ARG 1 parameters
+		ARG 2 weirdness
+	METHOD method_37827 writeBiomeAtShore (Lcom/google/common/collect/ImmutableList$Builder;Lnet/minecraft/class_6452$class_6454;Lnet/minecraft/class_6452$class_6454;Lnet/minecraft/class_6452$class_6454;Lnet/minecraft/class_5321;)V
+		ARG 1 parameters
+		ARG 2 temperature
+		ARG 3 humidity
+		ARG 4 weirdness
+		ARG 5 biome


### PR DESCRIPTION
Added mappings for `class_6461`, which is responsible for creating the vanilla parameters for the 1.18 multi noise biome source.