### PR TITLE
Fix the issue where superinterfaces are not included in record signatures

### DIFF
--- a/record_signatures.json
+++ b/record_signatures.json
@@ -6,6 +6,6 @@
 	"net/minecraft/class_2769$class_4933": "<T::Ljava/lang/Comparable<TT;>;>Ljava/lang/Record;",
 	"net/minecraft/class_6759": "<T::Ljava/lang/Object;>Ljava/lang/Record;",
 	"net/minecraft/class_6760": "<T::Ljava/lang/Object;>Ljava/lang/Record;",
-	"net/minecraft/class_5699$class_6739": "<A::Ljava/lang/Object;>Ljava/lang/Record;",
-	"net/minecraft/class_6492$class_6738": "<C::Ljava/lang/Object;>Ljava/lang/Record;"
+	"net/minecraft/class_5699$class_6739": "<A::Ljava/lang/Object;>Ljava/lang/Record;Lcom/mojang/serialization/Codec;",
+	"net/minecraft/class_6492$class_6738": "<C::Ljava/lang/Object;>Ljava/lang/Record;Lnet/minecraft/class_6492;"
 }


### PR DESCRIPTION
These records implement some interfaces. I forgot to include them in #2797.