### PR TITLE
Fix MoveToTargetPosGoal.getDesiredSquaredDistanceToTarget

### DIFF
--- a/mappings/net/minecraft/entity/ai/goal/MoveToTargetPosGoal.mapping
+++ b/mappings/net/minecraft/entity/ai/goal/MoveToTargetPosGoal.mapping
@@ -23,7 +23,7 @@ CLASS net/minecraft/class_1367 net/minecraft/entity/ai/goal/MoveToTargetPosGoal
 		ARG 5 maxYDifference
 	METHOD method_30953 getTargetPos ()Lnet/minecraft/class_2338;
 	METHOD method_6290 startMovingToTarget ()V
-	METHOD method_6291 getDesiredSquaredDistanceToTarget ()D
+	METHOD method_6291 getDesiredDistanceToTarget ()D
 	METHOD method_6292 findTargetPos ()Z
 	METHOD method_6293 getInterval (Lnet/minecraft/class_1314;)I
 		ARG 1 mob


### PR DESCRIPTION
It's a distance, not squared. The return value of this method is passed to `Vec3i#isWithinDistance` in `MoveToTargetPosGoal#tick`.
