### PR TITLE
1.18-exp3 spawning

### DIFF
--- a/mappings/net/minecraft/entity/passive/GoatEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/GoatEntity.mapping
@@ -12,6 +12,12 @@ CLASS net/minecraft/class_6053 net/minecraft/entity/passive/GoatEntity
 	METHOD method_35180 getMilkingSound ()Lnet/minecraft/class_3414;
 	METHOD method_36284 setScreaming (Z)V
 		ARG 1 screaming
+	METHOD method_37833 canSpawn (Lnet/minecraft/class_1299;Lnet/minecraft/class_1936;Lnet/minecraft/class_3730;Lnet/minecraft/class_2338;Ljava/util/Random;)Z
+		ARG 0 entityType
+		ARG 1 world
+		ARG 2 spawnReason
+		ARG 3 pos
+		ARG 4 random
 	CLASS class_6339 GoatPathNodeMaker
 		FIELD field_33489 pos Lnet/minecraft/class_2338$class_2339;
 	CLASS class_6340 GoatNavigation

--- a/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
+++ b/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
@@ -164,6 +164,10 @@ CLASS net/minecraft/class_3898 net/minecraft/server/world/ThreadedAnvilChunkStor
 	METHOD method_34869 getChebyshevDistance (Lnet/minecraft/class_1923;Lnet/minecraft/class_1297;)I
 		ARG 0 chunkPos
 		ARG 1 entity
+	METHOD method_37831 (Lnet/minecraft/class_1923;Lnet/minecraft/class_3222;)Z
+		ARG 1 player
+	METHOD method_37832 getMobSpawnablePlayers (Lnet/minecraft/class_1923;)Ljava/util/List;
+		ARG 1 chunkPos
 	CLASS class_3208 EntityTracker
 		COMMENT An entity tracker governs which players' clients can see an entity. Each
 		COMMENT tracker corresponds to one entity in a server world and is mapped from the

--- a/mappings/net/minecraft/world/SpawnDensityCapper.mapping
+++ b/mappings/net/minecraft/world/SpawnDensityCapper.mapping
@@ -1,0 +1,32 @@
+CLASS net/minecraft/class_6480 net/minecraft/world/SpawnDensityCapper
+	FIELD field_34290 chunkPosToMobSpawnablePlayers Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;
+	FIELD field_34291 playersToDensityCap Ljava/util/HashMap;
+	FIELD field_34292 threadedAnvilChunkStorage Lnet/minecraft/class_3898;
+	FIELD field_34293 world Lnet/minecraft/class_3218;
+	METHOD <init> (Lnet/minecraft/class_3898;Lnet/minecraft/class_3218;)V
+		ARG 1 threadedAnvilChunkStorage
+		ARG 2 world
+	METHOD method_37834 getMobSpawnablePlayers (J)Ljava/util/List;
+		ARG 1 chunkPos
+	METHOD method_37835 increaseDensity (JLnet/minecraft/class_1311;)V
+		ARG 1 chunkPos
+		ARG 3 spawnGroup
+	METHOD method_37836 canSpawn (Lnet/minecraft/class_1311;Lnet/minecraft/class_1923;)Z
+		ARG 1 spawnGroup
+		ARG 2 chunkPos
+	METHOD method_37837 (Lnet/minecraft/class_1311;Lnet/minecraft/class_5568;)Z
+		ARG 2 player
+	METHOD method_37838 (Lnet/minecraft/class_5568;)Lnet/minecraft/class_6480$class_6481;
+		ARG 1 player
+	METHOD method_37839 canSpawn (Lnet/minecraft/class_5568;Lnet/minecraft/class_1311;)Z
+		ARG 1 player
+		ARG 2 spawnGroup
+	METHOD method_37840 (J)Ljava/util/List;
+		ARG 1 chunkPos
+	CLASS class_6481 DensityCap
+		FIELD field_34295 spawnGroupsToDensity Lit/unimi/dsi/fastutil/objects/Object2FloatMap;
+		METHOD method_37841 canSpawn (Lnet/minecraft/class_1311;)Z
+			ARG 1 spawnGroup
+		METHOD method_37842 increaseDensity (Lnet/minecraft/class_1311;F)V
+			ARG 1 spawnGroup
+			ARG 2 delta

--- a/mappings/net/minecraft/world/SpawnHelper.mapping
+++ b/mappings/net/minecraft/world/SpawnHelper.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/class_1948 net/minecraft/world/SpawnHelper
 	FIELD field_24392 CHUNK_AREA I
 	FIELD field_24393 SPAWNABLE_GROUPS [Lnet/minecraft/class_1311;
 	FIELD field_30974 MIN_SPAWN_DISTANCE I
+	FIELD field_34296 SUCCESSFUL_SPAWN_CHANCE F
 	FIELD field_9292 LOGGER Lorg/apache/logging/log4j/Logger;
 	METHOD method_24930 spawnEntitiesInChunk (Lnet/minecraft/class_1311;Lnet/minecraft/class_3218;Lnet/minecraft/class_2791;Lnet/minecraft/class_2338;Lnet/minecraft/class_1948$class_5261;Lnet/minecraft/class_1948$class_5259;)V
 		ARG 0 group
@@ -50,6 +51,8 @@ CLASS net/minecraft/class_1948 net/minecraft/world/SpawnHelper
 		ARG 0 world
 		ARG 1 structureAccessor
 		ARG 2 chunkGenerator
+		ARG 3 spawnGroup
+		ARG 4 pos
 		ARG 5 biome
 	METHOD method_35238 (Lnet/minecraft/class_1299;Lnet/minecraft/class_2338;Lnet/minecraft/class_2791;)Z
 		ARG 0 type
@@ -62,6 +65,15 @@ CLASS net/minecraft/class_1948 net/minecraft/world/SpawnHelper
 		ARG 0 group
 		ARG 1 world
 		ARG 2 pos
+	METHOD method_37843 getRandomPosInChunkSection (Lnet/minecraft/class_1937;Lnet/minecraft/class_2818;I)Lnet/minecraft/class_2338;
+		ARG 0 world
+		ARG 1 chunk
+		ARG 2 minY
+	METHOD method_37844 shouldSpawnFortressMonsters (Lnet/minecraft/class_2338;Lnet/minecraft/class_3218;Lnet/minecraft/class_1311;Lnet/minecraft/class_5138;)Z
+		ARG 0 pos
+		ARG 1 world
+		ARG 2 spawnGroup
+		ARG 3 structureAccessor
 	METHOD method_8658 getEntitySpawnPos (Lnet/minecraft/class_4538;Lnet/minecraft/class_1299;II)Lnet/minecraft/class_2338;
 		ARG 0 world
 		ARG 1 entityType
@@ -124,16 +136,24 @@ CLASS net/minecraft/class_1948 net/minecraft/world/SpawnHelper
 		FIELD field_24398 cachedPos Lnet/minecraft/class_2338;
 		FIELD field_24399 cachedEntityType Lnet/minecraft/class_1299;
 		FIELD field_24400 cachedDensityMass D
+		FIELD field_34297 densityCapper Lnet/minecraft/class_6480;
+		FIELD field_34298 biome Lnet/minecraft/class_1959;
 		METHOD <init> (ILit/unimi/dsi/fastutil/objects/Object2IntOpenHashMap;Lnet/minecraft/class_5263;Lnet/minecraft/class_6480;)V
 			ARG 1 spawningChunkCount
+			ARG 2 groupToCount
 			ARG 3 densityField
+			ARG 4 densityCapper
 		METHOD method_27823 getSpawningChunkCount ()I
 		METHOD method_27824 test (Lnet/minecraft/class_1299;Lnet/minecraft/class_2338;Lnet/minecraft/class_2791;)Z
 			COMMENT @see SpawnHelper.Checker#test(EntityType, BlockPos, Chunk)
 			ARG 1 type
+			ARG 2 pos
+			ARG 3 chunk
 		METHOD method_27825 run (Lnet/minecraft/class_1308;Lnet/minecraft/class_2791;)V
 			COMMENT @see SpawnHelper.Runner#run(MobEntity, Chunk)
 			ARG 1 entity
 			ARG 2 chunk
 		METHOD method_27826 isBelowCap (Lnet/minecraft/class_1311;Lnet/minecraft/class_1923;)Z
+			ARG 1 spawnGroup
+			ARG 2 chunkPos
 		METHOD method_27830 getGroupToCount ()Lit/unimi/dsi/fastutil/objects/Object2IntMap;

--- a/mappings/net/minecraft/world/SpawnHelper.mapping
+++ b/mappings/net/minecraft/world/SpawnHelper.mapping
@@ -132,7 +132,7 @@ CLASS net/minecraft/class_1948 net/minecraft/world/SpawnHelper
 		FIELD field_24399 cachedEntityType Lnet/minecraft/class_1299;
 		FIELD field_24400 cachedDensityMass D
 		FIELD field_34297 densityCapper Lnet/minecraft/class_6480;
-		FIELD field_34298 biome Lnet/minecraft/class_1959;
+		FIELD field_34298 cachedBiome Lnet/minecraft/class_1959;
 		METHOD <init> (ILit/unimi/dsi/fastutil/objects/Object2IntOpenHashMap;Lnet/minecraft/class_5263;Lnet/minecraft/class_6480;)V
 			ARG 1 spawningChunkCount
 			ARG 2 groupToCount

--- a/mappings/net/minecraft/world/SpawnHelper.mapping
+++ b/mappings/net/minecraft/world/SpawnHelper.mapping
@@ -69,11 +69,6 @@ CLASS net/minecraft/class_1948 net/minecraft/world/SpawnHelper
 		ARG 0 world
 		ARG 1 chunk
 		ARG 2 minY
-	METHOD method_37844 shouldSpawnFortressMonsters (Lnet/minecraft/class_2338;Lnet/minecraft/class_3218;Lnet/minecraft/class_1311;Lnet/minecraft/class_5138;)Z
-		ARG 0 pos
-		ARG 1 world
-		ARG 2 spawnGroup
-		ARG 3 structureAccessor
 	METHOD method_8658 getEntitySpawnPos (Lnet/minecraft/class_4538;Lnet/minecraft/class_1299;II)Lnet/minecraft/class_2338;
 		ARG 0 world
 		ARG 1 entityType


### PR DESCRIPTION
Yep yep, some conflicts with #2629, fixing...

Some interesting stuff:

- `SUCCESSFUL_SPAWN_CHANCE` is 0.24 (= only 24% of spawn attempts actually spawn)
- there's now per-chunk per-player? mob cap. Named it density cap, any better names?
- `getMobSpawnablePlayers` takes chunkPos and returns list of non-spectator players within 128 block radius of the chunk.