### PR TITLE
1.18-exp4 stuff

### DIFF
--- a/mappings/net/minecraft/structure/ShiftableStructurePiece.mapping
+++ b/mappings/net/minecraft/structure/ShiftableStructurePiece.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3418 net/minecraft/structure/StructurePieceWithDimensions
+CLASS net/minecraft/class_3418 net/minecraft/structure/ShiftableStructurePiece
 	FIELD field_15241 hPos I
 	FIELD field_15242 depth I
 	FIELD field_15243 height I
@@ -12,10 +12,11 @@ CLASS net/minecraft/class_3418 net/minecraft/structure/StructurePieceWithDimensi
 		ARG 6 height
 		ARG 7 depth
 		ARG 8 orientation
-	METHOD method_14839 (Lnet/minecraft/class_1936;Lnet/minecraft/class_3341;I)Z
+	METHOD method_14839 adjustToAverageHeight (Lnet/minecraft/class_1936;Lnet/minecraft/class_3341;I)Z
 		ARG 1 world
 		ARG 2 boundingBox
-	METHOD method_37865 bury (Lnet/minecraft/class_1936;Lnet/minecraft/class_3341;I)Z
+		ARG 3 deltaY
+	METHOD method_37865 adjustToMinHeight (Lnet/minecraft/class_1936;Lnet/minecraft/class_3341;I)Z
 		ARG 1 world
 		ARG 2 boundingBox
 		ARG 3 deltaY

--- a/mappings/net/minecraft/structure/StructurePieceWithDimensions.mapping
+++ b/mappings/net/minecraft/structure/StructurePieceWithDimensions.mapping
@@ -15,3 +15,7 @@ CLASS net/minecraft/class_3418 net/minecraft/structure/StructurePieceWithDimensi
 	METHOD method_14839 (Lnet/minecraft/class_1936;Lnet/minecraft/class_3341;I)Z
 		ARG 1 world
 		ARG 2 boundingBox
+	METHOD method_37865 bury (Lnet/minecraft/class_1936;Lnet/minecraft/class_3341;I)Z
+		ARG 1 world
+		ARG 2 boundingBox
+		ARG 3 deltaY

--- a/mappings/net/minecraft/world/gen/feature/DefaultBiomeFeatures.mapping
+++ b/mappings/net/minecraft/world/gen/feature/DefaultBiomeFeatures.mapping
@@ -89,7 +89,7 @@ CLASS net/minecraft/class_3864 net/minecraft/world/gen/feature/DefaultBiomeFeatu
 		ARG 0 builder
 	METHOD method_17006 addDefaultOres (Lnet/minecraft/class_5485$class_5495;Z)V
 		ARG 0 builder
-		ARG 1 largeCopperOre
+		ARG 1 largeCopperOreBlob
 	METHOD method_17007 addExtraGoldOre (Lnet/minecraft/class_5485$class_5495;)V
 		ARG 0 builder
 	METHOD method_17008 addEmeraldOre (Lnet/minecraft/class_5485$class_5495;)V

--- a/mappings/net/minecraft/world/gen/feature/DefaultBiomeFeatures.mapping
+++ b/mappings/net/minecraft/world/gen/feature/DefaultBiomeFeatures.mapping
@@ -89,6 +89,7 @@ CLASS net/minecraft/class_3864 net/minecraft/world/gen/feature/DefaultBiomeFeatu
 		ARG 0 builder
 	METHOD method_17006 addDefaultOres (Lnet/minecraft/class_5485$class_5495;Z)V
 		ARG 0 builder
+		ARG 1 largeCopperOre
 	METHOD method_17007 addExtraGoldOre (Lnet/minecraft/class_5485$class_5495;)V
 		ARG 0 builder
 	METHOD method_17008 addEmeraldOre (Lnet/minecraft/class_5485$class_5495;)V
@@ -178,4 +179,6 @@ CLASS net/minecraft/class_3864 net/minecraft/world/gen/feature/DefaultBiomeFeatu
 	METHOD method_35924 addCaveWaterMobs (Lnet/minecraft/class_5483$class_5496;)V
 		ARG 0 builder
 	METHOD method_37794 addMeadowFlowers (Lnet/minecraft/class_5485$class_5495;)V
+		ARG 0 builder
+	METHOD method_37868 addDefaultOres (Lnet/minecraft/class_5485$class_5495;)V
 		ARG 0 builder

--- a/mappings/net/minecraft/world/gen/feature/StructureFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/StructureFeature.mapping
@@ -94,6 +94,12 @@ CLASS net/minecraft/class_3195 net/minecraft/world/gen/feature/StructureFeature
 	METHOD method_28664 init ()V
 	METHOD method_28665 getCodec ()Lcom/mojang/serialization/Codec;
 	METHOD method_36420 getUndergroundWaterCreatureSpawns ()Lnet/minecraft/class_6012;
+	METHOD method_37864 getLowestCornerSurfaceHeight (Lnet/minecraft/class_2794;IILnet/minecraft/class_1923;Lnet/minecraft/class_5539;)I
+		ARG 0 generator
+		ARG 1 width
+		ARG 2 height
+		ARG 3 chunkPos
+		ARG 4 world
 	CLASS class_3774 StructureStartFactory
 		METHOD create (Lnet/minecraft/class_3195;Lnet/minecraft/class_1923;IJ)Lnet/minecraft/class_3449;
 			ARG 1 feature

--- a/mappings/net/minecraft/world/gen/feature/StructureFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/StructureFeature.mapping
@@ -94,7 +94,7 @@ CLASS net/minecraft/class_3195 net/minecraft/world/gen/feature/StructureFeature
 	METHOD method_28664 init ()V
 	METHOD method_28665 getCodec ()Lcom/mojang/serialization/Codec;
 	METHOD method_36420 getUndergroundWaterCreatureSpawns ()Lnet/minecraft/class_6012;
-	METHOD method_37864 getLowestCornerSurfaceHeight (Lnet/minecraft/class_2794;IILnet/minecraft/class_1923;Lnet/minecraft/class_5539;)I
+	METHOD method_37864 getLowestCornerInGroundHeight (Lnet/minecraft/class_2794;IILnet/minecraft/class_1923;Lnet/minecraft/class_5539;)I
 		ARG 0 generator
 		ARG 1 deltaX
 		ARG 2 deltaZ

--- a/mappings/net/minecraft/world/gen/feature/StructureFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/StructureFeature.mapping
@@ -96,8 +96,8 @@ CLASS net/minecraft/class_3195 net/minecraft/world/gen/feature/StructureFeature
 	METHOD method_36420 getUndergroundWaterCreatureSpawns ()Lnet/minecraft/class_6012;
 	METHOD method_37864 getLowestCornerSurfaceHeight (Lnet/minecraft/class_2794;IILnet/minecraft/class_1923;Lnet/minecraft/class_5539;)I
 		ARG 0 generator
-		ARG 1 width
-		ARG 2 height
+		ARG 1 deltaX
+		ARG 2 deltaZ
 		ARG 3 chunkPos
 		ARG 4 world
 	CLASS class_3774 StructureStartFactory


### PR DESCRIPTION
Maps methods used by templates and new ore generation.

- `bury` prob needs javadoc , it's more like a side-effect-ful `canGenerate`: if it cannot generate, false, and if it can, then increase height by `deltaY` blocks (and since it is used with negative delta, bury by `-deltaY` blocks) and return true.
- `largeCopperOre` is true only in dripstone caves.
- `getLowestCornerSurfaceHeight` is just that; get min surface height of 4 corners from heightmap, and return lowest value. "width" and "height" here is deltaX and deltaZ, though I am not sure which one is better. This is used to check if the area (or, the corners) are filled with water in temple generation.