### PR TITLE
Fix build errors

### DIFF
--- a/mappings/net/minecraft/block/entity/BlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntity.mapping
@@ -34,8 +34,10 @@ CLASS net/minecraft/class_2586 net/minecraft/block/entity/BlockEntity
 	METHOD method_11016 getPos ()Lnet/minecraft/class_2338;
 	METHOD method_11017 getType ()Lnet/minecraft/class_2591;
 	METHOD method_16887 toInitialChunkDataNbt ()Lnet/minecraft/class_2487;
-		COMMENT Serializes the state of this block entity that is observable by clients. It is sent alongside the initial chunk data,
-		COMMENT as well as when the block entity implements {@link #toUpdatePacket} and decides to use the default {@link BlockEntityUpdateS2CPacket}.
+		COMMENT Serializes the state of this block entity that is observable by clients.
+		COMMENT It is sent alongside the initial chunk data, as well as when the block
+		COMMENT entity implements {@link #toUpdatePacket} and decides to use the default
+		COMMENT {@link net.minecraft.network.packet.s2c.play.BlockEntityUpdateS2CPacket}.
 	METHOD method_31662 setWorld (Lnet/minecraft/class_1937;)V
 		ARG 1 world
 	METHOD method_31663 markDirty (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)V

--- a/mappings/net/minecraft/world/gen/surfacebuilder/DefaultSurfaceBuilder.mapping
+++ b/mappings/net/minecraft/world/gen/surfacebuilder/DefaultSurfaceBuilder.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_3510 net/minecraft/world/gen/surfacebuilder/DefaultSur
 		ARG 1 random
 		ARG 2 column
 		ARG 3 biome
-		ARG 4 z
+		ARG 4 x
 		ARG 5 z
 		ARG 6 height
 		ARG 7 noise


### PR DESCRIPTION
Fixes these errors:
```
Overridden parameter name detected in net/minecraft/world/gen/surfacebuilder/DefaultSurfaceBuilder generate (Ljava/util/Random;Lnet/minecraft/world/gen/chunk/BlockColumn;Lnet/minecraft/world/biome/Biome;IIIDLnet/minecraft/block/BlockState;Lnet/minecraft/block/BlockState;Lnet/minecraft/block/BlockState;Lnet/minecraft/block/BlockState;Lnet/minecraft/block/BlockState;II)V slot 5, resetting
```
```
/__w/yarn/yarn/.gradle/temp/fakeSource/net/minecraft/block/entity/BlockEntity.java:272: error: reference not found

   * as well as when the block entity implements {@link #toUpdatePacket} and decides to use the default {@link BlockEntityUpdateS2CPacket}.
                                                                                                               ^
```