### PR TITLE
Fix some noise sampler stuff

### DIFF
--- a/mappings/net/minecraft/util/math/noise/PerlinNoiseSampler.mapping
+++ b/mappings/net/minecraft/util/math/noise/PerlinNoiseSampler.mapping
@@ -16,8 +16,8 @@ CLASS net/minecraft/class_3756 net/minecraft/util/math/noise/PerlinNoiseSampler
 		ARG 1 x
 		ARG 3 y
 		ARG 5 z
-	METHOD method_16449 permutate (I)I
-		ARG 1 hash
+	METHOD method_16449 map (I)I
+		ARG 1 input
 	METHOD method_16450 sample (IIIDDDD)D
 		ARG 1 sectionX
 		ARG 2 sectionY

--- a/mappings/net/minecraft/util/math/noise/PerlinNoiseSampler.mapping
+++ b/mappings/net/minecraft/util/math/noise/PerlinNoiseSampler.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_3756 net/minecraft/util/math/noise/PerlinNoiseSampler
 	FIELD field_16588 originZ D
 	FIELD field_16589 originY D
-	FIELD field_16590 permutations [B
+	FIELD field_16590 permutation [B
 	FIELD field_16591 originX D
 	METHOD <init> (Lnet/minecraft/class_5819;)V
 		ARG 1 random
@@ -16,7 +16,7 @@ CLASS net/minecraft/class_3756 net/minecraft/util/math/noise/PerlinNoiseSampler
 		ARG 1 x
 		ARG 3 y
 		ARG 5 z
-	METHOD method_16449 getGradient (I)I
+	METHOD method_16449 permutate (I)I
 		ARG 1 hash
 	METHOD method_16450 sample (IIIDDDD)D
 		ARG 1 sectionX
@@ -25,7 +25,7 @@ CLASS net/minecraft/class_3756 net/minecraft/util/math/noise/PerlinNoiseSampler
 		ARG 4 localX
 		ARG 6 localY
 		ARG 8 localZ
-		ARG 10 fadeLocalX
+		ARG 10 fadeLocalY
 	METHOD method_33658 sample (DDD)D
 		ARG 1 x
 		ARG 3 y

--- a/mappings/net/minecraft/util/math/noise/SimplexNoiseSampler.mapping
+++ b/mappings/net/minecraft/util/math/noise/SimplexNoiseSampler.mapping
@@ -23,8 +23,8 @@ CLASS net/minecraft/class_3541 net/minecraft/util/math/noise/SimplexNoiseSampler
 		ARG 4 y
 		ARG 6 z
 		ARG 8 distance
-	METHOD method_16456 permutate (I)I
-		ARG 1 hash
+	METHOD method_16456 map (I)I
+		ARG 1 input
 	METHOD method_22416 sample (DDD)D
 		ARG 1 x
 		ARG 3 y

--- a/mappings/net/minecraft/util/math/noise/SimplexNoiseSampler.mapping
+++ b/mappings/net/minecraft/util/math/noise/SimplexNoiseSampler.mapping
@@ -3,14 +3,14 @@ CLASS net/minecraft/class_3541 net/minecraft/util/math/noise/SimplexNoiseSampler
 	FIELD field_15762 originY D
 	FIELD field_15763 originX D
 	FIELD field_15764 SQRT_3 D
-	FIELD field_15765 permutations [I
+	FIELD field_15765 permutation [I
 	FIELD field_15766 GRADIENTS [[I
 	FIELD field_15767 UNSKEW_FACTOR_2D D
 	FIELD field_15768 SKEW_FACTOR_2D D
 	METHOD <init> (Lnet/minecraft/class_5819;)V
 		ARG 1 random
 	METHOD method_15431 dot ([IDDD)D
-		ARG 0 gArr
+		ARG 0 gradient
 		ARG 1 x
 		ARG 3 y
 		ARG 5 z
@@ -23,7 +23,7 @@ CLASS net/minecraft/class_3541 net/minecraft/util/math/noise/SimplexNoiseSampler
 		ARG 4 y
 		ARG 6 z
 		ARG 8 distance
-	METHOD method_16456 getGradient (I)I
+	METHOD method_16456 permutate (I)I
 		ARG 1 hash
 	METHOD method_22416 sample (DDD)D
 		ARG 1 x

--- a/mappings/net/minecraft/world/gen/noise/NoiseHelper.mapping
+++ b/mappings/net/minecraft/world/gen/noise/NoiseHelper.mapping
@@ -4,10 +4,10 @@ CLASS net/minecraft/class_5836 net/minecraft/world/gen/noise/NoiseHelper
 		ARG 1 originX
 		ARG 3 originY
 		ARG 5 originZ
-		ARG 7 permutations
+		ARG 7 permutation
 	METHOD method_39120 appendDebugInfo (Ljava/lang/StringBuilder;DDD[I)V
 		ARG 0 builder
 		ARG 1 originX
 		ARG 3 originY
 		ARG 5 originZ
-		ARG 7 permutations
+		ARG 7 permutation


### PR DESCRIPTION
* `permutations` → `permutation`: This array as a whole represents a single permutation on a set `{0, ..., 255}`.
* `getGradient` → `map`: This is a wrapper around the permutation array access.
* `fadeLocalX` → `fadeLocalY`: Matching went wrong in [21w05a](https://github.com/FabricMC/yarn/commit/323e6f8e29e7064360fecb0037e076c5e073dc72#diff-f6ebd0f1c3d2486618a72a10f316557704b999fc1a224180614472fc254f2809L28-L30).
