### PR TITLE
rename pauseWhenMobIdle to skipMobIdleCheck

### DIFF
--- a/mappings/net/minecraft/entity/ai/goal/MeleeAttackGoal.mapping
+++ b/mappings/net/minecraft/entity/ai/goal/MeleeAttackGoal.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_1366 net/minecraft/entity/ai/goal/MeleeAttackGoal
 	FIELD field_30218 MAX_ATTACK_TIME J
 	FIELD field_6500 speed D
 	FIELD field_6501 updateCountdownTicks I
-	FIELD field_6502 pauseWhenMobIdle Z
+	FIELD field_6502 skipMobIdleCheck Z
 	FIELD field_6503 mob Lnet/minecraft/class_1314;
 	FIELD field_6504 attackIntervalTicks I
 	FIELD field_6506 targetZ D
@@ -14,7 +14,7 @@ CLASS net/minecraft/class_1366 net/minecraft/entity/ai/goal/MeleeAttackGoal
 	METHOD <init> (Lnet/minecraft/class_1314;DZ)V
 		ARG 1 mob
 		ARG 2 speed
-		ARG 4 pauseWhenMobIdle
+		ARG 4 skipMobIdleCheck
 	METHOD method_28346 resetCooldown ()V
 	METHOD method_28347 isCooledDown ()Z
 	METHOD method_28348 getCooldown ()I

--- a/mappings/net/minecraft/entity/ai/goal/ZombieAttackGoal.mapping
+++ b/mappings/net/minecraft/entity/ai/goal/ZombieAttackGoal.mapping
@@ -4,4 +4,4 @@ CLASS net/minecraft/class_1396 net/minecraft/entity/ai/goal/ZombieAttackGoal
 	METHOD <init> (Lnet/minecraft/class_1642;DZ)V
 		ARG 1 zombie
 		ARG 2 speed
-		ARG 4 pauseWhenMobIdle
+		ARG 4 skipMobIdleCheck

--- a/mappings/net/minecraft/entity/mob/DrownedEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/DrownedEntity.mapping
@@ -22,7 +22,7 @@ CLASS net/minecraft/class_1551 net/minecraft/entity/mob/DrownedEntity
 		METHOD <init> (Lnet/minecraft/class_1551;DZ)V
 			ARG 1 drowned
 			ARG 2 speed
-			ARG 4 pauseWhenMobIdle
+			ARG 4 skipMobIdleCheck
 	CLASS class_1554 LeaveWaterGoal
 		FIELD field_7237 drowned Lnet/minecraft/class_1551;
 		METHOD <init> (Lnet/minecraft/class_1551;D)V

--- a/mappings/net/minecraft/entity/passive/BeeEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/BeeEntity.mapping
@@ -103,7 +103,7 @@ CLASS net/minecraft/class_4466 net/minecraft/entity/passive/BeeEntity
 		METHOD <init> (Lnet/minecraft/class_4466;Lnet/minecraft/class_1314;DZ)V
 			ARG 2 mob
 			ARG 3 speed
-			ARG 5 pauseWhenMobIdle
+			ARG 5 skipMobIdleCheck
 	CLASS class_4469 BeeFollowTargetGoal
 		METHOD <init> (Lnet/minecraft/class_4466;)V
 			ARG 1 bee

--- a/mappings/net/minecraft/entity/passive/PandaEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/PandaEntity.mapping
@@ -162,7 +162,7 @@ CLASS net/minecraft/class_1440 net/minecraft/entity/passive/PandaEntity
 		METHOD <init> (Lnet/minecraft/class_1440;DZ)V
 			ARG 1 panda
 			ARG 2 speed
-			ARG 4 pauseWhenMobIdle
+			ARG 4 skipMobIdleCheck
 	CLASS class_4056 LookAtEntityGoal
 		FIELD field_18116 panda Lnet/minecraft/class_1440;
 		METHOD <init> (Lnet/minecraft/class_1440;Ljava/lang/Class;F)V


### PR DESCRIPTION
The variable is used twice
```
if (!pauseWhenMobIdle) {
    //stops when idle
} else if {
    //other checks which get skipped
}
```
```
if (pauseWhenMobIdle || mob.canSee(player)){
    //Mob moves twords player 
}
```
most entities appear to have it set to false with the Ravager having it set to true

due to the second use i don't think `skipMobIdleCheck` is entierly accurate but i also can't think of something that makes sense for both