### PR TITLE
Fix typos

### DIFF
--- a/mappings/net/minecraft/GameVersion.mapping
+++ b/mappings/net/minecraft/GameVersion.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_6489 net/minecraft/GameVersion
 	COMMENT The game version interface used by Minecraft, replacing the javabridge
-	COMMENT one's occurences in Minecraft code.
+	COMMENT one's occurrences in Minecraft code.
 	METHOD method_37912 getSaveVersion ()Lnet/minecraft/class_6595;
 		COMMENT {@return the save version information for this game version}

--- a/mappings/net/minecraft/block/BedBlock.mapping
+++ b/mappings/net/minecraft/block/BedBlock.mapping
@@ -51,7 +51,7 @@ CLASS net/minecraft/class_2244 net/minecraft/block/BedBlock
 		ARG 4 ignoreInvalidPos
 	METHOD method_30837 getOnBedOffsets (Lnet/minecraft/class_2350;)[[I
 		ARG 0 bedDirection
-	METHOD method_30838 getAroundAndOnBedOffets (Lnet/minecraft/class_2350;Lnet/minecraft/class_2350;)[[I
+	METHOD method_30838 getAroundAndOnBedOffsets (Lnet/minecraft/class_2350;Lnet/minecraft/class_2350;)[[I
 		ARG 0 bedDirection
 		ARG 1 respawnDirection
 	METHOD method_30839 isBedBelow (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z

--- a/mappings/net/minecraft/block/EntityShapeContext.mapping
+++ b/mappings/net/minecraft/block/EntityShapeContext.mapping
@@ -11,7 +11,7 @@ CLASS net/minecraft/class_3727 net/minecraft/block/EntityShapeContext
 		ARG 1 descending
 		ARG 2 minY
 		ARG 4 heldItem
-		ARG 5 walkOnFluidPrecicate
+		ARG 5 walkOnFluidPredicate
 		ARG 6 entity
 	METHOD method_27867 (Lnet/minecraft/class_3611;)Z
 		ARG 0 fluid

--- a/mappings/net/minecraft/entity/mob/MobEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/MobEntity.mapping
@@ -230,7 +230,7 @@ CLASS net/minecraft/class_1308 net/minecraft/entity/mob/MobEntity
 		COMMENT <p>This is used by the look control.
 		COMMENT
 		COMMENT <p>It can return from {@code 1} for entities that can hardly raise their head,
-		COMMENT like axolotols or dolphins, or {@code 180} for entities that can freely raise
+		COMMENT like axolotls or dolphins, or {@code 180} for entities that can freely raise
 		COMMENT and lower their head, like guardians. The default return value is {@code 40}.
 	METHOD method_5979 canSpawn (Lnet/minecraft/class_1936;Lnet/minecraft/class_3730;)Z
 		ARG 1 world
@@ -247,7 +247,7 @@ CLASS net/minecraft/class_1308 net/minecraft/entity/mob/MobEntity
 		COMMENT <p>This is used by the body control.
 		COMMENT
 		COMMENT <p>It can return from {@code 1} for entities that can hardly rotate their head,
-		COMMENT like axolotols or dolphins, or {@code 180} for entities that can freely rotate
+		COMMENT like axolotls or dolphins, or {@code 180} for entities that can freely rotate
 		COMMENT their head, like shulkers. The default return value is {@code 75}.
 	METHOD method_5987 isAiDisabled ()Z
 	METHOD method_5988 getLookControl ()Lnet/minecraft/class_1333;

--- a/mappings/net/minecraft/entity/passive/AxolotlBrain.mapping
+++ b/mappings/net/minecraft/entity/passive/AxolotlBrain.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_5768 net/minecraft/entity/passive/AxolotlBrain
 	COMMENT
 	COMMENT <div class="fabric">
 	COMMENT <table border=1>
-	COMMENT <caption>Activites associated to the {@linkplain AxolotlEntity axolotl entity} brain</caption>
+	COMMENT <caption>Activities associated to the {@linkplain AxolotlEntity axolotl entity} brain</caption>
 	COMMENT <tr>
 	COMMENT   <th>Activity</th><th>Tasks</th>
 	COMMENT </tr>

--- a/mappings/net/minecraft/entity/player/HungerConstants.mapping
+++ b/mappings/net/minecraft/entity/player/HungerConstants.mapping
@@ -6,8 +6,8 @@ CLASS net/minecraft/class_6075 net/minecraft/entity/player/HungerConstants
 		COMMENT The maximum food level ({@value}) allowed in a hunger manager.
 	FIELD field_30706 INITIAL_SATURATION_LEVEL F
 		COMMENT The initial saturation level ({@value}) for a newly created hunger manager.
-	FIELD field_30708 EXHAUSION_UNIT F
-		COMMENT A value {@value} that when the exhausion reaches, the exhausion minuses itself
+	FIELD field_30708 EXHAUSTION_UNIT F
+		COMMENT A value {@value} that when the exhaustion reaches, the exhaustion minuses itself
 		COMMENT by to reduce the saturation or food level.
 	FIELD field_30709 SLOW_HEALING_STARVING_INTERVAL I
 		COMMENT When the food tick is a multiple of {@value}, the hunger manager may perform
@@ -17,8 +17,8 @@ CLASS net/minecraft/class_6075 net/minecraft/entity/player/HungerConstants
 		COMMENT fast healing logic.
 	FIELD field_30711 SLOW_HEALING_FOOD_LEVEL I
 		COMMENT The minimum food level ({@value}) required for the slow-healing mechanism.
-	FIELD field_30712 EXHAUSION_PER_HITPOINT I
-		COMMENT The exhausion from healing each hitpoint ({@value}), used for both fast and
+	FIELD field_30712 EXHAUSTION_PER_HITPOINT I
+		COMMENT The exhaustion from healing each hitpoint ({@value}), used for both fast and
 		COMMENT slow healing mechanisms.
 	FIELD field_30713 STARVING_FOOD_LEVEL I
 		COMMENT The maximum food level ({@value}) permitted for the starving mechanism to run.

--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -98,7 +98,7 @@ CLASS net/minecraft/class_1799 net/minecraft/item/ItemStack
 	FIELD field_8037 EMPTY Lnet/minecraft/class_1799;
 	FIELD field_8038 item Lnet/minecraft/class_1792;
 	FIELD field_8040 nbt Lnet/minecraft/class_2487;
-		COMMENT Repesents the item stack's custom NBT.
+		COMMENT Represents the item stack's custom NBT.
 		COMMENT <p>
 		COMMENT Stored at the key {@code tag} in the serialized item stack NBT.
 		COMMENT

--- a/mappings/net/minecraft/loot/function/SetDamageLootFunction.mapping
+++ b/mappings/net/minecraft/loot/function/SetDamageLootFunction.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_149 net/minecraft/loot/function/SetDamageLootFunction
 	FIELD field_1121 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_27910 add Z
 	METHOD <init> ([Lnet/minecraft/class_5341;Lnet/minecraft/class_5658;Z)V
-		ARG 1 conditons
+		ARG 1 conditions
 		ARG 2 durabilityRange
 		ARG 3 add
 	METHOD method_35542 builder (Lnet/minecraft/class_5658;Z)Lnet/minecraft/class_120$class_121;

--- a/mappings/net/minecraft/resource/Resource.mapping
+++ b/mappings/net/minecraft/resource/Resource.mapping
@@ -19,7 +19,7 @@ CLASS net/minecraft/class_3298 net/minecraft/resource/Resource
 	METHOD method_14483 getId ()Lnet/minecraft/class_2960;
 		COMMENT Returns the location of this resource.
 		COMMENT
-		COMMENT <p>Within each resource pack, this location is a unique identifer for a
+		COMMENT <p>Within each resource pack, this location is a unique identifier for a
 		COMMENT resource; however, in a resource manager, there may be multiple resources
 		COMMENT with the same location available.
 	METHOD method_14484 hasMetadata ()Z

--- a/mappings/net/minecraft/server/ServerNetworkIo.mapping
+++ b/mappings/net/minecraft/server/ServerNetworkIo.mapping
@@ -27,7 +27,7 @@ CLASS net/minecraft/class_3242 net/minecraft/server/ServerNetworkIo
 		COMMENT channel in-bound handler in the channel pipeline after a random delay between
 		COMMENT {@link #baseDelay} and {@code baseDelay + }{@link #extraDelay} milliseconds.
 		COMMENT
-		COMMENT @apiNote This may be used to simulate a laggy network enviroment.
+		COMMENT @apiNote This may be used to simulate a laggy network environment.
 		FIELD field_29772 TIMER Lio/netty/util/Timer;
 		FIELD field_29773 baseDelay I
 		FIELD field_29774 extraDelay I

--- a/mappings/net/minecraft/server/function/CommandFunctionManager.mapping
+++ b/mappings/net/minecraft/server/function/CommandFunctionManager.mapping
@@ -111,7 +111,7 @@ CLASS net/minecraft/class_2991 net/minecraft/server/function/CommandFunctionMana
 			COMMENT
 			COMMENT <p>This effectively swaps an entry with a command element with {@code /function}
 			COMMENT command at the head of the deque with another entry with a function element
-			COMMENT containing the actual command elemenets referenced in that function.
+			COMMENT containing the actual command elements referenced in that function.
 			ARG 1 function
 				COMMENT the function
 			ARG 2 source

--- a/mappings/net/minecraft/util/collection/LinkedBlockPosHashSet.mapping
+++ b/mappings/net/minecraft/util/collection/LinkedBlockPosHashSet.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_6136 net/minecraft/util/collection/LinkedBlockPosHashS
 	COMMENT <p>
 	COMMENT This has two major advantages:
 	COMMENT <ol>
-	COMMENT <li>Positions that are geometrically close together are grouped together in memory. This localises adjacent reads and writes.</li>
+	COMMENT <li>Positions that are geometrically close together are grouped together in memory. This localizes adjacent reads and writes.</li>
 	COMMENT <li>A larger number of positions can be comprised together into one long allowing for a smaller memory footprint.</li>
 	COMMENT </ol>
 	COMMENT @see net.minecraft.world.chunk.light.LevelPropagator

--- a/mappings/net/minecraft/world/WorldEvents.mapping
+++ b/mappings/net/minecraft/world/WorldEvents.mapping
@@ -346,5 +346,5 @@ CLASS net/minecraft/class_6088 net/minecraft/world/WorldEvents
 		COMMENT Bone meal is used.
 		COMMENT <br>Plays the bone meal item used sound event and spawns happy villager particles.
 		COMMENT <p>Called by {@link net.minecraft.item.BoneMealItem#useOnBlock(net.minecraft.item.ItemUsageContext) BoneMealItem#useOnBlock},
-		COMMENT an anonymus class in {@link net.minecraft.block.dispenser.DispenserBehavior#registerDefaults() DispenserBehavior#registerDefaults},
+		COMMENT an anonymous class in {@link net.minecraft.block.dispenser.DispenserBehavior#registerDefaults() DispenserBehavior#registerDefaults},
 		COMMENT and {@link net.minecraft.entity.ai.brain.task.BoneMealTask#keepRunning(net.minecraft.server.world.ServerWorld, net.minecraft.entity.passive.VillagerEntity, long) BoneMealTask#keepRunning}

--- a/mappings/net/minecraft/world/chunk/ChunkNibbleArray.mapping
+++ b/mappings/net/minecraft/world/chunk/ChunkNibbleArray.mapping
@@ -44,7 +44,7 @@ CLASS net/minecraft/class_2804 net/minecraft/world/chunk/ChunkNibbleArray
 		ARG 4 value
 	METHOD method_12146 isUninitialized ()Z
 	METHOD method_35320 bottomToString (I)Ljava/lang/String;
-		COMMENT {@return a hexademical string representation of the {@code y=0} level of
+		COMMENT {@return a hexadecimal string representation of the {@code y=0} level of
 		COMMENT this array}
 		COMMENT
 		COMMENT <p>It is useful for debugging the grid nibble array.

--- a/mappings/net/minecraft/world/chunk/PaletteResizeListener.mapping
+++ b/mappings/net/minecraft/world/chunk/PaletteResizeListener.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_2835 net/minecraft/world/chunk/PaletteResizeListener
-	COMMENT A listener for when a palette require more bits to hold a newly indexed
+	COMMENT A listener for when a palette requires more bits to hold a newly indexed
 	COMMENT object. A no-op listener may be used if the palette does not have to
 	COMMENT resize.
 	COMMENT

--- a/mappings/net/minecraft/world/chunk/PaletteResizeListener.mapping
+++ b/mappings/net/minecraft/world/chunk/PaletteResizeListener.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_2835 net/minecraft/world/chunk/PaletteResizeListener
-	COMMENT A listener for when a pallete require more bits to hold a newly indexed
+	COMMENT A listener for when a palette require more bits to hold a newly indexed
 	COMMENT object. A no-op listener may be used if the palette does not have to
 	COMMENT resize.
 	COMMENT
@@ -7,7 +7,7 @@ CLASS net/minecraft/class_2835 net/minecraft/world/chunk/PaletteResizeListener
 	METHOD onResize (ILjava/lang/Object;)I
 		COMMENT Callback for a palette's request to resize to at least {@code newBits}
 		COMMENT for each entry and to update the storage correspondingly in order to
-		COMMENT accomodate the new object. After the resize is completed in this method,
+		COMMENT accommodate the new object. After the resize is completed in this method,
 		COMMENT returns the ID assigned to the {@code object} in the updated palette.
 		COMMENT
 		COMMENT @return the ID for the {@code object} in the (possibly new) palette

--- a/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
+++ b/mappings/net/minecraft/world/chunk/PalettedContainer.mapping
@@ -113,13 +113,13 @@ CLASS net/minecraft/class_2841 net/minecraft/world/chunk/PalettedContainer
 		ARG 2 id
 	METHOD method_39957 copy ()Lnet/minecraft/class_2841;
 	CLASS class_4464 Counter
-		COMMENT A counter that receives a palette entry and its number of occurences
+		COMMENT A counter that receives a palette entry and its number of occurrences
 		COMMENT in the container.
 		METHOD accept (Ljava/lang/Object;I)V
 			ARG 1 object
 				COMMENT the palette entry
 			ARG 2 count
-				COMMENT the entry's number of occurence
+				COMMENT the entry's number of occurrence
 	CLASS class_6560 DataProvider
 		COMMENT A palette data provider constructs an empty data for a paletted
 		COMMENT container given a palette provider and a desired entry size in bits.

--- a/mappings/net/minecraft/world/chunk/SingularPalette.mapping
+++ b/mappings/net/minecraft/world/chunk/SingularPalette.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_6564 net/minecraft/world/chunk/SingularPalette
 		ARG 2 listener
 		ARG 3 entries
 	METHOD method_38316 create (ILnet/minecraft/class_2359;Lnet/minecraft/class_2835;Ljava/util/List;)Lnet/minecraft/class_2837;
-		COMMENT Creates a singular pallete. Used as method reference to create factory.
+		COMMENT Creates a singular palette. Used as method reference to create factory.
 		ARG 0 bitSize
 			COMMENT {@code 0}, as this palette has only 2<sup>0</sup>=1 entry
 		ARG 1 idList


### PR DESCRIPTION
Changes to mappings:

- `SetDamageLootFunction#<init>` `conditons` -> `conditions`
- `BedBlock#getAroundAndOnBedOffets` -> `getAroundAndOnBedOffsets`
- `EntityShapeContext#<init>` `walkOnFluidPrecicate` -> 
`walkOnFluidPredicate`
- `HungerConstants#EXHAUSION_UNIT` -> `EXHAUSTION_UNIT`
- `HungerConstants#EXHAUSION_PER_HITPOINT` -> `EXHAUSTION_PER_HITPOINT`

Others are javadocs.