### PR TITLE
Fix parameter mis-order in BrewingRecipeRegistry

### DIFF
--- a/mappings/net/minecraft/recipe/BrewingRecipeRegistry.mapping
+++ b/mappings/net/minecraft/recipe/BrewingRecipeRegistry.mapping
@@ -30,8 +30,8 @@ CLASS net/minecraft/class_1845 net/minecraft/recipe/BrewingRecipeRegistry
 	METHOD method_8077 isValidIngredient (Lnet/minecraft/class_1799;)Z
 		ARG 0 stack
 	METHOD method_8078 craft (Lnet/minecraft/class_1799;Lnet/minecraft/class_1799;)Lnet/minecraft/class_1799;
-		ARG 0 input
-		ARG 1 ingredient
+		ARG 0 ingredient
+		ARG 1 input
 	METHOD method_8079 isItemRecipeIngredient (Lnet/minecraft/class_1799;)Z
 		ARG 0 stack
 	METHOD method_8080 registerPotionType (Lnet/minecraft/class_1792;)V


### PR DESCRIPTION
The method `BrewingRecipeRegistry#craft(input, ingredient)` has the potion itemstack named `ingredient` but in the previous method `BrewingRecipeRegistry#hasPotionRecipe` the potion itemstack is `input`. They are inverted. One or the other should be swapped so the parameter names are consistent with what they represent in the context of potion brewing