### PR TITLE
Unpick key binding categories

### DIFF
--- a/unpick-definitions/key_bindings.unpick
+++ b/unpick-definitions/key_bindings.unpick
@@ -164,6 +164,7 @@ target_method net/minecraft/client/option/KeyBinding getCategory ()Ljava/lang/St
 	return key_categories
 target_method net/minecraft/client/option/StickyKeyBinding <init> (Ljava/lang/String;ILjava/lang/String;Ljava/util/function/BooleanSupplier;)V
 	param 1 key_codes
+	param 2 key_categories
 target_method net/minecraft/client/gui/Element keyPressed (III)Z
 	param 0 key_codes
 target_method net/minecraft/client/gui/Element keyReleased (III)Z

--- a/unpick-definitions/key_bindings.unpick
+++ b/unpick-definitions/key_bindings.unpick
@@ -130,6 +130,14 @@ constant key_codes org/lwjgl/glfw/GLFW GLFW_KEY_PRINT_SCREEN
 constant key_codes org/lwjgl/glfw/GLFW GLFW_KEY_WORLD_1
 constant key_codes org/lwjgl/glfw/GLFW GLFW_KEY_WORLD_2
 
+constant key_categories net/minecraft/client/option/KeyBinding MOVEMENT_CATEGORY
+constant key_categories net/minecraft/client/option/KeyBinding MISC_CATEGORY
+constant key_categories net/minecraft/client/option/KeyBinding MULTIPLAYER_CATEGORY
+constant key_categories net/minecraft/client/option/KeyBinding GAMEPLAY_CATEGORY
+constant key_categories net/minecraft/client/option/KeyBinding INVENTORY_CATEGORY
+constant key_categories net/minecraft/client/option/KeyBinding UI_CATEGORY
+constant key_categories net/minecraft/client/option/KeyBinding CREATIVE_CATEGORY
+
 target_method net/minecraft/client/util/InputUtil$Type mapKey (Lnet/minecraft/client/util/InputUtil$Type;Ljava/lang/String;I)V
 	param 2 key_codes
 target_method net/minecraft/client/util/InputUtil$Type createFromCode (I)Lnet/minecraft/client/util/InputUtil$Key;
@@ -144,12 +152,16 @@ target_method net/minecraft/client/util/InputUtil fromKeyCode (II)Lnet/minecraft
 	param 0 key_codes
 target_method net/minecraft/client/option/KeyBinding <init> (Ljava/lang/String;ILjava/lang/String;)V
 	param 1 key_codes
+	param 2 key_categories
 target_method net/minecraft/client/option/KeyBinding <init> (Ljava/lang/String;Lnet/minecraft/client/util/InputUtil$Type;ILjava/lang/String;)V
 	param 2 key_codes
+	param 3 key_categories
 target_method net/minecraft/client/option/KeyBinding matchesKey (II)Z
 	param 0 key_codes
 target_method net/minecraft/client/option/KeyBinding matchesMouse (I)Z
 	param 0 key_codes
+target_method net/minecraft/client/option/KeyBinding getCategory ()Ljava/lang/String;
+	return key_categories
 target_method net/minecraft/client/option/StickyKeyBinding <init> (Ljava/lang/String;ILjava/lang/String;Ljava/util/function/BooleanSupplier;)V
 	param 1 key_codes
 target_method net/minecraft/client/gui/Element keyPressed (III)Z


### PR DESCRIPTION
Note that this modifies the existing `key_codes.unpick` file and renames it to `key_bindings.unpick` since you can't have multiple target method definitions for the same target method.