### PR TITLE
22w06a resources

### DIFF
--- a/mappings/net/minecraft/resource/LifecycledResourceManager.mapping
+++ b/mappings/net/minecraft/resource/LifecycledResourceManager.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_6860 net/minecraft/resource/LifecycledResourceManager
+	COMMENT A lifecycled resource manager is available until it is {@linkplain #close()
+	COMMENT closed}. In principle, it should not be accessed any more after closing;
+	COMMENT use another resource manager instead.

--- a/mappings/net/minecraft/resource/LifecycledResourceManagerImpl.mapping
+++ b/mappings/net/minecraft/resource/LifecycledResourceManagerImpl.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_6861 net/minecraft/resource/LifecycledResourceManagerI
 	COMMENT <p>It handles resources by namespaces, hoping that most namespaces are
 	COMMENT defined in only few resource packs.
 	COMMENT
-	COMMENT @see NamespacedResourceManager
+	COMMENT @see NamespaceResourceManager
 	FIELD field_36389 subManagers Ljava/util/Map;
 	FIELD field_36390 packs Ljava/util/List;
 	METHOD <init> (Lnet/minecraft/class_3264;Ljava/util/List;)V

--- a/mappings/net/minecraft/resource/LifecycledResourceManagerImpl.mapping
+++ b/mappings/net/minecraft/resource/LifecycledResourceManagerImpl.mapping
@@ -1,0 +1,14 @@
+CLASS net/minecraft/class_6861 net/minecraft/resource/LifecycledResourceManagerImpl
+	COMMENT A basic implementation of resource manager with a lifecycle.
+	COMMENT
+	COMMENT <p>It handles resources by namespaces, hoping that most namespaces are
+	COMMENT defined in only few resource packs.
+	COMMENT
+	COMMENT @see NamespacedResourceManager
+	FIELD field_36389 subManagers Ljava/util/Map;
+	FIELD field_36390 packs Ljava/util/List;
+	METHOD <init> (Lnet/minecraft/class_3264;Ljava/util/List;)V
+		ARG 1 type
+		ARG 2 packs
+	METHOD method_40086 (Lnet/minecraft/class_3264;Ljava/lang/String;)Lnet/minecraft/class_3294;
+		ARG 1 namespace

--- a/mappings/net/minecraft/resource/NamespaceResourceManager.mapping
+++ b/mappings/net/minecraft/resource/NamespaceResourceManager.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_3294 net/minecraft/resource/NamespaceResourceManager
 	COMMENT on the heuristic that most namespaces are only defined in few resource
 	COMMENT packs, making loading in those namespaces faster.
 	COMMENT
-	COMMENT @see ResourceManagerImpl
+	COMMENT @see LifecycledResourceManagerImpl
 	FIELD field_14283 packList Ljava/util/List;
 	FIELD field_14284 type Lnet/minecraft/class_3264;
 	FIELD field_14285 LOGGER Lorg/slf4j/Logger;

--- a/mappings/net/minecraft/resource/NamespaceResourceManager.mapping
+++ b/mappings/net/minecraft/resource/NamespaceResourceManager.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_3294 net/minecraft/resource/NamespaceResourceManager
 	COMMENT A resource manager that only loads resources for a specific namespace.
-	COMMENT This is an implementation detail for {@link ResourceManagerImpl}, based
+	COMMENT This is an implementation detail for {@link LifecycledResourceManagerImpl}, based
 	COMMENT on the heuristic that most namespaces are only defined in few resource
 	COMMENT packs, making loading in those namespaces faster.
 	COMMENT

--- a/mappings/net/minecraft/resource/NamespaceResourceManager.mapping
+++ b/mappings/net/minecraft/resource/NamespaceResourceManager.mapping
@@ -1,4 +1,10 @@
 CLASS net/minecraft/class_3294 net/minecraft/resource/NamespaceResourceManager
+	COMMENT A resource manager that only loads resources for a specific namespace.
+	COMMENT This is an implementation detail for {@link ResourceManagerImpl}, based
+	COMMENT on the heuristic that most namespaces are only defined in few resource
+	COMMENT packs, making loading in those namespaces faster.
+	COMMENT
+	COMMENT @see ResourceManagerImpl
 	FIELD field_14283 packList Ljava/util/List;
 	FIELD field_14284 type Lnet/minecraft/class_3264;
 	FIELD field_14285 LOGGER Lorg/slf4j/Logger;

--- a/mappings/net/minecraft/resource/ProfiledResourceReload.mapping
+++ b/mappings/net/minecraft/resource/ProfiledResourceReload.mapping
@@ -19,6 +19,8 @@ CLASS net/minecraft/class_4010 net/minecraft/resource/ProfiledResourceReload
 		ARG 3 reloader
 		ARG 4 prepare
 		ARG 5 apply
+	METHOD method_18356 (Lnet/minecraft/class_3302;Lnet/minecraft/class_3533;Lnet/minecraft/class_3533;Ljava/util/concurrent/atomic/AtomicLong;Ljava/util/concurrent/atomic/AtomicLong;Ljava/lang/Void;)Lnet/minecraft/class_4010$class_4046;
+		ARG 5 dummy
 	METHOD method_18358 (Ljava/util/concurrent/Executor;Ljava/util/concurrent/atomic/AtomicLong;Ljava/lang/Runnable;)V
 		ARG 2 preparation
 	CLASS class_4046 Summary

--- a/mappings/net/minecraft/resource/ReloadableResourceManagerImpl.mapping
+++ b/mappings/net/minecraft/resource/ReloadableResourceManagerImpl.mapping
@@ -1,8 +1,27 @@
 CLASS net/minecraft/class_3304 net/minecraft/resource/ReloadableResourceManagerImpl
+	COMMENT A reloadable resource manager is always available to be accessed, and is the
+	COMMENT type used by the minecraft client instance. It has a backing {@linkplain
+	COMMENT #activeManager active resource manager} that it delegates to.
+	COMMENT
+	COMMENT <p>It starts with an empty active resource manager, and swaps the active
+	COMMENT resource manager whenever it {@linkplain #reload reloads}; in addition,
+	COMMENT {@linkplain #close closing} it will replace the active resource manager
+	COMMENT with an empty one, and the reloadable manager itself is still accessible to
+	COMMENT users, as opposed to the lifecycled resource manager.
 	FIELD field_14294 type Lnet/minecraft/class_3264;
 	FIELD field_14295 LOGGER Lorg/slf4j/Logger;
 	FIELD field_17935 reloaders Ljava/util/List;
+	FIELD field_36391 activeManager Lnet/minecraft/class_6860;
 	METHOD <init> (Lnet/minecraft/class_3264;)V
 		ARG 1 type
 	METHOD method_14477 registerReloader (Lnet/minecraft/class_3302;)V
+		COMMENT Registers a reloader to all future reloads on this resource
+		COMMENT manager.
+		ARG 1 reloader
 	METHOD method_18232 reload (Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Ljava/util/concurrent/CompletableFuture;Ljava/util/List;)Lnet/minecraft/class_4011;
+		COMMENT Swaps the active resource manager with another one backed by the given
+		COMMENT {@code packs} and start a {@linkplain SimpleResourceReload#start reload}.
+		ARG 1 prepareExecutor
+		ARG 2 applyExecutor
+		ARG 3 initialStage
+		ARG 4 packs

--- a/mappings/net/minecraft/resource/ResourcePack.mapping
+++ b/mappings/net/minecraft/resource/ResourcePack.mapping
@@ -1,8 +1,10 @@
 CLASS net/minecraft/class_3262 net/minecraft/resource/ResourcePack
 	COMMENT A resource pack, providing resources to resource managers.
 	COMMENT
-	COMMENT <p>They are single-use in each reload cycle of a reloadable resource manager.
-	COMMENT {@link ResourcePackProfile} is a persistent version of the resource packs.
+	COMMENT <p>They are single-use in the lifecycle of a {@linkplain LifecycledResourceManagerImpl
+	COMMENT lifecycled resource manager}. A {@link ResourcePackProfile} is a persistent
+	COMMENT representation of the resource packs, and can be used to recreate the packs
+	COMMENT on demand.
 	FIELD field_29780 METADATA_PATH_SUFFIX Ljava/lang/String;
 	FIELD field_29781 PACK_METADATA_NAME Ljava/lang/String;
 	METHOD method_14405 open (Lnet/minecraft/class_3264;Lnet/minecraft/class_2960;)Ljava/io/InputStream;

--- a/mappings/net/minecraft/resource/ResourceReload.mapping
+++ b/mappings/net/minecraft/resource/ResourceReload.mapping
@@ -1,8 +1,7 @@
 CLASS net/minecraft/class_4011 net/minecraft/resource/ResourceReload
 	COMMENT Represents a resource reload.
 	COMMENT
-	COMMENT @see ReloadableResourceManager#reload(java.util.concurrent.Executor,
-	COMMENT java.util.concurrent.Executor, CompletableFuture, java.util.List)
+	COMMENT @see SimpleResourceReload#start
 	METHOD method_18229 getProgress ()F
 		COMMENT Returns a fraction between 0 and 1 indicating the progress of this
 		COMMENT reload.

--- a/mappings/net/minecraft/resource/ResourceReloader.mapping
+++ b/mappings/net/minecraft/resource/ResourceReloader.mapping
@@ -1,8 +1,8 @@
 CLASS net/minecraft/class_3302 net/minecraft/resource/ResourceReloader
 	COMMENT A resource reloader performs actual reloading in its {@linkplain #reload
-	COMMENT reload} in a reloadable resource manager it is registered to.
+	COMMENT reload} when called by {@link SimpleResourceReload#start}.
 	COMMENT
-	COMMENT @see ReloadableResourceManager
+	COMMENT @see SimpleResourceReload#start
 	COMMENT @see SinglePreparationResourceReloader SinglePreparationResourceReloader
 	COMMENT (completes preparation in one method)
 	COMMENT @see SynchronousResourceReloader SynchronousResourceReloader

--- a/mappings/net/minecraft/resource/ServerResourceManager.mapping
+++ b/mappings/net/minecraft/resource/ServerResourceManager.mapping
@@ -8,11 +8,13 @@ CLASS net/minecraft/class_5350 net/minecraft/resource/ServerResourceManager
 	FIELD field_25341 serverAdvancementLoader Lnet/minecraft/class_2989;
 	FIELD field_25342 functionLoader Lnet/minecraft/class_5349;
 	FIELD field_28017 lootFunctionManager Lnet/minecraft/class_5640;
+	FIELD field_36491 LOGGER Lorg/slf4j/Logger;
 	METHOD <init> (Lnet/minecraft/class_5455$class_6890;Lnet/minecraft/class_2170$class_5364;I)V
 		ARG 2 commandEnvironment
 		ARG 3 functionPermissionLevel
 	METHOD method_29465 getFunctionLoader ()Lnet/minecraft/class_5349;
 	METHOD method_29466 reload (Lnet/minecraft/class_3300;Lnet/minecraft/class_5455$class_6890;Lnet/minecraft/class_2170$class_5364;ILjava/util/concurrent/Executor;Ljava/util/concurrent/Executor;)Ljava/util/concurrent/CompletableFuture;
+		ARG 0 manager
 		ARG 2 commandEnvironment
 		ARG 3 functionPermissionLevel
 		ARG 4 prepareExecutor
@@ -23,3 +25,4 @@ CLASS net/minecraft/class_5350 net/minecraft/resource/ServerResourceManager
 	METHOD method_29472 getCommandManager ()Lnet/minecraft/class_2170;
 	METHOD method_29473 getServerAdvancementLoader ()Lnet/minecraft/class_2989;
 	METHOD method_32703 getLootFunctionManager ()Lnet/minecraft/class_5640;
+	METHOD method_40427 getResourceReloaders ()Ljava/util/List;

--- a/mappings/net/minecraft/resource/SimpleResourceReload.mapping
+++ b/mappings/net/minecraft/resource/SimpleResourceReload.mapping
@@ -42,6 +42,24 @@ CLASS net/minecraft/class_4014 net/minecraft/resource/SimpleResourceReload
 		ARG 4 initialStage
 	METHOD method_18372 (Ljava/util/concurrent/Executor;Ljava/lang/Runnable;)V
 		ARG 2 preparation
+	METHOD method_40087 start (Lnet/minecraft/class_3300;Ljava/util/List;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;Ljava/util/concurrent/CompletableFuture;Z)Lnet/minecraft/class_4011;
+		COMMENT Starts a resource reload with the content from the {@code manager} supplied
+		COMMENT to the {@code reloaders}.
+		COMMENT
+		COMMENT @apiNote In vanilla, this is respectively called by {@link ReloadableResourceManagerImpl}
+		COMMENT on the client and {@link ServerResourceManager} on the server.
+		ARG 0 manager
+			COMMENT the resource manager, providing resources to the reloaders
+		ARG 1 reloaders
+			COMMENT the reloaders performing the reload
+		ARG 2 prepareExecutor
+			COMMENT the executor for the prepare stage, often asynchronous
+		ARG 3 applyExecutor
+			COMMENT the executor for the apply stage, synchronous with the game engine
+		ARG 4 initialStage
+			COMMENT the initial stage, must be completed before the reloaders can prepare resources
+		ARG 5 profiled
+			COMMENT whether to profile this reload and log the statistics
 	CLASS class_4047 Factory
 		COMMENT A factory that creates a completable future for each reloader in the
 		COMMENT resource reload.

--- a/src/packageDocs/java/net/minecraft/resource/package-info.java
+++ b/src/packageDocs/java/net/minecraft/resource/package-info.java
@@ -3,7 +3,7 @@
  */
 
 /**
- * Provides resources to Minecraft, including resource access and provision.
+ * Provides resources to Minecraft, including resource access, provision, and reloading.
  *
  * <p>"Data" as in "Data Packs" is considered resource as well.
  *
@@ -15,26 +15,25 @@
  * </tr>
  * <tr>
  *     <td>{@link Resource}</td>
- *     <td>Accesses binary data.</td>
+ *     <td>Accesses to binary data.</td>
  * </tr>
  * <tr>
  *     <td>{@link ResourceFactory}</td>
  *     <td>Provides a resource given an {@link net.minecraft.util.Identifier}.</td>
-
  * </tr>
  * <tr>
  *     <td>{@link ResourceManager}</td>
  *     <td>Exposes more resource access in addition to being a {@link ResourceFactory}.</td>
  * </tr>
  * <tr>
- *     <td>{@link ResourceReloader}</td>
- *     <td>The most common accessor to resources, acting during "reloads" to set up in-game contents.
- *     <br><i>This is usually implemented by mods using resources.</i></td>
+ *     <td>{@link LifecycledResourceManager}</td>
+ *     <td>A resource manager with a specific lifecycle, to fine-grain resource access.</td>
  * </tr>
  * <tr>
- *     <td>{@link ReloadableResourceManager}</td>
- *     <td>Performs reloads and manages {@link ResourceReloader}s in addition to being a {@link ResourceManager}.
- *     <br>Usually held by the game engine, it may be provided by the modding APIs as well.</td>
+ *     <td>{@link ResourceReloader}</td>
+ *     <td>The most common accessor to resources, acting during {@linkplain
+ *     SimpleResourceReload#start reloads} to set up in-game contents.
+ *     <br><i>This is usually implemented by mods using resources.</i></td>
  * </tr>
  * </table></div>
  *


### PR DESCRIPTION
So now:
 - Resource reloads are handled by `SimpleResourceReload#start` than by the managers, much cleaner
 - The old resource manager impl probably stayed the same; now named `LifecycledResourceManagerImpl` to show it should be discarded when `close()` is called. Good for programming habits
 - The `ReloadableResourceManagerImpl` now keeps a backing lifecycled manager that actually supply the resources, like the tag manager/factory etc.
   - `close()` it is different from closing the lifecycled one, as it only replaces the backing manager with an empty one (like initial state)
   - I am tempted to rename this to `StaticTagManager`, maybe later
   - This is only used by the client; the server has a similar record structure, not mapped by this pr (as it touches dynamic registries)
 - Reloaders are now registered to `ReloadableResourceManagerImpl.addReloader` and the return value of `ServerResourceManager.getReloaders()`, the latter one needs some mixin. Easier to mod in general.


------------
For the task is daunting, we will start with small ones. ~~Conflicts with #2995, where it maps my `LifecycledResourceManager` and impl to `AutoCloseableResourceManager` `CombinedResourceManager` (not accurate IMO)~~
