### PR TITLE
Add a note for where to get server's actual dynamic registry entries

### DIFF
--- a/mappings/net/minecraft/util/registry/BuiltinRegistries.mapping
+++ b/mappings/net/minecraft/util/registry/BuiltinRegistries.mapping
@@ -1,6 +1,13 @@
 CLASS net/minecraft/class_5458 net/minecraft/util/registry/BuiltinRegistries
 	COMMENT Stores a few hardcoded registries with builtin values for datapack-loadable registries,
 	COMMENT from which a registry tracker can create a new dynamic registry.
+	COMMENT
+	COMMENT <p>Note that these registries do not contain the actual entries that the server has,
+	COMMENT for that you will need to access it from {@link net.minecraft.util.registry.DynamicRegistryManager}.
+	COMMENT
+	COMMENT @see net.minecraft.server.MinecraftServer#getRegistryManager()
+	COMMENT @see net.minecraft.client.network.ClientPlayNetworkHandler#getRegistryManager()
+	COMMENT @see net.minecraft.util.registry.DynamicRegistryManager#get(RegistryKey)
 	FIELD field_25925 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_25926 REGISTRIES Lnet/minecraft/class_2378;
 	FIELD field_25927 CONFIGURED_SURFACE_BUILDER Lnet/minecraft/class_2378;


### PR DESCRIPTION
https://github.com/FabricMC/fabric/issues/1678 makes it clear that entries from `BuiltinRegistries` are different from what the server actually has.