### PR TITLE
Swap the names of the VertexBuffer#vertexFormat and VertexBuffer#elementFormat fields

### DIFF
--- a/mappings/net/minecraft/client/gl/VertexBuffer.mapping
+++ b/mappings/net/minecraft/client/gl/VertexBuffer.mapping
@@ -2,11 +2,11 @@ CLASS net/minecraft/class_291 net/minecraft/client/gl/VertexBuffer
 	FIELD field_1593 vertexCount I
 	FIELD field_1594 vertexBufferId I
 	FIELD field_27366 indexBufferId I
-	FIELD field_27367 vertexFormat Lnet/minecraft/class_293$class_5595;
+	FIELD field_27367 elementFormat Lnet/minecraft/class_293$class_5595;
 	FIELD field_27368 drawMode Lnet/minecraft/class_293$class_5596;
 	FIELD field_27369 usesTexture Z
 	FIELD field_29338 vertexArrayId I
-	FIELD field_29339 elementFormat Lnet/minecraft/class_293;
+	FIELD field_29339 vertexFormat Lnet/minecraft/class_293;
 	METHOD method_1352 upload (Lnet/minecraft/class_287;)V
 		ARG 1 buffer
 	METHOD method_1353 bind ()V


### PR DESCRIPTION
Previously, these fields were incorrectly swapped:

```java
private void uploadInternal(BufferBuilder buffer) {
	Pair<BufferBuilder.DrawArrayParameters, ByteBuffer> data = buffer.popData();
	BufferBuilder.DrawArrayParameters params = data.getFirst();

	// Inconsistent with DrawArrayParameters fields and getters
	this.vertexFormat = params.getElementFormat();
	this.elementFormat = params.getVertexFormat();
}
```

The field names in the VertexBuffer class have been updated to match the field names in the BufferBuilder.DrawArrayParameters class.