### PR TITLE
Rename the BlockStateModelGenerator#registerCarpet method to registerWoolAndCarpet

### DIFF
--- a/mappings/net/minecraft/data/client/model/BlockStateModelGenerator.mapping
+++ b/mappings/net/minecraft/data/client/model/BlockStateModelGenerator.mapping
@@ -219,7 +219,7 @@ CLASS net/minecraft/class_4910 net/minecraft/data/client/model/BlockStateModelGe
 	METHOD method_25640 createNorthDefaultRotationStates ()Lnet/minecraft/class_4926;
 	METHOD method_25641 registerSimpleCubeAll (Lnet/minecraft/class_2248;)V
 		ARG 1 block
-	METHOD method_25642 registerCarpet (Lnet/minecraft/class_2248;Lnet/minecraft/class_2248;)V
+	METHOD method_25642 registerWoolAndCarpet (Lnet/minecraft/class_2248;Lnet/minecraft/class_2248;)V
 		ARG 1 wool
 		ARG 2 carpet
 	METHOD method_25644 createSingletonBlockState (Lnet/minecraft/class_2248;Lnet/minecraft/class_2960;)Lnet/minecraft/class_4925;


### PR DESCRIPTION
This method handles registration for both wool and a carpet, such as moss blocks and moss carpets respectively.