### PR TITLE
Update arg to be consistent with its block counterpart

### DIFF
--- a/mappings/net/minecraft/client/render/RenderLayers.mapping
+++ b/mappings/net/minecraft/client/render/RenderLayers.mapping
@@ -9,6 +9,8 @@ CLASS net/minecraft/class_4696 net/minecraft/client/render/RenderLayers
 		ARG 0 state
 	METHOD method_23680 getFluidLayer (Lnet/minecraft/class_3610;)Lnet/minecraft/class_1921;
 		ARG 0 state
+	METHOD method_23681 (Ljava/util/HashMap;)V
+		ARG 0 map
 	METHOD method_23682 setFancyGraphicsOrBetter (Z)V
 		ARG 0 fancyGraphicsOrBetter
 	METHOD method_23683 getEntityBlockLayer (Lnet/minecraft/class_2680;Z)Lnet/minecraft/class_1921;


### PR DESCRIPTION
Unmapped argument in RenderLayers
- Inconsistent with its block counterpart, "map"
- "hashMap"