### PR TITLE
Standardise use of Oxidation over Oxidization

### DIFF
--- a/mappings/net/minecraft/block/Oxidizable.mapping
+++ b/mappings/net/minecraft/block/Oxidizable.mapping
@@ -15,4 +15,4 @@ CLASS net/minecraft/class_5955 net/minecraft/block/Oxidizable
 		ARG 0 block
 	METHOD method_34738 getUnaffectedOxidationState (Lnet/minecraft/class_2680;)Lnet/minecraft/class_2680;
 		ARG 0 state
-	CLASS class_5811 OxidizationLevel
+	CLASS class_5811 OxidationLevel

--- a/mappings/net/minecraft/block/OxidizableBlock.mapping
+++ b/mappings/net/minecraft/block/OxidizableBlock.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_5812 net/minecraft/block/OxidizableBlock
-	FIELD field_28709 oxidizationLevel Lnet/minecraft/class_5955$class_5811;
+	FIELD field_28709 oxidationLevel Lnet/minecraft/class_5955$class_5811;
 	METHOD <init> (Lnet/minecraft/class_5955$class_5811;Lnet/minecraft/class_4970$class_2251;)V
-		ARG 1 oxidizationLevel
+		ARG 1 oxidationLevel
 		ARG 2 settings

--- a/mappings/net/minecraft/block/OxidizableSlabBlock.mapping
+++ b/mappings/net/minecraft/block/OxidizableSlabBlock.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_5813 net/minecraft/block/OxidizableSlabBlock
-	FIELD field_28711 oxidizationLevel Lnet/minecraft/class_5955$class_5811;
+	FIELD field_28711 oxidationLevel Lnet/minecraft/class_5955$class_5811;
 	METHOD <init> (Lnet/minecraft/class_5955$class_5811;Lnet/minecraft/class_4970$class_2251;)V
-		ARG 1 oxidizationLevel
+		ARG 1 oxidationLevel
 		ARG 2 settings

--- a/mappings/net/minecraft/block/OxidizableStairsBlock.mapping
+++ b/mappings/net/minecraft/block/OxidizableStairsBlock.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_5814 net/minecraft/block/OxidizableStairsBlock
-	FIELD field_28713 oxidizationLevel Lnet/minecraft/class_5955$class_5811;
+	FIELD field_28713 oxidationLevel Lnet/minecraft/class_5955$class_5811;
 	METHOD <init> (Lnet/minecraft/class_5955$class_5811;Lnet/minecraft/class_2680;Lnet/minecraft/class_4970$class_2251;)V
-		ARG 1 oxidizationLevel
+		ARG 1 oxidationLevel
 		ARG 2 baseBlockState
 		ARG 3 settings

--- a/mappings/net/minecraft/entity/LightningEntity.mapping
+++ b/mappings/net/minecraft/entity/LightningEntity.mapping
@@ -9,17 +9,17 @@ CLASS net/minecraft/class_1538 net/minecraft/entity/LightningEntity
 	METHOD method_29498 setCosmetic (Z)V
 		ARG 1 cosmetic
 	METHOD method_31499 powerLightningRod ()V
-	METHOD method_34707 cleanOxidization (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)V
+	METHOD method_34707 cleanOxidation (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)V
 		ARG 0 world
 		ARG 1 pos
 	METHOD method_34708 (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)V
 		ARG 2 state
-	METHOD method_34709 cleanOxidizationAround (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2338$class_2339;I)V
+	METHOD method_34709 cleanOxidationAround (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2338$class_2339;I)V
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 mutablePos
 		ARG 3 count
-	METHOD method_34710 cleanOxidizationAround (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)Ljava/util/Optional;
+	METHOD method_34710 cleanOxidationAround (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)Ljava/util/Optional;
 		ARG 0 world
 		ARG 1 pos
 	METHOD method_35052 getChanneler ()Lnet/minecraft/class_3222;

--- a/mappings/net/minecraft/world/WorldEvents.mapping
+++ b/mappings/net/minecraft/world/WorldEvents.mapping
@@ -216,7 +216,7 @@ CLASS net/minecraft/class_6088 net/minecraft/world/WorldEvents
 		COMMENT <p>The ordinal direction the lightning rod is facing must be supplied as extra data.
 		COMMENT <br>A {@code -1} should be passed if the event is called by a lightning entity itself.
 		COMMENT <p>Called by {@link net.minecraft.block.LightningRodBlock#setPowered(net.minecraft.block.BlockState, net.minecraft.world.World, net.minecraft.util.math.BlockPos) LightningRodBlock#setPowered},
-		COMMENT and {@link net.minecraft.entity.LightningEntity#cleanOxidizationAround(net.minecraft.world.World, net.minecraft.util.math.BlockPos) LightningEntity#cleanOxidizationAround}
+		COMMENT and {@link net.minecraft.entity.LightningEntity#cleanOxidationAround(net.minecraft.world.World, net.minecraft.util.math.BlockPos) LightningEntity#cleanOxidationAround}
 	FIELD field_31156 BLOCK_WAXED I
 		COMMENT A block is waxed.
 		COMMENT <br>Plays the block waxing sound event and spawns waxing particles.


### PR DESCRIPTION
Previously, a mix of the two were used.

Mojang seems to use the word 'Oxidation' over 'Oxidization' (see [this blogpost](https://www.minecraft.net/en-us/article/minecraft-snapshot-20w45a)) so all instances of the latter have been changed to the former.