### PR TITLE
Rename AbstractBlock#hasSolidTopSurface to isSolidSurface

### DIFF
--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -444,7 +444,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 			ARG 1 world
 			ARG 2 pos
 			ARG 3 entity
-		METHOD method_26169 hasSolidTopSurface (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_1297;Lnet/minecraft/class_2350;)Z
+		METHOD method_26169 isSolidSurface (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_1297;Lnet/minecraft/class_2350;)Z
 			ARG 1 world
 			ARG 2 pos
 			ARG 3 entity


### PR DESCRIPTION
As mentioned in #2913, this method also takes a direction, allowing
you to check the solidity of other sides of the block. The other `hasSolidTopSurface`
method that doesn't take a direction is kept the same, since it just
calls the directional variant with the UP direction.
