### PR TITLE
Moved a couple classes

### DIFF
--- a/mappings/net/minecraft/data/client/TextureMap.mapping
+++ b/mappings/net/minecraft/data/client/TextureMap.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4944 net/minecraft/data/client/model/TextureMap
+CLASS net/minecraft/class_4944 net/minecraft/data/client/TextureMap
 	FIELD field_22997 entries Ljava/util/Map;
 	FIELD field_22998 inherited Ljava/util/Set;
 	METHOD method_25860 getId (Lnet/minecraft/class_2248;)Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/world/gen/noise/NoiseHelper.mapping
+++ b/mappings/net/minecraft/world/gen/noise/NoiseHelper.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_5836 net/minecraft/world/gen/NoiseHelper
+CLASS net/minecraft/class_5836 net/minecraft/world/gen/noise/NoiseHelper
 	METHOD method_39119 appendDebugInfo (Ljava/lang/StringBuilder;DDD[B)V
 		ARG 0 builder
 		ARG 1 originX


### PR DESCRIPTION
`TextureMap` moved to `data/client`  - `data/client/model` package is no longer used, but `TextureMap` was still in it accidentally due to being renamed by another PR
`NoiseHelper` moved to `world/gen/noise` - makes sense to be with other noise related classes