### PR TITLE
Rename the Texture class to TextureMap

### DIFF
--- a/mappings/net/minecraft/data/client/model/BlockStateModelGenerator.mapping
+++ b/mappings/net/minecraft/data/client/model/BlockStateModelGenerator.mapping
@@ -45,7 +45,7 @@ CLASS net/minecraft/class_4910 net/minecraft/data/client/model/BlockStateModelGe
 	METHOD method_25536 getTurtleEggModel (ILjava/lang/String;Lnet/minecraft/class_4944;)Lnet/minecraft/class_2960;
 		ARG 1 eggs
 		ARG 2 prefix
-		ARG 3 texture
+		ARG 3 textures
 	METHOD method_25537 registerItemModel (Lnet/minecraft/class_1792;)V
 		ARG 1 item
 	METHOD method_25538 registerParentedItemModel (Lnet/minecraft/class_1792;Lnet/minecraft/class_2960;)V
@@ -72,10 +72,10 @@ CLASS net/minecraft/class_4910 net/minecraft/data/client/model/BlockStateModelGe
 		ARG 1 plantBlock
 		ARG 2 flowerPotBlock
 		ARG 3 tintType
-	METHOD method_25546 registerCubeWithCustomTexture (Lnet/minecraft/class_2248;Lnet/minecraft/class_2248;Ljava/util/function/BiFunction;)V
+	METHOD method_25546 registerCubeWithCustomTextures (Lnet/minecraft/class_2248;Lnet/minecraft/class_2248;Ljava/util/function/BiFunction;)V
 		ARG 1 block
 		ARG 2 otherTextureSource
-		ARG 3 textureFactory
+		ARG 3 texturesFactory
 	METHOD method_25547 registerCrop (Lnet/minecraft/class_2248;Lnet/minecraft/class_2769;[I)V
 		ARG 1 crop
 		ARG 2 ageProperty
@@ -104,10 +104,10 @@ CLASS net/minecraft/class_4910 net/minecraft/data/client/model/BlockStateModelGe
 		ARG 1 block
 		ARG 2 suffix
 		ARG 3 model
-		ARG 4 textureFactory
+		ARG 4 texturesFactory
 	METHOD method_25558 registerBeehive (Lnet/minecraft/class_2248;Ljava/util/function/Function;)V
 		ARG 1 beehive
-		ARG 2 textureGetter
+		ARG 2 texturesFactory
 	METHOD method_25560 registerTopSoil (Lnet/minecraft/class_2248;Lnet/minecraft/class_2960;Lnet/minecraft/class_4935;)V
 		ARG 1 topSoil
 		ARG 2 modelId
@@ -115,7 +115,7 @@ CLASS net/minecraft/class_4910 net/minecraft/data/client/model/BlockStateModelGe
 	METHOD method_25561 registerPiston (Lnet/minecraft/class_2248;Lnet/minecraft/class_2960;Lnet/minecraft/class_4944;)V
 		ARG 1 piston
 		ARG 2 extendedModelId
-		ARG 3 texture
+		ARG 3 textures
 	METHOD method_25565 createBooleanModelMap (Lnet/minecraft/class_2746;Lnet/minecraft/class_2960;Lnet/minecraft/class_2960;)Lnet/minecraft/class_4926;
 		ARG 0 property
 		ARG 1 trueModel
@@ -394,37 +394,37 @@ CLASS net/minecraft/class_4910 net/minecraft/data/client/model/BlockStateModelGe
 	METHOD method_34608 createStoneState (Lnet/minecraft/class_2248;Lnet/minecraft/class_2960;Lnet/minecraft/class_4944;Ljava/util/function/BiConsumer;)Lnet/minecraft/class_4917;
 		ARG 0 block
 		ARG 1 modelId
-		ARG 2 texture
+		ARG 2 textures
 		ARG 3 modelCollector
 	METHOD method_34612 (Lnet/minecraft/class_5794;)V
 		ARG 1 family
 	METHOD method_34622 (Ljava/util/HashMap;)V
 		ARG 0 map
 	METHOD method_34623 (Lnet/minecraft/class_4944;)V
-		ARG 0 texture
+		ARG 0 textures
 	METHOD method_34624 (Lnet/minecraft/class_4944;Lnet/minecraft/class_2960;)Lnet/minecraft/class_4944;
 		ARG 1 id
 	METHOD method_34626 (Lnet/minecraft/class_2960;Lnet/minecraft/class_4944;)V
-		ARG 1 texture
+		ARG 1 textures
 	METHOD method_34628 (Lnet/minecraft/class_2960;Lnet/minecraft/class_2960;Lnet/minecraft/class_2960;Lnet/minecraft/class_2960;Lnet/minecraft/class_2960;Lnet/minecraft/class_2960;Ljava/lang/Boolean;Lnet/minecraft/class_2768;)Lnet/minecraft/class_4935;
 		ARG 7 shape
 	METHOD method_34631 createDeepslateState (Lnet/minecraft/class_2248;Lnet/minecraft/class_2960;Lnet/minecraft/class_4944;Ljava/util/function/BiConsumer;)Lnet/minecraft/class_4917;
 		ARG 0 block
 		ARG 1 modelId
-		ARG 2 texture
+		ARG 2 textures
 		ARG 3 modelCollector
 	METHOD method_34636 (Lnet/minecraft/class_4944;)V
-		ARG 0 texture
+		ARG 0 textures
 	METHOD method_34637 (Lnet/minecraft/class_4944;Lnet/minecraft/class_2960;)Lnet/minecraft/class_4944;
 		ARG 1 id
 	METHOD method_34638 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_4935;
 		ARG 0 id
 	METHOD method_34639 (Lnet/minecraft/class_2960;Lnet/minecraft/class_4944;)V
-		ARG 1 texture
+		ARG 1 textures
 	METHOD method_34644 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_4935;
 		ARG 0 id
 	METHOD method_34645 (Lnet/minecraft/class_2960;Lnet/minecraft/class_4944;)V
-		ARG 1 texture
+		ARG 1 textures
 	METHOD method_34649 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_4935;
 		ARG 0 id
 	METHOD method_34652 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_4935;
@@ -434,7 +434,7 @@ CLASS net/minecraft/class_4910 net/minecraft/data/client/model/BlockStateModelGe
 	METHOD method_34852 registerLightningRod ()V
 	METHOD method_35868 registerSingleton (Lnet/minecraft/class_2248;Lnet/minecraft/class_4944;Lnet/minecraft/class_4942;)V
 		ARG 1 block
-		ARG 2 texture
+		ARG 2 textures
 		ARG 3 model
 	METHOD method_36440 registerInfestedDeepslate ()V
 	METHOD method_37317 registerPottedAzaleaBush (Lnet/minecraft/class_2248;)V
@@ -455,12 +455,12 @@ CLASS net/minecraft/class_4910 net/minecraft/data/client/model/BlockStateModelGe
 		METHOD method_25715 includeWithoutItem ([Lnet/minecraft/class_2248;)Lnet/minecraft/class_4910$class_4911;
 			ARG 1 blocks
 	CLASS class_4912 BlockTexturePool
-		FIELD field_22837 texture Lnet/minecraft/class_4944;
+		FIELD field_22837 textures Lnet/minecraft/class_4944;
 		FIELD field_22838 baseModelId Lnet/minecraft/class_2960;
 		FIELD field_28553 knownModels Ljava/util/Map;
 		FIELD field_28554 family Lnet/minecraft/class_5794;
 		METHOD <init> (Lnet/minecraft/class_4910;Lnet/minecraft/class_4944;)V
-			ARG 2 texture
+			ARG 2 textures
 		METHOD method_25716 button (Lnet/minecraft/class_2248;)Lnet/minecraft/class_4910$class_4912;
 			ARG 1 buttonBlock
 		METHOD method_25717 sign (Lnet/minecraft/class_2248;)Lnet/minecraft/class_4910$class_4912;
@@ -501,9 +501,9 @@ CLASS net/minecraft/class_4910 net/minecraft/data/client/model/BlockStateModelGe
 		METHOD method_25726 getCrossModel ()Lnet/minecraft/class_4942;
 		METHOD method_25727 getFlowerPotCrossModel ()Lnet/minecraft/class_4942;
 	CLASS class_4914 LogTexturePool
-		FIELD field_22843 texture Lnet/minecraft/class_4944;
+		FIELD field_22843 textures Lnet/minecraft/class_4944;
 		METHOD <init> (Lnet/minecraft/class_4910;Lnet/minecraft/class_4944;)V
-			ARG 2 texture
+			ARG 2 textures
 		METHOD method_25728 wood (Lnet/minecraft/class_2248;)Lnet/minecraft/class_4910$class_4914;
 			ARG 1 woodBlock
 		METHOD method_25729 stem (Lnet/minecraft/class_2248;)Lnet/minecraft/class_4910$class_4914;
@@ -514,5 +514,5 @@ CLASS net/minecraft/class_4910 net/minecraft/data/client/model/BlockStateModelGe
 		METHOD create (Lnet/minecraft/class_2248;Lnet/minecraft/class_2960;Lnet/minecraft/class_4944;Ljava/util/function/BiConsumer;)Lnet/minecraft/class_4917;
 			ARG 1 block
 			ARG 2 modelId
-			ARG 3 texture
+			ARG 3 textures
 			ARG 4 modelCollector

--- a/mappings/net/minecraft/data/client/model/Model.mapping
+++ b/mappings/net/minecraft/data/client/model/Model.mapping
@@ -5,15 +5,15 @@ CLASS net/minecraft/class_4942 net/minecraft/data/client/model/Model
 	METHOD <init> (Ljava/util/Optional;Ljava/util/Optional;[Lnet/minecraft/class_4945;)V
 		ARG 1 parent
 		ARG 2 variant
-		ARG 3 requiredTextures
+		ARG 3 requiredTextureKeys
 	METHOD method_25846 upload (Lnet/minecraft/class_2248;Lnet/minecraft/class_4944;Ljava/util/function/BiConsumer;)Lnet/minecraft/class_2960;
 		ARG 1 block
-		ARG 2 texture
+		ARG 2 textures
 		ARG 3 modelCollector
 	METHOD method_25847 upload (Lnet/minecraft/class_2248;Ljava/lang/String;Lnet/minecraft/class_4944;Ljava/util/function/BiConsumer;)Lnet/minecraft/class_2960;
 		ARG 1 block
 		ARG 2 suffix
-		ARG 3 texture
+		ARG 3 textures
 		ARG 4 modelCollector
 	METHOD method_25848 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_4945;Lnet/minecraft/class_2960;)V
 		ARG 1 textureKey
@@ -21,13 +21,13 @@ CLASS net/minecraft/class_4942 net/minecraft/data/client/model/Model
 	METHOD method_25849 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2960;)V
 		ARG 1 parentId
 	METHOD method_25850 createTextureMap (Lnet/minecraft/class_4944;)Ljava/util/Map;
-		ARG 1 texture
+		ARG 1 textures
 	METHOD method_25852 upload (Lnet/minecraft/class_2960;Lnet/minecraft/class_4944;Ljava/util/function/BiConsumer;)Lnet/minecraft/class_2960;
 		ARG 1 id
-		ARG 2 texture
+		ARG 2 textures
 		ARG 3 modelCollector
 	METHOD method_25853 uploadWithoutVariant (Lnet/minecraft/class_2248;Ljava/lang/String;Lnet/minecraft/class_4944;Ljava/util/function/BiConsumer;)Lnet/minecraft/class_2960;
 		ARG 1 block
 		ARG 2 suffix
-		ARG 3 texture
+		ARG 3 textures
 		ARG 4 modelCollector

--- a/mappings/net/minecraft/data/client/model/Models.mapping
+++ b/mappings/net/minecraft/data/client/model/Models.mapping
@@ -4,12 +4,12 @@ CLASS net/minecraft/class_4943 net/minecraft/data/client/model/Models
 	METHOD method_25855 block (Ljava/lang/String;Ljava/lang/String;[Lnet/minecraft/class_4945;)Lnet/minecraft/class_4942;
 		ARG 0 parent
 		ARG 1 variant
-		ARG 2 requiredTextures
+		ARG 2 requiredTextureKeys
 	METHOD method_25856 block (Ljava/lang/String;[Lnet/minecraft/class_4945;)Lnet/minecraft/class_4942;
 		ARG 0 parent
-		ARG 1 requiredTextures
+		ARG 1 requiredTextureKeys
 	METHOD method_25857 make ([Lnet/minecraft/class_4945;)Lnet/minecraft/class_4942;
-		ARG 0 requiredTextures
+		ARG 0 requiredTextureKeys
 	METHOD method_25859 item (Ljava/lang/String;[Lnet/minecraft/class_4945;)Lnet/minecraft/class_4942;
 		ARG 0 parent
-		ARG 1 requiredTextures
+		ARG 1 requiredTextureKeys

--- a/mappings/net/minecraft/data/client/model/TextureMap.mapping
+++ b/mappings/net/minecraft/data/client/model/TextureMap.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4944 net/minecraft/data/client/model/Texture
+CLASS net/minecraft/class_4944 net/minecraft/data/client/model/TextureMap
 	FIELD field_22997 entries Ljava/util/Map;
 	FIELD field_22998 inherited Ljava/util/Set;
 	METHOD method_25860 getId (Lnet/minecraft/class_2248;)Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/data/client/model/TexturedModel.mapping
+++ b/mappings/net/minecraft/data/client/model/TexturedModel.mapping
@@ -20,11 +20,11 @@ CLASS net/minecraft/class_4946 net/minecraft/data/client/model/TexturedModel
 	FIELD field_23055 END_FOR_TOP_CUBE_COLUMN Lnet/minecraft/class_4946$class_4947;
 	FIELD field_23056 END_FOR_TOP_CUBE_COLUMN_HORIZONTAL Lnet/minecraft/class_4946$class_4947;
 	FIELD field_23057 SIDE_TOP_BOTTOM_WALL Lnet/minecraft/class_4946$class_4947;
-	FIELD field_23058 texture Lnet/minecraft/class_4944;
+	FIELD field_23058 textures Lnet/minecraft/class_4944;
 	FIELD field_23059 model Lnet/minecraft/class_4942;
 	FIELD field_23959 SIDE_END_WALL Lnet/minecraft/class_4946$class_4947;
 	METHOD <init> (Lnet/minecraft/class_4944;Lnet/minecraft/class_4942;)V
-		ARG 1 texture
+		ARG 1 textures
 		ARG 2 model
 	METHOD method_25914 getModel ()Lnet/minecraft/class_4942;
 	METHOD method_25915 upload (Lnet/minecraft/class_2248;Ljava/lang/String;Ljava/util/function/BiConsumer;)Lnet/minecraft/class_2960;
@@ -34,14 +34,14 @@ CLASS net/minecraft/class_4946 net/minecraft/data/client/model/TexturedModel
 	METHOD method_25916 upload (Lnet/minecraft/class_2248;Ljava/util/function/BiConsumer;)Lnet/minecraft/class_2960;
 		ARG 1 block
 		ARG 2 writer
-	METHOD method_25917 texture (Ljava/util/function/Consumer;)Lnet/minecraft/class_4946;
-		ARG 1 textureConsumer
+	METHOD method_25917 textures (Ljava/util/function/Consumer;)Lnet/minecraft/class_4946;
+		ARG 1 texturesConsumer
 	METHOD method_25918 makeFactory (Ljava/util/function/Function;Lnet/minecraft/class_4942;)Lnet/minecraft/class_4946$class_4947;
-		ARG 0 textureGetter
+		ARG 0 texturesGetter
 		ARG 1 model
 	METHOD method_25920 getCubeAll (Lnet/minecraft/class_2960;)Lnet/minecraft/class_4946;
 		ARG 0 id
-	METHOD method_25921 getTexture ()Lnet/minecraft/class_4944;
+	METHOD method_25921 getTextures ()Lnet/minecraft/class_4944;
 	CLASS class_4947 Factory
 		METHOD get (Lnet/minecraft/class_2248;)Lnet/minecraft/class_4946;
 			ARG 1 block


### PR DESCRIPTION
This class represents a map of texture keys to identifiers rather than a single texture.