### PR TITLE
Fix typo

### DIFF
--- a/mappings/net/minecraft/loot/function/SetBannerPatternFunction.mapping
+++ b/mappings/net/minecraft/loot/function/SetBannerPatternFunction.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_5592 net/minecraft/loot/function/SetBannerPatternFunct
 	FIELD field_27343 patterns Ljava/util/List;
 	FIELD field_27344 append Z
 	METHOD <init> ([Lnet/minecraft/class_5341;Ljava/util/List;Z)V
-		ARG 1 condiitons
+		ARG 1 conditions
 		ARG 2 patterns
 		ARG 3 append
 	METHOD method_35531 builder (Z)Lnet/minecraft/class_5592$class_6157;


### PR DESCRIPTION
`condiitons` -> `conditions`

noticed this while making #2904