### PR TITLE
Fix fov multiplier stuff

### DIFF
--- a/mappings/net/minecraft/client/network/AbstractClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/AbstractClientPlayerEntity.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_742 net/minecraft/client/network/AbstractClientPlayerE
 		ARG 1 world
 		ARG 2 profile
 	METHOD method_3117 getSkinTexture ()Lnet/minecraft/class_2960;
-	METHOD method_3118 getSpeed ()F
+	METHOD method_3118 getFovMultiplier ()F
 	METHOD method_3119 getCapeTexture ()Lnet/minecraft/class_2960;
 	METHOD method_3120 loadSkin (Lnet/minecraft/class_2960;Ljava/lang/String;)V
 		ARG 0 id

--- a/mappings/net/minecraft/client/render/GameRenderer.mapping
+++ b/mappings/net/minecraft/client/render/GameRenderer.mapping
@@ -73,7 +73,7 @@ CLASS net/minecraft/class_757 net/minecraft/client/render/GameRenderer
 	FIELD field_3996 SHADERS_LOCATIONS [Lnet/minecraft/class_2960;
 	FIELD field_3997 lastSkyDarkness F
 	FIELD field_3998 lastWindowFocusedTime J
-	FIELD field_3999 lastMovementFovMultiplier F
+	FIELD field_3999 lastFovMultiplier F
 	FIELD field_4001 renderingPanorama Z
 	FIELD field_4002 skyDarkness F
 	FIELD field_4003 floatingItemHeight F
@@ -88,7 +88,7 @@ CLASS net/minecraft/class_757 net/minecraft/client/render/GameRenderer
 	FIELD field_4015 client Lnet/minecraft/class_310;
 	FIELD field_4017 lastWorldIconUpdate J
 	FIELD field_4018 resourceManager Lnet/minecraft/class_3300;
-	FIELD field_4019 movementFovMultiplier F
+	FIELD field_4019 fovMultiplier F
 	FIELD field_4023 forcedShaderIndex I
 	FIELD field_4024 shader Lnet/minecraft/class_279;
 	FIELD field_4025 viewDistance F
@@ -158,7 +158,7 @@ CLASS net/minecraft/class_757 net/minecraft/client/render/GameRenderer
 		ARG 3 changingFov
 	METHOD method_3198 bobViewWhenHurt (Lnet/minecraft/class_4587;F)V
 		ARG 1 matrices
-	METHOD method_3199 updateMovementFovMultiplier ()V
+	METHOD method_3199 updateFovMultiplier ()V
 	METHOD method_3202 shouldRenderBlockOutline ()Z
 	METHOD method_3203 reset ()V
 	METHOD method_3207 disableShader ()V


### PR DESCRIPTION
* Renamed `AbstractClientPlayerEntity.getSpeed` to `getFovMulplier`. Closes #2911.
* Renamed `GameRenderer.movementFovMultiplier` to `fovMultiplier` because item usages (such as bow pulling) can affect the value.