### PR TITLE
Update mappingpoet to include a warning for records' behavior under reflection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -889,7 +889,7 @@ javadoc {
 				'implSpec:a:Implementation Requirements:',
 				'implNote:a:Implementation Note:'
 		)
-		taglets "net.fabricmc.mappingpoet.jd.MappingTaglet"
+		taglets "net.fabricmc.mappingpoet.jd.RecordWarningTaglet", "net.fabricmc.mappingpoet.jd.MappingTaglet"
 		// taglet path, header, extra stylesheet settings deferred
 		it.use()
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ name_proposal_version=0.1.2
 # Javadoc generation/linking
 fabric_loader_version=0.11.6
 jetbrains_annotations_version=22.0.0
-mappingpoet_version=0.3.0
+mappingpoet_version=0.3.1


### PR DESCRIPTION
Warning text:
https://github.com/FabricMC/MappingPoet/blob/master/src/main/resources/record_warning.txt

```
<div class="deprecation-block"><span class="deprecated-label">Warning: This class is not a record at runtime!</span>
<div class="deprecation-comment">Due to Proguard processing, This class is not a record at
       runtime when inspected by reflection. In addition, if this record has any type parameter,
       inspecting generic types through reflection may have unexpected results or throw exceptions.
       See <a href="https://fabricmc.net/wiki/tutorial:reflection#records">
       The Fabric Wiki</a> for more details.</div>
</div>
```

See also https://fabricmc.net/wiki/tutorial:reflection#records for detailed explanation.