### PR TITLE
Mapped parts of class_6466

### DIFF
--- a/mappings/net/minecraft/util/function/ToFloatFunction.mapping
+++ b/mappings/net/minecraft/util/function/ToFloatFunction.mapping
@@ -1,3 +1,8 @@
 CLASS net/minecraft/class_6468 net/minecraft/util/function/ToFloatFunction
+	METHOD apply (Ljava/lang/Object;)F
+		ARG 1 x
+	METHOD method_37748 (Lnet/minecraft/class_6462$class_6465;Lnet/minecraft/class_6468;Ljava/lang/Object;)F
+		ARG 3 x
 	METHOD method_37749 combine (Lnet/minecraft/class_6468;Lnet/minecraft/class_6462$class_6465;)Lnet/minecraft/class_6468;
 		ARG 1 other
+		ARG 2 combineFunction

--- a/mappings/net/minecraft/world/biome/source/BiomeSource.mapping
+++ b/mappings/net/minecraft/world/biome/source/BiomeSource.mapping
@@ -17,6 +17,9 @@ CLASS net/minecraft/class_1966 net/minecraft/world/biome/source/BiomeSource
 	METHOD method_37617 addDebugInfo (Ljava/util/List;Lnet/minecraft/class_2338;)V
 		ARG 1 info
 		ARG 2 pos
+	METHOD method_37845 getTerrainParameters (II)Lnet/minecraft/class_1966$class_6482;
+		ARG 1 x
+		ARG 2 z
 	METHOD method_8754 hasStructureFeature (Lnet/minecraft/class_3195;)Z
 		ARG 1 feature
 	METHOD method_8762 locateBiome (IIIILjava/util/function/Predicate;Ljava/util/Random;)Lnet/minecraft/class_2338;

--- a/mappings/net/minecraft/world/biome/source/BiomeSource.mapping
+++ b/mappings/net/minecraft/world/biome/source/BiomeSource.mapping
@@ -34,3 +34,11 @@ CLASS net/minecraft/class_1966 net/minecraft/world/biome/source/BiomeSource
 		ARG 2 y
 		ARG 3 z
 		ARG 4 radius
+	CLASS class_6482 TerrainParameters
+		FIELD field_34300 offset D
+		FIELD field_34301 factor D
+		FIELD field_34302 coast Z
+		METHOD <init> (DDZ)V
+			ARG 1 offset
+			ARG 3 factor
+			ARG 5 coast

--- a/mappings/net/minecraft/world/biome/source/MultiNoiseBiomeSource.mapping
+++ b/mappings/net/minecraft/world/biome/source/MultiNoiseBiomeSource.mapping
@@ -18,6 +18,7 @@ CLASS net/minecraft/class_4766 net/minecraft/world/biome/source/MultiNoiseBiomeS
 	FIELD field_34191 continentalnessNoise Lnet/minecraft/class_5216;
 	FIELD field_34192 erosionNoise Lnet/minecraft/class_5216;
 	FIELD field_34193 locationOffsetNoise Lnet/minecraft/class_5216;
+	FIELD field_34194 terrainParameters Lnet/minecraft/class_6466;
 	FIELD field_34195 minQuartY I
 	FIELD field_34196 maxQuartY I
 	METHOD <init> (JLnet/minecraft/class_6452$class_6455;Ljava/util/Optional;)V

--- a/mappings/net/minecraft/world/biome/source/util/VanillaBiomeParameters.mapping
+++ b/mappings/net/minecraft/world/biome/source/util/VanillaBiomeParameters.mapping
@@ -10,17 +10,19 @@ CLASS net/minecraft/class_6461 net/minecraft/world/biome/source/util/VanillaBiom
 	FIELD field_34206 OCEAN_CONTINENTALNESS Lnet/minecraft/class_6452$class_6454;
 	FIELD field_34207 SHORE_CONTINENTALNESS Lnet/minecraft/class_6452$class_6454;
 	FIELD field_34208 RIVER_CONTINENTALNESS Lnet/minecraft/class_6452$class_6454;
-	FIELD field_34209 NEXT_TO_SHORE_CONTINENTALNESS Lnet/minecraft/class_6452$class_6454;
-	FIELD field_34210 NEAR_SHORE_CONTINENTALNESS Lnet/minecraft/class_6452$class_6454;
-	FIELD field_34211 FAR_FROM_SHORE_CONTINENTALNESS Lnet/minecraft/class_6452$class_6454;
+	FIELD field_34209 NEAR_INLAND_CONTINENTALNESS Lnet/minecraft/class_6452$class_6454;
+	FIELD field_34210 MID_INLAND_CONTINENTALNESS Lnet/minecraft/class_6452$class_6454;
+	FIELD field_34211 FAR_INLAND_CONTINENTALNESS Lnet/minecraft/class_6452$class_6454;
 	FIELD field_34212 OCEAN_BIOMES [[Lnet/minecraft/class_5321;
 	FIELD field_34213 COMMON_BIOMES [[Lnet/minecraft/class_5321;
-	FIELD field_34214 SPECIAL_BIOMES [[Lnet/minecraft/class_5321;
+	FIELD field_34214 UNCOMMON_BIOMES [[Lnet/minecraft/class_5321;
 	FIELD field_34215 HILL_BIOMES [[Lnet/minecraft/class_5321;
-	FIELD field_34282 PLATEAU_BIOMES [[Lnet/minecraft/class_5321;
+	FIELD field_34282 NEAR_MOUNTAIN_BIOMES [[Lnet/minecraft/class_5321;
+	FIELD field_34313 SPECIAL_NEAR_MOUNTAIN_BIOMES [[Lnet/minecraft/class_5321;
 	METHOD method_37702 getHillBiome (IILnet/minecraft/class_6452$class_6454;)Lnet/minecraft/class_5321;
 		ARG 1 temperature
 		ARG 2 humidity
+		ARG 3 weirdness
 	METHOD method_37703 getRegularBiome (IILnet/minecraft/class_6452$class_6454;)Lnet/minecraft/class_5321;
 		ARG 1 temperature
 		ARG 2 humidity
@@ -39,7 +41,7 @@ CLASS net/minecraft/class_6461 net/minecraft/world/biome/source/util/VanillaBiom
 		ARG 6 weirdness
 		ARG 7 offset
 		ARG 8 biome
-	METHOD method_37708 getPlateauOrFrozenBiome (IILnet/minecraft/class_6452$class_6454;)Lnet/minecraft/class_5321;
+	METHOD method_37708 getNearMountainBiome (IILnet/minecraft/class_6452$class_6454;)Lnet/minecraft/class_5321;
 		ARG 1 temperature
 		ARG 2 humidity
 		ARG 3 weirdness
@@ -57,7 +59,7 @@ CLASS net/minecraft/class_6461 net/minecraft/world/biome/source/util/VanillaBiom
 		ARG 6 weirdness
 		ARG 7 offset
 		ARG 8 biome
-	METHOD method_37712 getMountainSlopesOrRegularBiome (IILnet/minecraft/class_6452$class_6454;)Lnet/minecraft/class_5321;
+	METHOD method_37712 getMountainSlopeBiome (IILnet/minecraft/class_6452$class_6454;)Lnet/minecraft/class_5321;
 		ARG 1 temperature
 		ARG 2 humidity
 		ARG 3 weirdness
@@ -76,3 +78,32 @@ CLASS net/minecraft/class_6461 net/minecraft/world/biome/source/util/VanillaBiom
 	METHOD method_37718 writeRiverBiomes (Lcom/google/common/collect/ImmutableList$Builder;Lnet/minecraft/class_6452$class_6454;)V
 		ARG 1 parameters
 		ARG 2 weirdness
+	METHOD method_37846 getBiomeOrShatteredSavanna (ILnet/minecraft/class_5321;)Lnet/minecraft/class_5321;
+		ARG 1 temperature
+		ARG 2 biome
+	METHOD method_37847 (Lcom/google/common/collect/ImmutableList$Builder;)V
+		ARG 1 parameters
+	METHOD method_37855 getWeirdnessDescription (D)Ljava/lang/String;
+		ARG 0 weirdness
+	METHOD method_37856 getNoiseRangeIndex (D[Lnet/minecraft/class_6452$class_6454;)Ljava/lang/String;
+		ARG 1 noise
+		ARG 3 ranges
+	METHOD method_37857 getBadlandsBiome (ILnet/minecraft/class_6452$class_6454;)Lnet/minecraft/class_5321;
+		ARG 1 humidity
+		ARG 2 weirdness
+	METHOD method_37858 getContinentalnessDescription (D)Ljava/lang/String;
+		ARG 1 continentalness
+	METHOD method_37859 getBadlandsOrRegularBiome (IILnet/minecraft/class_6452$class_6454;)Lnet/minecraft/class_5321;
+		ARG 1 temperature
+		ARG 2 humidity
+		ARG 3 weirdness
+	METHOD method_37860 getErosionDescription (D)Ljava/lang/String;
+		ARG 1 erosion
+	METHOD method_37861 getTemperatureDescription (D)Ljava/lang/String;
+		ARG 1 temperature
+	METHOD method_37862 getPeakBiome (IILnet/minecraft/class_6452$class_6454;)Lnet/minecraft/class_5321;
+		ARG 1 temperature
+		ARG 2 humidity
+		ARG 3 weirdness
+	METHOD method_37863 getHumidityDescription (D)Ljava/lang/String;
+		ARG 1 humidity

--- a/mappings/net/minecraft/world/biome/source/util/VanillaTerrainParameters.mapping
+++ b/mappings/net/minecraft/world/biome/source/util/VanillaTerrainParameters.mapping
@@ -1,8 +1,9 @@
-CLASS net/minecraft/class_6466
+CLASS net/minecraft/class_6466 net/minecraft/world/biome/source/util/VanillaTerrainParameters
+	FIELD field_34228 OFFSET_VALUE_OFFSET F
 	FIELD field_34229 offsetSpline Lnet/minecraft/class_6468;
 	FIELD field_34230 factorSpline Lnet/minecraft/class_6468;
 	METHOD method_37730 init ()V
-	METHOD method_37731 (F)F
+	METHOD method_37731 getNormalizedWeirdness (F)F
 		ARG 0 weirdness
 	METHOD method_37732 createTerrainNoisePoint (FFF)Lnet/minecraft/class_6466$class_6467;
 		ARG 1 continentalnessNoise
@@ -10,20 +11,29 @@ CLASS net/minecraft/class_6466
 		ARG 3 weirdnessNoise
 	METHOD method_37734 getOffset (Lnet/minecraft/class_6466$class_6467;)F
 		ARG 1 point
-	METHOD method_37735 (Ljava/lang/String;FFFFF)Lnet/minecraft/class_6462;
+	METHOD method_37735 createFlatOffsetSpline (Ljava/lang/String;FFFFF)Lnet/minecraft/class_6462;
 		ARG 0 name
-	METHOD method_37736 (Ljava/lang/String;FFFFFFF)Lnet/minecraft/class_6462;
+	METHOD method_37736 createLandSpline (Ljava/lang/String;FFFFFFF)Lnet/minecraft/class_6462;
 		ARG 0 name
+		ARG 5 continentalness
 	METHOD method_37737 buildErosionFactorSpline (Ljava/lang/String;FZLjava/lang/String;)Lnet/minecraft/class_6462;
 		ARG 0 erosionName
 		ARG 1 value
 		ARG 2 addShatteredRidges
 		ARG 3 weirdnessName
-	METHOD method_37741 (FFF)F
+	METHOD method_37738 debug ([Ljava/lang/String;)V
+	METHOD method_37739 createSimpleOffsetSpline ()Lnet/minecraft/class_6462;
+	METHOD method_37740 createMountainousOffsetSpline (F)Lnet/minecraft/class_6462;
+		ARG 0 continentalness
+	METHOD method_37741 getOffsetValue (FFF)F
+		ARG 0 weirdness
 		ARG 1 continentalness
+		ARG 2 weirdnessThreshold
 	METHOD method_37742 getFactor (Lnet/minecraft/class_6466$class_6467;)F
 		ARG 1 point
-	METHOD method_37743 (F)Lnet/minecraft/class_6462;
+	METHOD method_37743 createLandSpline (F)Lnet/minecraft/class_6462;
+		ARG 0 continentalness
+	METHOD method_37744 (F)F
 		ARG 0 continentalness
 	CLASS class_6467 TerrainNoisePoint
 		FIELD field_34231 continentalnessNoise F

--- a/mappings/net/minecraft/world/biome/source/util/VanillaTerrainParameters.mapping
+++ b/mappings/net/minecraft/world/biome/source/util/VanillaTerrainParameters.mapping
@@ -15,7 +15,6 @@ CLASS net/minecraft/class_6466 net/minecraft/world/biome/source/util/VanillaTerr
 		ARG 0 name
 	METHOD method_37736 createLandSpline (Ljava/lang/String;FFFFFFFZZ)Lnet/minecraft/class_6462;
 		ARG 0 name
-		ARG 5 continentalness
 	METHOD method_37737 buildErosionFactorSpline (Ljava/lang/String;FZLjava/lang/String;)Lnet/minecraft/class_6462;
 		ARG 0 erosionName
 		ARG 1 value


### PR DESCRIPTION
This class creates two splines which are used to calculate the terrain parameters returned in `method_37845` from the noise values of continentalness, erosion and weirdness.