### PR TITLE
Update method mappings in RecipesProvider

### DIFF
--- a/mappings/net/minecraft/data/server/RecipesProvider.mapping
+++ b/mappings/net/minecraft/data/server/RecipesProvider.mapping
@@ -224,14 +224,14 @@ CLASS net/minecraft/class_2446 net/minecraft/data/server/RecipesProvider
 	METHOD method_33714 convertBetween (Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;)Ljava/lang/String;
 		ARG 0 from
 		ARG 1 to
-	METHOD method_33715 offerRecipe (Ljava/util/function/Consumer;Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;I)V
+	METHOD method_33715 offerStonecuttingRecipe (Ljava/util/function/Consumer;Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;I)V
 		ARG 0 exporter
 		ARG 1 output
 		ARG 2 input
 		ARG 3 count
 	METHOD method_33716 getItemPath (Lnet/minecraft/class_1935;)Ljava/lang/String;
 		ARG 0 item
-	METHOD method_33717 offerRecipe (Ljava/util/function/Consumer;Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;)V
+	METHOD method_33717 offerStonecuttingRecipe (Ljava/util/function/Consumer;Lnet/minecraft/class_1935;Lnet/minecraft/class_1935;)V
 		ARG 0 exporter
 		ARG 1 output
 		ARG 2 input


### PR DESCRIPTION
The offerRecipe methods in the RecipesProvider class are actually creating a stonecutter recipe (it appends the "_stonecutting" suffix).

Went with "offerStonecuttingRecipe" (with an "ing" instead of "er") to disambiguate from a method that would create a recipe for crafting stonecutters.