### PR TITLE
Fix entity param name for updateKilledAdvancementCriterion

### DIFF
--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -614,7 +614,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_5713 checkWaterState ()V
 	METHOD method_5715 isSneaking ()Z
 	METHOD method_5716 updateKilledAdvancementCriterion (Lnet/minecraft/class_1297;ILnet/minecraft/class_1282;)V
-		ARG 1 killer
+		ARG 1 entityKilled
 		ARG 2 score
 		ARG 3 damageSource
 	METHOD method_5717 setInNetherPortal (Lnet/minecraft/class_2338;)V


### PR DESCRIPTION
Look at the last line of `ServerPlayerEntity#updateKilledAdvancementCriterion`
`Criteria.PLAYER_KILLED_ENTITY.trigger(this, killer, damageSource);`
that's the "player_killed_entity" trigger, and the method called on it's parameters are incorrectly named because clearly "this" is the player, and should be the killer, not the
entity passed into the `ServerPlayerEntity#updateKilledAdvancementCriterion` method.

Can also look at `Entity#updateKilledAdvancementCriterion` for further confirmation where
it triggers the "entity_killed_player" trigger and that's guarded by a check if the entity parameter is an instance of `ServerPlayerEntity`, so that means the entity is the one being killed, not the killer.