### PR TITLE
Fix broken javadoc jar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [17-jdk]
+        java: [17-jdk, 18-jdk]
     runs-on: ubuntu-20.04
     container:
       image: openjdk:${{ matrix.java }}
@@ -14,7 +14,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       - run: ./gradlew build javadocJar checkMappings --stacktrace
       - name: Build artifacts
-        if: ${{ matrix.java == '17-jdk' }}
+        if: ${{ matrix.java == '18-jdk' }}
         continue-on-error: true
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ jobs:
     if: ${{ github.repository_owner == 'FabricMC' }}
     runs-on: ubuntu-20.04
     container:
-      image: openjdk:17-jdk
+      image: openjdk:18-jdk
       options: --user root
     steps:
       - uses: actions/checkout@v2

--- a/build.gradle
+++ b/build.gradle
@@ -867,6 +867,7 @@ javadoc {
 		it.use()
 
 		addBooleanOption "-allow-script-in-comments", true
+		addBooleanOption "-ignore-source-errors", true
 		links(
 				'https://guava.dev/releases/21.0/api/docs/',
 				'https://www.javadoc.io/doc/com.google.code.gson/gson/2.8.0/',

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,11 @@ dependencies {
 	decompileClasspath "net.fabricmc:cfr:${project.cfr_version}"
 	mappingPoetJar "net.fabricmc:mappingpoet:${project.mappingpoet_version}"
 	unpick "net.fabricmc.unpick:unpick-cli:${project.unpick_version}"
+	// Update asm to allow running on JDK 18
+	unpick "org.ow2.asm:asm:9.2"
+	unpick "org.ow2.asm:asm-tree:9.2"
+	unpick "org.ow2.asm:asm-commons:9.2"
+	unpick "org.ow2.asm:asm-util:9.2"
 }
 
 def setupGroup = "jar setup"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Build against JDK 18
- Update Gradle
- Update asm for unpick
- set ignore-source-errors as suggested in #2873