### PR TITLE
Allow regular builds to produce artifacts (notably javadocs) for inspection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       - run: ./gradlew build javadocJar checkMappings --stacktrace
       - name: Build artifacts
-        if: ${{ matrix.java == '16-jdk' }}
+        if: ${{ matrix.java == '17-jdk' }}
         continue-on-error: true
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
A piece of vestige left in the ci java version bump.

The source level for the yarn javadoc/package/constants will stay at 16 until mojang bumps (which I would expect to happen very quickly as 16 is already EOL now)