### PR TITLE
Fix record signatures

### DIFF
--- a/record_signatures.json
+++ b/record_signatures.json
@@ -3,5 +3,9 @@
 	"net/minecraft/class_2841$class_6562": "<T:Ljava/lang/Object;>Ljava/lang/Record;",
 	"net/minecraft/class_6497": "<T::Ljava/lang/Comparable<TT;>;>Ljava/lang/Record;",
 	"net/minecraft/class_6535": "<T::Lnet/minecraft/class_6534;>Ljava/lang/Record;",
-	"net/minecraft/class_2769$class_4933": "<T::Ljava/lang/Comparable<TT;>;>Ljava/lang/Record;"
+	"net/minecraft/class_2769$class_4933": "<T::Ljava/lang/Comparable<TT;>;>Ljava/lang/Record;",
+	"net/minecraft/class_6759": "<T::Ljava/lang/Object;>Ljava/lang/Record;",
+	"net/minecraft/class_6760": "<T::Ljava/lang/Object;>Ljava/lang/Record;",
+	"net/minecraft/class_5699$class_6739": "<A::Ljava/lang/Object;>Ljava/lang/Record;",
+	"net/minecraft/class_6492$class_6738": "<C::Ljava/lang/Object;>Ljava/lang/Record;"
 }


### PR DESCRIPTION
Fixes the genFakeSource errors e.g.
```
/__w/yarn/yarn/.gradle/temp/fakeSource/net/minecraft/class_6759.java:38: error: cannot find symbol
record class_6759(T type, BlockPos pos, int delay, TickPriority priority) {
                  ^
  symbol:   class T
  location: class class_6759
```

See https://github.com/FabricMC/yarn/runs/4033308142#step:5:196 for the list of errors.