### PR TITLE
Rename misleading VertexBuffer-related names

### DIFF
--- a/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
+++ b/mappings/com/mojang/blaze3d/platform/GlStateManager.mapping
@@ -42,7 +42,7 @@ CLASS com/mojang/blaze3d/platform/GlStateManager
 		ARG 0 index
 	METHOD _drawElements (IIIJ)V
 		ARG 0 mode
-		ARG 1 first
+		ARG 1 count
 		ARG 2 type
 		ARG 3 indices
 	METHOD _enableVertexAttribArray (I)V

--- a/mappings/com/mojang/blaze3d/systems/RenderSystem.mapping
+++ b/mappings/com/mojang/blaze3d/systems/RenderSystem.mapping
@@ -44,8 +44,8 @@ CLASS com/mojang/blaze3d/systems/RenderSystem
 		ARG 0 mask
 	METHOD drawElements (III)V
 		ARG 0 mode
-		ARG 1 first
-		ARG 2 count
+		ARG 1 count
+		ARG 2 type
 	METHOD flipFrame (J)V
 		ARG 0 window
 	METHOD getString (ILjava/util/function/Consumer;)V

--- a/mappings/net/minecraft/client/gl/VertexBuffer.mapping
+++ b/mappings/net/minecraft/client/gl/VertexBuffer.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_291 net/minecraft/client/gl/VertexBuffer
 	FIELD field_27366 indexBufferId I
 	FIELD field_27367 elementFormat Lnet/minecraft/class_293$class_5595;
 	FIELD field_27368 drawMode Lnet/minecraft/class_293$class_5596;
-	FIELD field_27369 usesTexture Z
+	FIELD field_27369 hasNoIndexBuffer Z
 	FIELD field_29338 vertexArrayId I
 	FIELD field_29339 vertexFormat Lnet/minecraft/class_293;
 	METHOD method_1352 upload (Lnet/minecraft/class_287;)V
@@ -33,6 +33,6 @@ CLASS net/minecraft/class_291 net/minecraft/client/gl/VertexBuffer
 		ARG 2 projectionMatrix
 		ARG 3 shader
 	METHOD method_34432 drawVertices ()V
-	METHOD method_34435 getElementFormat ()Lnet/minecraft/class_293;
+	METHOD method_34435 getVertexFormat ()Lnet/minecraft/class_293;
 	METHOD method_34437 bindVertexArray ()V
 	METHOD method_35665 drawElements ()V

--- a/mappings/net/minecraft/client/render/BufferBuilder.mapping
+++ b/mappings/net/minecraft/client/render/BufferBuilder.mapping
@@ -14,11 +14,11 @@ CLASS net/minecraft/class_287 net/minecraft/client/render/BufferBuilder
 	FIELD field_20884 elementOffset I
 	FIELD field_21594 textured Z
 	FIELD field_21595 hasOverlay Z
-	FIELD field_27348 currentParameters [Lnet/minecraft/class_1160;
-	FIELD field_27349 cameraX F
-	FIELD field_27350 cameraY F
-	FIELD field_27351 cameraZ F
-	FIELD field_27352 cameraOffset Z
+	FIELD field_27348 sortingPrimitiveCenters [Lnet/minecraft/class_1160;
+	FIELD field_27349 sortingCameraX F
+	FIELD field_27350 sortingCameraY F
+	FIELD field_27351 sortingCameraZ F
+	FIELD field_27352 hasNoVertexBuffer Z
 	FIELD field_32050 MAX_BUFFER_SIZE I
 	METHOD <init> (I)V
 		ARG 1 initialCapacity
@@ -40,13 +40,13 @@ CLASS net/minecraft/class_287 net/minecraft/client/render/BufferBuilder
 	METHOD method_23477 reset ()V
 	METHOD method_23918 setFormat (Lnet/minecraft/class_293;)V
 		ARG 1 format
-	METHOD method_31948 setCameraPosition (FFF)V
+	METHOD method_31948 sortFrom (FFF)V
 		ARG 1 cameraX
 		ARG 2 cameraY
 		ARG 3 cameraZ
-	METHOD method_31949 createConsumer (Lnet/minecraft/class_293$class_5595;)Lit/unimi/dsi/fastutil/ints/IntConsumer;
+	METHOD method_31949 createIndexWriter (Lnet/minecraft/class_293$class_5595;)Lit/unimi/dsi/fastutil/ints/IntConsumer;
 		ARG 1 elementFormat
-	METHOD method_31950 writeCameraOffset (Lnet/minecraft/class_293$class_5595;)V
+	METHOD method_31950 writeSortedIndices (Lnet/minecraft/class_293$class_5595;)V
 		ARG 1 elementFormat
 	METHOD method_31951 (I)V
 		ARG 1 value
@@ -54,40 +54,40 @@ CLASS net/minecraft/class_287 net/minecraft/client/render/BufferBuilder
 		ARG 1 value
 	METHOD method_31953 (I)V
 		ARG 1 value
-	METHOD method_31954 buildParameterVector ()[Lnet/minecraft/class_1160;
+	METHOD method_31954 buildPrimitiveCenters ()[Lnet/minecraft/class_1160;
 	CLASS class_4574 DrawArrayParameters
 		FIELD field_20779 vertexFormat Lnet/minecraft/class_293;
 		FIELD field_20780 count I
 		FIELD field_20781 mode Lnet/minecraft/class_293$class_5596;
 		FIELD field_27354 vertexCount I
 		FIELD field_27355 elementFormat Lnet/minecraft/class_293$class_5595;
-		FIELD field_27356 cameraOffset Z
-		FIELD field_27357 textured Z
+		FIELD field_27356 hasNoVertexBuffer Z
+		FIELD field_27357 hasNoIndexBuffer Z
 		METHOD <init> (Lnet/minecraft/class_293;IILnet/minecraft/class_293$class_5596;Lnet/minecraft/class_293$class_5595;ZZ)V
 			ARG 1 vertexFormat
 			ARG 2 count
 			ARG 3 vertexCount
 			ARG 4 mode
 			ARG 5 elementFormat
-			ARG 6 cameraOffset
-			ARG 7 textured
+			ARG 6 hasNoVertexBuffer
+			ARG 7 hasNoIndexBuffer
 		METHOD method_22634 getVertexFormat ()Lnet/minecraft/class_293;
 		METHOD method_22635 getCount ()I
 		METHOD method_22636 getMode ()Lnet/minecraft/class_293$class_5596;
 		METHOD method_31955 getVertexCount ()I
 		METHOD method_31956 getElementFormat ()Lnet/minecraft/class_293$class_5595;
-		METHOD method_31957 getLimit ()I
-		METHOD method_31958 getDrawStart ()I
-		METHOD method_31959 isCameraOffset ()Z
-		METHOD method_31960 isTextured ()Z
-		METHOD method_31961 getDrawLength ()I
+		METHOD method_31957 getIndexBufferStart ()I
+		METHOD method_31958 getIndexBufferEnd ()I
+		METHOD method_31959 hasNoVertexBuffer ()Z
+		METHOD method_31960 hasNoIndexBuffer ()Z
+		METHOD method_31961 getIndexBufferLength ()I
 	CLASS class_5594 State
 		FIELD field_27358 drawMode Lnet/minecraft/class_293$class_5596;
 		FIELD field_27359 vertexCount I
-		FIELD field_27360 currentParameters [Lnet/minecraft/class_1160;
-		FIELD field_27361 cameraX F
-		FIELD field_27362 cameraY F
-		FIELD field_27363 cameraZ F
+		FIELD field_27360 sortingPrimitiveCenters [Lnet/minecraft/class_1160;
+		FIELD field_27361 sortingCameraX F
+		FIELD field_27362 sortingCameraY F
+		FIELD field_27363 sortingCameraZ F
 		METHOD <init> (Lnet/minecraft/class_293$class_5596;I[Lnet/minecraft/class_1160;FFF)V
 			ARG 1 drawMode
 			ARG 2 vertexCount

--- a/mappings/net/minecraft/client/render/VertexFormat.mapping
+++ b/mappings/net/minecraft/client/render/VertexFormat.mapping
@@ -22,10 +22,10 @@ CLASS net/minecraft/class_293 net/minecraft/client/render/VertexFormat
 	METHOD method_34449 innerStartDrawing ()V
 	METHOD method_34450 innerEndDrawing ()V
 	CLASS class_5595 IntType
-		FIELD field_27374 count I
+		FIELD field_27374 type I
 		FIELD field_27375 size I
 		METHOD <init> (Ljava/lang/String;III)V
-			ARG 3 count
+			ARG 3 type
 			ARG 4 size
 		METHOD method_31972 getSmallestTypeFor (I)Lnet/minecraft/class_293$class_5595;
 			COMMENT Gets the smallest type in which the given number fits.


### PR DESCRIPTION
This PR updates some misleading VertexBuffer/GL-related names:
 - `cameraOffset` and `textured` in `BufferBuilder.DrawArrayParameters` refer to whether the built buffer should not have vertex data or index data uploaded.
 - `RenderSystem.drawElements()` has mismatched parameters, `first` referring to `count`, and `count` referring to `type`.
 - `VertexBuffer.getElementFormat()` returns `VertexBuffer.vertexFormat`.
 - `BufferBuilder.currentParameters` is used to store primitive center points for geometry sorting, so has been renamed.
 - `BufferBuilder.setCameraPosition()` indicates to the builder to sort the geometry when uploading, but this is not very clear from the name.
 - `BufferBuilder.DrawArrayParameters` has functions to get pointers within the buffer to be used for vertex data / index data. These were misleadingly named: `getLimit()` returns the index buffer data start, and `getDrawStart()` returns the index buffer data end.