### PR TITLE
ChunkRegion block placement validation mappings

### DIFF
--- a/mappings/net/minecraft/world/ChunkRegion.mapping
+++ b/mappings/net/minecraft/world/ChunkRegion.mapping
@@ -32,5 +32,3 @@ CLASS net/minecraft/class_3233 net/minecraft/world/ChunkRegion
 	METHOD method_14340 (Lnet/minecraft/class_2338;)Lnet/minecraft/class_1951;
 		ARG 1 pos
 	METHOD method_33561 getCenterPos ()Lnet/minecraft/class_1923;
-	METHOD method_37368 isValidForSetBlock (Lnet/minecraft/class_2338;)Z
-		COMMENT @return true, if the given position is an accessible position for the setBlockState function

--- a/mappings/net/minecraft/world/ChunkRegion.mapping
+++ b/mappings/net/minecraft/world/ChunkRegion.mapping
@@ -15,8 +15,13 @@ CLASS net/minecraft/class_3233 net/minecraft/world/ChunkRegion
 	FIELD field_26822 structureAccessor Lnet/minecraft/class_5138;
 	FIELD field_28557 centerPos Lnet/minecraft/class_1923;
 	FIELD field_33755 placementRadius I
-		COMMENT the number of neighboring chunks which can be accessed for block placement
-		COMMENT a value of 0 means that only this chunk is accessible, a positive values means that the given amount of neighbours are accessible in each direction, a negative value means that this region shouldn't be used for block placement
+		COMMENT The number of neighboring chunks which can be accessed for block
+		COMMENT placement.
+		COMMENT
+		COMMENT <p>A value of {@code 0} means that only this chunk is accessible. A
+		COMMENT positive value means that the given amount of neighbors are accessible
+		COMMENT in each direction. A negative value means that this region shouldn't be
+		COMMENT used for block placement.
 	METHOD <init> (Lnet/minecraft/class_3218;Ljava/util/List;Lnet/minecraft/class_2806;I)V
 		ARG 1 world
 		ARG 4 placementRadius

--- a/mappings/net/minecraft/world/ChunkRegion.mapping
+++ b/mappings/net/minecraft/world/ChunkRegion.mapping
@@ -14,8 +14,12 @@ CLASS net/minecraft/class_3233 net/minecraft/world/ChunkRegion
 	FIELD field_23789 upperCorner Lnet/minecraft/class_1923;
 	FIELD field_26822 structureAccessor Lnet/minecraft/class_5138;
 	FIELD field_28557 centerPos Lnet/minecraft/class_1923;
+	FIELD field_33755 placementRadius I
+		COMMENT the number of neighbouring chunks which can be accessed for block placement
+		COMMENT a value of 0 means that only this chunk is accessible, a positive values means that the given amount of neighbours are accessible in each direction, a negative value means that this region shouldn't be used for block placement
 	METHOD <init> (Lnet/minecraft/class_3218;Ljava/util/List;Lnet/minecraft/class_2806;I)V
 		ARG 1 world
+		ARG 4 placementRadius
 	METHOD method_14337 (Lnet/minecraft/class_2338;)Lnet/minecraft/class_1951;
 		ARG 1 pos
 	METHOD method_14338 markBlockForPostProcessing (Lnet/minecraft/class_2338;)V
@@ -23,3 +27,5 @@ CLASS net/minecraft/class_3233 net/minecraft/world/ChunkRegion
 	METHOD method_14340 (Lnet/minecraft/class_2338;)Lnet/minecraft/class_1951;
 		ARG 1 pos
 	METHOD method_33561 getCenterPos ()Lnet/minecraft/class_1923;
+	METHOD method_37368 isValidForSetBlock (Lnet/minecraft/class_2338;)Z
+		COMMENT @return true, if the given position is an accessible position for the setBlockState function

--- a/mappings/net/minecraft/world/ChunkRegion.mapping
+++ b/mappings/net/minecraft/world/ChunkRegion.mapping
@@ -15,7 +15,7 @@ CLASS net/minecraft/class_3233 net/minecraft/world/ChunkRegion
 	FIELD field_26822 structureAccessor Lnet/minecraft/class_5138;
 	FIELD field_28557 centerPos Lnet/minecraft/class_1923;
 	FIELD field_33755 placementRadius I
-		COMMENT the number of neighbouring chunks which can be accessed for block placement
+		COMMENT the number of neighboring chunks which can be accessed for block placement
 		COMMENT a value of 0 means that only this chunk is accessible, a positive values means that the given amount of neighbours are accessible in each direction, a negative value means that this region shouldn't be used for block placement
 	METHOD <init> (Lnet/minecraft/class_3218;Ljava/util/List;Lnet/minecraft/class_2806;I)V
 		ARG 1 world

--- a/mappings/net/minecraft/world/StructureWorldAccess.mapping
+++ b/mappings/net/minecraft/world/StructureWorldAccess.mapping
@@ -2,4 +2,6 @@ CLASS net/minecraft/class_5281 net/minecraft/world/StructureWorldAccess
 	METHOD method_30275 getStructures (Lnet/minecraft/class_4076;Lnet/minecraft/class_3195;)Ljava/util/stream/Stream;
 		ARG 1 pos
 		ARG 2 feature
+	METHOD method_37368 isValidForSetBlock (Lnet/minecraft/class_2338;)Z
+		ARG 1 pos
 	METHOD method_8412 getSeed ()J

--- a/mappings/net/minecraft/world/StructureWorldAccess.mapping
+++ b/mappings/net/minecraft/world/StructureWorldAccess.mapping
@@ -3,5 +3,7 @@ CLASS net/minecraft/class_5281 net/minecraft/world/StructureWorldAccess
 		ARG 1 pos
 		ARG 2 feature
 	METHOD method_37368 isValidForSetBlock (Lnet/minecraft/class_2338;)Z
+		COMMENT {@return {@code true} if the given position is an accessible position
+		COMMENT for the {@code setBlockState} function}
 		ARG 1 pos
 	METHOD method_8412 getSeed ()J


### PR DESCRIPTION
mappings for:
- a function which is used for validating a BlockPos before setting the block
- a field specifying in which radius the chunks around the center of a ChunkRegion are accessible
