### PR TITLE
Spawn point tweaks and fixes

### DIFF
--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -73,6 +73,9 @@ CLASS net/minecraft/class_1657 net/minecraft/entity/player/PlayerEntity
 	METHOD method_26091 findRespawnPosition (Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;FZZ)Ljava/util/Optional;
 		ARG 0 world
 		ARG 1 pos
+		ARG 2 angle
+		ARG 3 forced
+		ARG 4 alive
 	METHOD method_26956 createPlayerAttributes ()Lnet/minecraft/class_5132$class_5133;
 	METHOD method_31548 getInventory ()Lnet/minecraft/class_1661;
 	METHOD method_31549 getAbilities ()Lnet/minecraft/class_1656;

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -71,11 +71,22 @@ CLASS net/minecraft/class_1657 net/minecraft/entity/player/PlayerEntity
 	METHOD method_23669 startFallFlying ()V
 	METHOD method_23670 stopFallFlying ()V
 	METHOD method_26091 findRespawnPosition (Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;FZZ)Ljava/util/Optional;
+		COMMENT Finds the precise respawn position from a {@link BlockPos} in a world.
+		COMMENT Also applies respawning effects on the spawn point blocks
+		COMMENT such as decreasing respawn anchor charges.
+		COMMENT
+		COMMENT <p>If {@code forced} is {@code false}, this method will only apply to
+		COMMENT respawn anchors and beds. If it's {@code true}, a respawn point can be anywhere
+		COMMENT as long as the player can spawn inside the necessary blocks.
 		ARG 0 world
+			COMMENT the world where the spawn point is located
 		ARG 1 pos
+			COMMENT the spawn point as a {@link BlockPos}
 		ARG 2 angle
 		ARG 3 forced
+			COMMENT {@code true} if the spawn point is forced, {@code false} otherwise
 		ARG 4 alive
+			COMMENT if {@code true}, the player is alive, otherwise respawning after a death
 	METHOD method_26956 createPlayerAttributes ()Lnet/minecraft/class_5132$class_5133;
 	METHOD method_31548 getInventory ()Lnet/minecraft/class_1661;
 	METHOD method_31549 getAbilities ()Lnet/minecraft/class_1656;

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -164,7 +164,7 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 		ARG 4 forced
 			COMMENT whether the new spawn point is {@linkplain #isSpawnForced() forced}
 		ARG 5 sendMessage
-			COMMENT if {@code true}, a chat message about the spawn point change will be sent
+			COMMENT if {@code true}, a game message about the spawn point change will be sent
 	METHOD method_26285 isBedTooFarAway (Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Z
 		ARG 1 pos
 		ARG 2 direction

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -39,7 +39,7 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	FIELD field_13998 joinInvulnerabilityTicks I
 	FIELD field_23191 spawnPointDimension Lnet/minecraft/class_5321;
 	FIELD field_23192 spawnPointPosition Lnet/minecraft/class_2338;
-	FIELD field_23193 spawnPointSet Z
+	FIELD field_23193 spawnForced Z
 	FIELD field_26353 spawnAngle F
 	FIELD field_26821 textStream Lnet/minecraft/class_5513;
 	FIELD field_28860 filterText Z
@@ -153,13 +153,18 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 		ARG 1 origin
 	METHOD method_26280 getSpawnPointPosition ()Lnet/minecraft/class_2338;
 	METHOD method_26281 getSpawnPointDimension ()Lnet/minecraft/class_5321;
-	METHOD method_26282 isSpawnPointSet ()Z
+	METHOD method_26282 isSpawnForced ()Z
 	METHOD method_26284 setSpawnPoint (Lnet/minecraft/class_5321;Lnet/minecraft/class_2338;FZZ)V
+		COMMENT Sets the player's spawn point.
 		ARG 1 dimension
+			COMMENT the new spawn dimension
 		ARG 2 pos
+			COMMENT the new spawn point, or {@code null} if resetting to the world spawn
 		ARG 3 angle
-		ARG 4 spawnPointSet
+		ARG 4 forced
+			COMMENT whether the new spawn point is {@linkplain #isSpawnForced() forced}
 		ARG 5 sendMessage
+			COMMENT if {@code true}, a chat message about the spawn point change will be sent
 	METHOD method_26285 isBedTooFarAway (Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Z
 		ARG 1 pos
 		ARG 2 direction


### PR DESCRIPTION
- `spawnPointSet` -> `spawnForced` + getter
  - To match the NBT key, and because a non-forced spawn point (e.g. a bed) can be set
- Added various parameter mappings and some jd