### PR TITLE
Map two new classes

### DIFF
--- a/mappings/net/minecraft/class_6780.mapping
+++ b/mappings/net/minecraft/class_6780.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/class_6780
-	METHOD method_38109 getBiome (IIILnet/minecraft/class_6544$class_6552;)Lnet/minecraft/class_1959;

--- a/mappings/net/minecraft/world/biome/source/BiomeSupplier.mapping
+++ b/mappings/net/minecraft/world/biome/source/BiomeSupplier.mapping
@@ -1,0 +1,6 @@
+CLASS net/minecraft/class_6780 net/minecraft/world/biome/source/BiomeSupplier
+	METHOD method_38109 getBiome (IIILnet/minecraft/class_6544$class_6552;)Lnet/minecraft/class_1959;
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+		ARG 4 noise

--- a/mappings/net/minecraft/world/gen/feature/util/FeatureDebugLogger.mapping
+++ b/mappings/net/minecraft/world/gen/feature/util/FeatureDebugLogger.mapping
@@ -1,0 +1,25 @@
+CLASS net/minecraft/class_6785 net/minecraft/world/gen/feature/util/FeatureDebugLogger
+	FIELD field_35704 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_35705 FEATURES Lcom/google/common/cache/LoadingCache;
+	METHOD method_39597 clear ()V
+	METHOD method_39598 incrementTotalChunksCount (Lnet/minecraft/class_3218;)V
+		ARG 0 world
+	METHOD method_39599 incrementFeatureCount (Lnet/minecraft/class_3218;Lnet/minecraft/class_2975;Ljava/util/Optional;)V
+		ARG 0 world
+		ARG 1 configuredFeature
+		ARG 2 placedFeature
+	METHOD method_39600 (Lnet/minecraft/class_3218;Lnet/minecraft/class_6785$class_6787;)V
+		ARG 0 world
+		ARG 1 features
+	METHOD method_39601 (Lnet/minecraft/class_6785$class_6786;Ljava/lang/Integer;)Ljava/lang/Integer;
+		ARG 0 featureData
+		ARG 1 count
+	METHOD method_39602 (Ljava/lang/String;Ljava/lang/Integer;Lnet/minecraft/class_2378;Lnet/minecraft/class_6785$class_6786;Ljava/lang/Integer;)V
+		ARG 3 featureData
+		ARG 4 count
+	METHOD method_39603 dump ()V
+	CLASS 1
+		METHOD load (Ljava/lang/Object;)Ljava/lang/Object;
+			ARG 1 world
+	CLASS class_6786 FeatureData
+	CLASS class_6787 Features


### PR DESCRIPTION
`BiomeSupplier`, which is implemented in `BiomeSource` (and perhaps some other places since it's technically functional interface), and `FeatureDebugLogger`, an unused debugging util.