### PR TITLE
Remove reference to wool

### DIFF
--- a/mappings/net/minecraft/util/DyeColor.mapping
+++ b/mappings/net/minecraft/util/DyeColor.mapping
@@ -8,7 +8,7 @@ CLASS net/minecraft/class_1767 net/minecraft/util/DyeColor
 	FIELD field_7960 fireworkColor I
 	FIELD field_7965 id I
 	METHOD <init> (Ljava/lang/String;IILjava/lang/String;ILnet/minecraft/class_3620;II)V
-		ARG 3 woolId
+		ARG 3 id
 		ARG 4 name
 		ARG 5 color
 		ARG 6 mapColor


### PR DESCRIPTION
The field name is `id`, the getter is `getId`, but the parameter name in the enum ctor is still `woolId` even tho that doesn't really have anything to do with wool still.