### PR TITLE
1.18-exp6 Chase command

### DIFF
--- a/mappings/net/minecraft/server/chase/ChaseClient.mapping
+++ b/mappings/net/minecraft/server/chase/ChaseClient.mapping
@@ -1,0 +1,17 @@
+CLASS net/minecraft/class_6486 net/minecraft/server/chase/ChaseClient
+	FIELD field_34352 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_34354 ip Ljava/lang/String;
+	FIELD field_34355 port I
+	FIELD field_34356 minecraftServer Lnet/minecraft/server/MinecraftServer;
+	FIELD field_34357 running Z
+	FIELD field_34358 socket Ljava/net/Socket;
+	FIELD field_34359 thread Ljava/lang/Thread;
+	METHOD <init> (Ljava/lang/String;ILnet/minecraft/server/MinecraftServer;)V
+		ARG 1 ip
+		ARG 2 port
+		ARG 3 minecraftServer
+	METHOD method_37875 start ()V
+	METHOD method_37876 executeCommand (Ljava/lang/String;)V
+		ARG 1 command
+	METHOD method_37877 stop ()V
+	METHOD method_37878 run ()V

--- a/mappings/net/minecraft/server/chase/ChaseServer.mapping
+++ b/mappings/net/minecraft/server/chase/ChaseServer.mapping
@@ -1,0 +1,18 @@
+CLASS net/minecraft/class_6487 net/minecraft/server/chase/ChaseServer
+	FIELD field_34360 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_34361 port I
+	FIELD field_34362 playerManager Lnet/minecraft/class_3324;
+	FIELD field_34363 interval I
+	FIELD field_34364 running Z
+	FIELD field_34365 socket Ljava/net/ServerSocket;
+	METHOD <init> (ILnet/minecraft/class_3324;I)V
+		ARG 1 port
+		ARG 2 playerManager
+		ARG 3 interval
+	METHOD method_37879 start ()V
+	METHOD method_37880 writeCommandToStream (Ljava/io/DataOutputStream;)V
+		ARG 1 stream
+	METHOD method_37881 streamCommand (Ljava/net/Socket;)V
+		ARG 1 socket
+	METHOD method_37882 stop ()V
+	METHOD method_37884 run ()V

--- a/mappings/net/minecraft/server/command/ChaseCommand.mapping
+++ b/mappings/net/minecraft/server/command/ChaseCommand.mapping
@@ -1,0 +1,14 @@
+CLASS net/minecraft/class_6488 net/minecraft/server/command/ChaseCommand
+	FIELD field_34366 server Lnet/minecraft/class_6487;
+	FIELD field_34367 client Lnet/minecraft/class_6486;
+	METHOD method_37885 register (Lcom/mojang/brigadier/CommandDispatcher;)V
+		ARG 0 dispatcher
+	METHOD method_37887 stop (Lnet/minecraft/class_2168;)I
+		ARG 0 source
+	METHOD method_37888 startServer (Lnet/minecraft/class_2168;I)I
+		ARG 0 source
+		ARG 1 port
+	METHOD method_37889 startClient (Lnet/minecraft/class_2168;Ljava/lang/String;I)I
+		ARG 0 source
+		ARG 1 ip
+		ARG 2 port


### PR DESCRIPTION
Maps the new Chase command, and its associated classes. Note this command isn't registered by default, and thus cannot be used in-game without mods.

The Chase command synchronizes the movements of a player in two different instances of the game, as seen [on twitter here.](https://twitter.com/henrikkniberg/status/1432375731586277376?s=20)