### PR TITLE
Fix translation key and display name, close #2693

### DIFF
--- a/mappings/net/minecraft/client/world/GeneratorType.mapping
+++ b/mappings/net/minecraft/client/world/GeneratorType.mapping
@@ -7,8 +7,10 @@ CLASS net/minecraft/class_5317 net/minecraft/client/world/GeneratorType
 	FIELD field_25057 SINGLE_BIOME_CAVES Lnet/minecraft/class_5317;
 	FIELD field_25058 SINGLE_BIOME_FLOATING_ISLANDS Lnet/minecraft/class_5317;
 	FIELD field_25059 DEBUG_ALL_BLOCK_STATES Lnet/minecraft/class_5317;
-	FIELD field_25060 translationKey Lnet/minecraft/class_2561;
-	METHOD method_29075 getTranslationKey ()Lnet/minecraft/class_2561;
+	FIELD field_25060 displayName Lnet/minecraft/class_2561;
+	METHOD <init> (Ljava/lang/String;)V
+		ARG 1 translationKeySuffix
+	METHOD method_29075 getDisplayName ()Lnet/minecraft/class_2561;
 	METHOD method_29076 getChunkGenerator (Lnet/minecraft/class_2378;Lnet/minecraft/class_2378;J)Lnet/minecraft/class_2794;
 		ARG 1 biomeRegistry
 		ARG 2 chunkGeneratorSettingsRegistry

--- a/mappings/net/minecraft/item/ItemGroup.mapping
+++ b/mappings/net/minecraft/item/ItemGroup.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_1761 net/minecraft/item/ItemGroup
-	FIELD field_26391 translationKey Lnet/minecraft/class_2561;
+	FIELD field_26391 displayName Lnet/minecraft/class_2561;
 	FIELD field_7914 REDSTONE Lnet/minecraft/class_1761;
 	FIELD field_7915 SEARCH Lnet/minecraft/class_1761;
 	FIELD field_7916 COMBAT Lnet/minecraft/class_1761;
@@ -25,7 +25,7 @@ CLASS net/minecraft/class_1761 net/minecraft/item/ItemGroup
 	METHOD <init> (ILjava/lang/String;)V
 		ARG 1 index
 		ARG 2 id
-	METHOD method_7737 getTranslationKey ()Lnet/minecraft/class_2561;
+	METHOD method_7737 getDisplayName ()Lnet/minecraft/class_2561;
 	METHOD method_7738 appendStacks (Lnet/minecraft/class_2371;)V
 		ARG 1 stacks
 	METHOD method_7739 setName (Ljava/lang/String;)Lnet/minecraft/class_1761;

--- a/mappings/net/minecraft/scoreboard/AbstractTeam.mapping
+++ b/mappings/net/minecraft/scoreboard/AbstractTeam.mapping
@@ -20,7 +20,7 @@ CLASS net/minecraft/class_270 net/minecraft/scoreboard/AbstractTeam
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;I)V
 			ARG 3 name
 			ARG 4 value
-		METHOD method_1209 getTranslationKey ()Lnet/minecraft/class_2561;
+		METHOD method_1209 getDisplayName ()Lnet/minecraft/class_2561;
 		METHOD method_1210 getRule (Ljava/lang/String;)Lnet/minecraft/class_270$class_271;
 			ARG 0 name
 	CLASS class_272 VisibilityRule
@@ -32,4 +32,4 @@ CLASS net/minecraft/class_270 net/minecraft/scoreboard/AbstractTeam
 			ARG 4 value
 		METHOD method_1213 getRule (Ljava/lang/String;)Lnet/minecraft/class_270$class_272;
 			ARG 0 name
-		METHOD method_1214 getTranslationKey ()Lnet/minecraft/class_2561;
+		METHOD method_1214 getDisplayName ()Lnet/minecraft/class_2561;


### PR DESCRIPTION
Closes #2693

Uses `displayName` as item stack, etc. In addition, the item group already has a string `name`, so I chose `displayName` across the board.