### PR TITLE
1.18.1-rc1 stuff

### DIFF
--- a/mappings/net/minecraft/client/realms/RealmsClient.mapping
+++ b/mappings/net/minecraft/client/realms/RealmsClient.mapping
@@ -144,6 +144,8 @@ CLASS net/minecraft/class_4341 net/minecraft/client/realms/RealmsClient
 		ARG 1 pendingInvite
 	METHOD method_35684 getPlayerActivities (J)Lnet/minecraft/class_6193;
 		ARG 1 worldId
+	METHOD method_39979 getErrorMessage (I)Ljava/lang/String;
+		ARG 0 httpResultCode
 	CLASS class_4342 CompatibleVersionResponse
 		FIELD field_19582 COMPATIBLE Lnet/minecraft/class_4341$class_4342;
 		FIELD field_19583 OUTDATED Lnet/minecraft/class_4341$class_4342;

--- a/mappings/net/minecraft/client/realms/exception/RealmsServiceException.mapping
+++ b/mappings/net/minecraft/client/realms/exception/RealmsServiceException.mapping
@@ -1,5 +1,7 @@
 CLASS net/minecraft/class_4355 net/minecraft/client/realms/exception/RealmsServiceException
 	FIELD field_19604 httpResultCode I
+	FIELD field_36319 httpResponseText Ljava/lang/String;
+	FIELD field_36320 error Lnet/minecraft/class_4345;
 	METHOD <init> (ILjava/lang/String;)V
 		ARG 1 httpResultCode
 		ARG 2 httpResponseText
@@ -7,3 +9,5 @@ CLASS net/minecraft/class_4355 net/minecraft/client/realms/exception/RealmsServi
 		ARG 1 httpResultCode
 		ARG 2 httpResponseText
 		ARG 3 error
+	METHOD method_39980 getErrorCode (I)I
+		ARG 1 fallback

--- a/mappings/net/minecraft/client/realms/gui/screen/RealmsGenericErrorScreen.mapping
+++ b/mappings/net/minecraft/client/realms/gui/screen/RealmsGenericErrorScreen.mapping
@@ -1,13 +1,23 @@
 CLASS net/minecraft/class_4394 net/minecraft/client/realms/gui/screen/RealmsGenericErrorScreen
 	FIELD field_22695 parent Lnet/minecraft/class_437;
+	FIELD field_36321 errorMessages Lcom/mojang/datafixers/util/Pair;
+	FIELD field_36322 description Lnet/minecraft/class_5489;
 	METHOD <init> (Lnet/minecraft/class_2561;Lnet/minecraft/class_2561;Lnet/minecraft/class_437;)V
 		ARG 1 line1
 		ARG 2 line2
+		ARG 3 parent
 	METHOD <init> (Lnet/minecraft/class_2561;Lnet/minecraft/class_437;)V
 		ARG 1 line2
+		ARG 2 parent
 	METHOD <init> (Lnet/minecraft/class_4355;Lnet/minecraft/class_437;)V
 		ARG 1 realmsServiceException
-	METHOD method_21282 errorMessage (Lnet/minecraft/class_2561;)Lcom/mojang/datafixers/util/Pair;
-	METHOD method_21283 errorMessage (Lnet/minecraft/class_2561;Lnet/minecraft/class_2561;)Lcom/mojang/datafixers/util/Pair;
+		ARG 2 parent
+	METHOD method_21282 getErrorMessages (Lnet/minecraft/class_2561;)Lcom/mojang/datafixers/util/Pair;
+		ARG 0 description
+	METHOD method_21283 getErrorMessages (Lnet/minecraft/class_2561;Lnet/minecraft/class_2561;)Lcom/mojang/datafixers/util/Pair;
+		ARG 0 title
+		ARG 1 description
 	METHOD method_25160 (Lnet/minecraft/class_4185;)V
 		ARG 1 button
+	METHOD method_39981 getErrorMessages (Lnet/minecraft/class_4355;)Lcom/mojang/datafixers/util/Pair;
+		ARG 0 exception

--- a/mappings/net/minecraft/client/realms/gui/screen/RealmsGenericErrorScreen.mapping
+++ b/mappings/net/minecraft/client/realms/gui/screen/RealmsGenericErrorScreen.mapping
@@ -3,11 +3,11 @@ CLASS net/minecraft/class_4394 net/minecraft/client/realms/gui/screen/RealmsGene
 	FIELD field_36321 errorMessages Lcom/mojang/datafixers/util/Pair;
 	FIELD field_36322 description Lnet/minecraft/class_5489;
 	METHOD <init> (Lnet/minecraft/class_2561;Lnet/minecraft/class_2561;Lnet/minecraft/class_437;)V
-		ARG 1 line1
-		ARG 2 line2
+		ARG 1 title
+		ARG 2 description
 		ARG 3 parent
 	METHOD <init> (Lnet/minecraft/class_2561;Lnet/minecraft/class_437;)V
-		ARG 1 line2
+		ARG 1 description
 		ARG 2 parent
 	METHOD <init> (Lnet/minecraft/class_4355;Lnet/minecraft/class_437;)V
 		ARG 1 realmsServiceException

--- a/mappings/net/minecraft/entity/ai/pathing/EntityNavigation.mapping
+++ b/mappings/net/minecraft/entity/ai/pathing/EntityNavigation.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/class_1408 net/minecraft/entity/ai/pathing/EntityNavigation
 	FIELD field_6675 tickCount I
 	FIELD field_6677 world Lnet/minecraft/class_1937;
 	FIELD field_6678 nodeMaker Lnet/minecraft/class_8;
-	FIELD field_6679 shouldRecalculate Z
+	FIELD field_6679 inRecalculationCooldown Z
 	FIELD field_6680 lastNodePosition Lnet/minecraft/class_2382;
 	FIELD field_6681 currentPath Lnet/minecraft/class_11;
 	FIELD field_6682 currentNodeTimeout D

--- a/mappings/net/minecraft/entity/ai/pathing/EntityNavigation.mapping
+++ b/mappings/net/minecraft/entity/ai/pathing/EntityNavigation.mapping
@@ -25,7 +25,7 @@ CLASS net/minecraft/class_1408 net/minecraft/entity/ai/pathing/EntityNavigation
 	METHOD <init> (Lnet/minecraft/class_1308;Lnet/minecraft/class_1937;)V
 		ARG 1 mob
 		ARG 2 world
-	METHOD method_18053 onBlockChanged (Lnet/minecraft/class_2338;)Z
+	METHOD method_18053 shouldRecalculatePath (Lnet/minecraft/class_2338;)Z
 		ARG 1 pos
 	METHOD method_18416 findPathToAny (Ljava/util/Set;IZIF)Lnet/minecraft/class_11;
 		ARG 1 positions

--- a/mappings/net/minecraft/server/filter/TextFilterer.mapping
+++ b/mappings/net/minecraft/server/filter/TextFilterer.mapping
@@ -18,6 +18,7 @@ CLASS net/minecraft/class_5514 net/minecraft/server/filter/TextFilterer
 		ARG 4 serverId
 		ARG 5 roomId
 		ARG 6 ignorer
+		ARG 7 parallelism
 	METHOD method_31295 sendJsonRequest (Lcom/google/gson/JsonObject;Ljava/net/URL;)Lcom/google/gson/JsonObject;
 		ARG 1 payload
 		ARG 2 endpoint

--- a/mappings/net/minecraft/server/filter/TextFilterer.mapping
+++ b/mappings/net/minecraft/server/filter/TextFilterer.mapping
@@ -10,11 +10,14 @@ CLASS net/minecraft/class_5514 net/minecraft/server/filter/TextFilterer
 	FIELD field_26831 serverId Ljava/lang/String;
 	FIELD field_26832 ignorer Lnet/minecraft/class_5514$class_5515;
 	FIELD field_26833 executor Ljava/util/concurrent/ExecutorService;
+	FIELD field_36318 room Ljava/lang/String;
 	METHOD <init> (Ljava/net/URI;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Lnet/minecraft/class_5514$class_5515;I)V
 		ARG 1 apiUrl
 		ARG 2 apiKey
 		ARG 3 ruleId
 		ARG 4 serverId
+		ARG 5 room
+		ARG 6 ignorer
 	METHOD method_31295 sendJsonRequest (Lcom/google/gson/JsonObject;Ljava/net/URL;)Lcom/google/gson/JsonObject;
 		ARG 1 payload
 		ARG 2 endpoint

--- a/mappings/net/minecraft/server/filter/TextFilterer.mapping
+++ b/mappings/net/minecraft/server/filter/TextFilterer.mapping
@@ -10,13 +10,13 @@ CLASS net/minecraft/class_5514 net/minecraft/server/filter/TextFilterer
 	FIELD field_26831 serverId Ljava/lang/String;
 	FIELD field_26832 ignorer Lnet/minecraft/class_5514$class_5515;
 	FIELD field_26833 executor Ljava/util/concurrent/ExecutorService;
-	FIELD field_36318 room Ljava/lang/String;
+	FIELD field_36318 roomId Ljava/lang/String;
 	METHOD <init> (Ljava/net/URI;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Lnet/minecraft/class_5514$class_5515;I)V
 		ARG 1 apiUrl
 		ARG 2 apiKey
 		ARG 3 ruleId
 		ARG 4 serverId
-		ARG 5 room
+		ARG 5 roomId
 		ARG 6 ignorer
 	METHOD method_31295 sendJsonRequest (Lcom/google/gson/JsonObject;Ljava/net/URL;)Lcom/google/gson/JsonObject;
 		ARG 1 payload

--- a/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
+++ b/mappings/net/minecraft/server/world/ThreadedAnvilChunkStorage.mapping
@@ -194,6 +194,18 @@ CLASS net/minecraft/class_3898 net/minecraft/server/world/ThreadedAnvilChunkStor
 		ARG 1 pos
 	METHOD method_39925 save (Lnet/minecraft/class_3193;)Z
 		ARG 1 chunkHolder
+	METHOD method_39975 isWithinDistance (IIIII)Z
+		ARG 0 x1
+		ARG 1 z1
+		ARG 2 x2
+		ARG 3 z2
+		ARG 4 distance
+	METHOD method_39976 isOnDistanceEdge (IIIII)Z
+		ARG 0 x1
+		ARG 1 z1
+		ARG 2 x2
+		ARG 3 z2
+		ARG 4 distance
 	CLASS class_3208 EntityTracker
 		COMMENT An entity tracker governs which players' clients can see an entity. Each
 		COMMENT tracker corresponds to one entity in a server world and is mapped from the

--- a/mappings/net/minecraft/util/Util.mapping
+++ b/mappings/net/minecraft/util/Util.mapping
@@ -148,6 +148,9 @@ CLASS net/minecraft/class_156 net/minecraft/util/Util
 	METHOD method_38646 setMissingBreakpointHandler (Ljava/util/function/Consumer;)V
 		ARG 0 missingBreakpointHandler
 	METHOD method_38648 getMaxBackgroundThreads ()I
+	METHOD method_39977 error (Ljava/lang/String;Ljava/lang/Throwable;)V
+		ARG 0 message
+		ARG 1 throwable
 	METHOD method_645 previous (Ljava/lang/Iterable;Ljava/lang/Object;)Ljava/lang/Object;
 		ARG 0 iterable
 		ARG 1 object


### PR DESCRIPTION
Realms error handling, TACS, text filtering room config :eyes:, one debug util, and `EntityNavigation` change (reusing name from now-removed 6343, is doing the same thing).