### PR TITLE
Fix javadoc reference errors

### DIFF
--- a/mappings/net/minecraft/client/render/entity/model/MinecartEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/MinecartEntityModel.mapping
@@ -22,9 +22,6 @@ CLASS net/minecraft/class_580 net/minecraft/client/render/entity/model/MinecartE
 	COMMENT <tr>
 	COMMENT   <td>{@code right}</td><td>{@linkplain #root Root part}</td><td></td>
 	COMMENT </tr>
-	COMMENT <tr>
-	COMMENT   <td>{@value #CONTENTS}</td><td>{@linkplain #root Root part}</td><td>{@link #contents}</td>
-	COMMENT </tr>
 	COMMENT </table>
 	COMMENT </div>
 	FIELD field_27452 root Lnet/minecraft/class_630;

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -51,8 +51,6 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	FIELD field_29994 UUID_KEY Ljava/lang/String;
 	FIELD field_33758 hasVisualFire Z
 	FIELD field_34927 collidedSoftly Z
-		COMMENT Whether the collision velocity (speed at which the entity hit a given surface)
-		COMMENT is lower than {@link Entity#MAX_SOFT_COLLISION_SPEED}.
 	FIELD field_35101 chunkPos Lnet/minecraft/class_1923;
 	FIELD field_35588 blockStateAtPos Lnet/minecraft/class_2680;
 	FIELD field_5951 ridingCooldown I

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -136,7 +136,9 @@ CLASS net/minecraft/class_1657 net/minecraft/entity/player/PlayerEntity
 	METHOD method_7269 trySleep (Lnet/minecraft/class_2338;)Lcom/mojang/datafixers/util/Either;
 		COMMENT Tries to start sleeping on a block.
 		COMMENT
-		COMMENT @return an {@link Either.Right} if successful, otherwise an {@link Either.Left} containing the failure reason
+		COMMENT @return an {@link com.mojang.datafixers.util.Either.Right Either.Right}
+		COMMENT if successful, otherwise an {@link com.mojang.datafixers.util.Either.Left
+		COMMENT Either.Left} containing the failure reason
 		ARG 1 pos
 			COMMENT the position of the bed block
 	METHOD method_7270 giveItemStack (Lnet/minecraft/class_1799;)Z

--- a/mappings/net/minecraft/util/math/MathHelper.mapping
+++ b/mappings/net/minecraft/util/math/MathHelper.mapping
@@ -156,8 +156,6 @@ CLASS net/minecraft/class_3532 net/minecraft/util/math/MathHelper
 		ARG 1 divisor
 	METHOD method_15388 stepUnwrappedAngleTowards (FFF)F
 		COMMENT Steps from {@code from} degrees towards {@code to} degrees, changing the value by at most {@code step} degrees.
-		COMMENT
-		COMMENT <p>This method does not wrap the resulting angle, so {@link #stepAngleTowards(float, float, float)} should be used in preference.
 		ARG 0 from
 		ARG 1 to
 		ARG 2 step


### PR DESCRIPTION
Fixes these errors:
```
/__w/yarn/yarn/.gradle/temp/fakeSource/net/minecraft/client/render/entity/model/MinecartEntityModel.java:34: error: value does not refer to a constant
 *   <td>{@value #CONTENTS}</td><td>{@linkplain #root Root part}</td><td>{@link #contents}</td>
         ^
/__w/yarn/yarn/.gradle/temp/fakeSource/net/minecraft/client/render/entity/model/MinecartEntityModel.java:34: error: reference not found
 *   <td>{@value #CONTENTS}</td><td>{@linkplain #root Root part}</td><td>{@link #contents}</td>
                 ^
/__w/yarn/yarn/.gradle/temp/fakeSource/net/minecraft/client/render/entity/model/MinecartEntityModel.java:34: error: reference not found
 *   <td>{@value #CONTENTS}</td><td>{@linkplain #root Root part}</td><td>{@link #contents}</td>
                                                                                ^
/__w/yarn/yarn/.gradle/temp/fakeSource/net/minecraft/entity/Entity.java:550: error: reference not found
   * is lower than {@link Entity#MAX_SOFT_COLLISION_SPEED}.
                          ^
/__w/yarn/yarn/.gradle/temp/fakeSource/net/minecraft/entity/player/PlayerEntity.java:1285: error: reference not found
   * @return an {@link Either.Right} if successful, otherwise an {@link Either.Left} containing the failure reason
                       ^
/__w/yarn/yarn/.gradle/temp/fakeSource/net/minecraft/entity/player/PlayerEntity.java:1285: error: reference not found
   * @return an {@link Either.Right} if successful, otherwise an {@link Either.Left} containing the failure reason
                                                                        ^
/__w/yarn/yarn/.gradle/temp/fakeSource/net/minecraft/util/math/MathHelper.java:588: error: reference not found
   * <p>This method does not wrap the resulting angle, so {@link #stepAngleTowards(float, float, float)} should be used in preference.
                                                                 ^
7 errors
```
