### PR TITLE
Rename Fertilizable to BoneMealable

### DIFF
--- a/mappings/net/minecraft/block/BoneMealable.mapping
+++ b/mappings/net/minecraft/block/BoneMealable.mapping
@@ -1,10 +1,10 @@
-CLASS net/minecraft/class_2256 net/minecraft/block/Fertilizable
+CLASS net/minecraft/class_2256 net/minecraft/block/BoneMealable
 	METHOD method_9650 canGrow (Lnet/minecraft/class_1937;Ljava/util/Random;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)Z
 		ARG 1 world
 		ARG 2 random
 		ARG 3 pos
 		ARG 4 state
-	METHOD method_9651 isFertilizable (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Z)Z
+	METHOD method_9651 isBoneMealable (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Z)Z
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state


### PR DESCRIPTION
When a player refers to the act of using bone meal in-game, they would say:
"Let's bone meal that wheat field," instead of, "Let's _fertilize_ that wheat field."

This may also cause confusion with the fertilization/pollination feature of bees.