### PR TITLE
Rename incorrectly-named intersectsEntities methods

### DIFF
--- a/mappings/net/minecraft/world/CollisionView.mapping
+++ b/mappings/net/minecraft/world/CollisionView.mapping
@@ -31,9 +31,9 @@ CLASS net/minecraft/class_1941 net/minecraft/world/CollisionView
 	METHOD method_8600 getCollisions (Lnet/minecraft/class_1297;Lnet/minecraft/class_238;)Ljava/lang/Iterable;
 		ARG 1 entity
 		ARG 2 box
-	METHOD method_8606 intersectsEntities (Lnet/minecraft/class_1297;)Z
-		ARG 1 entity
-	METHOD method_8611 intersectsEntities (Lnet/minecraft/class_1297;Lnet/minecraft/class_265;)Z
+	METHOD method_8606 doesNotIntersectEntities (Lnet/minecraft/class_1297;)Z
+		ARG 1 except
+	METHOD method_8611 doesNotIntersectEntities (Lnet/minecraft/class_1297;Lnet/minecraft/class_265;)Z
 		ARG 1 except
 		ARG 2 shape
 	METHOD method_8621 getWorldBorder ()Lnet/minecraft/class_2784;

--- a/mappings/net/minecraft/world/CollisionView.mapping
+++ b/mappings/net/minecraft/world/CollisionView.mapping
@@ -32,7 +32,7 @@ CLASS net/minecraft/class_1941 net/minecraft/world/CollisionView
 		ARG 1 entity
 		ARG 2 box
 	METHOD method_8606 doesNotIntersectEntities (Lnet/minecraft/class_1297;)Z
-		ARG 1 except
+		ARG 1 entity
 	METHOD method_8611 doesNotIntersectEntities (Lnet/minecraft/class_1297;Lnet/minecraft/class_265;)Z
 		ARG 1 except
 		ARG 2 shape

--- a/mappings/net/minecraft/world/EntityView.mapping
+++ b/mappings/net/minecraft/world/EntityView.mapping
@@ -101,6 +101,6 @@ CLASS net/minecraft/class_1924 net/minecraft/world/EntityView
 		ARG 5 z
 		ARG 7 maxDistance
 		ARG 9 targetPredicate
-	METHOD method_8611 intersectsEntities (Lnet/minecraft/class_1297;Lnet/minecraft/class_265;)Z
-		ARG 1 entity
+	METHOD method_8611 doesNotIntersectEntities (Lnet/minecraft/class_1297;Lnet/minecraft/class_265;)Z
+		ARG 1 except
 		ARG 2 shape


### PR DESCRIPTION
Fixes #2901 

Also renamed param for `EntityView#doesNotIntersectEntities` to match the CollisionView name - will javadoc in that PR.