### PR TITLE
Rename DefaultBiomeCreator to OverworldBiomeCreator and add mappings for Nether and End counterparts

### DIFF
--- a/mappings/net/minecraft/world/biome/EndBiomeCreator.mapping
+++ b/mappings/net/minecraft/world/biome/EndBiomeCreator.mapping
@@ -1,0 +1,7 @@
+CLASS net/minecraft/class_6726 net/minecraft/world/biome/EndBiomeCreator
+	METHOD method_39140 createEndBarrens ()Lnet/minecraft/class_1959;
+	METHOD method_39141 createEndBiome (Lnet/minecraft/class_5485$class_5495;)Lnet/minecraft/class_1959;
+	METHOD method_39142 createTheEnd ()Lnet/minecraft/class_1959;
+	METHOD method_39143 createEndMidlands ()Lnet/minecraft/class_1959;
+	METHOD method_39144 createEndHighlands ()Lnet/minecraft/class_1959;
+	METHOD method_39145 createSmallEndIslands ()Lnet/minecraft/class_1959;

--- a/mappings/net/minecraft/world/biome/NetherBiomeCreator.mapping
+++ b/mappings/net/minecraft/world/biome/NetherBiomeCreator.mapping
@@ -1,0 +1,6 @@
+CLASS net/minecraft/class_6727 net/minecraft/world/biome/NetherBiomeCreator
+	METHOD method_39146 createNetherWastes ()Lnet/minecraft/class_1959;
+	METHOD method_39147 createSoulSandValley ()Lnet/minecraft/class_1959;
+	METHOD method_39148 createBasaltDeltas ()Lnet/minecraft/class_1959;
+	METHOD method_39149 createCrimsonForest ()Lnet/minecraft/class_1959;
+	METHOD method_39150 createWarpedForest ()Lnet/minecraft/class_1959;

--- a/mappings/net/minecraft/world/biome/OverworldBiomeCreator.mapping
+++ b/mappings/net/minecraft/world/biome/OverworldBiomeCreator.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_5478 net/minecraft/world/biome/DefaultBiomeCreator
+CLASS net/minecraft/class_5478 net/minecraft/world/biome/OverworldBiomeCreator
 	METHOD method_30683 createJungle ()Lnet/minecraft/class_1959;
 	METHOD method_30684 createMushroomFields ()Lnet/minecraft/class_1959;
 	METHOD method_30685 createBeach (ZZ)Lnet/minecraft/class_1959;


### PR DESCRIPTION
Looks like Nether's and End's biome creator has been extracted out to their own classes in 21w41a.