### PR TITLE
22w11a commands

### DIFF
--- a/mappings/net/minecraft/client/network/ClientCommandSource.mapping
+++ b/mappings/net/minecraft/client/network/ClientCommandSource.mapping
@@ -13,3 +13,5 @@ CLASS net/minecraft/class_637 net/minecraft/client/network/ClientCommandSource
 	METHOD method_2931 onCommandSuggestions (ILcom/mojang/brigadier/suggestion/Suggestions;)V
 		ARG 1 completionId
 		ARG 2 suggestions
+	METHOD method_41232 (Lnet/minecraft/class_2172$class_7078;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;Lnet/minecraft/class_2378;)Ljava/util/concurrent/CompletableFuture;
+		ARG 3 registry

--- a/mappings/net/minecraft/command/argument/ArgumentHelper.mapping
+++ b/mappings/net/minecraft/command/argument/ArgumentHelper.mapping
@@ -1,0 +1,32 @@
+CLASS net/minecraft/class_7218 net/minecraft/command/argument/ArgumentHelper
+	FIELD field_37975 LOGGER Lorg/slf4j/Logger;
+	FIELD field_37976 MIN_FLAG B
+	FIELD field_37977 MAX_FLAG B
+	METHOD method_41986 hasMinFlag (B)Z
+		ARG 0 flags
+	METHOD method_41987 writeArgument (Lcom/google/gson/JsonObject;Lcom/mojang/brigadier/arguments/ArgumentType;)V
+		ARG 0 json
+		ARG 1 argumentType
+	METHOD method_41988 writeArgumentProperties (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2314$class_7217;)V
+		ARG 0 json
+		ARG 1 properties
+	METHOD method_41989 writeArgumentProperties (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2314;Lnet/minecraft/class_2314$class_7217;)V
+		ARG 0 json
+		ARG 1 serializer
+		ARG 2 properties
+	METHOD method_41990 toJson (Lcom/mojang/brigadier/CommandDispatcher;Lcom/mojang/brigadier/tree/CommandNode;)Lcom/google/gson/JsonObject;
+		ARG 0 dispatcher
+		ARG 1 rootNode
+	METHOD method_41991 collectUsedArgumentTypes (Lcom/mojang/brigadier/tree/CommandNode;)Ljava/util/Set;
+		ARG 0 rootNode
+	METHOD method_41992 collectUsedArgumentTypes (Lcom/mojang/brigadier/tree/CommandNode;Ljava/util/Set;Ljava/util/Set;)V
+		ARG 0 node
+		ARG 1 usedArgumentTypes
+		ARG 2 visitedNodes
+	METHOD method_41993 (Ljava/util/Set;Ljava/util/Set;Lcom/mojang/brigadier/tree/CommandNode;)V
+		ARG 2 child
+	METHOD method_41994 getMinMaxFlag (ZZ)I
+		ARG 0 hasMin
+		ARG 1 hasMax
+	METHOD method_41995 hasMaxFlag (B)Z
+		ARG 0 flags

--- a/mappings/net/minecraft/command/argument/ArgumentTypes.mapping
+++ b/mappings/net/minecraft/command/argument/ArgumentTypes.mapping
@@ -1,7 +1,18 @@
 CLASS net/minecraft/class_2316 net/minecraft/command/argument/ArgumentTypes
 	FIELD field_10921 CLASS_MAP Ljava/util/Map;
 	METHOD method_10015 register (Lnet/minecraft/class_2378;)Lnet/minecraft/class_2314;
+		ARG 0 registry
 	METHOD method_10017 register (Lnet/minecraft/class_2378;Ljava/lang/String;Ljava/lang/Class;Lnet/minecraft/class_2314;)Lnet/minecraft/class_2314;
 		COMMENT Registers an argument type's serializer.
+		ARG 0 registry
+		ARG 1 id
+		ARG 2 clazz
+		ARG 3 serializer
 	METHOD method_41181 upcast (Ljava/lang/Class;)Ljava/lang/Class;
 		ARG 0 clazz
+	METHOD method_41983 get (Lcom/mojang/brigadier/arguments/ArgumentType;)Lnet/minecraft/class_2314;
+		ARG 0 argumentType
+	METHOD method_41984 has (Ljava/lang/Class;)Z
+		ARG 0 clazz
+	METHOD method_41985 getArgumentTypeProperties (Lcom/mojang/brigadier/arguments/ArgumentType;)Lnet/minecraft/class_2314$class_7217;
+		ARG 0 argumentType

--- a/mappings/net/minecraft/command/argument/BlockArgumentParser.mapping
+++ b/mappings/net/minecraft/command/argument/BlockArgumentParser.mapping
@@ -23,6 +23,44 @@ CLASS net/minecraft/class_2259 net/minecraft/command/argument/BlockArgumentParse
 	FIELD field_32803 PROPERTY_DEFINER C
 	FIELD field_32804 PROPERTY_SEPARATOR C
 	FIELD field_32805 TAG_PREFIX C
+	FIELD field_37965 UNKNOWN_BLOCK_TAG_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
+	FIELD field_37966 registryWrapper Lnet/minecraft/class_7225;
+	FIELD field_37967 allowSnbt Z
+	METHOD <init> (Lnet/minecraft/class_7225;Lcom/mojang/brigadier/StringReader;ZZ)V
+		ARG 1 registryWrapper
+		ARG 2 reader
+		ARG 3 allowTag
+		ARG 4 allowSnbt
+	METHOD method_41955 block (Lnet/minecraft/class_7225;Lcom/mojang/brigadier/StringReader;Z)Lnet/minecraft/class_2259$class_7211;
+		ARG 0 registryWrapper
+		ARG 1 reader
+		ARG 2 allowSnbt
+	METHOD method_41956 block (Lnet/minecraft/class_2378;Lcom/mojang/brigadier/StringReader;Z)Lnet/minecraft/class_2259$class_7211;
+		ARG 0 registry
+		ARG 1 reader
+		ARG 2 allowSnbt
+	METHOD method_41957 block (Lnet/minecraft/class_2378;Ljava/lang/String;Z)Lnet/minecraft/class_2259$class_7211;
+		ARG 0 registry
+		ARG 1 string
+		ARG 2 allowSnbt
+	METHOD method_41958 (Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
+		ARG 0 tag
+	METHOD method_41959 (Lnet/minecraft/class_5321;)Ljava/lang/String;
+		ARG 0 key
+	METHOD method_41960 blockOrTag (Lnet/minecraft/class_7225;Lcom/mojang/brigadier/StringReader;Z)Lcom/mojang/datafixers/util/Either;
+		ARG 0 registryWrapper
+		ARG 1 reader
+		ARG 2 allowSnbt
+	METHOD method_41961 blockOrTag (Lnet/minecraft/class_2378;Lcom/mojang/brigadier/StringReader;Z)Lcom/mojang/datafixers/util/Either;
+		ARG 0 registry
+		ARG 1 reader
+		ARG 2 allowSnbt
+	METHOD method_41962 blockOrTag (Lnet/minecraft/class_2378;Ljava/lang/String;Z)Lcom/mojang/datafixers/util/Either;
+		ARG 0 registry
+		ARG 1 string
+		ARG 2 allowSnbt
+	METHOD method_41963 suggestBlockId (Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
+		ARG 1 builder
 	METHOD method_9659 parseBlockProperties ()V
 	METHOD method_9660 (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
 		ARG 0 block
@@ -41,7 +79,10 @@ CLASS net/minecraft/class_2259 net/minecraft/command/argument/BlockArgumentParse
 	METHOD method_9665 suggestBlockProperties (Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 builder
 	METHOD method_9666 getSuggestions (Lnet/minecraft/class_7225;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;ZZ)Ljava/util/concurrent/CompletableFuture;
+		ARG 0 registryWrapper
 		ARG 1 builder
+		ARG 2 allowTag
+		ARG 3 allowSnbt
 	METHOD method_9667 suggestTagProperties (Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 builder
 	METHOD method_9668 parsePropertyValue (Lnet/minecraft/class_2769;Ljava/lang/String;I)V
@@ -83,8 +124,11 @@ CLASS net/minecraft/class_2259 net/minecraft/command/argument/BlockArgumentParse
 		ARG 1 builder
 	METHOD method_9690 suggestTagPropertyValues (Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 builder
+		ARG 2 name
 	METHOD method_9691 (Ljava/lang/Object;Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
 		ARG 0 block
 		ARG 1 property
 	METHOD method_9693 suggestEqualsCharacter (Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 builder
+	CLASS class_7211 BlockResult
+	CLASS class_7212 TagResult

--- a/mappings/net/minecraft/command/argument/BlockPredicateArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/BlockPredicateArgumentType.mapping
@@ -1,11 +1,23 @@
 CLASS net/minecraft/class_2252 net/minecraft/command/argument/BlockPredicateArgumentType
 	FIELD field_10672 EXAMPLES Ljava/util/Collection;
+	FIELD field_37963 registryWrapper Lnet/minecraft/class_7225;
+	METHOD <init> (Lnet/minecraft/class_7157;)V
+		ARG 1 registryWrapperFactory
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 context
+		ARG 2 builder
+	METHOD method_41951 (Lnet/minecraft/class_2259$class_7211;)Lnet/minecraft/class_2252$class_2254;
+		ARG 0 result
+	METHOD method_41952 (Lnet/minecraft/class_2259$class_7212;)Lnet/minecraft/class_2252$class_2254;
+		ARG 0 result
+	METHOD method_41953 parse (Lnet/minecraft/class_7225;Lcom/mojang/brigadier/StringReader;)Lnet/minecraft/class_2252$class_2254;
+		ARG 0 registryWrapper
+		ARG 1 reader
 	METHOD method_9644 getBlockPredicate (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Ljava/util/function/Predicate;
 		ARG 0 context
 		ARG 1 name
 	METHOD method_9645 blockPredicate (Lnet/minecraft/class_7157;)Lnet/minecraft/class_2252;
+		ARG 0 registryWrapperFactory
 	METHOD parse (Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;
 		ARG 1 reader
 	CLASS class_2253 StatePredicate
@@ -25,6 +37,7 @@ CLASS net/minecraft/class_2252 net/minecraft/command/argument/BlockPredicateArgu
 		FIELD field_10677 nbt Lnet/minecraft/class_2487;
 		FIELD field_10678 properties Ljava/util/Map;
 		METHOD <init> (Lnet/minecraft/class_6885;Ljava/util/Map;Lnet/minecraft/class_2487;)V
+			ARG 1 tag
 			ARG 2 properties
 			ARG 3 nbt
 		METHOD test (Ljava/lang/Object;)Z

--- a/mappings/net/minecraft/command/argument/BlockPredicateArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/BlockPredicateArgumentType.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_2252 net/minecraft/command/argument/BlockPredicateArgu
 	FIELD field_10672 EXAMPLES Ljava/util/Collection;
 	FIELD field_37963 registryWrapper Lnet/minecraft/class_7225;
 	METHOD <init> (Lnet/minecraft/class_7157;)V
-		ARG 1 registryWrapperFactory
+		ARG 1 commandRegistryAccess
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 context
 		ARG 2 builder
@@ -17,7 +17,7 @@ CLASS net/minecraft/class_2252 net/minecraft/command/argument/BlockPredicateArgu
 		ARG 0 context
 		ARG 1 name
 	METHOD method_9645 blockPredicate (Lnet/minecraft/class_7157;)Lnet/minecraft/class_2252;
-		ARG 0 registryWrapperFactory
+		ARG 0 commandRegistryAccess
 	METHOD parse (Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;
 		ARG 1 reader
 	CLASS class_2253 StatePredicate

--- a/mappings/net/minecraft/command/argument/BlockStateArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/BlockStateArgumentType.mapping
@@ -1,8 +1,13 @@
 CLASS net/minecraft/class_2257 net/minecraft/command/argument/BlockStateArgumentType
 	FIELD field_10679 EXAMPLES Ljava/util/Collection;
+	FIELD field_37964 registryWrapper Lnet/minecraft/class_7225;
+	METHOD <init> (Lnet/minecraft/class_7157;)V
+		ARG 1 registryWrapperFactory
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 context
+		ARG 2 builder
 	METHOD method_9653 blockState (Lnet/minecraft/class_7157;)Lnet/minecraft/class_2257;
+		ARG 0 registryWrapperFactory
 	METHOD method_9655 getBlockState (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lnet/minecraft/class_2247;
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/command/argument/BlockStateArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/BlockStateArgumentType.mapping
@@ -2,12 +2,12 @@ CLASS net/minecraft/class_2257 net/minecraft/command/argument/BlockStateArgument
 	FIELD field_10679 EXAMPLES Ljava/util/Collection;
 	FIELD field_37964 registryWrapper Lnet/minecraft/class_7225;
 	METHOD <init> (Lnet/minecraft/class_7157;)V
-		ARG 1 registryWrapperFactory
+		ARG 1 commandRegistryAccess
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 context
 		ARG 2 builder
 	METHOD method_9653 blockState (Lnet/minecraft/class_7157;)Lnet/minecraft/class_2257;
-		ARG 0 registryWrapperFactory
+		ARG 0 commandRegistryAccess
 	METHOD method_9655 getBlockState (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lnet/minecraft/class_2247;
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/command/argument/EntityArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/EntityArgumentType.mapping
@@ -41,3 +41,11 @@ CLASS net/minecraft/class_2186 net/minecraft/command/argument/EntityArgumentType
 	METHOD parse (Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;
 		ARG 1 reader
 	CLASS class_2187 Serializer
+		FIELD field_37850 SINGLE_FLAG B
+		FIELD field_37851 PLAYERS_ONLY_FLAG B
+		CLASS class_7171 Properties
+			FIELD field_37853 single Z
+			FIELD field_37854 playersOnly Z
+			METHOD <init> (Lnet/minecraft/class_2186$class_2187;ZZ)V
+				ARG 2 single
+				ARG 3 playersOnly

--- a/mappings/net/minecraft/command/argument/ItemPredicateArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/ItemPredicateArgumentType.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_2293 net/minecraft/command/argument/ItemPredicateArgum
 	FIELD field_10812 EXAMPLES Ljava/util/Collection;
 	FIELD field_37974 registryWrapper Lnet/minecraft/class_7225;
 	METHOD <init> (Lnet/minecraft/class_7157;)V
-		ARG 1 registryWrapperFactory
+		ARG 1 commandRegistryAccess
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 context
 		ARG 2 builder
@@ -20,7 +20,7 @@ CLASS net/minecraft/class_2293 net/minecraft/command/argument/ItemPredicateArgum
 	METHOD method_41982 (Ljava/util/function/Predicate;Lnet/minecraft/class_2487;Lnet/minecraft/class_1799;)Z
 		ARG 2 stack
 	METHOD method_9801 itemPredicate (Lnet/minecraft/class_7157;)Lnet/minecraft/class_2293;
-		ARG 0 registryWrapperFactory
+		ARG 0 commandRegistryAccess
 	METHOD method_9804 getItemStackPredicate (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Ljava/util/function/Predicate;
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/command/argument/ItemPredicateArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/ItemPredicateArgumentType.mapping
@@ -1,11 +1,29 @@
 CLASS net/minecraft/class_2293 net/minecraft/command/argument/ItemPredicateArgumentType
 	FIELD field_10812 EXAMPLES Ljava/util/Collection;
+	FIELD field_37974 registryWrapper Lnet/minecraft/class_7225;
+	METHOD <init> (Lnet/minecraft/class_7157;)V
+		ARG 1 registryWrapperFactory
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 context
+		ARG 2 builder
+	METHOD method_41977 (Lnet/minecraft/class_2291$class_7215;)Lnet/minecraft/class_2293$class_2295;
+		ARG 0 item
+	METHOD method_41978 (Lnet/minecraft/class_2291$class_7215;Lnet/minecraft/class_6880;)Z
+		ARG 1 item2
+	METHOD method_41979 (Lnet/minecraft/class_2291$class_7216;)Lnet/minecraft/class_2293$class_2295;
+		ARG 0 tag
+	METHOD method_41980 (Ljava/util/function/Predicate;Lnet/minecraft/class_1799;)Z
+		ARG 1 stack
+	METHOD method_41981 getItemStackPredicate (Ljava/util/function/Predicate;Lnet/minecraft/class_2487;)Lnet/minecraft/class_2293$class_2295;
+		ARG 0 predicate
+		ARG 1 nbt
+	METHOD method_41982 (Ljava/util/function/Predicate;Lnet/minecraft/class_2487;Lnet/minecraft/class_1799;)Z
+		ARG 2 stack
 	METHOD method_9801 itemPredicate (Lnet/minecraft/class_7157;)Lnet/minecraft/class_2293;
-	METHOD method_9804 getItemPredicate (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Ljava/util/function/Predicate;
+		ARG 0 registryWrapperFactory
+	METHOD method_9804 getItemStackPredicate (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Ljava/util/function/Predicate;
 		ARG 0 context
 		ARG 1 name
 	METHOD parse (Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;
 		ARG 1 reader
-	CLASS class_2295 ItemPredicateArgument
+	CLASS class_2295 ItemStackPredicateArgument

--- a/mappings/net/minecraft/command/argument/ItemStackArgument.mapping
+++ b/mappings/net/minecraft/command/argument/ItemStackArgument.mapping
@@ -3,7 +3,9 @@ CLASS net/minecraft/class_2290 net/minecraft/command/argument/ItemStackArgument
 	FIELD field_10797 OVERSTACKED_EXCEPTION Lcom/mojang/brigadier/exceptions/Dynamic2CommandExceptionType;
 	FIELD field_10798 nbt Lnet/minecraft/class_2487;
 	METHOD <init> (Lnet/minecraft/class_6880;Lnet/minecraft/class_2487;)V
+		ARG 1 item
 		ARG 2 nbt
+	METHOD method_41967 getIdString ()Ljava/lang/String;
 	METHOD method_9781 createStack (IZ)Lnet/minecraft/class_1799;
 		ARG 1 amount
 		ARG 2 checkOverstack

--- a/mappings/net/minecraft/command/argument/ItemStackArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/ItemStackArgumentType.mapping
@@ -2,12 +2,12 @@ CLASS net/minecraft/class_2287 net/minecraft/command/argument/ItemStackArgumentT
 	FIELD field_10790 EXAMPLES Ljava/util/Collection;
 	FIELD field_37970 registryWrapper Lnet/minecraft/class_7225;
 	METHOD <init> (Lnet/minecraft/class_7157;)V
-		ARG 1 registryWrapperFactory
+		ARG 1 commandRegistryAccess
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 context
 		ARG 2 builder
 	METHOD method_9776 itemStack (Lnet/minecraft/class_7157;)Lnet/minecraft/class_2287;
-		ARG 0 registryWrapperFactory
+		ARG 0 commandRegistryAccess
 	METHOD method_9777 getItemStackArgument (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lnet/minecraft/class_2290;
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/command/argument/ItemStackArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/ItemStackArgumentType.mapping
@@ -1,8 +1,13 @@
 CLASS net/minecraft/class_2287 net/minecraft/command/argument/ItemStackArgumentType
 	FIELD field_10790 EXAMPLES Ljava/util/Collection;
+	FIELD field_37970 registryWrapper Lnet/minecraft/class_7225;
+	METHOD <init> (Lnet/minecraft/class_7157;)V
+		ARG 1 registryWrapperFactory
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 context
+		ARG 2 builder
 	METHOD method_9776 itemStack (Lnet/minecraft/class_7157;)Lnet/minecraft/class_2287;
+		ARG 0 registryWrapperFactory
 	METHOD method_9777 getItemStackArgument (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lnet/minecraft/class_2290;
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/command/argument/ItemStringReader.mapping
+++ b/mappings/net/minecraft/command/argument/ItemStringReader.mapping
@@ -8,17 +8,42 @@ CLASS net/minecraft/class_2291 net/minecraft/command/argument/ItemStringReader
 	FIELD field_10807 nbt Lnet/minecraft/class_2487;
 	FIELD field_33066 LEFT_CURLY_BRACKET C
 	FIELD field_33067 HASH_SIGN C
+	FIELD field_37971 UNKNOWN_TAG_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
+	FIELD field_37972 registryWrapper Lnet/minecraft/class_7225;
+	FIELD field_37973 result Lcom/mojang/datafixers/util/Either;
+	METHOD <init> (Lnet/minecraft/class_7225;Lcom/mojang/brigadier/StringReader;Z)V
+		ARG 1 registryWrapper
+		ARG 2 reader
+		ARG 3 allowTag
+	METHOD method_41970 (Lnet/minecraft/class_2291;Lnet/minecraft/class_6880;)Lnet/minecraft/class_2291$class_7215;
+		ARG 1 item
+	METHOD method_41971 (Lnet/minecraft/class_2291;Lnet/minecraft/class_6885;)Lnet/minecraft/class_2291$class_7216;
+		ARG 1 tag
+	METHOD method_41972 item (Lnet/minecraft/class_7225;Lcom/mojang/brigadier/StringReader;)Lnet/minecraft/class_2291$class_7215;
+		ARG 0 registryWrapper
+		ARG 1 reader
+	METHOD method_41973 (Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
+		ARG 0 tag
+	METHOD method_41974 itemOrTag (Lnet/minecraft/class_7225;Lcom/mojang/brigadier/StringReader;)Lcom/mojang/datafixers/util/Either;
+		ARG 0 registryWrapper
+		ARG 1 reader
+	METHOD method_41975 suggestItemId (Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
+		ARG 1 builder
 	METHOD method_9787 readTag ()V
 	METHOD method_9788 readNbt ()V
 	METHOD method_9789 consume ()V
-	METHOD method_9791 suggestAny (Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
+	METHOD method_9791 suggestItemOrTagId (Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 builder
 	METHOD method_9792 (Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
 		ARG 0 id
 	METHOD method_9793 getSuggestions (Lnet/minecraft/class_7225;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;Z)Ljava/util/concurrent/CompletableFuture;
+		ARG 0 registryWrapper
 		ARG 1 builder
+		ARG 2 allowTag
 	METHOD method_9794 suggestItem (Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 builder
 	METHOD method_9795 readItem ()V
 	METHOD method_9796 suggestTag (Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 builder
+	CLASS class_7215 ItemResult
+	CLASS class_7216 TagResult

--- a/mappings/net/minecraft/command/argument/NbtPathArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/NbtPathArgumentType.mapping
@@ -10,6 +10,8 @@ CLASS net/minecraft/class_2203 net/minecraft/command/argument/NbtPathArgumentTyp
 	METHOD method_9352 readCompoundChildNode (Lcom/mojang/brigadier/StringReader;Ljava/lang/String;)Lnet/minecraft/class_2203$class_2210;
 		ARG 0 reader
 		ARG 1 name
+	METHOD method_9353 (Lnet/minecraft/class_2487;Lnet/minecraft/class_2520;)Z
+		ARG 1 nbt
 	METHOD method_9355 isNameCharacter (C)Z
 		ARG 0 c
 	METHOD method_9356 (Ljava/lang/Object;)Lcom/mojang/brigadier/Message;

--- a/mappings/net/minecraft/command/argument/RegistryKeyArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/RegistryKeyArgumentType.mapping
@@ -31,3 +31,7 @@ CLASS net/minecraft/class_7079 net/minecraft/command/argument/RegistryKeyArgumen
 	METHOD parse (Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;
 		ARG 1 reader
 	CLASS class_7080 Serializer
+		CLASS class_7197 Properties
+			FIELD field_37917 registryRef Lnet/minecraft/class_5321;
+			METHOD <init> (Lnet/minecraft/class_7079$class_7080;Lnet/minecraft/class_5321;)V
+				ARG 2 registryRef

--- a/mappings/net/minecraft/command/argument/RegistryPredicateArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/RegistryPredicateArgumentType.mapping
@@ -36,6 +36,10 @@ CLASS net/minecraft/class_7066 net/minecraft/command/argument/RegistryPredicateA
 			ARG 1 registryRef
 		METHOD method_41176 asString ()Ljava/lang/String;
 	CLASS class_7069 Serializer
+		CLASS class_7199 Properties
+			FIELD field_37929 registryRef Lnet/minecraft/class_5321;
+			METHOD <init> (Lnet/minecraft/class_7066$class_7069;Lnet/minecraft/class_5321;)V
+				ARG 2 registryRef
 	CLASS class_7070 TagBased
 		METHOD test (Ljava/lang/Object;)Z
 			ARG 1 entry

--- a/mappings/net/minecraft/command/argument/ScoreHolderArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/ScoreHolderArgumentType.mapping
@@ -42,3 +42,8 @@ CLASS net/minecraft/class_2233 net/minecraft/command/argument/ScoreHolderArgumen
 		METHOD <init> (Lnet/minecraft/class_2300;)V
 			ARG 1 selector
 	CLASS class_2236 Serializer
+		FIELD field_37930 MULTIPLE_FLAG B
+		CLASS class_7200 Properties
+			FIELD field_37932 multiple Z
+			METHOD <init> (Lnet/minecraft/class_2233$class_2236;Z)V
+				ARG 2 multiple

--- a/mappings/net/minecraft/command/argument/serialize/ArgumentSerializer.mapping
+++ b/mappings/net/minecraft/command/argument/serialize/ArgumentSerializer.mapping
@@ -13,4 +13,4 @@ CLASS net/minecraft/class_2314 net/minecraft/command/argument/serialize/Argument
 	CLASS class_7217 ArgumentTypeProperties
 		METHOD method_41728 getSerializer ()Lnet/minecraft/class_2314;
 		METHOD method_41730 createType (Lnet/minecraft/class_7157;)Lcom/mojang/brigadier/arguments/ArgumentType;
-			ARG 1 registryWrapperFactory
+			ARG 1 commandRegistryAccess

--- a/mappings/net/minecraft/command/argument/serialize/ArgumentSerializer.mapping
+++ b/mappings/net/minecraft/command/argument/serialize/ArgumentSerializer.mapping
@@ -2,7 +2,15 @@ CLASS net/minecraft/class_2314 net/minecraft/command/argument/serialize/Argument
 	COMMENT Serializes an argument type to be sent to the client.
 	METHOD method_10005 fromPacket (Lnet/minecraft/class_2540;)Lnet/minecraft/class_2314$class_7217;
 		ARG 1 buf
-	METHOD method_10006 toJson (Lnet/minecraft/class_2314$class_7217;Lcom/google/gson/JsonObject;)V
+	METHOD method_10006 writeJson (Lnet/minecraft/class_2314$class_7217;Lcom/google/gson/JsonObject;)V
+		ARG 1 properties
 		ARG 2 json
-	METHOD method_10007 toPacket (Lnet/minecraft/class_2314$class_7217;Lnet/minecraft/class_2540;)V
+	METHOD method_10007 writePacket (Lnet/minecraft/class_2314$class_7217;Lnet/minecraft/class_2540;)V
+		ARG 1 properties
 		ARG 2 buf
+	METHOD method_41726 getArgumentTypeProperties (Lcom/mojang/brigadier/arguments/ArgumentType;)Lnet/minecraft/class_2314$class_7217;
+		ARG 1 argumentType
+	CLASS class_7217 ArgumentTypeProperties
+		METHOD method_41728 getSerializer ()Lnet/minecraft/class_2314;
+		METHOD method_41730 createType (Lnet/minecraft/class_7157;)Lcom/mojang/brigadier/arguments/ArgumentType;
+			ARG 1 registryWrapperFactory

--- a/mappings/net/minecraft/command/argument/serialize/ConstantArgumentSerializer.mapping
+++ b/mappings/net/minecraft/command/argument/serialize/ConstantArgumentSerializer.mapping
@@ -7,7 +7,7 @@ CLASS net/minecraft/class_2319 net/minecraft/command/argument/serialize/Constant
 	METHOD method_41999 of (Ljava/util/function/Supplier;)Lnet/minecraft/class_2319;
 		ARG 0 typeSupplier
 	METHOD method_42000 (Ljava/util/function/Supplier;Lnet/minecraft/class_7157;)Lcom/mojang/brigadier/arguments/ArgumentType;
-		ARG 1 registryWrapperFactory
+		ARG 1 commandRegistryAccess
 	CLASS class_7219 Properties
 		FIELD field_37980 typeSupplier Ljava/util/function/Function;
 		METHOD <init> (Lnet/minecraft/class_2319;Ljava/util/function/Function;)V

--- a/mappings/net/minecraft/command/argument/serialize/ConstantArgumentSerializer.mapping
+++ b/mappings/net/minecraft/command/argument/serialize/ConstantArgumentSerializer.mapping
@@ -1,1 +1,14 @@
 CLASS net/minecraft/class_2319 net/minecraft/command/argument/serialize/ConstantArgumentSerializer
+	FIELD field_37978 properties Lnet/minecraft/class_2319$class_7219;
+	METHOD <init> (Ljava/util/function/Function;)V
+		ARG 1 typeSupplier
+	METHOD method_41998 of (Ljava/util/function/Function;)Lnet/minecraft/class_2319;
+		ARG 0 typeSupplier
+	METHOD method_41999 of (Ljava/util/function/Supplier;)Lnet/minecraft/class_2319;
+		ARG 0 typeSupplier
+	METHOD method_42000 (Ljava/util/function/Supplier;Lnet/minecraft/class_7157;)Lcom/mojang/brigadier/arguments/ArgumentType;
+		ARG 1 registryWrapperFactory
+	CLASS class_7219 Properties
+		FIELD field_37980 typeSupplier Ljava/util/function/Function;
+		METHOD <init> (Lnet/minecraft/class_2319;Ljava/util/function/Function;)V
+			ARG 2 typeSupplier

--- a/mappings/net/minecraft/command/argument/serialize/DoubleArgumentSerializer.mapping
+++ b/mappings/net/minecraft/command/argument/serialize/DoubleArgumentSerializer.mapping
@@ -1,1 +1,7 @@
 CLASS net/minecraft/class_2326 net/minecraft/command/argument/serialize/DoubleArgumentSerializer
+	CLASS class_7220 Properties
+		FIELD field_37982 min D
+		FIELD field_37983 max D
+		METHOD <init> (Lnet/minecraft/class_2326;DD)V
+			ARG 2 min
+			ARG 4 max

--- a/mappings/net/minecraft/command/argument/serialize/FloatArgumentSerializer.mapping
+++ b/mappings/net/minecraft/command/argument/serialize/FloatArgumentSerializer.mapping
@@ -1,1 +1,7 @@
 CLASS net/minecraft/class_2327 net/minecraft/command/argument/serialize/FloatArgumentSerializer
+	CLASS class_7221 Properties
+		FIELD field_37985 min F
+		FIELD field_37986 max F
+		METHOD <init> (Lnet/minecraft/class_2327;FF)V
+			ARG 2 min
+			ARG 3 max

--- a/mappings/net/minecraft/command/argument/serialize/IntegerArgumentSerializer.mapping
+++ b/mappings/net/minecraft/command/argument/serialize/IntegerArgumentSerializer.mapping
@@ -1,1 +1,7 @@
 CLASS net/minecraft/class_2330 net/minecraft/command/argument/serialize/IntegerArgumentSerializer
+	CLASS class_7222 Properties
+		FIELD field_37988 min I
+		FIELD field_37989 max I
+		METHOD <init> (Lnet/minecraft/class_2330;II)V
+			ARG 2 min
+			ARG 3 max

--- a/mappings/net/minecraft/command/argument/serialize/LongArgumentSerializer.mapping
+++ b/mappings/net/minecraft/command/argument/serialize/LongArgumentSerializer.mapping
@@ -1,1 +1,7 @@
 CLASS net/minecraft/class_4461 net/minecraft/command/argument/serialize/LongArgumentSerializer
+	CLASS class_7223 Properties
+		FIELD field_37991 min J
+		FIELD field_37992 max J
+		METHOD <init> (Lnet/minecraft/class_4461;JJ)V
+			ARG 2 min
+			ARG 4 max

--- a/mappings/net/minecraft/command/argument/serialize/StringArgumentSerializer.mapping
+++ b/mappings/net/minecraft/command/argument/serialize/StringArgumentSerializer.mapping
@@ -1,1 +1,5 @@
 CLASS net/minecraft/class_2332 net/minecraft/command/argument/serialize/StringArgumentSerializer
+	CLASS class_7224 Properties
+		FIELD field_37994 type Lcom/mojang/brigadier/arguments/StringArgumentType$StringType;
+		METHOD <init> (Lnet/minecraft/class_2332;Lcom/mojang/brigadier/arguments/StringArgumentType$StringType;)V
+			ARG 2 type

--- a/mappings/net/minecraft/command/suggestion/SuggestionProviders.mapping
+++ b/mappings/net/minecraft/command/suggestion/SuggestionProviders.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/class_2321 net/minecraft/command/suggestion/SuggestionProvid
 	FIELD field_10934 AVAILABLE_SOUNDS Lcom/mojang/brigadier/suggestion/SuggestionProvider;
 	FIELD field_10935 SUMMONABLE_ENTITIES Lcom/mojang/brigadier/suggestion/SuggestionProvider;
 	METHOD method_10022 register (Lnet/minecraft/class_2960;Lcom/mojang/brigadier/suggestion/SuggestionProvider;)Lcom/mojang/brigadier/suggestion/SuggestionProvider;
-		ARG 0 name
+		ARG 0 id
 		ARG 1 provider
 	METHOD method_10023 (Lnet/minecraft/class_1299;)Lcom/mojang/brigadier/Message;
 		ARG 0 entityType
@@ -17,7 +17,7 @@ CLASS net/minecraft/class_2321 net/minecraft/command/suggestion/SuggestionProvid
 		ARG 1 builder
 	METHOD method_10026 getLocalProvider (Lcom/mojang/brigadier/suggestion/SuggestionProvider;)Lcom/mojang/brigadier/suggestion/SuggestionProvider;
 		ARG 0 provider
-	METHOD method_10027 computeName (Lcom/mojang/brigadier/suggestion/SuggestionProvider;)Lnet/minecraft/class_2960;
+	METHOD method_10027 computeId (Lcom/mojang/brigadier/suggestion/SuggestionProvider;)Lnet/minecraft/class_2960;
 		ARG 0 provider
 	METHOD method_10028 (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 0 context
@@ -29,10 +29,10 @@ CLASS net/minecraft/class_2321 net/minecraft/command/suggestion/SuggestionProvid
 		ARG 0 context
 		ARG 1 builder
 	CLASS class_2322 LocalProvider
-		FIELD field_10936 name Lnet/minecraft/class_2960;
+		FIELD field_10936 id Lnet/minecraft/class_2960;
 		FIELD field_10937 provider Lcom/mojang/brigadier/suggestion/SuggestionProvider;
 		METHOD <init> (Lnet/minecraft/class_2960;Lcom/mojang/brigadier/suggestion/SuggestionProvider;)V
-			ARG 1 name
+			ARG 1 id
 			ARG 2 provider
 		METHOD getSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 			ARG 1 context

--- a/mappings/net/minecraft/network/packet/s2c/play/CommandTreeS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/CommandTreeS2CPacket.mapping
@@ -1,20 +1,86 @@
 CLASS net/minecraft/class_2641 net/minecraft/network/packet/s2c/play/CommandTreeS2CPacket
-	METHOD method_11401 writeNode (Lcom/mojang/brigadier/tree/CommandNode;Lit/unimi/dsi/fastutil/objects/Object2IntMap;)Lnet/minecraft/class_2641$class_2642;
+	FIELD field_38038 rootSize I
+	FIELD field_38039 nodes Ljava/util/List;
+	METHOD <init> (Lcom/mojang/brigadier/tree/RootCommandNode;)V
+		ARG 1 rootNode
+	METHOD <init> (Lnet/minecraft/class_2540;)V
+		ARG 1 buf
+	METHOD method_11401 createNodeData (Lcom/mojang/brigadier/tree/CommandNode;Lit/unimi/dsi/fastutil/objects/Object2IntMap;)Lnet/minecraft/class_2641$class_2642;
+		ARG 0 node
+		ARG 1 nodes
 	METHOD method_11402 readArgumentBuilder (Lnet/minecraft/class_2540;B)Lnet/minecraft/class_2641$class_7235;
 		ARG 0 buf
+		ARG 1 flags
 	METHOD method_11403 getCommandTree (Lnet/minecraft/class_7157;)Lcom/mojang/brigadier/tree/RootCommandNode;
+		ARG 1 registryWrapperFactory
 	METHOD method_11405 readCommandNode (Lnet/minecraft/class_2540;)Lnet/minecraft/class_2641$class_2642;
 		ARG 0 buf
 	METHOD method_30944 traverse (Lcom/mojang/brigadier/tree/RootCommandNode;)Lit/unimi/dsi/fastutil/objects/Object2IntMap;
 		ARG 0 commandTree
 	METHOD method_30945 collectNodes (Lit/unimi/dsi/fastutil/objects/Object2IntMap;)Ljava/util/List;
 		ARG 0 nodes
-	METHOD method_30946 build (Ljava/util/List;)V
+	METHOD method_30946 validate (Ljava/util/List;)V
 		ARG 0 nodeDatas
+	METHOD method_34119 (Lnet/minecraft/class_2540;Lnet/minecraft/class_2641$class_2642;)V
+		ARG 0 buf2
+		ARG 1 node
+	METHOD method_42067 validate (Ljava/util/List;Ljava/util/function/BiPredicate;)V
+		ARG 0 nodeDatas
+		ARG 1 validater
+	METHOD method_42068 (Ljava/util/function/BiPredicate;Ljava/util/List;Lit/unimi/dsi/fastutil/ints/IntSet;I)Z
+		ARG 0 index
 	CLASS class_2642 CommandNodeData
 		FIELD field_12124 flags I
 		FIELD field_12125 childNodeIndices [I
 		FIELD field_12126 redirectNodeIndex I
+		FIELD field_38043 suggestableNode Lnet/minecraft/class_2641$class_7235;
 		METHOD <init> (Lnet/minecraft/class_2641$class_7235;II[I)V
+			ARG 1 suggestableNode
+			ARG 2 flags
 			ARG 3 redirectNodeIndex
 			ARG 4 childNodeIndices
+		METHOD method_42074 validateRedirectNodeIndex (Lit/unimi/dsi/fastutil/ints/IntSet;)Z
+			ARG 1 indices
+		METHOD method_42075 write (Lnet/minecraft/class_2540;)V
+			ARG 1 buf
+		METHOD method_42076 validateChildNodeIndices (Lit/unimi/dsi/fastutil/ints/IntSet;)Z
+			ARG 1 indices
+	CLASS class_7232 ArgumentNode
+		FIELD field_38040 name Ljava/lang/String;
+		FIELD field_38041 properties Lnet/minecraft/class_2314$class_7217;
+		FIELD field_38042 id Lnet/minecraft/class_2960;
+		METHOD <init> (Lcom/mojang/brigadier/tree/ArgumentCommandNode;)V
+			ARG 1 node
+		METHOD <init> (Ljava/lang/String;Lnet/minecraft/class_2314$class_7217;Lnet/minecraft/class_2960;)V
+			ARG 1 name
+			ARG 2 properties
+			ARG 3 id
+		METHOD method_42069 computeId (Lcom/mojang/brigadier/suggestion/SuggestionProvider;)Lnet/minecraft/class_2960;
+			ARG 0 provider
+		METHOD method_42072 write (Lnet/minecraft/class_2540;Lnet/minecraft/class_2314$class_7217;)V
+			ARG 0 buf
+			ARG 1 properties
+		METHOD method_42073 write (Lnet/minecraft/class_2540;Lnet/minecraft/class_2314;Lnet/minecraft/class_2314$class_7217;)V
+			ARG 0 buf
+			ARG 1 serializer
+			ARG 2 properties
+	CLASS class_7233 LiteralNode
+		FIELD field_38044 literal Ljava/lang/String;
+		METHOD <init> (Ljava/lang/String;)V
+			ARG 1 literal
+	CLASS class_7234 CommandTree
+		FIELD field_38045 registryWrapperFactory Lnet/minecraft/class_7157;
+		FIELD field_38046 nodeDatas Ljava/util/List;
+		FIELD field_38047 nodes Ljava/util/List;
+		METHOD <init> (Lnet/minecraft/class_7157;Ljava/util/List;)V
+			ARG 1 registryWrapperFactory
+			ARG 2 nodeDatas
+		METHOD method_42077 getNode (I)Lcom/mojang/brigadier/tree/CommandNode;
+			ARG 1 index
+		METHOD method_42078 (Lcom/mojang/brigadier/context/CommandContext;)I
+			ARG 0 context
+	CLASS class_7235 SuggestableNode
+		METHOD method_42070 createArgumentBuilder (Lnet/minecraft/class_7157;)Lcom/mojang/brigadier/builder/ArgumentBuilder;
+			ARG 1 registryWrapperFactory
+		METHOD method_42071 write (Lnet/minecraft/class_2540;)V
+			ARG 1 buf

--- a/mappings/net/minecraft/network/packet/s2c/play/CommandTreeS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/CommandTreeS2CPacket.mapping
@@ -12,7 +12,7 @@ CLASS net/minecraft/class_2641 net/minecraft/network/packet/s2c/play/CommandTree
 		ARG 0 buf
 		ARG 1 flags
 	METHOD method_11403 getCommandTree (Lnet/minecraft/class_7157;)Lcom/mojang/brigadier/tree/RootCommandNode;
-		ARG 1 registryWrapperFactory
+		ARG 1 commandRegistryAccess
 	METHOD method_11405 readCommandNode (Lnet/minecraft/class_2540;)Lnet/minecraft/class_2641$class_2642;
 		ARG 0 buf
 	METHOD method_30944 traverse (Lcom/mojang/brigadier/tree/RootCommandNode;)Lit/unimi/dsi/fastutil/objects/Object2IntMap;
@@ -69,11 +69,11 @@ CLASS net/minecraft/class_2641 net/minecraft/network/packet/s2c/play/CommandTree
 		METHOD <init> (Ljava/lang/String;)V
 			ARG 1 literal
 	CLASS class_7234 CommandTree
-		FIELD field_38045 registryWrapperFactory Lnet/minecraft/class_7157;
+		FIELD field_38045 commandRegistryAccess Lnet/minecraft/class_7157;
 		FIELD field_38046 nodeDatas Ljava/util/List;
 		FIELD field_38047 nodes Ljava/util/List;
 		METHOD <init> (Lnet/minecraft/class_7157;Ljava/util/List;)V
-			ARG 1 registryWrapperFactory
+			ARG 1 commandRegistryAccess
 			ARG 2 nodeDatas
 		METHOD method_42077 getNode (I)Lcom/mojang/brigadier/tree/CommandNode;
 			ARG 1 index
@@ -81,6 +81,6 @@ CLASS net/minecraft/class_2641 net/minecraft/network/packet/s2c/play/CommandTree
 			ARG 0 context
 	CLASS class_7235 SuggestableNode
 		METHOD method_42070 createArgumentBuilder (Lnet/minecraft/class_7157;)Lcom/mojang/brigadier/builder/ArgumentBuilder;
-			ARG 1 registryWrapperFactory
+			ARG 1 commandRegistryAccess
 		METHOD method_42071 write (Lnet/minecraft/class_2540;)V
 			ARG 1 buf

--- a/mappings/net/minecraft/server/DataPackContents.mapping
+++ b/mappings/net/minecraft/server/DataPackContents.mapping
@@ -13,6 +13,7 @@ CLASS net/minecraft/class_5350 net/minecraft/server/DataPackContents
 	FIELD field_25342 functionLoader Lnet/minecraft/class_5349;
 	FIELD field_28017 lootFunctionManager Lnet/minecraft/class_5640;
 	FIELD field_36491 LOGGER Lorg/slf4j/Logger;
+	FIELD field_38051 commandRegistryAccess Lnet/minecraft/class_7157;
 	METHOD <init> (Lnet/minecraft/class_5455$class_6890;Lnet/minecraft/class_2170$class_5364;I)V
 		ARG 1 dynamicRegistryManager
 		ARG 2 commandEnvironment
@@ -51,6 +52,11 @@ CLASS net/minecraft/class_5350 net/minecraft/server/DataPackContents
 		ARG 0 entry
 	METHOD method_40424 (Lnet/minecraft/class_5321;Ljava/util/Map$Entry;)Lnet/minecraft/class_6862;
 		ARG 1 entry
+	METHOD method_40425 (Lnet/minecraft/class_5350;Ljava/lang/Object;)Lnet/minecraft/class_5350;
+		ARG 1 void_
 	METHOD method_40426 (Lnet/minecraft/class_5455;Lnet/minecraft/class_3505$class_6863;)V
 		ARG 1 tags
 	METHOD method_40427 getContents ()Ljava/util/List;
+	METHOD method_42095 (Lnet/minecraft/class_5350;Ljava/lang/Object;Ljava/lang/Throwable;)V
+		ARG 1 void_
+		ARG 2 throwable

--- a/mappings/net/minecraft/server/command/ChaseCommand.mapping
+++ b/mappings/net/minecraft/server/command/ChaseCommand.mapping
@@ -1,18 +1,36 @@
 CLASS net/minecraft/class_6634 net/minecraft/server/command/ChaseCommand
 	FIELD field_34999 DIMENSIONS Lcom/google/common/collect/BiMap;
+	FIELD field_35000 LOCALHOST Ljava/lang/String;
+	FIELD field_35001 BIND_ALL Ljava/lang/String;
+	FIELD field_35002 DEFAULT_PORT I
+	FIELD field_35003 INTERVAL I
 	FIELD field_35004 server Lnet/minecraft/class_6632;
 	FIELD field_35005 client Lnet/minecraft/class_6630;
 	METHOD method_38770 register (Lcom/mojang/brigadier/CommandDispatcher;)V
 		ARG 0 dispatcher
+	METHOD method_38771 (Lcom/mojang/brigadier/context/CommandContext;)I
+		ARG 0 context
 	METHOD method_38772 stop (Lnet/minecraft/class_2168;)I
 		ARG 0 source
 	METHOD method_38773 startServer (Lnet/minecraft/class_2168;Ljava/lang/String;I)I
 		ARG 0 source
 		ARG 1 ip
 		ARG 2 port
+	METHOD method_38774 (Lcom/mojang/brigadier/context/CommandContext;)I
+		ARG 0 context
 	METHOD method_38775 isRunning (Lnet/minecraft/class_2168;)Z
 		ARG 0 source
 	METHOD method_38776 startClient (Lnet/minecraft/class_2168;Ljava/lang/String;I)I
 		ARG 0 source
 		ARG 1 ip
 		ARG 2 port
+	METHOD method_38777 (Lcom/mojang/brigadier/context/CommandContext;)I
+		ARG 0 context
+	METHOD method_38778 (Lcom/mojang/brigadier/context/CommandContext;)I
+		ARG 0 context
+	METHOD method_38779 (Lcom/mojang/brigadier/context/CommandContext;)I
+		ARG 0 context
+	METHOD method_38780 (Lcom/mojang/brigadier/context/CommandContext;)I
+		ARG 0 context
+	METHOD method_38781 (Lcom/mojang/brigadier/context/CommandContext;)I
+		ARG 0 context

--- a/mappings/net/minecraft/server/command/ClearCommand.mapping
+++ b/mappings/net/minecraft/server/command/ClearCommand.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_3020 net/minecraft/server/command/ClearCommand
 		ARG 0 playerName
 	METHOD method_13076 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
-		ARG 1 registryWrapperFactory
+		ARG 1 commandRegistryAccess
 	METHOD method_13077 execute (Lnet/minecraft/class_2168;Ljava/util/Collection;Ljava/util/function/Predicate;I)I
 		ARG 0 source
 		ARG 1 targets

--- a/mappings/net/minecraft/server/command/ClearCommand.mapping
+++ b/mappings/net/minecraft/server/command/ClearCommand.mapping
@@ -9,6 +9,7 @@ CLASS net/minecraft/class_3020 net/minecraft/server/command/ClearCommand
 		ARG 0 playerName
 	METHOD method_13076 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
+		ARG 1 registryWrapperFactory
 	METHOD method_13077 execute (Lnet/minecraft/class_2168;Ljava/util/Collection;Ljava/util/function/Predicate;I)I
 		ARG 0 source
 		ARG 1 targets

--- a/mappings/net/minecraft/server/command/CloneCommand.mapping
+++ b/mappings/net/minecraft/server/command/CloneCommand.mapping
@@ -12,6 +12,7 @@ CLASS net/minecraft/class_3023 net/minecraft/server/command/CloneCommand
 		ARG 0 context
 	METHOD method_13089 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
+		ARG 1 registryWrapperFactory
 	METHOD method_13090 execute (Lnet/minecraft/class_2168;Lnet/minecraft/class_2338;Lnet/minecraft/class_2338;Lnet/minecraft/class_2338;Ljava/util/function/Predicate;Lnet/minecraft/class_3023$class_3025;)I
 		ARG 0 source
 		ARG 1 begin

--- a/mappings/net/minecraft/server/command/CloneCommand.mapping
+++ b/mappings/net/minecraft/server/command/CloneCommand.mapping
@@ -12,7 +12,7 @@ CLASS net/minecraft/class_3023 net/minecraft/server/command/CloneCommand
 		ARG 0 context
 	METHOD method_13089 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
-		ARG 1 registryWrapperFactory
+		ARG 1 commandRegistryAccess
 	METHOD method_13090 execute (Lnet/minecraft/class_2168;Lnet/minecraft/class_2338;Lnet/minecraft/class_2338;Lnet/minecraft/class_2338;Ljava/util/function/Predicate;Lnet/minecraft/class_3023$class_3025;)I
 		ARG 0 source
 		ARG 1 begin

--- a/mappings/net/minecraft/server/command/CommandManager.mapping
+++ b/mappings/net/minecraft/server/command/CommandManager.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_2170 net/minecraft/server/command/CommandManager
 	FIELD field_9833 LOGGER Lorg/slf4j/Logger;
 	METHOD <init> (Lnet/minecraft/class_2170$class_5364;Lnet/minecraft/class_7157;)V
 		ARG 1 environment
-		ARG 2 registryWrapperFactory
+		ARG 2 commandRegistryAccess
 	METHOD method_23917 getException (Lcom/mojang/brigadier/ParseResults;)Lcom/mojang/brigadier/exceptions/CommandSyntaxException;
 		ARG 0 parse
 	METHOD method_30851 (Lcom/mojang/brigadier/arguments/ArgumentType;)Ljava/lang/String;

--- a/mappings/net/minecraft/server/command/CommandManager.mapping
+++ b/mappings/net/minecraft/server/command/CommandManager.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/class_2170 net/minecraft/server/command/CommandManager
 	FIELD field_9833 LOGGER Lorg/slf4j/Logger;
 	METHOD <init> (Lnet/minecraft/class_2170$class_5364;Lnet/minecraft/class_7157;)V
 		ARG 1 environment
+		ARG 2 registryWrapperFactory
 	METHOD method_23917 getException (Lcom/mojang/brigadier/ParseResults;)Lcom/mojang/brigadier/exceptions/CommandSyntaxException;
 		ARG 0 parse
 	METHOD method_30851 (Lcom/mojang/brigadier/arguments/ArgumentType;)Ljava/lang/String;
@@ -10,6 +11,11 @@ CLASS net/minecraft/class_2170 net/minecraft/server/command/CommandManager
 	METHOD method_30852 checkMissing ()V
 	METHOD method_30853 (Lcom/mojang/brigadier/arguments/ArgumentType;)Z
 		ARG 0 type
+	METHOD method_41710 (Lcom/mojang/brigadier/CommandDispatcher;Lcom/mojang/brigadier/tree/CommandNode;Lcom/mojang/brigadier/tree/CommandNode;Lcom/mojang/brigadier/tree/CommandNode;Ljava/util/Collection;)V
+		ARG 1 parent
+		ARG 2 child
+		ARG 3 sibling
+		ARG 4 inputs
 	METHOD method_9235 getDispatcher ()Lcom/mojang/brigadier/CommandDispatcher;
 	METHOD method_9236 (Ljava/lang/String;Lnet/minecraft/class_2583;)Lnet/minecraft/class_2583;
 		ARG 1 style

--- a/mappings/net/minecraft/server/command/ExecuteCommand.mapping
+++ b/mappings/net/minecraft/server/command/ExecuteCommand.mapping
@@ -64,7 +64,7 @@ CLASS net/minecraft/class_3050 net/minecraft/server/command/ExecuteCommand
 		ARG 2 context
 	METHOD method_13271 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
-		ARG 1 registryWrapperFactory
+		ARG 1 commandRegistryAccess
 	METHOD method_13272 testBlocksCondition (Lcom/mojang/brigadier/context/CommandContext;Z)Ljava/util/OptionalInt;
 		ARG 0 context
 		ARG 1 masked
@@ -137,7 +137,7 @@ CLASS net/minecraft/class_3050 net/minecraft/server/command/ExecuteCommand
 		ARG 0 root
 		ARG 1 argumentBuilder
 		ARG 2 positive
-		ARG 3 registryWrapperFactory
+		ARG 3 commandRegistryAccess
 	METHOD method_13299 (Ljava/lang/Integer;Ljava/lang/Integer;)Z
 		ARG 0 a
 		ARG 1 b

--- a/mappings/net/minecraft/server/command/ExecuteCommand.mapping
+++ b/mappings/net/minecraft/server/command/ExecuteCommand.mapping
@@ -64,6 +64,7 @@ CLASS net/minecraft/class_3050 net/minecraft/server/command/ExecuteCommand
 		ARG 2 context
 	METHOD method_13271 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
+		ARG 1 registryWrapperFactory
 	METHOD method_13272 testBlocksCondition (Lcom/mojang/brigadier/context/CommandContext;Z)Ljava/util/OptionalInt;
 		ARG 0 context
 		ARG 1 masked
@@ -79,6 +80,9 @@ CLASS net/minecraft/class_3050 net/minecraft/server/command/ExecuteCommand
 		ARG 3 context
 		ARG 4 success
 		ARG 5 result
+	METHOD method_13278 (Lcom/mojang/brigadier/ResultConsumer;Lcom/mojang/brigadier/ResultConsumer;)Lcom/mojang/brigadier/ResultConsumer;
+		ARG 0 consumer
+		ARG 1 consumer2
 	METHOD method_13279 (Lcom/mojang/brigadier/ResultConsumer;Lcom/mojang/brigadier/ResultConsumer;Lcom/mojang/brigadier/context/CommandContext;ZI)V
 		ARG 2 context
 		ARG 3 success
@@ -133,11 +137,14 @@ CLASS net/minecraft/class_3050 net/minecraft/server/command/ExecuteCommand
 		ARG 0 root
 		ARG 1 argumentBuilder
 		ARG 2 positive
+		ARG 3 registryWrapperFactory
 	METHOD method_13299 (Ljava/lang/Integer;Ljava/lang/Integer;)Z
 		ARG 0 a
 		ARG 1 b
 	METHOD method_13300 (ZLcom/mojang/brigadier/context/CommandContext;)Ljava/util/Collection;
 		ARG 1 context
+	METHOD method_13301 (ZLnet/minecraft/class_3164$class_3167;Lcom/mojang/brigadier/context/CommandContext;)Ljava/util/Collection;
+		ARG 2 context
 	METHOD method_13302 (Ljava/lang/Integer;Ljava/lang/Integer;)Z
 		ARG 0 a
 		ARG 1 b

--- a/mappings/net/minecraft/server/command/FillCommand.mapping
+++ b/mappings/net/minecraft/server/command/FillCommand.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_3057 net/minecraft/server/command/FillCommand
 		ARG 0 context
 	METHOD method_13347 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
-		ARG 1 registryWrapperFactory
+		ARG 1 commandRegistryAccess
 	METHOD method_13348 (Lnet/minecraft/class_2694;)Z
 		ARG 0 pos
 	METHOD method_13349 (Lcom/mojang/brigadier/context/CommandContext;)I

--- a/mappings/net/minecraft/server/command/FillCommand.mapping
+++ b/mappings/net/minecraft/server/command/FillCommand.mapping
@@ -9,6 +9,7 @@ CLASS net/minecraft/class_3057 net/minecraft/server/command/FillCommand
 		ARG 0 context
 	METHOD method_13347 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
+		ARG 1 registryWrapperFactory
 	METHOD method_13348 (Lnet/minecraft/class_2694;)Z
 		ARG 0 pos
 	METHOD method_13349 (Lcom/mojang/brigadier/context/CommandContext;)I

--- a/mappings/net/minecraft/server/command/ForceLoadCommand.mapping
+++ b/mappings/net/minecraft/server/command/ForceLoadCommand.mapping
@@ -38,5 +38,7 @@ CLASS net/minecraft/class_3060 net/minecraft/server/command/ForceLoadCommand
 	METHOD method_13376 (Ljava/lang/Object;Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
 		ARG 0 maxCount
 		ARG 1 count
+	METHOD method_13377 (Lnet/minecraft/class_3218;J)V
+		ARG 1 chunkPos
 	METHOD method_13378 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context

--- a/mappings/net/minecraft/server/command/GameModeCommand.mapping
+++ b/mappings/net/minecraft/server/command/GameModeCommand.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_3064 net/minecraft/server/command/GameModeCommand
+	FIELD field_33393 REQUIRED_PERMISSION_LEVEL I
 	METHOD method_13386 (Lnet/minecraft/class_1934;Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 1 context
 	METHOD method_13387 execute (Lcom/mojang/brigadier/context/CommandContext;Ljava/util/Collection;Lnet/minecraft/class_1934;)I

--- a/mappings/net/minecraft/server/command/GiveCommand.mapping
+++ b/mappings/net/minecraft/server/command/GiveCommand.mapping
@@ -9,6 +9,7 @@ CLASS net/minecraft/class_3068 net/minecraft/server/command/GiveCommand
 		ARG 3 count
 	METHOD method_13402 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
+		ARG 1 registryWrapperFactory
 	METHOD method_13403 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context
 	METHOD method_13404 (Lnet/minecraft/class_2168;)Z

--- a/mappings/net/minecraft/server/command/GiveCommand.mapping
+++ b/mappings/net/minecraft/server/command/GiveCommand.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_3068 net/minecraft/server/command/GiveCommand
 		ARG 3 count
 	METHOD method_13402 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
-		ARG 1 registryWrapperFactory
+		ARG 1 commandRegistryAccess
 	METHOD method_13403 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context
 	METHOD method_13404 (Lnet/minecraft/class_2168;)Z

--- a/mappings/net/minecraft/server/command/ItemCommand.mapping
+++ b/mappings/net/minecraft/server/command/ItemCommand.mapping
@@ -11,7 +11,7 @@ CLASS net/minecraft/class_5687 net/minecraft/server/command/ItemCommand
 		ARG 1 slotId
 	METHOD method_32707 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
-		ARG 1 registryWrapperFactory
+		ARG 1 commandRegistryAccess
 	METHOD method_32708 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context
 	METHOD method_32709 (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;

--- a/mappings/net/minecraft/server/command/ItemCommand.mapping
+++ b/mappings/net/minecraft/server/command/ItemCommand.mapping
@@ -11,6 +11,7 @@ CLASS net/minecraft/class_5687 net/minecraft/server/command/ItemCommand
 		ARG 1 slotId
 	METHOD method_32707 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
+		ARG 1 registryWrapperFactory
 	METHOD method_32708 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context
 	METHOD method_32709 (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;

--- a/mappings/net/minecraft/server/command/LootCommand.mapping
+++ b/mappings/net/minecraft/server/command/LootCommand.mapping
@@ -47,7 +47,7 @@ CLASS net/minecraft/class_3039 net/minecraft/server/command/LootCommand
 		ARG 2 messageSender
 	METHOD method_13193 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
-		ARG 1 registryWrapperFactory
+		ARG 1 commandRegistryAccess
 	METHOD method_13195 (Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
 		ARG 0 entityName
 	METHOD method_13196 executeInsert (Lnet/minecraft/class_2168;Lnet/minecraft/class_2338;Ljava/util/List;Lnet/minecraft/class_3039$class_3040;)I

--- a/mappings/net/minecraft/server/command/LootCommand.mapping
+++ b/mappings/net/minecraft/server/command/LootCommand.mapping
@@ -47,6 +47,7 @@ CLASS net/minecraft/class_3039 net/minecraft/server/command/LootCommand
 		ARG 2 messageSender
 	METHOD method_13193 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
+		ARG 1 registryWrapperFactory
 	METHOD method_13195 (Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
 		ARG 0 entityName
 	METHOD method_13196 executeInsert (Lnet/minecraft/class_2168;Lnet/minecraft/class_2338;Ljava/util/List;Lnet/minecraft/class_3039$class_3040;)I
@@ -74,6 +75,9 @@ CLASS net/minecraft/class_3039 net/minecraft/server/command/LootCommand
 		ARG 0 context
 		ARG 1 stacks
 		ARG 2 messageSender
+	METHOD method_13203 (Lnet/minecraft/class_7157;Lcom/mojang/brigadier/builder/ArgumentBuilder;Lnet/minecraft/class_3039$class_3041;)Lcom/mojang/brigadier/builder/ArgumentBuilder;
+		ARG 1 builder
+		ARG 2 constructor
 	METHOD method_13204 (Lnet/minecraft/class_3039$class_3041;Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 1 context
 	METHOD method_13205 (Lnet/minecraft/class_3039$class_3041;Lcom/mojang/brigadier/context/CommandContext;)I

--- a/mappings/net/minecraft/server/command/ResetChunksCommand.mapping
+++ b/mappings/net/minecraft/server/command/ResetChunksCommand.mapping
@@ -20,3 +20,5 @@ CLASS net/minecraft/class_6608 net/minecraft/server/command/ResetChunksCommand
 		ARG 0 chunk
 	METHOD method_38628 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context
+	METHOD method_39500 (Lcom/mojang/brigadier/context/CommandContext;)I
+		ARG 0 context

--- a/mappings/net/minecraft/server/command/SayCommand.mapping
+++ b/mappings/net/minecraft/server/command/SayCommand.mapping
@@ -3,3 +3,5 @@ CLASS net/minecraft/class_3110 net/minecraft/server/command/SayCommand
 		ARG 0 dispatcher
 	METHOD method_13563 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context
+	METHOD method_13564 (Lnet/minecraft/class_2168;)Z
+		ARG 0 source

--- a/mappings/net/minecraft/server/command/ServerCommandSource.mapping
+++ b/mappings/net/minecraft/server/command/ServerCommandSource.mapping
@@ -42,6 +42,8 @@ CLASS net/minecraft/class_2168 net/minecraft/server/command/ServerCommandSource
 		ARG 12 entityAnchor
 	METHOD method_36321 withOutput (Lnet/minecraft/class_2165;)Lnet/minecraft/class_2168;
 		ARG 1 output
+	METHOD method_41212 (Lnet/minecraft/class_2172$class_7078;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;Lnet/minecraft/class_2378;)Ljava/util/concurrent/CompletableFuture;
+		ARG 3 registry
 	METHOD method_9206 withLevel (I)Lnet/minecraft/class_2168;
 		ARG 1 level
 	METHOD method_9207 getPlayer ()Lnet/minecraft/class_3222;

--- a/mappings/net/minecraft/server/command/SetBlockCommand.mapping
+++ b/mappings/net/minecraft/server/command/SetBlockCommand.mapping
@@ -12,7 +12,7 @@ CLASS net/minecraft/class_3119 net/minecraft/server/command/SetBlockCommand
 		ARG 0 context
 	METHOD method_13623 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
-		ARG 1 registryWrapperFactory
+		ARG 1 commandRegistryAccess
 	METHOD method_13624 (Lnet/minecraft/class_2694;)Z
 		ARG 0 pos
 	METHOD method_13625 (Lcom/mojang/brigadier/context/CommandContext;)I

--- a/mappings/net/minecraft/server/command/SetBlockCommand.mapping
+++ b/mappings/net/minecraft/server/command/SetBlockCommand.mapping
@@ -12,6 +12,7 @@ CLASS net/minecraft/class_3119 net/minecraft/server/command/SetBlockCommand
 		ARG 0 context
 	METHOD method_13623 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
+		ARG 1 registryWrapperFactory
 	METHOD method_13624 (Lnet/minecraft/class_2694;)Z
 		ARG 0 pos
 	METHOD method_13625 (Lcom/mojang/brigadier/context/CommandContext;)I


### PR DESCRIPTION
Another big changes. First commit contains the core, second one is for misc stuff, and third one is mapping the individual command classes.

- `ArgumentHelper` contains helper methods for arguments. It has methods to check for flags indicating whether argument properties (see below) have min/max, and also a writer used in datagen and used argument type collector to punish anyone who doesn't register them.
- `ArgumentTypeProperties` are properties of individual ArgumentType uses (min/max value, bound registry, whether multiple values are allowed, etc). Fields are mostly named from datagen keys/values so long as it makes sense (e.g. `players` boolean renamed to `playersOnly`)
- "item predicate" renamed in places where it is a item stack predicate
- toJson/toPacket in ArgumentSerializer renamed to writeJson/writePacket because they do not return values, instead writes them
- And mapped many new methods in CommandTreeS2CPacket. Good luck reviewing this mojank mess.