### PR TITLE
Rename 'integer' parameter and add name for lambda parameter in CampfireBlockEntity

### DIFF
--- a/mappings/net/minecraft/block/entity/CampfireBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/CampfireBlockEntity.mapping
@@ -9,7 +9,9 @@ CLASS net/minecraft/class_3924 net/minecraft/block/entity/CampfireBlockEntity
 		ARG 1 item
 	METHOD method_17503 addItem (Lnet/minecraft/class_1799;I)Z
 		ARG 1 item
-		ARG 2 integer
+		ARG 2 cookTime
+	METHOD method_17504 (Lnet/minecraft/class_1263;Lnet/minecraft/class_3920;)Lnet/minecraft/class_1799;
+		ARG 1 recipe
 	METHOD method_17505 getItemsBeingCooked ()Lnet/minecraft/class_2371;
 	METHOD method_17506 spawnItemsBeingCooked ()V
 	METHOD method_17510 updateListeners ()V


### PR DESCRIPTION
Fixes #2917 and gives the lambda parameter in `litServerTick` the name, `recipe`, since it's mapping a list of recipes.