### PR TITLE
Chunk generator stuff

### DIFF
--- a/mappings/net/minecraft/world/gen/chunk/ChunkGenerator.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/ChunkGenerator.mapping
@@ -142,7 +142,7 @@ CLASS net/minecraft/class_2794 net/minecraft/world/gen/chunk/ChunkGenerator
 	METHOD method_40450 getDebugHudText (Ljava/util/List;Lnet/minecraft/class_7138;Lnet/minecraft/class_2338;)V
 		ARG 1 text
 	METHOD method_41039 streamStructureSets ()Ljava/util/stream/Stream;
-	METHOD method_41042 getStructuresRegistryForCodec (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/Products$P1;
+	METHOD method_41042 createStructureSetRegistryGetter (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/Products$P1;
 		ARG 0 instance
 	METHOD method_41053 shouldStructureGenerateInRange (Lnet/minecraft/class_6880;Lnet/minecraft/class_7138;JIII)Z
 		ARG 1 structureSet

--- a/mappings/net/minecraft/world/gen/chunk/ChunkGenerator.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/ChunkGenerator.mapping
@@ -8,18 +8,19 @@ CLASS net/minecraft/class_2794 net/minecraft/world/gen/chunk/ChunkGenerator
 		COMMENT <p>This is used by {@link FlatChunkGenerator} to overwrite biome properties like whether lakes generate, while preserving the original biome ID.
 	FIELD field_24746 CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_24747 biomeSource Lnet/minecraft/class_1966;
-	FIELD field_36405 strongholdPositions Ljava/util/Map;
+	FIELD field_36405 concentricRingPositions Ljava/util/Map;
 	FIELD field_37053 structureSetRegistry Lnet/minecraft/class_2378;
-	FIELD field_37054 structureSets Ljava/util/Optional;
+	FIELD field_37054 structureOverrides Ljava/util/Optional;
 	FIELD field_37055 structurePlacements Ljava/util/Map;
+	FIELD field_37056 hasComputedStructurePlacements Z
 	FIELD field_37254 LOGGER Lorg/slf4j/Logger;
 	METHOD <init> (Lnet/minecraft/class_2378;Ljava/util/Optional;Lnet/minecraft/class_1966;)V
 		ARG 1 structureSetRegistry
-		ARG 2 structureSets
+		ARG 2 structureOverrides
 		ARG 3 biomeSource
 	METHOD <init> (Lnet/minecraft/class_2378;Ljava/util/Optional;Lnet/minecraft/class_1966;Lnet/minecraft/class_1966;)V
 		ARG 1 structureSetRegistry
-		ARG 2 structureSets
+		ARG 2 structureOverrides
 		ARG 3 populationSource
 		ARG 4 biomeSource
 	METHOD method_12088 populateNoise (Ljava/util/concurrent/Executor;Lnet/minecraft/class_6748;Lnet/minecraft/class_7138;Lnet/minecraft/class_5138;Lnet/minecraft/class_2791;)Ljava/util/concurrent/CompletableFuture;
@@ -115,7 +116,7 @@ CLASS net/minecraft/class_2794 net/minecraft/world/gen/chunk/ChunkGenerator
 		ARG 3 world
 		ARG 4 noiseConfig
 	METHOD method_28506 getCodec ()Lcom/mojang/serialization/Codec;
-	METHOD method_28509 generateStrongholdPositions (Lnet/minecraft/class_6880;Lnet/minecraft/class_7138;Lnet/minecraft/class_6871;)Ljava/util/concurrent/CompletableFuture;
+	METHOD method_28509 generateConcentricRingPositions (Lnet/minecraft/class_6880;Lnet/minecraft/class_7138;Lnet/minecraft/class_6871;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 structureSet
 		ARG 2 noiseConfig
 		ARG 3 concentricRingsStructurePlacement
@@ -141,6 +142,8 @@ CLASS net/minecraft/class_2794 net/minecraft/world/gen/chunk/ChunkGenerator
 	METHOD method_40450 getDebugHudText (Ljava/util/List;Lnet/minecraft/class_7138;Lnet/minecraft/class_2338;)V
 		ARG 1 text
 	METHOD method_41039 streamStructureSets ()Ljava/util/stream/Stream;
+	METHOD method_41042 getStructuresRegistryForCodec (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/Products$P1;
+		ARG 0 instance
 	METHOD method_41053 shouldStructureGenerateInRange (Lnet/minecraft/class_6880;Lnet/minecraft/class_7138;JIII)Z
 		ARG 1 structureSet
 		ARG 2 noiseConfig

--- a/mappings/net/minecraft/world/gen/chunk/FlatChunkGenerator.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/FlatChunkGenerator.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_2897 net/minecraft/world/gen/chunk/FlatChunkGenerator
 	FIELD field_24510 config Lnet/minecraft/class_3232;
 	FIELD field_24769 CODEC Lcom/mojang/serialization/Codec;
 	METHOD <init> (Lnet/minecraft/class_2378;Lnet/minecraft/class_3232;)V
-		ARG 1 structureFeatureRegistry
+		ARG 1 structureSetRegistry
 		ARG 2 config
 	METHOD method_28002 (Lnet/minecraft/class_2680;)Lnet/minecraft/class_2680;
 		ARG 0 state

--- a/mappings/net/minecraft/world/gen/chunk/FlatChunkGeneratorConfig.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/FlatChunkGeneratorConfig.mapping
@@ -8,18 +8,23 @@ CLASS net/minecraft/class_3232 net/minecraft/world/gen/chunk/FlatChunkGeneratorC
 	FIELD field_24976 hasFeatures Z
 	FIELD field_24977 hasLakes Z
 	FIELD field_26748 biomeRegistry Lnet/minecraft/class_2378;
+	FIELD field_37145 structureOverrides Ljava/util/Optional;
 	METHOD <init> (Ljava/util/Optional;Lnet/minecraft/class_2378;)V
+		ARG 1 structureOverrides
 		ARG 2 biomeRegistry
 	METHOD <init> (Lnet/minecraft/class_2378;Ljava/util/Optional;Ljava/util/List;ZZLjava/util/Optional;)V
 		ARG 1 biomeRegistry
+		ARG 2 structureOverrides
 		ARG 3 layers
 		ARG 4 hasLakes
 		ARG 5 hasFeatures
 		ARG 6 biome
 	METHOD method_14309 getDefaultConfig (Lnet/minecraft/class_2378;Lnet/minecraft/class_2378;)Lnet/minecraft/class_3232;
 		ARG 0 biomeRegistry
+		ARG 1 structureSetRegistry
 	METHOD method_14312 getLayerBlocks ()Ljava/util/List;
 	METHOD method_14325 setBiome (Lnet/minecraft/class_6880;)V
+		ARG 1 biome
 	METHOD method_14326 getBiome ()Lnet/minecraft/class_6880;
 	METHOD method_14327 getLayers ()Ljava/util/List;
 	METHOD method_14330 updateLayerBlocks ()V
@@ -30,7 +35,9 @@ CLASS net/minecraft/class_3232 net/minecraft/world/gen/chunk/FlatChunkGeneratorC
 	METHOD method_28917 createBiome ()Lnet/minecraft/class_6880;
 	METHOD method_29965 withLayers (Ljava/util/List;Ljava/util/Optional;)Lnet/minecraft/class_3232;
 		ARG 1 layers
+		ARG 2 structureOverrides
 	METHOD method_33067 checkHeight (Lnet/minecraft/class_3232;)Lcom/mojang/serialization/DataResult;
 		ARG 0 config
 	METHOD method_34741 (Lnet/minecraft/class_2680;)Z
 		ARG 0 state
+	METHOD method_41139 getStructureOverrides ()Ljava/util/Optional;

--- a/mappings/net/minecraft/world/gen/chunk/NoiseChunkGenerator.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/NoiseChunkGenerator.mapping
@@ -6,14 +6,16 @@ CLASS net/minecraft/class_3754 net/minecraft/world/gen/chunk/NoiseChunkGenerator
 	FIELD field_34591 fluidLevelSampler Lnet/minecraft/class_6350$class_6565;
 	FIELD field_35361 noiseRegistry Lnet/minecraft/class_2378;
 	METHOD <init> (Lnet/minecraft/class_2378;Lnet/minecraft/class_2378;Lnet/minecraft/class_1966;Lnet/minecraft/class_1966;Lnet/minecraft/class_6880;)V
-		ARG 1 structureRegistry
+		ARG 1 structureSetRegistry
 		ARG 2 noiseRegistry
 		ARG 3 populationSource
 		ARG 4 biomeSource
+		ARG 5 settings
 	METHOD <init> (Lnet/minecraft/class_2378;Lnet/minecraft/class_2378;Lnet/minecraft/class_1966;Lnet/minecraft/class_6880;)V
-		ARG 1 structureRegistry
+		ARG 1 structureSetRegistry
 		ARG 2 noiseRegistry
 		ARG 3 biomeSource
+		ARG 4 settings
 	METHOD method_26263 sampleHeightmap (Lnet/minecraft/class_5539;Lnet/minecraft/class_7138;IILorg/apache/commons/lang3/mutable/MutableObject;Ljava/util/function/Predicate;)Ljava/util/OptionalInt;
 	METHOD method_28548 matchesSettings (Lnet/minecraft/class_5321;)Z
 	METHOD method_28549 (Lnet/minecraft/class_3754;)Lnet/minecraft/class_6880;


### PR DESCRIPTION
got the structureOverrides name from the codec for the various chunk generators, field name was `structure_overrides`.

other names were just copied from the type of the field/param