### PR TITLE
Simplify codec names in `MaterialRules`

### DIFF
--- a/mappings/net/minecraft/world/gen/surfacebuilder/MaterialRules.mapping
+++ b/mappings/net/minecraft/world/gen/surfacebuilder/MaterialRules.mapping
@@ -60,11 +60,11 @@ CLASS net/minecraft/class_6686 net/minecraft/world/gen/surfacebuilder/MaterialRu
 		ARG 1 id
 		ARG 2 codecHolder
 	CLASS class_6687 TerracottaBandsMaterialRule
-		FIELD field_35226 RULE_CODEC Lnet/minecraft/class_7243;
+		FIELD field_35226 CODEC Lnet/minecraft/class_7243;
 		METHOD apply (Ljava/lang/Object;)Ljava/lang/Object;
 			ARG 1 context
 	CLASS class_6689 BiomeMaterialCondition
-		FIELD field_35228 CONDITION_CODEC Lnet/minecraft/class_7243;
+		FIELD field_35228 CODEC Lnet/minecraft/class_7243;
 		FIELD field_36414 biomes Ljava/util/List;
 		FIELD field_36415 predicate Ljava/util/function/Predicate;
 		METHOD <init> (Ljava/util/List;)V
@@ -73,7 +73,7 @@ CLASS net/minecraft/class_6686 net/minecraft/world/gen/surfacebuilder/MaterialRu
 			ARG 1 context
 		CLASS class_6690 BiomePredicate
 	CLASS class_6691 BlockMaterialRule
-		FIELD field_35231 RULE_CODEC Lnet/minecraft/class_7243;
+		FIELD field_35231 CODEC Lnet/minecraft/class_7243;
 		METHOD <init> (Lnet/minecraft/class_2680;)V
 			ARG 1 resultState
 		METHOD apply (Ljava/lang/Object;)Ljava/lang/Object;
@@ -130,7 +130,7 @@ CLASS net/minecraft/class_6686 net/minecraft/world/gen/surfacebuilder/MaterialRu
 		CLASS class_6771 SurfacePredicate
 		CLASS class_6772 BiomeTemperaturePredicate
 	CLASS class_6701 HoleMaterialCondition
-		FIELD field_35244 CONDITION_CODEC Lnet/minecraft/class_7243;
+		FIELD field_35244 CODEC Lnet/minecraft/class_7243;
 		METHOD apply (Ljava/lang/Object;)Ljava/lang/Object;
 			ARG 1 context
 	CLASS class_6702 LazyAbstractPredicate
@@ -146,13 +146,13 @@ CLASS net/minecraft/class_6686 net/minecraft/world/gen/surfacebuilder/MaterialRu
 			COMMENT
 			COMMENT @return the unique value for this position
 	CLASS class_6703 NoiseThresholdMaterialCondition
-		FIELD field_35248 CONDITION_CODEC Lnet/minecraft/class_7243;
+		FIELD field_35248 CODEC Lnet/minecraft/class_7243;
 		METHOD apply (Ljava/lang/Object;)Ljava/lang/Object;
 			ARG 1 context
 		CLASS class_6704 NoiseThresholdPredicate
 	CLASS class_6706 InvertedBooleanSupplier
 	CLASS class_6707 NotMaterialCondition
-		FIELD field_35251 CONDITION_CODEC Lnet/minecraft/class_7243;
+		FIELD field_35251 CODEC Lnet/minecraft/class_7243;
 		METHOD apply (Ljava/lang/Object;)Ljava/lang/Object;
 			ARG 1 context
 	CLASS class_6708 MaterialRule
@@ -164,17 +164,17 @@ CLASS net/minecraft/class_6686 net/minecraft/world/gen/surfacebuilder/MaterialRu
 		COMMENT Applies the given block state rules in sequence, and returns the first result that
 		COMMENT isn't {@code null}. Returns {@code null} if none of the passed rules match.
 	CLASS class_6710 SequenceMaterialRule
-		FIELD field_35253 RULE_CODEC Lnet/minecraft/class_7243;
+		FIELD field_35253 CODEC Lnet/minecraft/class_7243;
 		METHOD apply (Ljava/lang/Object;)Ljava/lang/Object;
 			ARG 1 context
 	CLASS class_6711 SimpleBlockStateRule
 		COMMENT Always returns the given {@link BlockState}.
 	CLASS class_6712 SteepMaterialCondition
-		FIELD field_35255 CONDITION_CODEC Lnet/minecraft/class_7243;
+		FIELD field_35255 CODEC Lnet/minecraft/class_7243;
 		METHOD apply (Ljava/lang/Object;)Ljava/lang/Object;
 			ARG 1 context
 	CLASS class_6713 StoneDepthMaterialCondition
-		FIELD field_35257 CONDITION_CODEC Lnet/minecraft/class_7243;
+		FIELD field_35257 CODEC Lnet/minecraft/class_7243;
 		METHOD apply (Ljava/lang/Object;)Ljava/lang/Object;
 			ARG 1 context
 		CLASS class_6714 StoneDepthPredicate
@@ -185,34 +185,34 @@ CLASS net/minecraft/class_6686 net/minecraft/world/gen/surfacebuilder/MaterialRu
 			ARG 2 y
 			ARG 3 z
 	CLASS class_6716 TemperatureMaterialCondition
-		FIELD field_35261 CONDITION_CODEC Lnet/minecraft/class_7243;
+		FIELD field_35261 CODEC Lnet/minecraft/class_7243;
 		METHOD apply (Ljava/lang/Object;)Ljava/lang/Object;
 			ARG 1 context
 	CLASS class_6717 ConditionalBlockStateRule
 		COMMENT Applies another block state rule if the given predicate matches, and returns
 		COMMENT {@code null} otherwise.
 	CLASS class_6718 ConditionMaterialRule
-		FIELD field_35263 RULE_CODEC Lnet/minecraft/class_7243;
+		FIELD field_35263 CODEC Lnet/minecraft/class_7243;
 		METHOD apply (Ljava/lang/Object;)Ljava/lang/Object;
 			ARG 1 context
 	CLASS class_6720 WaterMaterialCondition
-		FIELD field_35264 CONDITION_CODEC Lnet/minecraft/class_7243;
+		FIELD field_35264 CODEC Lnet/minecraft/class_7243;
 		METHOD apply (Ljava/lang/Object;)Ljava/lang/Object;
 			ARG 1 context
 		CLASS class_6721 WaterPredicate
 	CLASS class_6722 AboveYMaterialCondition
-		FIELD field_35266 CONDITION_CODEC Lnet/minecraft/class_7243;
+		FIELD field_35266 CODEC Lnet/minecraft/class_7243;
 		METHOD apply (Ljava/lang/Object;)Ljava/lang/Object;
 			ARG 1 context
 		CLASS class_6723 AboveYPredicate
 	CLASS class_6770 SurfaceMaterialCondition
-		FIELD field_35601 CONDITION_CODEC Lnet/minecraft/class_7243;
+		FIELD field_35601 CODEC Lnet/minecraft/class_7243;
 		METHOD apply (Ljava/lang/Object;)Ljava/lang/Object;
 			ARG 1 context
 	CLASS class_6773 HorizontalLazyAbstractPredicate
 	CLASS class_6774 FullLazyAbstractPredicate
 	CLASS class_6775 VerticalGradientMaterialCondition
-		FIELD field_35626 CONDITION_CODEC Lnet/minecraft/class_7243;
+		FIELD field_35626 CODEC Lnet/minecraft/class_7243;
 		METHOD apply (Ljava/lang/Object;)Ljava/lang/Object;
 			ARG 1 context
 		CLASS class_6776 VerticalGradientPredicate


### PR DESCRIPTION
Renames `RULE_CODEC` and `CONDITION_CODEC` to `CODEC`. I assume they were previously named in a redundant way to workaround FabricMC/Enigma#191.