### PR TITLE
Fix OptionsScreen.createDifficultyButtonWidget parameter

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/option/OptionsScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/option/OptionsScreen.mapping
@@ -32,6 +32,7 @@ CLASS net/minecraft/class_429 net/minecraft/client/gui/screen/option/OptionsScre
 	METHOD method_29975 refreshResourcePacks (Lnet/minecraft/class_3283;)V
 		ARG 1 resourcePackManager
 	METHOD method_39486 createDifficultyButtonWidget (IIILjava/lang/String;Lnet/minecraft/class_310;)Lnet/minecraft/class_5676;
+		ARG 0 buttonIndex
 		ARG 1 width
 		ARG 2 height
 		ARG 3 translationKey

--- a/mappings/net/minecraft/client/gui/screen/option/OptionsScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/option/OptionsScreen.mapping
@@ -34,7 +34,7 @@ CLASS net/minecraft/class_429 net/minecraft/client/gui/screen/option/OptionsScre
 	METHOD method_39486 createDifficultyButtonWidget (IIILjava/lang/String;Lnet/minecraft/class_310;)Lnet/minecraft/class_5676;
 		ARG 1 width
 		ARG 2 height
-		ARG 3 text
+		ARG 3 translationKey
 		ARG 4 client
 	METHOD method_39487 (Lnet/minecraft/class_310;Lnet/minecraft/class_5676;Lnet/minecraft/class_1267;)V
 		ARG 2 difficulty


### PR DESCRIPTION
Renamed `text` to `translationKey` because it's passed to `TranslatableText` constructor.