### PR TITLE
Minor Block javadoc improvements

### DIFF
--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_2248 net/minecraft/block/Block
 	COMMENT A block is a voxel in a {@linkplain World world}. {@link AbstractBlock},
-	COMMENT this class and its subclasses define all logic for those voxels.
+	COMMENT this class, and its subclasses define all logic for those voxels.
 	COMMENT
 	COMMENT <p>There is exactly one instance for every type of block. Every stone
 	COMMENT block for example in a world shares the same block instance. Each block

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_2248 net/minecraft/block/Block
 	COMMENT A block is a voxel in a {@linkplain World world}.
-	COMMENT This class and its subclasses define all logics for those voxels.
+	COMMENT This class and its subclasses define all logic for those voxels.
 	COMMENT
 	COMMENT <p>There is exactly one instance for every type of block. Every stone
 	COMMENT block for example in a world shares the same block instance. Each block
@@ -16,7 +16,7 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 	COMMENT
 	COMMENT <p>In the world, the actual voxels are not stored as blocks, but as
 	COMMENT {@linkplain BlockState block states}. The possible states of the block
-	COMMENT is defined by {@link appendProperties}.
+	COMMENT is defined by {@link #appendProperties}.
 	COMMENT
 	COMMENT @see BlockState
 	FIELD field_10638 LOGGER Lorg/apache/logging/log4j/Logger;

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_2248 net/minecraft/block/Block
-	COMMENT A block is a voxel in a {@linkplain World world}.
-	COMMENT This class and its subclasses define all logic for those voxels.
+	COMMENT A block is a voxel in a {@linkplain World world}. {@link AbstractBlock},
+	COMMENT this class and its subclasses define all logic for those voxels.
 	COMMENT
 	COMMENT <p>There is exactly one instance for every type of block. Every stone
 	COMMENT block for example in a world shares the same block instance. Each block
@@ -18,6 +18,7 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 	COMMENT {@linkplain BlockState block states}. The possible states of the block
 	COMMENT is defined by {@link #appendProperties}.
 	COMMENT
+	COMMENT @see AbstractBlock
 	COMMENT @see BlockState
 	FIELD field_10638 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_10642 translationKey Ljava/lang/String;

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -16,7 +16,7 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 	COMMENT
 	COMMENT <p>In the world, the actual voxels are not stored as blocks, but as
 	COMMENT {@linkplain BlockState block states}. The possible states of the block
-	COMMENT is defined by {@link #appendProperties}.
+	COMMENT are defined by {@link #appendProperties}.
 	COMMENT
 	COMMENT @see AbstractBlock
 	COMMENT @see BlockState


### PR DESCRIPTION
- Added mention of `AbstractBlock` as it contains many of the useful block methods
- "logic" is uncountable (and thus singular) in this context
- Fixed broken `{@link}` to a member
- Fixed broken grammar ("the possible states ... ~~is~~ *are*")