### PR TITLE
Rename the BackgroundHelper class to ColorHelper

### DIFF
--- a/mappings/net/minecraft/client/gui/hud/ColorHelper.mapping
+++ b/mappings/net/minecraft/client/gui/hud/ColorHelper.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_5253 net/minecraft/client/gui/hud/BackgroundHelper
+CLASS net/minecraft/class_5253 net/minecraft/client/gui/hud/ColorHelper
 	CLASS class_5254 ColorMixer
 		METHOD method_27762 getAlpha (I)I
 			ARG 0 argb

--- a/mappings/net/minecraft/util/math/ColorHelper.mapping
+++ b/mappings/net/minecraft/util/math/ColorHelper.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_5253 net/minecraft/client/gui/hud/ColorHelper
+CLASS net/minecraft/class_5253 net/minecraft/util/math/ColorHelper
 	CLASS class_5254 ColorMixer
 		METHOD method_27762 getAlpha (I)I
 			ARG 0 argb

--- a/mappings/net/minecraft/util/math/ColorHelper.mapping
+++ b/mappings/net/minecraft/util/math/ColorHelper.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_5253 net/minecraft/util/math/ColorHelper
-	CLASS class_5254 ColorMixer
+	CLASS class_5254 Argb
 		METHOD method_27762 getAlpha (I)I
 			ARG 0 argb
 		METHOD method_27763 mixColor (II)I


### PR DESCRIPTION
This pull request renames and repackages the `BackgroundHelper` class as it is used for general color math on both clients and servers.

Fixes #2907