### PR TITLE
Pattern name BACKSLASH_S_PATTERN does not indicate what the pattern does

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/CommandSuggestor.mapping
+++ b/mappings/net/minecraft/client/gui/screen/CommandSuggestor.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_4717 net/minecraft/client/gui/screen/CommandSuggestor
-	FIELD field_21596 BACKSLASH_S_PATTERN Ljava/util/regex/Pattern;
+	FIELD field_21596 WHITESPACE_PATTERN Ljava/util/regex/Pattern;
 	FIELD field_21597 client Lnet/minecraft/class_310;
 	FIELD field_21598 owner Lnet/minecraft/class_437;
 	FIELD field_21599 textField Lnet/minecraft/class_342;
@@ -54,7 +54,7 @@ CLASS net/minecraft/class_4717 net/minecraft/client/gui/screen/CommandSuggestor
 		ARG 2 firstCharacterIndex
 	METHOD method_23929 showUsages (Lnet/minecraft/class_124;)V
 		ARG 1 formatting
-	METHOD method_23930 getLastPlayerNameStart (Ljava/lang/String;)I
+	METHOD method_23930 getStartOfCurrentWord (Ljava/lang/String;)I
 		ARG 0 input
 	METHOD method_23931 provideRenderText (Ljava/lang/String;I)Lnet/minecraft/class_5481;
 		ARG 1 original


### PR DESCRIPTION
The pattern BACKSLASH_S_PATTERN is very literally named after the regex. This is confusing as the pattern isn't detecting any backslashes or s, it detects white-space. I have therefore renamed it WHITESPACE_PATTERN.

This also made clear that the function getLastPlayerNameStart just gets the first character of the current word and doesn't have anything to do with player names specifically, so I have renamed that also.

Forgive me if I have done anything wrong, this is my first pull request.