### PR TITLE
Use "offhand" instead of "offHand"

### DIFF
--- a/mappings/net/minecraft/client/render/item/HeldItemRenderer.mapping
+++ b/mappings/net/minecraft/client/render/item/HeldItemRenderer.mapping
@@ -28,10 +28,10 @@ CLASS net/minecraft/class_759 net/minecraft/client/render/item/HeldItemRenderer
 	FIELD field_4044 itemRenderer Lnet/minecraft/class_918;
 	FIELD field_4046 renderManager Lnet/minecraft/class_898;
 	FIELD field_4047 mainHand Lnet/minecraft/class_1799;
-	FIELD field_4048 offHand Lnet/minecraft/class_1799;
+	FIELD field_4048 offhand Lnet/minecraft/class_1799;
 	FIELD field_4050 client Lnet/minecraft/class_310;
-	FIELD field_4051 prevEquipProgressOffHand F
-	FIELD field_4052 equipProgressOffHand F
+	FIELD field_4051 prevEquipProgressOffhand F
+	FIELD field_4052 equipProgressOffhand F
 	FIELD field_4053 prevEquipProgressMainHand F
 	METHOD <init> (Lnet/minecraft/class_310;)V
 		ARG 1 client
@@ -118,9 +118,9 @@ CLASS net/minecraft/class_759 net/minecraft/client/render/item/HeldItemRenderer
 		ARG 0 player
 	CLASS class_5773 HandRenderType
 		FIELD field_28387 renderMainHand Z
-		FIELD field_28388 renderOffHand Z
+		FIELD field_28388 renderOffhand Z
 		METHOD <init> (Ljava/lang/String;IZZ)V
 			ARG 3 renderMainHand
-			ARG 4 renderOffHand
+			ARG 4 renderOffhand
 		METHOD method_33305 shouldOnlyRender (Lnet/minecraft/class_1268;)Lnet/minecraft/class_759$class_5773;
 			ARG 0 hand

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_23128 SOUL_SPEED_BOOST_ID Ljava/util/UUID;
 	FIELD field_27859 POWDER_SNOW_SLOW_ID Ljava/util/UUID;
 	FIELD field_30064 USING_ITEM_FLAG I
-	FIELD field_30065 OFF_HAND_ACTIVE_FLAG I
+	FIELD field_30065 OFFHAND_ACTIVE_FLAG I
 	FIELD field_30066 USING_RIPTIDE_FLAG I
 	FIELD field_30082 noDrag Z
 	FIELD field_6210 bodyTrackingIncrements I
@@ -471,7 +471,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 2 state
 	METHOD method_6078 onDeath (Lnet/minecraft/class_1282;)V
 		ARG 1 source
-	METHOD method_6079 getOffHandStack ()Lnet/minecraft/class_1799;
+	METHOD method_6079 getOffhandStack ()Lnet/minecraft/class_1799;
 	METHOD method_6081 getRecentDamageSource ()Lnet/minecraft/class_1282;
 	METHOD method_6082 teleport (DDDZ)Z
 		ARG 1 x

--- a/mappings/net/minecraft/entity/ai/brain/task/RemoveOffHandItemTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/RemoveOffHandItemTask.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_4830 net/minecraft/entity/ai/brain/task/RemoveOffHandItemTask

--- a/mappings/net/minecraft/entity/ai/brain/task/RemoveOffhandItemTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/RemoveOffhandItemTask.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_4830 net/minecraft/entity/ai/brain/task/RemoveOffhandItemTask

--- a/mappings/net/minecraft/entity/mob/PiglinBrain.mapping
+++ b/mappings/net/minecraft/entity/mob/PiglinBrain.mapping
@@ -55,7 +55,7 @@ CLASS net/minecraft/class_4838 net/minecraft/entity/mob/PiglinBrain
 	METHOD method_24738 makeGoToSoulFireTask ()Lnet/minecraft/class_4121;
 	METHOD method_24739 isGoldHoldingPlayer (Lnet/minecraft/class_1309;)Z
 		ARG 0 target
-	METHOD method_24741 consumeOffHandItem (Lnet/minecraft/class_4836;Z)V
+	METHOD method_24741 consumeOffhandItem (Lnet/minecraft/class_4836;Z)V
 		ARG 0 piglin
 		ARG 1 barter
 	METHOD method_24742 angerAtCloserTargets (Lnet/minecraft/class_5418;Lnet/minecraft/class_1309;)V
@@ -153,11 +153,11 @@ CLASS net/minecraft/class_4838 net/minecraft/entity/mob/PiglinBrain
 	METHOD method_24849 barterItem (Lnet/minecraft/class_4836;Lnet/minecraft/class_1799;)V
 		ARG 0 piglin
 		ARG 1 stack
-	METHOD method_24850 doesNotHaveGoldInOffHand (Lnet/minecraft/class_4836;)Z
+	METHOD method_24850 doesNotHaveGoldInOffhand (Lnet/minecraft/class_4836;)Z
 		ARG 0 piglin
-	METHOD method_24917 hasItemInOffHand (Lnet/minecraft/class_4836;)Z
+	METHOD method_24917 hasItemInOffhand (Lnet/minecraft/class_4836;)Z
 		ARG 0 piglin
-	METHOD method_25948 pickupItemWithOffHand (Lnet/minecraft/class_4836;)V
+	METHOD method_25948 pickupItemWithOffhand (Lnet/minecraft/class_4836;)V
 		ARG 0 piglin
 	METHOD method_26350 getNearbyPiglins (Lnet/minecraft/class_5418;)Ljava/util/List;
 		ARG 0 piglin
@@ -187,7 +187,7 @@ CLASS net/minecraft/class_4838 net/minecraft/entity/mob/PiglinBrain
 	METHOD method_30087 getSound (Lnet/minecraft/class_4836;Lnet/minecraft/class_4168;)Lnet/minecraft/class_3414;
 		ARG 0 piglin
 		ARG 1 activity
-	METHOD method_30089 swapItemWithOffHand (Lnet/minecraft/class_4836;Lnet/minecraft/class_1799;)V
+	METHOD method_30089 swapItemWithOffhand (Lnet/minecraft/class_4836;Lnet/minecraft/class_1799;)V
 		ARG 0 piglin
 		ARG 1 stack
 	METHOD method_30090 goToNemesisTask ()Lnet/minecraft/class_4809;

--- a/mappings/net/minecraft/entity/mob/PiglinEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/PiglinEntity.mapping
@@ -23,7 +23,7 @@ CLASS net/minecraft/class_4836 net/minecraft/entity/mob/PiglinEntity
 		ARG 1 stack
 	METHOD method_24844 equipToMainHand (Lnet/minecraft/class_1799;)V
 		ARG 1 stack
-	METHOD method_24845 equipToOffHand (Lnet/minecraft/class_1799;)V
+	METHOD method_24845 equipToOffhand (Lnet/minecraft/class_1799;)V
 		ARG 1 stack
 	METHOD method_24846 canEquipStack (Lnet/minecraft/class_1799;)Z
 		COMMENT Returns whether this piglin can equip into or replace current equipment slot.

--- a/mappings/net/minecraft/entity/player/PlayerInventory.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerInventory.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_1661 net/minecraft/entity/player/PlayerInventory
 		COMMENT The maximum cooldown ({@value} ticks) applied to timed use items such as the Eye of Ender.
 	FIELD field_30638 MAIN_SIZE I
 		COMMENT The number of slots ({@value}) in the main (non-hotbar) section of the inventory.
-	FIELD field_30639 OFF_HAND_SLOT I
+	FIELD field_30639 OFFHAND_SLOT I
 		COMMENT Zero-based index of the offhand slot.
 		COMMENT
 		COMMENT <p>This value is the result of the sum {@code MAIN_SIZE (36) + ARMOR_SIZE (4)}.</p>
@@ -19,7 +19,7 @@ CLASS net/minecraft/class_1661 net/minecraft/entity/player/PlayerInventory
 	FIELD field_33768 HELMET_SLOTS [I
 	FIELD field_7542 changeCount I
 	FIELD field_7543 combinedInventory Ljava/util/List;
-	FIELD field_7544 offHand Lnet/minecraft/class_2371;
+	FIELD field_7544 offhand Lnet/minecraft/class_2371;
 	FIELD field_7545 selectedSlot I
 	FIELD field_7546 player Lnet/minecraft/class_1657;
 	FIELD field_7547 main Lnet/minecraft/class_2371;

--- a/mappings/net/minecraft/network/packet/s2c/play/EntityAnimationS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/EntityAnimationS2CPacket.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_2616 net/minecraft/network/packet/s2c/play/EntityAnima
 	FIELD field_33295 SWING_MAIN_HAND I
 	FIELD field_33296 DAMAGE I
 	FIELD field_33297 WAKE_UP I
-	FIELD field_33298 SWING_OFF_HAND I
+	FIELD field_33298 SWING_OFFHAND I
 	FIELD field_33299 CRIT I
 	FIELD field_33300 ENCHANTED_HIT I
 	METHOD <init> (Lnet/minecraft/class_1297;I)V


### PR DESCRIPTION
Resolves #2818

Question: should we remap `Hand.OFF_HAND` (an enum)?