### PR TITLE
Map some palette stuff

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ cfr_version=0.0.6
 # Javadoc generation/linking
 fabric_loader_version=0.11.6
 jetbrains_annotations_version=21.0.1
-mappingpoet_version=0.2.9
+mappingpoet_version=0.2.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ cfr_version=0.0.6
 # Javadoc generation/linking
 fabric_loader_version=0.11.6
 jetbrains_annotations_version=21.0.1
-mappingpoet_version=0.2.8
+mappingpoet_version=0.2.9

--- a/mappings/net/minecraft/class_6490.mapping
+++ b/mappings/net/minecraft/class_6490.mapping
@@ -1,8 +1,0 @@
-CLASS net/minecraft/class_6490
-	METHOD method_15210 set (II)V
-	METHOD method_15211 get (I)I
-	METHOD method_15212 getStorage ()[J
-	METHOD method_15214 setAndGetOldValue (II)I
-	METHOD method_15215 getSize ()I
-	METHOD method_21739 forEach (Ljava/util/function/IntConsumer;)V
-	METHOD method_34896 getElementBits ()I

--- a/mappings/net/minecraft/util/collection/EmptyPaletteStorage.mapping
+++ b/mappings/net/minecraft/util/collection/EmptyPaletteStorage.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_6502 net/minecraft/util/collection/EmptyPaletteStorage
 	COMMENT An empty palette storage has a size, but all its elements are 0.
-	FIELD field_34401 EMPTY_STORAGE [J
+	FIELD field_34401 EMPTY_DATA [J
 	FIELD field_34402 size I
 	METHOD <init> (I)V
 		ARG 1 size

--- a/mappings/net/minecraft/util/collection/EmptyPaletteStorage.mapping
+++ b/mappings/net/minecraft/util/collection/EmptyPaletteStorage.mapping
@@ -1,0 +1,6 @@
+CLASS net/minecraft/class_6502 net/minecraft/util/collection/EmptyPaletteStorage
+	COMMENT An empty palette storage has a size, but all its elements are 0.
+	FIELD field_34401 EMPTY_STORAGE [J
+	FIELD field_34402 size I
+	METHOD <init> (I)V
+		ARG 1 size

--- a/mappings/net/minecraft/util/collection/IndexedIterable.mapping
+++ b/mappings/net/minecraft/util/collection/IndexedIterable.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_2359 net/minecraft/util/collection/IndexedIterable
+	FIELD field_34829 ABSENT_RAW_ID I
 	METHOD method_10200 get (I)Ljava/lang/Object;
 		ARG 1 index
 	METHOD method_10204 size ()I

--- a/mappings/net/minecraft/util/collection/Int2ObjectBiMap.mapping
+++ b/mappings/net/minecraft/util/collection/Int2ObjectBiMap.mapping
@@ -5,6 +5,8 @@ CLASS net/minecraft/class_3513 net/minecraft/util/collection/Int2ObjectBiMap
 	FIELD field_15649 nextId I
 	FIELD field_15650 EMPTY Ljava/lang/Object;
 	FIELD field_15651 values [Ljava/lang/Object;
+	FIELD field_29828 ABSENT I
+	FIELD field_29829 LOAD_FACTOR F
 	METHOD <init> (I)V
 		ARG 1 size
 	METHOD method_15222 getIdFromIndex (I)I
@@ -29,3 +31,5 @@ CLASS net/minecraft/class_3513 net/minecraft/util/collection/Int2ObjectBiMap
 		ARG 1 index
 	METHOD method_34904 contains (Ljava/lang/Object;)Z
 		ARG 1 value
+	METHOD method_37913 create (I)Lnet/minecraft/class_3513;
+		ARG 0 expectedSize

--- a/mappings/net/minecraft/util/collection/PackedIntegerArray.mapping
+++ b/mappings/net/minecraft/util/collection/PackedIntegerArray.mapping
@@ -21,6 +21,10 @@ CLASS net/minecraft/class_3508 net/minecraft/util/collection/PackedIntegerArray
 	METHOD <init> (II)V
 		ARG 1 elementBits
 		ARG 2 size
+	METHOD <init> (IILjava/util/stream/IntStream;)V
+		ARG 1 elementBits
+		ARG 2 size
+		ARG 3 values
 	METHOD <init> (II[J)V
 		ARG 1 elementBits
 		ARG 2 size
@@ -37,3 +41,5 @@ CLASS net/minecraft/class_3508 net/minecraft/util/collection/PackedIntegerArray
 		ARG 1 consumer
 	METHOD method_27284 getStorageIndex (I)I
 		ARG 1 index
+	METHOD method_37972 (Lorg/apache/commons/lang3/mutable/MutableInt;I)V
+		ARG 2 value

--- a/mappings/net/minecraft/util/collection/PackedIntegerArray.mapping
+++ b/mappings/net/minecraft/util/collection/PackedIntegerArray.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_3508 net/minecraft/util/collection/PackedIntegerArray
-	FIELD field_15631 storage [J
+	FIELD field_15631 data [J
 	FIELD field_15632 size I
 	FIELD field_15633 elementBits I
 	FIELD field_15634 maxValue J
@@ -28,7 +28,7 @@ CLASS net/minecraft/class_3508 net/minecraft/util/collection/PackedIntegerArray
 	METHOD <init> (II[J)V
 		ARG 1 elementBits
 		ARG 2 size
-		ARG 3 storage
+		ARG 3 data
 	METHOD method_15210 (II)V
 		ARG 1 index
 		ARG 2 value

--- a/mappings/net/minecraft/util/collection/PaletteStorage.mapping
+++ b/mappings/net/minecraft/util/collection/PaletteStorage.mapping
@@ -10,8 +10,8 @@ CLASS net/minecraft/class_6490 net/minecraft/util/collection/PaletteStorage
 		COMMENT {@return the value at {@code index} in this storage}
 		ARG 1 index
 			COMMENT the index
-	METHOD method_15212 getStorage ()[J
-		COMMENT {@return the backing value of this storage}
+	METHOD method_15212 getData ()[J
+		COMMENT {@return the backing data of this storage}
 	METHOD method_15214 swap (II)I
 		COMMENT Sets {@code value} to {@code index} and returns the previous value in
 		COMMENT this storage.

--- a/mappings/net/minecraft/util/collection/PaletteStorage.mapping
+++ b/mappings/net/minecraft/util/collection/PaletteStorage.mapping
@@ -1,0 +1,30 @@
+CLASS net/minecraft/class_6490 net/minecraft/util/collection/PaletteStorage
+	COMMENT A storage whose values are raw IDs held by palettes.
+	METHOD method_15210 set (II)V
+		COMMENT Sets {@code value} to {@code index} in this storage.
+		ARG 1 index
+			COMMENT the index
+		ARG 2 value
+			COMMENT the value to set
+	METHOD method_15211 get (I)I
+		COMMENT {@return the value at {@code index} in this storage}
+		ARG 1 index
+			COMMENT the index
+	METHOD method_15212 getStorage ()[J
+		COMMENT {@return the backing value of this storage}
+	METHOD method_15214 swap (II)I
+		COMMENT Sets {@code value} to {@code index} and returns the previous value in
+		COMMENT this storage.
+		COMMENT
+		COMMENT @return the previous value
+		ARG 1 index
+			COMMENT the index
+		ARG 2 value
+			COMMENT the value to set
+	METHOD method_15215 getSize ()I
+		COMMENT {@return the size of, or the number of elements in, this storage}
+	METHOD method_21739 forEach (Ljava/util/function/IntConsumer;)V
+		COMMENT Executes an {@code action} on all values in this storage, sequentially.
+		ARG 1 action
+	METHOD method_34896 getElementBits ()I
+		COMMENT {@return the number of bits each element in this storage uses}

--- a/mappings/net/minecraft/util/math/MathHelper.mapping
+++ b/mappings/net/minecraft/util/math/MathHelper.mapping
@@ -27,8 +27,14 @@ CLASS net/minecraft/class_3532 net/minecraft/util/math/MathHelper
 	METHOD method_15341 floorMod (FF)F
 		ARG 0 dividend
 		ARG 1 divisor
-	METHOD method_15342 log2DeBruijn (I)I
+	METHOD method_15342 ceilLog2 (I)I
+		COMMENT {@return ceil(log<sub>2</sub>({@code value}))}
+		COMMENT
+		COMMENT <p>The vanilla implementation uses the de Bruijn sequence.
+		COMMENT
+		COMMENT @see Integer#numberOfLeadingZeros(int)
 		ARG 0 value
+			COMMENT the input value
 	METHOD method_15343 parseInt (Ljava/lang/String;I)I
 		ARG 0 string
 		ARG 1 fallback
@@ -56,8 +62,14 @@ CLASS net/minecraft/class_3532 net/minecraft/util/math/MathHelper
 		ARG 0 value
 		ARG 2 min
 		ARG 4 max
-	METHOD method_15351 log2 (I)I
+	METHOD method_15351 floorLog2 (I)I
+		COMMENT {@return floor(log<sub>2</sub>({@code value}))}
+		COMMENT
+		COMMENT <p>The vanilla implementation uses the de Bruijn sequence.
+		COMMENT
+		COMMENT @see Integer#numberOfLeadingZeros(int)
 		ARG 0 value
+			COMMENT the input value
 	METHOD method_15352 isPowerOfTwo (I)Z
 		ARG 0 value
 	METHOD method_15353 packRgb (FFF)I

--- a/mappings/net/minecraft/world/chunk/ArrayPalette.mapping
+++ b/mappings/net/minecraft/world/chunk/ArrayPalette.mapping
@@ -1,10 +1,16 @@
 CLASS net/minecraft/class_2834 net/minecraft/world/chunk/ArrayPalette
+	COMMENT A palette that stores the possible entries in an array and maps them
+	COMMENT to their indices in the array.
 	FIELD field_12900 idList Lnet/minecraft/class_2359;
 	FIELD field_12901 size I
 	FIELD field_12903 indexBits I
 	FIELD field_12904 array [Ljava/lang/Object;
-	FIELD field_12905 resizeListener Lnet/minecraft/class_2835;
+	FIELD field_12905 listener Lnet/minecraft/class_2835;
 	METHOD <init> (Lnet/minecraft/class_2359;ILnet/minecraft/class_2835;)V
-		ARG 2 integer
-		ARG 3 resizeListener
+		ARG 1 idList
+		ARG 2 bits
+		ARG 3 listener
 	METHOD method_38295 create (ILnet/minecraft/class_2359;Lnet/minecraft/class_2835;)Lnet/minecraft/class_2837;
+		ARG 0 bits
+		ARG 1 idList
+		ARG 2 listener

--- a/mappings/net/minecraft/world/chunk/ArrayPalette.mapping
+++ b/mappings/net/minecraft/world/chunk/ArrayPalette.mapping
@@ -7,3 +7,4 @@ CLASS net/minecraft/class_2834 net/minecraft/world/chunk/ArrayPalette
 	METHOD <init> (Lnet/minecraft/class_2359;ILnet/minecraft/class_2835;)V
 		ARG 2 integer
 		ARG 3 resizeListener
+	METHOD method_38295 create (ILnet/minecraft/class_2359;Lnet/minecraft/class_2835;)Lnet/minecraft/class_2837;

--- a/mappings/net/minecraft/world/chunk/BiMapPalette.mapping
+++ b/mappings/net/minecraft/world/chunk/BiMapPalette.mapping
@@ -4,5 +4,16 @@ CLASS net/minecraft/class_2814 net/minecraft/world/chunk/BiMapPalette
 	FIELD field_12824 map Lnet/minecraft/class_3513;
 	FIELD field_12825 resizeHandler Lnet/minecraft/class_2835;
 	METHOD <init> (Lnet/minecraft/class_2359;ILnet/minecraft/class_2835;)V
+		ARG 1 idList
 		ARG 2 indexBits
 		ARG 3 resizeHandler
+	METHOD <init> (Lnet/minecraft/class_2359;ILnet/minecraft/class_2835;Ljava/util/List;)V
+		ARG 1 idList
+		ARG 2 bits
+		ARG 3 listener
+		ARG 4 entries
+	METHOD method_38287 create (ILnet/minecraft/class_2359;Lnet/minecraft/class_2835;)Lnet/minecraft/class_2837;
+		ARG 0 bits
+		ARG 1 idList
+		ARG 2 listener
+	METHOD method_38288 getElements ()Ljava/util/List;

--- a/mappings/net/minecraft/world/chunk/BiMapPalette.mapping
+++ b/mappings/net/minecraft/world/chunk/BiMapPalette.mapping
@@ -1,12 +1,13 @@
 CLASS net/minecraft/class_2814 net/minecraft/world/chunk/BiMapPalette
+	COMMENT A palette backed by a bidirectional hash table.
 	FIELD field_12821 idList Lnet/minecraft/class_2359;
 	FIELD field_12822 indexBits I
 	FIELD field_12824 map Lnet/minecraft/class_3513;
-	FIELD field_12825 resizeHandler Lnet/minecraft/class_2835;
+	FIELD field_12825 listener Lnet/minecraft/class_2835;
 	METHOD <init> (Lnet/minecraft/class_2359;ILnet/minecraft/class_2835;)V
 		ARG 1 idList
 		ARG 2 indexBits
-		ARG 3 resizeHandler
+		ARG 3 listener
 	METHOD <init> (Lnet/minecraft/class_2359;ILnet/minecraft/class_2835;Ljava/util/List;)V
 		ARG 1 idList
 		ARG 2 bits

--- a/mappings/net/minecraft/world/chunk/EntryMissingException.mapping
+++ b/mappings/net/minecraft/world/chunk/EntryMissingException.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_6558 net/minecraft/world/chunk/EntryMissingException
+	METHOD <init> (I)V
+		ARG 1 index

--- a/mappings/net/minecraft/world/chunk/IdListPalette.mapping
+++ b/mappings/net/minecraft/world/chunk/IdListPalette.mapping
@@ -1,2 +1,6 @@
 CLASS net/minecraft/class_2816 net/minecraft/world/chunk/IdListPalette
 	FIELD field_12828 idList Lnet/minecraft/class_2359;
+	METHOD <init> (Lnet/minecraft/class_2359;)V
+		ARG 1 idList
+	METHOD method_38286 create (ILnet/minecraft/class_2359;Lnet/minecraft/class_2835;)Lnet/minecraft/class_2837;
+		ARG 1 idList

--- a/mappings/net/minecraft/world/chunk/IdListPalette.mapping
+++ b/mappings/net/minecraft/world/chunk/IdListPalette.mapping
@@ -1,6 +1,10 @@
 CLASS net/minecraft/class_2816 net/minecraft/world/chunk/IdListPalette
+	COMMENT A palette that directly stores the raw ID of entries to the palette
+	COMMENT container storage.
 	FIELD field_12828 idList Lnet/minecraft/class_2359;
 	METHOD <init> (Lnet/minecraft/class_2359;)V
 		ARG 1 idList
 	METHOD method_38286 create (ILnet/minecraft/class_2359;Lnet/minecraft/class_2835;)Lnet/minecraft/class_2837;
+		ARG 0 bits
 		ARG 1 idList
+		ARG 2 listener

--- a/mappings/net/minecraft/world/chunk/Palette.mapping
+++ b/mappings/net/minecraft/world/chunk/Palette.mapping
@@ -1,20 +1,29 @@
 CLASS net/minecraft/class_2837 net/minecraft/world/chunk/Palette
-	COMMENT A palette maps objects from and to ids to make storage easier.
-	COMMENT While the objects palettes handle are already represented by integer
-	COMMENT IDs, further shrinking IDs in cases where only a few are used can better
-	COMMENT decrease storage usage and network traffic volume.
+	COMMENT A palette maps objects from and to small integer IDs that uses less
+	COMMENT number of bits to make storage smaller.
+	COMMENT
+	COMMENT <p>While the objects palettes handle are already represented by integer
+	COMMENT IDs, shrinking IDs in cases where only a few appear can further reduce
+	COMMENT storage space and network traffic volume.
+	COMMENT
+	COMMENT @see PalettedContainer
 	METHOD method_12197 getSize ()I
 		COMMENT {@return the size of the palette}
-	METHOD method_12287 toPacket (Lnet/minecraft/class_2540;)V
+	METHOD method_12287 writePacket (Lnet/minecraft/class_2540;)V
+		COMMENT Writes this palette to the {@code buf}.
 		ARG 1 buf
+			COMMENT the packet byte buffer
 	METHOD method_12288 get (I)Ljava/lang/Object;
 		COMMENT {@return the object associated with the given {@code id}}
 		COMMENT
 		COMMENT @throws EntryMissingException if this ID does not exist in this palette
 		ARG 1 id
 			COMMENT the ID to look up
-	METHOD method_12289 fromPacket (Lnet/minecraft/class_2540;)V
+	METHOD method_12289 readPacket (Lnet/minecraft/class_2540;)V
+		COMMENT Initializes this palette from the {@code buf}. Clears the preexisting
+		COMMENT data in this palette.
 		ARG 1 buf
+			COMMENT the packet byte buffer
 	METHOD method_12290 getPacketSize ()I
 		COMMENT {@return the serialized size of this palette in a byte buf, in bytes}
 	METHOD method_12291 index (Ljava/lang/Object;)I
@@ -22,7 +31,8 @@ CLASS net/minecraft/class_2837 net/minecraft/world/chunk/Palette
 		COMMENT
 		COMMENT <p>If the object does not yet exist in this palette, this palette will
 		COMMENT register the object. If the palette is too small to include this object,
-		COMMENT the resize listener will be called and this palette will be discarded.
+		COMMENT a {@linkplain PaletteResizeListener resize listener} will be called and
+		COMMENT this palette may be discarded.
 		ARG 1 object
 			COMMENT the object to look up
 	METHOD method_19525 hasAny (Ljava/util/function/Predicate;)Z
@@ -30,8 +40,16 @@ CLASS net/minecraft/class_2837 net/minecraft/world/chunk/Palette
 		COMMENT predicate}}
 		ARG 1 predicate
 	CLASS class_6559 Factory
-		COMMENT An interface for the palettes' constructors.
+		COMMENT An interface for easy creation of palettes.
 		METHOD create (ILnet/minecraft/class_2359;Lnet/minecraft/class_2835;)Lnet/minecraft/class_2837;
+			COMMENT Creates a palette.
+			COMMENT
+			COMMENT @return the created new palette
 			ARG 1 bits
+				COMMENT the number of bits each entry uses in the storage
 			ARG 2 idList
+				COMMENT the indices of possible palette entries and their full integer IDs;
+				COMMENT useful for palette serialization
 			ARG 3 listener
+				COMMENT the resize listener, called when this palette runs out of capacity when
+				COMMENT assigning index to new entries

--- a/mappings/net/minecraft/world/chunk/Palette.mapping
+++ b/mappings/net/minecraft/world/chunk/Palette.mapping
@@ -1,12 +1,37 @@
 CLASS net/minecraft/class_2837 net/minecraft/world/chunk/Palette
-	METHOD method_12197 getIndexBits ()I
+	COMMENT A palette maps objects from and to ids to make storage easier.
+	COMMENT While the objects palettes handle are already represented by integer
+	COMMENT IDs, further shrinking IDs in cases where only a few are used can better
+	COMMENT decrease storage usage and network traffic volume.
+	METHOD method_12197 getSize ()I
+		COMMENT {@return the size of the palette}
 	METHOD method_12287 toPacket (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
-	METHOD method_12288 getByIndex (I)Ljava/lang/Object;
-		ARG 1 index
+	METHOD method_12288 get (I)Ljava/lang/Object;
+		COMMENT {@return the object associated with the given {@code id}}
+		COMMENT
+		COMMENT @throws EntryMissingException if this ID does not exist in this palette
+		ARG 1 id
+			COMMENT the ID to look up
 	METHOD method_12289 fromPacket (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD method_12290 getPacketSize ()I
-	METHOD method_12291 getIndex (Ljava/lang/Object;)I
+		COMMENT {@return the serialized size of this palette in a byte buf, in bytes}
+	METHOD method_12291 index (Ljava/lang/Object;)I
+		COMMENT {@return the ID of an object in this palette}
+		COMMENT
+		COMMENT <p>If the object does not yet exist in this palette, this palette will
+		COMMENT register the object. If the palette is too small to include this object,
+		COMMENT the resize listener will be called and this palette will be discarded.
 		ARG 1 object
-	METHOD method_19525 accepts (Ljava/util/function/Predicate;)Z
+			COMMENT the object to look up
+	METHOD method_19525 hasAny (Ljava/util/function/Predicate;)Z
+		COMMENT {@return {@code true} if any entry in this palette passes the {@code
+		COMMENT predicate}}
+		ARG 1 predicate
+	CLASS class_6559 Factory
+		COMMENT An interface for the palettes' constructors.
+		METHOD create (ILnet/minecraft/class_2359;Lnet/minecraft/class_2835;)Lnet/minecraft/class_2837;
+			ARG 1 bits
+			ARG 2 idList
+			ARG 3 listener

--- a/mappings/net/minecraft/world/chunk/PaletteResizeListener.mapping
+++ b/mappings/net/minecraft/world/chunk/PaletteResizeListener.mapping
@@ -1,4 +1,4 @@
 CLASS net/minecraft/class_2835 net/minecraft/world/chunk/PaletteResizeListener
 	METHOD onResize (ILjava/lang/Object;)I
-		ARG 1 newSize
-		ARG 2 objectAdded
+		ARG 1 newBits
+		ARG 2 object

--- a/mappings/net/minecraft/world/chunk/PaletteResizeListener.mapping
+++ b/mappings/net/minecraft/world/chunk/PaletteResizeListener.mapping
@@ -1,4 +1,15 @@
 CLASS net/minecraft/class_2835 net/minecraft/world/chunk/PaletteResizeListener
+	COMMENT A listener for when a pallete require more bits to hold a newly indexed
+	COMMENT object. A no-op listener may be used if the palette does not have to
+	COMMENT resize.
+	COMMENT
+	COMMENT @see Palette#index(Object)
 	METHOD onResize (ILjava/lang/Object;)I
+		COMMENT Callback for a palette's request to resize to at least {@code newBits}
+		COMMENT for each entry and to update the storage correspondingly in order to
+		COMMENT accomodate the new object. After the resize is completed in this method,
+		COMMENT returns the ID assigned to the {@code object} in the updated palette.
+		COMMENT
+		COMMENT @return the ID for the {@code object} in the (possibly new) palette
 		ARG 1 newBits
 		ARG 2 object

--- a/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
+++ b/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
@@ -1,11 +1,29 @@
 CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
+	FIELD field_34558 dummyListener Lnet/minecraft/class_2835;
+	FIELD field_34559 idList Lnet/minecraft/class_2359;
+	FIELD field_34560 data Lnet/minecraft/class_2841$class_6561;
+	FIELD field_34561 paletteProvider Lnet/minecraft/class_2841$class_6563;
+	FIELD field_34562 semaphore Ljava/util/concurrent/Semaphore;
+	FIELD field_34563 lockStack Lnet/minecraft/class_5831;
+	METHOD <init> (Lnet/minecraft/class_2359;Ljava/lang/Object;Lnet/minecraft/class_2841$class_6563;)V
+		ARG 1 idList
+		ARG 2 object
+		ARG 3 paletteProvider
+	METHOD <init> (Lnet/minecraft/class_2359;Lnet/minecraft/class_2841$class_6563;Lnet/minecraft/class_2841$class_6560;Lnet/minecraft/class_6490;Ljava/util/List;)V
+		ARG 1 idList
+		ARG 2 paletteProvider
+		ARG 3 dataProvider
+		ARG 4 storage
+		ARG 5 entries
 	METHOD method_12321 get (III)Ljava/lang/Object;
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
 	METHOD method_12322 set (ILjava/lang/Object;)V
 		ARG 1 index
+		ARG 2 value
 	METHOD method_12325 toPacket (Lnet/minecraft/class_2540;)V
+		ARG 1 buf
 	METHOD method_12326 fromPacket (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD method_12327 getPacketSize ()I
@@ -21,20 +39,116 @@ CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
 		ARG 1 added
 	METHOD method_12334 lock ()V
 	METHOD method_12335 unlock ()V
-	METHOD method_12336 setAndGetOldValue (ILjava/lang/Object;)Ljava/lang/Object;
+	METHOD method_12336 swap (ILjava/lang/Object;)Ljava/lang/Object;
 		ARG 1 index
 		ARG 2 value
-	METHOD method_16678 set (IIILjava/lang/Object;)Ljava/lang/Object;
+	METHOD method_16678 swap (IIILjava/lang/Object;)Ljava/lang/Object;
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
 		ARG 4 value
 	METHOD method_19526 hasAny (Ljava/util/function/Predicate;)Z
+		COMMENT {@return {@code true} if any object in this container's palette matches
+		COMMENT this predicate}
+		ARG 1 predicate
 	METHOD method_21732 count (Lnet/minecraft/class_2841$class_4464;)V
-		ARG 1 consumer
+		ARG 1 counter
+	METHOD method_21733 (Lnet/minecraft/class_2841$class_4464;Lit/unimi/dsi/fastutil/ints/Int2IntMap$Entry;)V
+		ARG 2 entry
+	METHOD method_21734 increment (Lit/unimi/dsi/fastutil/ints/Int2IntMap;I)V
+		ARG 0 map
+		ARG 1 key
+	METHOD method_35321 set (IIILjava/lang/Object;)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+		ARG 4 value
+	METHOD method_38296 (Lcom/mojang/serialization/Codec;Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 1 instance
+	METHOD method_38297 createNewData (Lnet/minecraft/class_2841$class_6561;I)Lnet/minecraft/class_2841$class_6561;
+		ARG 1 data
+		ARG 2 size
+	METHOD method_38298 createCodec (Lnet/minecraft/class_2359;Lcom/mojang/serialization/Codec;Lnet/minecraft/class_2841$class_6563;)Lcom/mojang/serialization/Codec;
+		ARG 0 idMap
+		ARG 1 elementCodec
+		ARG 2 provider
 	METHOD method_38300 write (Lnet/minecraft/class_2359;Lnet/minecraft/class_2841$class_6563;)Lnet/minecraft/class_2841$class_6562;
+		ARG 1 idMap
+		ARG 2 provider
 	METHOD method_38301 read (Lnet/minecraft/class_2359;Lnet/minecraft/class_2841$class_6563;Lnet/minecraft/class_2841$class_6562;)Lcom/mojang/serialization/DataResult;
-	CLASS class_4464 CountConsumer
+		ARG 0 idList
+		ARG 1 provider
+		ARG 2 serialized
+	METHOD method_38302 (Lnet/minecraft/class_2359;Lnet/minecraft/class_2841$class_6563;Lnet/minecraft/class_2841;)Lnet/minecraft/class_2841$class_6562;
+		ARG 2 container
+	METHOD method_38303 (Lnet/minecraft/class_2359;Lnet/minecraft/class_2841$class_6563;Lnet/minecraft/class_2841$class_6562;)Lcom/mojang/serialization/DataResult;
+		ARG 2 serialized
+	CLASS class_4464 Counter
 		METHOD accept (Ljava/lang/Object;I)V
 			ARG 1 object
 			ARG 2 count
+	CLASS class_6560 DataProvider
+		FIELD comp_72 factory Lnet/minecraft/class_2837$class_6559;
+			COMMENT the palette factory
+		FIELD comp_73 bits I
+			COMMENT the number of bits each element use
+		METHOD comp_72 factory ()Lnet/minecraft/class_2837$class_6559;
+		METHOD comp_73 bits ()I
+		METHOD method_38305 createData (Lnet/minecraft/class_2359;Lnet/minecraft/class_2835;I[J)Lnet/minecraft/class_2841$class_6561;
+			ARG 1 idList
+			ARG 2 listener
+			ARG 3 size
+			ARG 4 storage
+	CLASS class_6561 Data
+		FIELD comp_74 provider Lnet/minecraft/class_2841$class_6560;
+		METHOD <init> (Lnet/minecraft/class_2841$class_6560;Lnet/minecraft/class_6490;Lnet/minecraft/class_2837;)V
+			ARG 1 provider
+			ARG 2 storage
+			ARG 3 palette
+		METHOD comp_74 provider ()Lnet/minecraft/class_2841$class_6560;
+		METHOD method_38306 getPacketSize ()I
+		METHOD method_38307 set (ILjava/lang/Object;)V
+			ARG 1 index
+			ARG 2 value
+		METHOD method_38308 copyFrom (Lnet/minecraft/class_2837;Lnet/minecraft/class_6490;)V
+			ARG 1 palette
+			ARG 2 storage
+		METHOD method_38309 writeTo (Lnet/minecraft/class_2540;)V
+			ARG 1 buf
+		METHOD method_38310 storage ()Lnet/minecraft/class_6490;
+		METHOD method_38311 palette ()Lnet/minecraft/class_2837;
+	CLASS class_6562 Serialized
+		FIELD comp_75 palette Ljava/util/List;
+		FIELD comp_76 data Ljava/util/Optional;
+		METHOD comp_75 palette ()Ljava/util/List;
+		METHOD comp_76 data ()Ljava/util/Optional;
+	CLASS class_6563 PaletteProvider
+		FIELD field_34566 SINGULAR Lnet/minecraft/class_2837$class_6559;
+		FIELD field_34567 ARRAY Lnet/minecraft/class_2837$class_6559;
+		FIELD field_34568 BI_MAP Lnet/minecraft/class_2837$class_6559;
+		FIELD field_34569 FOUR_BITS Lnet/minecraft/class_2841$class_6563;
+			COMMENT The palette provider that tries to convert ID lists to compressed
+			COMMENT palettes if the number of bits used is no more than 4. Used in vanilla
+			COMMENT by blocks.
+		FIELD field_34570 TWO_BITS Lnet/minecraft/class_2841$class_6563;
+			COMMENT The palette provider that tries to convert ID lists to compressed
+			COMMENT palettes if the number of bits used is no more than 2. Used in vanilla
+			COMMENT by biomes.
+		FIELD field_34571 ID_LIST Lnet/minecraft/class_2837$class_6559;
+		FIELD field_34572 bits I
+		METHOD <init> (I)V
+			ARG 1 bits
+		METHOD method_38312 getPaletteSize ()I
+		METHOD method_38313 computeIndex (III)I
+			ARG 1 x
+			ARG 2 y
+			ARG 3 z
+		METHOD method_38314 createDataProvider (Lnet/minecraft/class_2359;I)Lnet/minecraft/class_2841$class_6560;
+			COMMENT
+			ARG 1 idList
+				COMMENT
+			ARG 2 bits
+				COMMENT the number of bits needed to represent all palette entries
+		METHOD method_38315 getBits (Lnet/minecraft/class_2359;I)I
+			ARG 1 idList
+			ARG 2 size

--- a/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
+++ b/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
@@ -1,4 +1,8 @@
 CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
+	COMMENT A paletted container stores objects in 3D voxels as small integer indices,
+	COMMENT governed by "palettes" that map between these objects and indices.
+	COMMENT
+	COMMENT @see Palette
 	FIELD field_34558 dummyListener Lnet/minecraft/class_2835;
 	FIELD field_34559 idList Lnet/minecraft/class_2359;
 	FIELD field_34560 data Lnet/minecraft/class_2841$class_6561;
@@ -22,12 +26,17 @@ CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
 	METHOD method_12322 set (ILjava/lang/Object;)V
 		ARG 1 index
 		ARG 2 value
-	METHOD method_12325 toPacket (Lnet/minecraft/class_2540;)V
+	METHOD method_12325 writePacket (Lnet/minecraft/class_2540;)V
+		COMMENT Writes this container to the packet byte buffer.
 		ARG 1 buf
-	METHOD method_12326 fromPacket (Lnet/minecraft/class_2540;)V
+			COMMENT the packet byte buffer
+	METHOD method_12326 readPacket (Lnet/minecraft/class_2540;)V
+		COMMENT Reads data from the packet byte buffer into this container. Previous data
+		COMMENT in this container is discarded.
 		ARG 1 buf
+			COMMENT the packet byte buffer
 	METHOD method_12327 getPacketSize ()I
-	METHOD method_12328 setSync (IIILjava/lang/Object;)Ljava/lang/Object;
+	METHOD method_12328 swap (IIILjava/lang/Object;)Ljava/lang/Object;
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
@@ -38,11 +47,14 @@ CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
 		ARG 0 newSize
 		ARG 1 added
 	METHOD method_12334 lock ()V
+		COMMENT Acquires the semaphore on this container, and crashes if it cannot be
+		COMMENT acquired.
 	METHOD method_12335 unlock ()V
+		COMMENT Releases the semaphore on this container.
 	METHOD method_12336 swap (ILjava/lang/Object;)Ljava/lang/Object;
 		ARG 1 index
 		ARG 2 value
-	METHOD method_16678 swap (IIILjava/lang/Object;)Ljava/lang/Object;
+	METHOD method_16678 swapUnsafe (IIILjava/lang/Object;)Ljava/lang/Object;
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
@@ -65,13 +77,25 @@ CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
 		ARG 4 value
 	METHOD method_38296 (Lcom/mojang/serialization/Codec;Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 1 instance
-	METHOD method_38297 createNewData (Lnet/minecraft/class_2841$class_6561;I)Lnet/minecraft/class_2841$class_6561;
-		ARG 1 data
-		ARG 2 size
+	METHOD method_38297 getCompatibleData (Lnet/minecraft/class_2841$class_6561;I)Lnet/minecraft/class_2841$class_6561;
+		COMMENT {@return a compatible data object for the given entry {@code bits} size}
+		COMMENT This may return a new data object or return {@code previousData} if it
+		COMMENT can be reused.
+		ARG 1 previousData
+			COMMENT the previous data, may be reused if suitable
+		ARG 2 bits
+			COMMENT the number of bits each entry uses
 	METHOD method_38298 createCodec (Lnet/minecraft/class_2359;Lcom/mojang/serialization/Codec;Lnet/minecraft/class_2841$class_6563;)Lcom/mojang/serialization/Codec;
+		COMMENT Creates a codec for a paletted container with a specific palette provider.
+		COMMENT
+		COMMENT @return the created codec
 		ARG 0 idList
-		ARG 1 elementCodec
+			COMMENT the id list to map between objects and full integer IDs
+		ARG 1 entryCodec
+			COMMENT the codec for each entry in the palette
 		ARG 2 provider
+			COMMENT the palette provider that controls how the data are serialized and what
+			COMMENT types of palette are used for what entry bit sizes
 	METHOD method_38300 write (Lnet/minecraft/class_2359;Lnet/minecraft/class_2841$class_6563;)Lnet/minecraft/class_2841$class_6562;
 		ARG 1 idList
 		ARG 2 provider
@@ -84,10 +108,16 @@ CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
 	METHOD method_38303 (Lnet/minecraft/class_2359;Lnet/minecraft/class_2841$class_6563;Lnet/minecraft/class_2841$class_6562;)Lcom/mojang/serialization/DataResult;
 		ARG 2 serialized
 	CLASS class_4464 Counter
+		COMMENT A counter that receives a palette entry and its number of occurences
+		COMMENT in the container.
 		METHOD accept (Ljava/lang/Object;I)V
 			ARG 1 object
+				COMMENT the palette entry
 			ARG 2 count
+				COMMENT the entry's number of occurence
 	CLASS class_6560 DataProvider
+		COMMENT A palette data provider constructs an empty data for a paletted
+		COMMENT container given a palette provider and a desired entry size in bits.
 		FIELD comp_72 factory Lnet/minecraft/class_2837$class_6559;
 			COMMENT the palette factory
 		FIELD comp_73 bits I
@@ -100,6 +130,7 @@ CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
 			ARG 3 size
 			ARG 4 storage
 	CLASS class_6561 Data
+		COMMENT Runtime representation of data in a paletted container.
 		FIELD comp_74 provider Lnet/minecraft/class_2841$class_6560;
 		METHOD <init> (Lnet/minecraft/class_2841$class_6560;Lnet/minecraft/class_6490;Lnet/minecraft/class_2837;)V
 			ARG 1 provider
@@ -107,44 +138,73 @@ CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
 			ARG 3 palette
 		METHOD comp_74 provider ()Lnet/minecraft/class_2841$class_6560;
 		METHOD method_38306 getPacketSize ()I
+			COMMENT {@return the size of this data, in bytes, when written to a packet}
+			COMMENT
+			COMMENT @see #writeTo(PacketByteBuf)
 		METHOD method_38307 set (ILjava/lang/Object;)V
+			COMMENT Sets an entry to the storage's given index.
 			ARG 1 index
+				COMMENT the index in the storage
 			ARG 2 value
-		METHOD method_38308 copyFrom (Lnet/minecraft/class_2837;Lnet/minecraft/class_6490;)V
+				COMMENT the entry to set
+		METHOD method_38308 importFrom (Lnet/minecraft/class_2837;Lnet/minecraft/class_6490;)V
+			COMMENT Imports the data from the other {@code storage} with the other
+			COMMENT {@code palette}.
 			ARG 1 palette
+				COMMENT the other palette
 			ARG 2 storage
-		METHOD method_38309 writeTo (Lnet/minecraft/class_2540;)V
+				COMMENT the other storage
+		METHOD method_38309 writePacket (Lnet/minecraft/class_2540;)V
 			ARG 1 buf
 		METHOD method_38310 storage ()Lnet/minecraft/class_6490;
 		METHOD method_38311 palette ()Lnet/minecraft/class_2837;
 	CLASS class_6562 Serialized
+		COMMENT The storage form of the paletted container in the {@linkplain
+		COMMENT PalettedContainer#createCodec codec}. The {@code palette} is the entries
+		COMMENT in the palette, but the interpretation of data depends on the palette
+		COMMENT provider specified for the codec.
+		COMMENT
+		COMMENT @see PalettedContainer#createCodec
 		FIELD comp_75 palette Ljava/util/List;
+			COMMENT the palette
 		FIELD comp_76 data Ljava/util/Optional;
+			COMMENT the data of the container
 		METHOD comp_75 palette ()Ljava/util/List;
 		METHOD comp_76 data ()Ljava/util/Optional;
 	CLASS class_6563 PaletteProvider
+		COMMENT A palette provider determines what type of palette to choose given the
+		COMMENT bits used to represent each element. In addition, it controls how the
+		COMMENT data in the serialized container is read based on the palette given.
 		FIELD field_34566 SINGULAR Lnet/minecraft/class_2837$class_6559;
 		FIELD field_34567 ARRAY Lnet/minecraft/class_2837$class_6559;
 		FIELD field_34568 BI_MAP Lnet/minecraft/class_2837$class_6559;
-		FIELD field_34569 FOUR_BITS Lnet/minecraft/class_2841$class_6563;
-			COMMENT The palette provider that tries to convert ID lists to compressed
-			COMMENT palettes if the number of bits used is no more than 4. Used in vanilla
-			COMMENT by blocks.
-		FIELD field_34570 TWO_BITS Lnet/minecraft/class_2841$class_6563;
-			COMMENT The palette provider that tries to convert ID lists to compressed
-			COMMENT palettes if the number of bits used is no more than 2. Used in vanilla
-			COMMENT by biomes.
+		FIELD field_34569 BLOCK_STATE Lnet/minecraft/class_2841$class_6563;
+			COMMENT A palette provider that stores {@code 4096} objects in a container.
+			COMMENT Used in vanilla by block states in a chunk section.
+		FIELD field_34570 BIOME Lnet/minecraft/class_2841$class_6563;
+			COMMENT A palette provider that stores {@code 64} objects in a container.
+			COMMENT Used in vanilla by biomes in a chunk section.
 		FIELD field_34571 ID_LIST Lnet/minecraft/class_2837$class_6559;
-		FIELD field_34572 bits I
+		FIELD field_34572 edgeBits I
 		METHOD <init> (I)V
-			ARG 1 bits
-		METHOD method_38312 getPaletteSize ()I
+			ARG 1 edgeBits
+		METHOD method_38312 getContainerSize ()I
+			COMMENT {@return the size of the container's data desired by this provider}
 		METHOD method_38313 computeIndex (III)I
+			COMMENT {@return the index of an object in the storage given its x, y, z coordinates}
 			ARG 1 x
+				COMMENT the x coordinate
 			ARG 2 y
+				COMMENT the y coordinate
 			ARG 3 z
+				COMMENT the z coordinate
 		METHOD method_38314 createDataProvider (Lnet/minecraft/class_2359;I)Lnet/minecraft/class_2841$class_6560;
+			COMMENT Creates a data provider that is suitable to represent objects with
+			COMMENT {@code bits} size in the storage.
+			COMMENT
+			COMMENT @return the data provider
 			ARG 1 idList
+				COMMENT the id list that maps between objects and full integer IDs
 			ARG 2 bits
 				COMMENT the number of bits needed to represent all palette entries
 		METHOD method_38315 getBits (Lnet/minecraft/class_2359;I)I

--- a/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
+++ b/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
@@ -69,11 +69,11 @@ CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
 		ARG 1 data
 		ARG 2 size
 	METHOD method_38298 createCodec (Lnet/minecraft/class_2359;Lcom/mojang/serialization/Codec;Lnet/minecraft/class_2841$class_6563;)Lcom/mojang/serialization/Codec;
-		ARG 0 idMap
+		ARG 0 idList
 		ARG 1 elementCodec
 		ARG 2 provider
 	METHOD method_38300 write (Lnet/minecraft/class_2359;Lnet/minecraft/class_2841$class_6563;)Lnet/minecraft/class_2841$class_6562;
-		ARG 1 idMap
+		ARG 1 idList
 		ARG 2 provider
 	METHOD method_38301 read (Lnet/minecraft/class_2359;Lnet/minecraft/class_2841$class_6563;Lnet/minecraft/class_2841$class_6562;)Lcom/mojang/serialization/DataResult;
 		ARG 0 idList
@@ -144,9 +144,7 @@ CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
 			ARG 2 y
 			ARG 3 z
 		METHOD method_38314 createDataProvider (Lnet/minecraft/class_2359;I)Lnet/minecraft/class_2841$class_6560;
-			COMMENT
 			ARG 1 idList
-				COMMENT
 			ARG 2 bits
 				COMMENT the number of bits needed to represent all palette entries
 		METHOD method_38315 getBits (Lnet/minecraft/class_2359;I)I

--- a/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
+++ b/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
@@ -140,7 +140,7 @@ CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
 		METHOD method_38306 getPacketSize ()I
 			COMMENT {@return the size of this data, in bytes, when written to a packet}
 			COMMENT
-			COMMENT @see #writeTo(PacketByteBuf)
+			COMMENT @see #writePacket(PacketByteBuf)
 		METHOD method_38307 set (ILjava/lang/Object;)V
 			COMMENT Sets an entry to the storage's given index.
 			ARG 1 index

--- a/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
+++ b/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
@@ -163,8 +163,6 @@ CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
 				COMMENT the other storage
 		METHOD method_38309 writePacket (Lnet/minecraft/class_2540;)V
 			ARG 1 buf
-		METHOD method_38310 storage ()Lnet/minecraft/class_6490;
-		METHOD method_38311 palette ()Lnet/minecraft/class_2837;
 	CLASS class_6562 Serialized
 		COMMENT The storage form of the paletted container in the {@linkplain
 		COMMENT PalettedContainer#createCodec codec}. The {@code palette} is the entries

--- a/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
+++ b/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
@@ -131,12 +131,19 @@ CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
 			ARG 4 storage
 	CLASS class_6561 Data
 		COMMENT Runtime representation of data in a paletted container.
-		FIELD comp_74 provider Lnet/minecraft/class_2841$class_6560;
+		FIELD comp_118 storage Lnet/minecraft/class_6490;
+			COMMENT the data
+		FIELD comp_119 palette Lnet/minecraft/class_2837;
+			COMMENT the palette for the storage
+		FIELD comp_74 configuration Lnet/minecraft/class_2841$class_6560;
+			COMMENT the data provider that derives the palette and storage of this data
 		METHOD <init> (Lnet/minecraft/class_2841$class_6560;Lnet/minecraft/class_6490;Lnet/minecraft/class_2837;)V
-			ARG 1 provider
+			ARG 1 configuration
 			ARG 2 storage
 			ARG 3 palette
-		METHOD comp_74 provider ()Lnet/minecraft/class_2841$class_6560;
+		METHOD comp_118 storage ()Lnet/minecraft/class_6490;
+		METHOD comp_119 palette ()Lnet/minecraft/class_2837;
+		METHOD comp_74 configuration ()Lnet/minecraft/class_2841$class_6560;
 		METHOD method_38306 getPacketSize ()I
 			COMMENT {@return the size of this data, in bytes, when written to a packet}
 			COMMENT
@@ -165,12 +172,12 @@ CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
 		COMMENT provider specified for the codec.
 		COMMENT
 		COMMENT @see PalettedContainer#createCodec
-		FIELD comp_75 palette Ljava/util/List;
+		FIELD comp_75 paletteEntries Ljava/util/List;
 			COMMENT the palette
-		FIELD comp_76 data Ljava/util/Optional;
+		FIELD comp_76 storage Ljava/util/Optional;
 			COMMENT the data of the container
-		METHOD comp_75 palette ()Ljava/util/List;
-		METHOD comp_76 data ()Ljava/util/Optional;
+		METHOD comp_75 paletteEntries ()Ljava/util/List;
+		METHOD comp_76 storage ()Ljava/util/Optional;
 	CLASS class_6563 PaletteProvider
 		COMMENT A palette provider determines what type of palette to choose given the
 		COMMENT bits used to represent each element. In addition, it controls how the

--- a/mappings/net/minecraft/world/chunk/SingularPalette.mapping
+++ b/mappings/net/minecraft/world/chunk/SingularPalette.mapping
@@ -1,0 +1,11 @@
+CLASS net/minecraft/class_6564 net/minecraft/world/chunk/SingularPalette
+	COMMENT A palette that only holds one type of item.
+	FIELD field_34573 idList Lnet/minecraft/class_2359;
+	FIELD field_34574 entry Ljava/lang/Object;
+	FIELD field_34575 listener Lnet/minecraft/class_2835;
+	METHOD <init> (Lnet/minecraft/class_2359;Lnet/minecraft/class_2835;)V
+		ARG 1 idList
+		ARG 2 listener
+	METHOD method_38316 create (ILnet/minecraft/class_2359;Lnet/minecraft/class_2835;)Lnet/minecraft/class_2837;
+		ARG 1 idList
+		ARG 2 listener

--- a/mappings/net/minecraft/world/chunk/SingularPalette.mapping
+++ b/mappings/net/minecraft/world/chunk/SingularPalette.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_6564 net/minecraft/world/chunk/SingularPalette
-	COMMENT A palette that only holds one type of item.
+	COMMENT A palette that only holds a unique entry. Useful for void chunks or a
+	COMMENT single biome.
 	FIELD field_34573 idList Lnet/minecraft/class_2359;
 	FIELD field_34574 entry Ljava/lang/Object;
 	FIELD field_34575 listener Lnet/minecraft/class_2835;
@@ -7,5 +8,8 @@ CLASS net/minecraft/class_6564 net/minecraft/world/chunk/SingularPalette
 		ARG 1 idList
 		ARG 2 listener
 	METHOD method_38316 create (ILnet/minecraft/class_2359;Lnet/minecraft/class_2835;)Lnet/minecraft/class_2837;
+		COMMENT Creates a singular pallete. Used as method reference to create factory.
+		ARG 0 bitSize
+			COMMENT {@code 0}, as this palette has only 2<sup>0</sup>=1 entry.
 		ARG 1 idList
 		ARG 2 listener

--- a/mappings/net/minecraft/world/chunk/SingularPalette.mapping
+++ b/mappings/net/minecraft/world/chunk/SingularPalette.mapping
@@ -10,6 +10,6 @@ CLASS net/minecraft/class_6564 net/minecraft/world/chunk/SingularPalette
 	METHOD method_38316 create (ILnet/minecraft/class_2359;Lnet/minecraft/class_2835;)Lnet/minecraft/class_2837;
 		COMMENT Creates a singular pallete. Used as method reference to create factory.
 		ARG 0 bitSize
-			COMMENT {@code 0}, as this palette has only 2<sup>0</sup>=1 entry.
+			COMMENT {@code 0}, as this palette has only 2<sup>0</sup>=1 entry
 		ARG 1 idList
 		ARG 2 listener


### PR DESCRIPTION
Required to get javadoc working because singular palette otherwise has access problems

Also affected by #2700 so that I cannot map a few record components and that is quite disturbing (for understanding code)

In conjunction with #2683 and FabricMC/MappingPoet@24d0ec723c8e90298b365b73e843d4667579aee9, javadoc should finally be back (though the format may be a little bit wrong)