### PR TITLE
Rename the BlockStateModelGenerator#registerCauldron method to registerCauldrons

### DIFF
--- a/mappings/net/minecraft/data/client/model/BlockStateModelGenerator.mapping
+++ b/mappings/net/minecraft/data/client/model/BlockStateModelGenerator.mapping
@@ -349,7 +349,7 @@ CLASS net/minecraft/class_4910 net/minecraft/data/client/model/BlockStateModelGe
 	METHOD method_25707 registerPumpkins ()V
 	METHOD method_25708 registerNorthDefaultHorizontalRotation (Lnet/minecraft/class_2248;)V
 		ARG 1 block
-	METHOD method_25709 registerCauldron ()V
+	METHOD method_25709 registerCauldrons ()V
 	METHOD method_25710 registerShulkerBox (Lnet/minecraft/class_2248;)V
 		ARG 1 shulkerBox
 	METHOD method_25711 registerChorusFlower ()V


### PR DESCRIPTION
This method handles registration for all vanilla cauldrons:

- Empty cauldrons
- Lava cauldrons
- Water cauldrons
- Powder snow cauldrons