### PR TITLE
Move the EightWayDirection class to the net.minecraft.util.math package

### DIFF
--- a/mappings/net/minecraft/util/math/EightWayDirection.mapping
+++ b/mappings/net/minecraft/util/math/EightWayDirection.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2355 net/minecraft/util/EightWayDirection
+CLASS net/minecraft/class_2355 net/minecraft/util/math/EightWayDirection
 	FIELD field_11078 directions Ljava/util/Set;
 	METHOD <init> (Ljava/lang/String;I[Lnet/minecraft/class_2350;)V
 		ARG 3 directions


### PR DESCRIPTION
The `Direction` and `EightWayDirection` classes should be in the same package. Since the `EightWayDirection` class is less commonly used, it is moved.