### PR TITLE
Fixed A Mapping Mismatch in A Constructor Method

### DIFF
--- a/mappings/net/minecraft/block/Material.mapping
+++ b/mappings/net/minecraft/block/Material.mapping
@@ -85,7 +85,7 @@ CLASS net/minecraft/class_3614 net/minecraft/block/Material
 		ARG 4 blocksMovement
 		ARG 5 blocksLight
 		ARG 6 burnable
-		ARG 7 breakByHand
+		ARG 7 replaceable
 		ARG 8 pistonBehavior
 	METHOD method_15797 isLiquid ()Z
 	METHOD method_15798 getPistonBehavior ()Lnet/minecraft/class_3619;

--- a/mappings/net/minecraft/block/Material.mapping
+++ b/mappings/net/minecraft/block/Material.mapping
@@ -84,8 +84,8 @@ CLASS net/minecraft/class_3614 net/minecraft/block/Material
 		ARG 3 solid
 		ARG 4 blocksMovement
 		ARG 5 blocksLight
-		ARG 6 breakByHand
-		ARG 7 burnable
+		ARG 6 burnable
+		ARG 7 breakByHand
 		ARG 8 pistonBehavior
 	METHOD method_15797 isLiquid ()Z
 	METHOD method_15798 getPistonBehavior ()Lnet/minecraft/class_3619;


### PR DESCRIPTION
The mapping of constructor method of net.minecraft.block.Material does not match correctly.
