### PR TITLE
1.18-pre7 sound

### DIFF
--- a/mappings/net/minecraft/client/sound/Channel.mapping
+++ b/mappings/net/minecraft/client/sound/Channel.mapping
@@ -11,7 +11,7 @@ CLASS net/minecraft/class_4235 net/minecraft/client/sound/Channel
 	METHOD method_19725 (Lnet/minecraft/class_4235$class_4236;)Lnet/minecraft/class_4224;
 		ARG 0 source
 	METHOD method_19727 execute (Ljava/util/function/Consumer;)V
-		ARG 1 sourceStreamConsumer
+		ARG 1 sourcesConsumer
 	METHOD method_19728 close ()V
 	CLASS class_4236 SourceManager
 		FIELD field_18941 source Lnet/minecraft/class_4224;

--- a/mappings/net/minecraft/client/sound/Channel.mapping
+++ b/mappings/net/minecraft/client/sound/Channel.mapping
@@ -8,7 +8,10 @@ CLASS net/minecraft/class_4235 net/minecraft/client/sound/Channel
 	METHOD method_19722 tick ()V
 	METHOD method_19723 createSource (Lnet/minecraft/class_4225$class_4105;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 mode
+	METHOD method_19725 (Lnet/minecraft/class_4235$class_4236;)Lnet/minecraft/class_4224;
+		ARG 0 source
 	METHOD method_19727 execute (Ljava/util/function/Consumer;)V
+		ARG 1 sourceStreamConsumer
 	METHOD method_19728 close ()V
 	CLASS class_4236 SourceManager
 		FIELD field_18941 source Lnet/minecraft/class_4224;

--- a/mappings/net/minecraft/client/sound/MusicType.mapping
+++ b/mappings/net/minecraft/client/sound/MusicType.mapping
@@ -1,4 +1,9 @@
 CLASS net/minecraft/class_1143 net/minecraft/client/sound/MusicType
+	FIELD field_29804 MENU_MIN_DELAY I
+	FIELD field_29805 MENU_MAX_DELAY I
+	FIELD field_29806 GAME_MIN_DELAY I
+	FIELD field_29807 GAME_MAX_DELAY I
+	FIELD field_29808 END_MIN_DELAY I
 	FIELD field_5576 UNDERWATER Lnet/minecraft/class_5195;
 	FIELD field_5578 CREDITS Lnet/minecraft/class_5195;
 	FIELD field_5580 DRAGON Lnet/minecraft/class_5195;

--- a/mappings/net/minecraft/client/sound/OggAudioStream.mapping
+++ b/mappings/net/minecraft/client/sound/OggAudioStream.mapping
@@ -3,11 +3,18 @@ CLASS net/minecraft/class_4228 net/minecraft/client/sound/OggAudioStream
 	FIELD field_18908 format Ljavax/sound/sampled/AudioFormat;
 	FIELD field_18909 inputStream Ljava/io/InputStream;
 	FIELD field_18910 buffer Ljava/nio/ByteBuffer;
+	FIELD field_31898 BUFFER_SIZE I
 	METHOD <init> (Ljava/io/InputStream;)V
 		ARG 1 inputStream
 	METHOD method_19674 readOggFile (Lnet/minecraft/class_4228$class_4229;)Z
+		ARG 1 channelList
 	METHOD method_19675 readChannels (Ljava/nio/FloatBuffer;Lnet/minecraft/class_4228$class_4229;)V
+		ARG 1 buf
+		ARG 2 channelList
 	METHOD method_19676 readChannels (Ljava/nio/FloatBuffer;Ljava/nio/FloatBuffer;Lnet/minecraft/class_4228$class_4229;)V
+		ARG 1 buf
+		ARG 2 buf2
+		ARG 3 channelList
 	METHOD method_19677 readHeader ()Z
 	METHOD method_19678 increaseBufferSize ()V
 	METHOD method_19721 getBuffer ()Ljava/nio/ByteBuffer;
@@ -20,4 +27,5 @@ CLASS net/minecraft/class_4228 net/minecraft/client/sound/OggAudioStream
 			ARG 1 size
 		METHOD method_19679 getBuffer ()Ljava/nio/ByteBuffer;
 		METHOD method_19680 addChannel (F)V
+			ARG 1 data
 		METHOD method_19682 init ()V

--- a/mappings/net/minecraft/client/sound/RepeatingAudioStream.mapping
+++ b/mappings/net/minecraft/client/sound/RepeatingAudioStream.mapping
@@ -6,4 +6,8 @@ CLASS net/minecraft/class_4856 net/minecraft/client/sound/RepeatingAudioStream
 		ARG 1 delegateFactory
 		ARG 2 inputStream
 	CLASS class_4857 DelegateFactory
+		METHOD create (Ljava/io/InputStream;)Lnet/minecraft/class_4234;
+			ARG 1 stream
 	CLASS class_4858 ReusableInputStream
+		METHOD <init> (Ljava/io/InputStream;)V
+			ARG 1 stream

--- a/mappings/net/minecraft/client/sound/Sound.mapping
+++ b/mappings/net/minecraft/client/sound/Sound.mapping
@@ -30,3 +30,4 @@ CLASS net/minecraft/class_1111 net/minecraft/client/sound/Sound
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
 			ARG 3 name
 		METHOD method_4773 getByName (Ljava/lang/String;)Lnet/minecraft/class_1111$class_1112;
+			ARG 0 name

--- a/mappings/net/minecraft/client/sound/SoundLoader.mapping
+++ b/mappings/net/minecraft/client/sound/SoundLoader.mapping
@@ -4,8 +4,12 @@ CLASS net/minecraft/class_4237 net/minecraft/client/sound/SoundLoader
 	METHOD <init> (Lnet/minecraft/class_3300;)V
 		ARG 1 resourceManager
 	METHOD method_19738 close ()V
+	METHOD method_19740 (Lnet/minecraft/class_1111;)Ljava/util/concurrent/CompletableFuture;
+		ARG 1 sound
 	METHOD method_19741 loadStatic (Ljava/util/Collection;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 sounds
+	METHOD method_19742 (Ljava/util/concurrent/CompletableFuture;)V
+		ARG 0 soundFuture
 	METHOD method_19743 loadStatic (Lnet/minecraft/class_2960;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 id
 	METHOD method_19744 loadStreamed (Lnet/minecraft/class_2960;Z)Ljava/util/concurrent/CompletableFuture;

--- a/mappings/net/minecraft/client/sound/SoundManager.mapping
+++ b/mappings/net/minecraft/client/sound/SoundManager.mapping
@@ -50,7 +50,9 @@ CLASS net/minecraft/class_1144 net/minecraft/client/sound/SoundManager
 	METHOD method_4882 close ()V
 	CLASS class_4009 SoundList
 		FIELD field_17908 loadedSounds Ljava/util/Map;
-		METHOD method_18186 addTo (Ljava/util/Map;Lnet/minecraft/class_1140;)V
+		METHOD method_18186 reload (Ljava/util/Map;Lnet/minecraft/class_1140;)V
+			ARG 1 sounds
+			ARG 2 soundSystem
 		METHOD method_18187 register (Lnet/minecraft/class_2960;Lnet/minecraft/class_1110;Lnet/minecraft/class_3300;)V
 			ARG 1 id
 			ARG 2 entry

--- a/mappings/net/minecraft/client/sound/SoundSystem.mapping
+++ b/mappings/net/minecraft/client/sound/SoundSystem.mapping
@@ -12,6 +12,7 @@ CLASS net/minecraft/class_1140 net/minecraft/client/sound/SoundSystem
 	FIELD field_34827 OPENAL_SOFT_ON Ljava/lang/String;
 	FIELD field_34828 OPENAL_SOFT_ON_LENGTH I
 	FIELD field_34967 lastSoundDeviceCheckTime J
+	FIELD field_35083 deviceChangeStatus Ljava/util/concurrent/atomic/AtomicReference;
 	FIELD field_5550 ticks I
 	FIELD field_5551 preloadedSounds Ljava/util/List;
 	FIELD field_5552 loader Lnet/minecraft/class_1144;
@@ -29,15 +30,29 @@ CLASS net/minecraft/class_1140 net/minecraft/client/sound/SoundSystem
 		ARG 3 resourceManager
 	METHOD method_19748 (FFLnet/minecraft/class_243;Lnet/minecraft/class_4224;)V
 		ARG 3 source
+	METHOD method_19749 (FFLnet/minecraft/class_1113$class_1114;FZZLnet/minecraft/class_243;ZLnet/minecraft/class_4224;)V
+		ARG 8 source
 	METHOD method_19750 (FLnet/minecraft/class_4224;)V
+		ARG 1 source
+	METHOD method_19752 (Lnet/minecraft/class_4231;Lnet/minecraft/class_4224;)V
 		ARG 1 source
 	METHOD method_19753 stop (Lnet/minecraft/class_1113;)V
 		ARG 1 sound
 	METHOD method_19754 (Lnet/minecraft/class_1113;Lnet/minecraft/class_4235$class_4236;)V
 		ARG 1 source
 		ARG 2 sourceManager
+	METHOD method_19755 (Lnet/minecraft/class_4234;Lnet/minecraft/class_4224;)V
+		ARG 1 source
 	METHOD method_19756 (Lnet/minecraft/class_4235$class_4236;)V
 		ARG 0 source
+	METHOD method_19757 (Lnet/minecraft/class_4235$class_4236;Lnet/minecraft/class_4231;)V
+		ARG 1 sound
+	METHOD method_19758 (Lnet/minecraft/class_4235$class_4236;Lnet/minecraft/class_4234;)V
+		ARG 1 stream
+	METHOD method_19759 (Ljava/util/stream/Stream;)V
+		ARG 0 sources
+	METHOD method_19760 (Ljava/util/stream/Stream;)V
+		ARG 0 sources
 	METHOD method_19761 pauseAll ()V
 	METHOD method_19762 resumeAll ()V
 	METHOD method_20185 tick (Z)V
@@ -85,3 +100,4 @@ CLASS net/minecraft/class_1140 net/minecraft/client/sound/SoundSystem
 		ARG 1 listener
 	METHOD method_4856 stop ()V
 	METHOD method_4857 tick ()V
+	CLASS class_6665 DeviceChangeStatus

--- a/mappings/net/minecraft/client/sound/Source.mapping
+++ b/mappings/net/minecraft/client/sound/Source.mapping
@@ -9,6 +9,8 @@ CLASS net/minecraft/class_4224 net/minecraft/client/sound/Source
 	METHOD method_19638 create ()Lnet/minecraft/class_4224;
 	METHOD method_19639 setPitch (F)V
 		ARG 1 pitch
+	METHOD method_19640 read (I)V
+		ARG 1 count
 	METHOD method_19641 setPosition (Lnet/minecraft/class_243;)V
 		ARG 1 pos
 	METHOD method_19642 setBuffer (Lnet/minecraft/class_4231;)V
@@ -23,6 +25,8 @@ CLASS net/minecraft/class_4224 net/minecraft/client/sound/Source
 	METHOD method_19646 close ()V
 	METHOD method_19647 setVolume (F)V
 		ARG 1 volume
+	METHOD method_19648 (I)V
+		ARG 1 pointer
 	METHOD method_19649 setRelative (Z)V
 		ARG 1 relative
 	METHOD method_19650 play ()V

--- a/mappings/net/minecraft/client/sound/WeightedSoundSet.mapping
+++ b/mappings/net/minecraft/client/sound/WeightedSoundSet.mapping
@@ -8,4 +8,5 @@ CLASS net/minecraft/class_1146 net/minecraft/client/sound/WeightedSoundSet
 		ARG 2 subtitle
 	METHOD method_35812 getId ()Lnet/minecraft/class_2960;
 	METHOD method_4885 add (Lnet/minecraft/class_1148;)V
+		ARG 1 container
 	METHOD method_4886 getSubtitle ()Lnet/minecraft/class_2561;


### PR DESCRIPTION
Renames `SoundManager$SoundList#addTo` to `reload`, because the passed map will have all items cleared first. This method is also called exclusively inside resource reloading code.