### PR TITLE
21w37a version and shared constants

### DIFF
--- a/mappings/net/minecraft/SaveVersion.mapping
+++ b/mappings/net/minecraft/SaveVersion.mapping
@@ -25,7 +25,8 @@ CLASS net/minecraft/class_6595 net/minecraft/SaveVersion
 		ARG 1 other
 	METHOD method_38494 getId ()I
 		COMMENT {@return the integer data version of this save version}
-	METHOD method_38495 hasOldWorldHeight ()Z
-		COMMENT This method always returns {@code false}, but its usage appears to
-		COMMENT indicate that it returns if this save version has the old 0 to 255 world
-		COMMENT height limit.
+	METHOD method_38495 hasNewWorldHeight ()Z
+		COMMENT {@reeturn if this save version has the new -64 to 319 world height limit.}
+		COMMENT
+		COMMENT <p>This corresponds to world versions {@code 2693} to {@code 2706}, or
+		COMMENT game versions 21w06a to 21w14a.

--- a/mappings/net/minecraft/SaveVersion.mapping
+++ b/mappings/net/minecraft/SaveVersion.mapping
@@ -25,7 +25,7 @@ CLASS net/minecraft/class_6595 net/minecraft/SaveVersion
 		ARG 1 other
 	METHOD method_38494 getId ()I
 		COMMENT {@return the integer data version of this save version}
-	METHOD method_38495 hasNewWorldHeight ()Z
+	METHOD method_38495 hasIncompatibleWorldHeight ()Z
 		COMMENT {@return if this save version has the new -64 to 319 world height limit}
 		COMMENT
 		COMMENT <p>This corresponds to world versions {@code 2693} to {@code 2706}, or

--- a/mappings/net/minecraft/SaveVersion.mapping
+++ b/mappings/net/minecraft/SaveVersion.mapping
@@ -26,7 +26,7 @@ CLASS net/minecraft/class_6595 net/minecraft/SaveVersion
 	METHOD method_38494 getId ()I
 		COMMENT {@return the integer data version of this save version}
 	METHOD method_38495 hasNewWorldHeight ()Z
-		COMMENT {@reeturn if this save version has the new -64 to 319 world height limit.}
+		COMMENT {@return if this save version has the new -64 to 319 world height limit}
 		COMMENT
 		COMMENT <p>This corresponds to world versions {@code 2693} to {@code 2706}, or
 		COMMENT game versions 21w06a to 21w14a.

--- a/mappings/net/minecraft/SharedConstants.mapping
+++ b/mappings/net/minecraft/SharedConstants.mapping
@@ -22,7 +22,7 @@ CLASS net/minecraft/class_155 net/minecraft/SharedConstants
 	FIELD field_29739 DATA_PACK_VERSION I
 	FIELD field_29740 DATA_VERSION_KEY Ljava/lang/String;
 	FIELD field_34371 DEBUG_BIOME_SOURCE Z
-	FIELD field_34373 MAIN_SERIES Ljava/lang/String;
+	FIELD field_34373 CURRENT_SERIES Ljava/lang/String;
 	METHOD method_16673 getGameVersion ()Lnet/minecraft/class_6489;
 	METHOD method_31372 getProtocolVersion ()I
 	METHOD method_34872 setGameVersion (Lnet/minecraft/class_6489;)V

--- a/mappings/net/minecraft/SharedConstants.mapping
+++ b/mappings/net/minecraft/SharedConstants.mapping
@@ -18,8 +18,11 @@ CLASS net/minecraft/class_155 net/minecraft/SharedConstants
 	FIELD field_29734 RELEASE_TARGET Ljava/lang/String;
 	FIELD field_29735 RELEASE_TARGET_PROTOCOL_VERSION I
 	FIELD field_29737 SNBT_TOO_OLD_THRESHOLD I
+	FIELD field_29738 RESOURCE_PACK_VERSION I
+	FIELD field_29739 DATA_PACK_VERSION I
 	FIELD field_29740 DATA_VERSION_KEY Ljava/lang/String;
 	FIELD field_34371 DEBUG_BIOME_SOURCE Z
+	FIELD field_34373 MAIN_SERIES Ljava/lang/String;
 	METHOD method_16673 getGameVersion ()Lnet/minecraft/class_6489;
 	METHOD method_31372 getProtocolVersion ()I
 	METHOD method_34872 setGameVersion (Lnet/minecraft/class_6489;)V

--- a/mappings/net/minecraft/client/gui/screen/world/WorldListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/screen/world/WorldListWidget.mapping
@@ -7,7 +7,7 @@ CLASS net/minecraft/class_528 net/minecraft/client/gui/screen/world/WorldListWid
 	FIELD field_26608 SNAPSHOT_FIRST_LINE Lnet/minecraft/class_2561;
 	FIELD field_26609 SNAPSHOT_SECOND_LINE Lnet/minecraft/class_2561;
 	FIELD field_26610 LOCKED_TEXT Lnet/minecraft/class_2561;
-	FIELD field_28857 PRE_WORLDHEIGHT_TEXT Lnet/minecraft/class_2561;
+	FIELD field_28857 INCOMPATIBLE_WORLDHEIGHT_TEXT Lnet/minecraft/class_2561;
 	FIELD field_3237 parent Lnet/minecraft/class_526;
 	FIELD field_3238 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_3239 levels Ljava/util/List;

--- a/mappings/net/minecraft/world/level/storage/LevelSummary.mapping
+++ b/mappings/net/minecraft/world/level/storage/LevelSummary.mapping
@@ -29,14 +29,14 @@ CLASS net/minecraft/class_34 net/minecraft/world/level/storage/LevelSummary
 	METHOD method_27430 createDetails ()Lnet/minecraft/class_2561;
 	METHOD method_29586 getVersionInfo ()Lnet/minecraft/class_5315;
 	METHOD method_33405 getConversionWarning ()Lnet/minecraft/class_34$class_5781;
-	METHOD method_33783 isPostWorldHeightChangeVersion ()Z
+	METHOD method_33783 hasIncompatibleWorldHeight ()Z
 		COMMENT Returns whether the level is from a version after the world height was changed to -64 to 320.
 		COMMENT
 		COMMENT <p>This corresponds to world versions {@code 2693} to {@code 2706}, or
 		COMMENT game versions 21w06a to 21w14a.
 	METHOD method_33784 isUnavailable ()Z
 	METHOD method_35505 getLevelInfo ()Lnet/minecraft/class_1940;
-	METHOD method_38496 isAvailable ()Z
+	METHOD method_38496 isVersionAvailable ()Z
 	CLASS class_5781 ConversionWarning
 		FIELD field_28440 backup Z
 		FIELD field_28441 boldRedFormatting Z

--- a/mappings/net/minecraft/world/level/storage/LevelSummary.mapping
+++ b/mappings/net/minecraft/world/level/storage/LevelSummary.mapping
@@ -29,12 +29,14 @@ CLASS net/minecraft/class_34 net/minecraft/world/level/storage/LevelSummary
 	METHOD method_27430 createDetails ()Lnet/minecraft/class_2561;
 	METHOD method_29586 getVersionInfo ()Lnet/minecraft/class_5315;
 	METHOD method_33405 getConversionWarning ()Lnet/minecraft/class_34$class_5781;
-	METHOD method_33783 isPreWorldHeightChangeVersion ()Z
-		COMMENT Returns whether the level is from a version before the world height was changed to -64 to 320.
+	METHOD method_33783 isPostWorldHeightChangeVersion ()Z
+		COMMENT Returns whether the level is from a version after the world height was changed to -64 to 320.
 		COMMENT
-		COMMENT <p>This includes world versions {@code 2692} and earlier (21w05b and earlier).
+		COMMENT <p>This corresponds to world versions {@code 2693} to {@code 2706}, or
+		COMMENT game versions 21w06a to 21w14a.
 	METHOD method_33784 isUnavailable ()Z
 	METHOD method_35505 getLevelInfo ()Lnet/minecraft/class_1940;
+	METHOD method_38496 isAvailable ()Z
 	CLASS class_5781 ConversionWarning
 		FIELD field_28440 backup Z
 		FIELD field_28441 boldRedFormatting Z


### PR DESCRIPTION
There's some confusing changes (e.g. worlds with new height is UNavailable, but doesn't look like worlds with old heights are unavailable)