### PR TITLE
Fix the names of style fields in the CommandSuggestor class indicating the wrong type

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/CommandSuggestor.mapping
+++ b/mappings/net/minecraft/client/gui/screen/CommandSuggestor.mapping
@@ -18,9 +18,9 @@ CLASS net/minecraft/class_4717 net/minecraft/client/gui/screen/CommandSuggestor
 	FIELD field_21612 window Lnet/minecraft/class_4717$class_464;
 	FIELD field_21613 windowActive Z
 	FIELD field_21614 completingSuggestions Z
-	FIELD field_25885 ERROR_FORMATTING Lnet/minecraft/class_2583;
-	FIELD field_25886 INFO_FORMATTING Lnet/minecraft/class_2583;
-	FIELD field_25887 HIGHLIGHT_FORMATTINGS Ljava/util/List;
+	FIELD field_25885 ERROR_STYLE Lnet/minecraft/class_2583;
+	FIELD field_25886 INFO_STYLE Lnet/minecraft/class_2583;
+	FIELD field_25887 HIGHLIGHT_STYLES Ljava/util/List;
 	METHOD <init> (Lnet/minecraft/class_310;Lnet/minecraft/class_437;Lnet/minecraft/class_342;Lnet/minecraft/class_327;ZZIIZI)V
 		ARG 1 client
 		ARG 2 owner


### PR DESCRIPTION
Fixes #2625