### PR TITLE
Rename Panda flag from 'scared' to 'sitting'

### DIFF
--- a/mappings/net/minecraft/client/render/entity/model/PandaEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/PandaEntityModel.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_586 net/minecraft/client/render/entity/model/PandaEntityModel
 	FIELD field_3468 playAnimationProgress F
 	FIELD field_3469 lieOnBackAnimationProgress F
-	FIELD field_3470 scaredAnimationProgress F
+	FIELD field_3470 sittingAnimationProgress F
 	METHOD <init> (Lnet/minecraft/class_630;)V
 		ARG 1 root
 	METHOD method_32022 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/entity/passive/PandaEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/PandaEntity.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/class_1440 net/minecraft/entity/passive/PandaEntity
 	FIELD field_30343 MAIN_GENE_MUTATION_CHANCE I
 	FIELD field_30344 SNEEZING_FLAG I
 	FIELD field_30345 PLAYING_FLAG I
-	FIELD field_30346 SCARED_FLAG I
+	FIELD field_30346 SITTING_FLAG I
 	FIELD field_30347 LYING_ON_BACK_FLAG I
 	FIELD field_30348 EATING_ANIMATION_INTERVAL I
 	FIELD field_30349 HIDDEN_GENE_MUTATION_CHANCE I
@@ -21,8 +21,8 @@ CLASS net/minecraft/class_1440 net/minecraft/entity/passive/PandaEntity
 	FIELD field_6773 lastRollOverAnimationProgress F
 	FIELD field_6774 lieOnBackAnimationProgress F
 	FIELD field_6775 lastLieOnBackAnimationProgress F
-	FIELD field_6777 scaredAnimationProgress F
-	FIELD field_6779 lastScaredAnimationProgress F
+	FIELD field_6777 sittingAnimationProgress F
+	FIELD field_6779 lastSittingAnimationProgress F
 	FIELD field_6780 EATING_TICKS Lnet/minecraft/class_2940;
 	FIELD field_6781 HIDDEN_GENE Lnet/minecraft/class_2940;
 	METHOD method_16106 canEat (Lnet/minecraft/class_1799;)Z
@@ -39,8 +39,8 @@ CLASS net/minecraft/class_1440 net/minecraft/entity/passive/PandaEntity
 	METHOD method_6508 getHiddenGene ()Lnet/minecraft/class_1440$class_1443;
 	METHOD method_6509 isWorried ()Z
 	METHOD method_6512 playEatingAnimation ()V
-	METHOD method_6513 setScared (Z)V
-		ARG 1 scared
+	METHOD method_6513 setSitting (Z)V
+		ARG 1 sitting
 	METHOD method_6514 isLyingOnBack ()Z
 	METHOD method_6515 initGenes (Lnet/minecraft/class_1440;Lnet/minecraft/class_1440;)V
 		ARG 1 mother
@@ -61,9 +61,9 @@ CLASS net/minecraft/class_1440 net/minecraft/entity/passive/PandaEntity
 	METHOD method_6532 getSneezeProgress ()I
 	METHOD method_6533 hasPandaFlag (I)Z
 		ARG 1 bitmask
-	METHOD method_6534 getScaredAnimationProgress (F)F
+	METHOD method_6534 getSittingAnimationProgress (F)F
 		ARG 1 tickDelta
-	METHOD method_6535 isScared ()Z
+	METHOD method_6535 isSitting ()Z
 	METHOD method_6536 updateEatingAnimation ()V
 	METHOD method_6537 updatePlaying ()V
 	METHOD method_6538 resetAttributes ()V
@@ -71,7 +71,7 @@ CLASS net/minecraft/class_1440 net/minecraft/entity/passive/PandaEntity
 		ARG 1 sneezeProgress
 	METHOD method_6541 setPlaying (Z)V
 		ARG 1 playing
-	METHOD method_6544 updateScaredAnimation ()V
+	METHOD method_6544 updateSittingAnimation ()V
 	METHOD method_6545 isSneezing ()Z
 	METHOD method_6546 setSneezing (Z)V
 		ARG 1 sneezing

--- a/unpick-definitions/entity_flags.unpick
+++ b/unpick-definitions/entity_flags.unpick
@@ -47,7 +47,7 @@ target_method net/minecraft/entity/LivingEntity setLivingFlag (IZ)V
 
 constant panda_flags net/minecraft/entity/passive/PandaEntity SNEEZING_FLAG
 constant panda_flags net/minecraft/entity/passive/PandaEntity PLAYING_FLAG
-constant panda_flags net/minecraft/entity/passive/PandaEntity SCARED_FLAG
+constant panda_flags net/minecraft/entity/passive/PandaEntity SITTING_FLAG
 constant panda_flags net/minecraft/entity/passive/PandaEntity LYING_ON_BACK_FLAG
 
 target_method net/minecraft/entity/passive/PandaEntity hasPandaFlag (I)Z


### PR DESCRIPTION
When you send the entity metadata packet with the appropriate update to the client
the panda's behavior can be better described as sitting up rather than being scared