### PR TITLE
Fix typo

### DIFF
--- a/mappings/net/minecraft/world/gen/feature/OrePlacedFeatures.mapping
+++ b/mappings/net/minecraft/world/gen/feature/OrePlacedFeatures.mapping
@@ -40,7 +40,7 @@ CLASS net/minecraft/class_6816 net/minecraft/world/gen/feature/OrePlacedFeatures
 	FIELD field_36077 ORE_REDSTONE Lnet/minecraft/class_6796;
 	METHOD method_39732 modifiersWithCount (ILnet/minecraft/class_6797;)Ljava/util/List;
 		ARG 0 count
-		ARG 1 heightModfier
+		ARG 1 heightModifer
 	METHOD method_39733 modifiers (Lnet/minecraft/class_6797;Lnet/minecraft/class_6797;)Ljava/util/List;
 		ARG 0 countModifier
 		ARG 1 heightModifier

--- a/mappings/net/minecraft/world/gen/feature/OrePlacedFeatures.mapping
+++ b/mappings/net/minecraft/world/gen/feature/OrePlacedFeatures.mapping
@@ -40,7 +40,7 @@ CLASS net/minecraft/class_6816 net/minecraft/world/gen/feature/OrePlacedFeatures
 	FIELD field_36077 ORE_REDSTONE Lnet/minecraft/class_6796;
 	METHOD method_39732 modifiersWithCount (ILnet/minecraft/class_6797;)Ljava/util/List;
 		ARG 0 count
-		ARG 1 heightModifer
+		ARG 1 heightModifier
 	METHOD method_39733 modifiers (Lnet/minecraft/class_6797;Lnet/minecraft/class_6797;)Ljava/util/List;
 		ARG 0 countModifier
 		ARG 1 heightModifier


### PR DESCRIPTION
in net.minecraft.world.gen.feature.OrePlacedFeatures#modifiersWithCount()
rename parameter heightModfier -> heightModifier