### PR TITLE
Fix wrong mappings at InGameHud

### DIFF
--- a/mappings/net/minecraft/client/gui/hud/InGameHud.mapping
+++ b/mappings/net/minecraft/client/gui/hud/InGameHud.mapping
@@ -9,13 +9,13 @@ CLASS net/minecraft/class_329 net/minecraft/client/gui/hud/InGameHud
 	FIELD field_2014 lastHealthValue I
 	FIELD field_2015 playerListHud Lnet/minecraft/class_355;
 	FIELD field_2016 title Lnet/minecraft/class_2561;
-	FIELD field_2017 titleRemainTicks I
+	FIELD field_2017 titleStayTicks I
 	FIELD field_2018 overlayMessage Lnet/minecraft/class_2561;
 	FIELD field_2019 PUMPKIN_BLUR Lnet/minecraft/class_2960;
 	FIELD field_2020 VIGNETTE_TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_2021 chatHud Lnet/minecraft/class_338;
 	FIELD field_2022 listeners Ljava/util/Map;
-	FIELD field_2023 titleTotalTicks I
+	FIELD field_2023 titleRemainingTicks I
 	FIELD field_2024 itemRenderer Lnet/minecraft/class_918;
 	FIELD field_2025 spectatorHud Lnet/minecraft/class_365;
 	FIELD field_2026 debugHud Lnet/minecraft/class_340;

--- a/mappings/net/minecraft/client/gui/hud/InGameHud.mapping
+++ b/mappings/net/minecraft/client/gui/hud/InGameHud.mapping
@@ -15,7 +15,7 @@ CLASS net/minecraft/class_329 net/minecraft/client/gui/hud/InGameHud
 	FIELD field_2020 VIGNETTE_TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_2021 chatHud Lnet/minecraft/class_338;
 	FIELD field_2022 listeners Ljava/util/Map;
-	FIELD field_2023 titleRemainingTicks I
+	FIELD field_2023 titleRemainTicks I
 	FIELD field_2024 itemRenderer Lnet/minecraft/class_918;
 	FIELD field_2025 spectatorHud Lnet/minecraft/class_365;
 	FIELD field_2026 debugHud Lnet/minecraft/class_340;


### PR DESCRIPTION
`Lnet/minecraft/client/gui/hud/InGameHud;titleTotalTicks:I` and `Lnet/minecraft/client/gui/hud/InGameHud;titleRemainTicks:I` have some wrong mappings
The renaming is simple:
* `titleTotalTicks` -> `titleRemainTicks` or `titleRemainingTicks` (The initial commit of the PR has `titleRemainTicks`)
* `titleRemainTicks` -> `titleStayTicks`

Total ticks seems like the total time it is on the screen, but it is a reducing value, as it can be seen on `Lnet/minecraft/client/gui/hud/InGameHud;tick()V` where it has `--this.titleTotalTicks;`
Remain ticks seem to be the ticks remaining for the title on the screen, but it is the amount of ticks between fade out and fade in, on `TitleCommand` at `/title times fadeIn stay fadeOut` it's variable is labled `stay`