### PR TITLE
Screen#{isPauseScreen -> shouldPause}

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/Screen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/Screen.mapping
@@ -66,7 +66,7 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 		COMMENT <p>If the client is in a world, renders the translucent background gradient.
 		COMMENT Otherwise {@linkplain #renderBackgroundTexture(int) renders the background texture}.
 		ARG 1 matrices
-	METHOD method_25421 isPauseScreen ()Z
+	METHOD method_25421 shouldPause ()Z
 	METHOD method_25422 shouldCloseOnEsc ()Z
 		COMMENT Checks whether this screen should be closed when the escape key is pressed.
 	METHOD method_25423 init (Lnet/minecraft/class_310;II)V


### PR DESCRIPTION
1. The current name implies that whether the screen pauses the game is a permanent property; which it is not (it is checked every render tick).
2. We know that it's a screen.
