### PR TITLE
Map rendering stuff

### DIFF
--- a/mappings/com/mojang/blaze3d/platform/GLX.mapping
+++ b/mappings/com/mojang/blaze3d/platform/GLX.mapping
@@ -13,6 +13,12 @@ CLASS com/mojang/blaze3d/platform/GLX
 		ARG 0 callback
 	METHOD _shouldClose (Lnet/minecraft/class_1041;)Z
 		ARG 0 window
+	METHOD lambda$_initGlfw$0 (Ljava/lang/Integer;Ljava/lang/String;)V
+		ARG 0 code
+		ARG 1 message
+	METHOD lambda$_initGlfw$1 (Ljava/util/List;IJ)V
+		ARG 1 code
+		ARG 2 pointer
 	METHOD make (Ljava/lang/Object;Ljava/util/function/Consumer;)Ljava/lang/Object;
 		ARG 0 object
 		ARG 1 initializer

--- a/mappings/com/mojang/blaze3d/platform/TextureUtil.mapping
+++ b/mappings/com/mojang/blaze3d/platform/TextureUtil.mapping
@@ -29,3 +29,9 @@ CLASS com/mojang/blaze3d/platform/TextureUtil
 		ARG 0 inputStream
 	METHOD releaseTextureId (I)V
 		ARG 0 id
+	METHOD writeAsPNG (Ljava/lang/String;IIII)V
+		ARG 0 filename
+		ARG 1 id
+		ARG 2 scales
+		ARG 3 width
+		ARG 4 height

--- a/mappings/com/mojang/blaze3d/systems/RenderSystem.mapping
+++ b/mappings/com/mojang/blaze3d/systems/RenderSystem.mapping
@@ -1,8 +1,32 @@
 CLASS com/mojang/blaze3d/systems/RenderSystem
+	METHOD _setShaderColor (FFFF)V
+		ARG 0 red
+		ARG 1 green
+		ARG 2 blue
+		ARG 3 alpha
+	METHOD _setShaderFogColor (FFFF)V
+		ARG 0 red
+		ARG 1 green
+		ARG 2 blue
+		ARG 3 alpha
+	METHOD _setShaderFogEnd (F)V
+		ARG 0 shaderFogEnd
+	METHOD _setShaderFogShape (Lnet/minecraft/class_6854;)V
+		ARG 0 shaderFogShape
+	METHOD _setShaderFogStart (F)V
+		ARG 0 shaderFogStart
+	METHOD _setShaderTexture (II)V
+		ARG 0 texture
+		ARG 1 glId
+	METHOD _setShaderTexture (ILnet/minecraft/class_2960;)V
+		ARG 0 texture
+		ARG 1 id
 	METHOD activeTexture (I)V
 		ARG 0 texture
 	METHOD bindTexture (I)V
 		ARG 0 texture
+	METHOD bindTextureForSetup (I)V
+		ARG 0 id
 	METHOD blendEquation (I)V
 		ARG 0 mode
 	METHOD blendFunc (II)V
@@ -31,6 +55,8 @@ CLASS com/mojang/blaze3d/systems/RenderSystem
 		ARG 3 alpha
 	METHOD clearDepth (D)V
 		ARG 0 depth
+	METHOD clearStencil (I)V
+		ARG 0 stencil
 	METHOD colorMask (ZZZZ)V
 		ARG 0 red
 		ARG 1 green
@@ -46,18 +72,38 @@ CLASS com/mojang/blaze3d/systems/RenderSystem
 		ARG 0 mode
 		ARG 1 count
 		ARG 2 type
+	METHOD enableScissor (IIII)V
+		ARG 0 x
+		ARG 1 y
+		ARG 2 width
+		ARG 3 height
 	METHOD flipFrame (J)V
 		ARG 0 window
+	METHOD getSequentialBuffer (Lnet/minecraft/class_293$class_5596;)Lcom/mojang/blaze3d/systems/RenderSystem$class_5590;
+		ARG 0 drawMode
+	METHOD getShaderTexture (I)I
+		ARG 0 texture
 	METHOD getString (ILjava/util/function/Consumer;)V
 		ARG 0 name
 		ARG 1 consumer
+	METHOD getTextureId (I)I
+		ARG 0 texture
+	METHOD glBindBuffer (ILjava/util/function/IntSupplier;)V
+		ARG 0 target
+		ARG 1 bufferSupplier
+	METHOD glBindVertexArray (Ljava/util/function/Supplier;)V
+		ARG 0 arraySupplier
 	METHOD glBufferData (ILjava/nio/ByteBuffer;I)V
 		ARG 0 target
 		ARG 1 data
 		ARG 2 usage
 	METHOD glDeleteBuffers (I)V
 		ARG 0 buffer
+	METHOD glDeleteVertexArrays (I)V
+		ARG 0 array
 	METHOD glGenBuffers (Ljava/util/function/Consumer;)V
+		ARG 0 consumer
+	METHOD glGenVertexArrays (Ljava/util/function/Consumer;)V
 		ARG 0 consumer
 	METHOD glUniform1 (ILjava/nio/FloatBuffer;)V
 		ARG 0 location
@@ -103,6 +149,12 @@ CLASS com/mojang/blaze3d/systems/RenderSystem
 	METHOD initRenderer (IZ)V
 		ARG 0 debugVerbosity
 		ARG 1 debugSync
+	METHOD lambda$static$0 (Lit/unimi/dsi/fastutil/ints/IntConsumer;I)V
+		ARG 0 indexConsumer
+		ARG 1 vertexCount
+	METHOD lambda$static$1 (Lit/unimi/dsi/fastutil/ints/IntConsumer;I)V
+		ARG 0 indexConsumer
+		ARG 1 vertexCount
 	METHOD limitDisplayFPS (I)V
 		ARG 0 fps
 	METHOD lineWidth (F)V
@@ -112,6 +164,9 @@ CLASS com/mojang/blaze3d/systems/RenderSystem
 	METHOD pixelStore (II)V
 		ARG 0 pname
 		ARG 1 param
+	METHOD polygonMode (II)V
+		ARG 0 face
+		ARG 1 mode
 	METHOD polygonOffset (FF)V
 		ARG 0 factor
 		ARG 1 units
@@ -127,8 +182,47 @@ CLASS com/mojang/blaze3d/systems/RenderSystem
 		ARG 0 renderCall
 	METHOD renderCrosshair (I)V
 		ARG 0 size
+	METHOD runAsFancy (Ljava/lang/Runnable;)V
+		ARG 0 runnable
 	METHOD setErrorCallback (Lorg/lwjgl/glfw/GLFWErrorCallbackI;)V
 		ARG 0 callback
+	METHOD setInverseViewRotationMatrix (Lnet/minecraft/class_4581;)V
+		ARG 0 inverseViewRotationMatrix
+	METHOD setProjectionMatrix (Lnet/minecraft/class_1159;)V
+		ARG 0 projectionMatrix
+	METHOD setShader (Ljava/util/function/Supplier;)V
+		ARG 0 shaderSupplier
+	METHOD setShaderColor (FFFF)V
+		ARG 0 red
+		ARG 1 green
+		ARG 2 blue
+		ARG 3 alpha
+	METHOD setShaderFogColor (FFF)V
+		ARG 0 red
+		ARG 1 green
+		ARG 2 blue
+	METHOD setShaderFogColor (FFFF)V
+		ARG 0 red
+		ARG 1 green
+		ARG 2 blue
+		ARG 3 alpha
+	METHOD setShaderFogEnd (F)V
+		ARG 0 shaderFogEnd
+	METHOD setShaderFogShape (Lnet/minecraft/class_6854;)V
+		ARG 0 shaderFogShape
+	METHOD setShaderFogStart (F)V
+		ARG 0 shaderFogStart
+	METHOD setShaderGameTime (JF)V
+		ARG 0 time
+		ARG 2 tickDelta
+	METHOD setShaderTexture (II)V
+		ARG 0 texture
+		ARG 1 glId
+	METHOD setShaderTexture (ILnet/minecraft/class_2960;)V
+		ARG 0 texture
+		ARG 1 id
+	METHOD setTextureMatrix (Lnet/minecraft/class_1159;)V
+		ARG 0 textureMatrix
 	METHOD setupDefaultState (IIII)V
 		ARG 0 x
 		ARG 1 y
@@ -137,10 +231,14 @@ CLASS com/mojang/blaze3d/systems/RenderSystem
 	METHOD setupOverlayColor (Ljava/util/function/IntSupplier;I)V
 		ARG 0 texture
 		ARG 1 size
+	METHOD setupShaderLights (Lnet/minecraft/class_5944;)V
+		ARG 0 shader
 	METHOD stencilFunc (III)V
 		ARG 0 func
 		ARG 1 ref
 		ARG 2 mask
+	METHOD stencilMask (I)V
+		ARG 0 mask
 	METHOD stencilOp (III)V
 		ARG 0 sfail
 		ARG 1 dpfail
@@ -161,11 +259,23 @@ CLASS com/mojang/blaze3d/systems/RenderSystem
 		FIELD field_27335 id I
 		FIELD field_27336 elementFormat Lnet/minecraft/class_293$class_5595;
 		FIELD field_27337 size I
+		METHOD <init> (IILcom/mojang/blaze3d/systems/RenderSystem$class_5590$class_5591;)V
+			ARG 1 sizeMultiplier
+			ARG 2 increment
+			ARG 3 indexMapper
 		METHOD method_31920 grow (I)V
 			ARG 1 newSize
 		METHOD method_31922 getIndexConsumer (Ljava/nio/ByteBuffer;)Lit/unimi/dsi/fastutil/ints/IntConsumer;
 			ARG 1 indicesBuffer
+		METHOD method_31923 (Ljava/nio/ByteBuffer;I)V
+			ARG 1 index
 		METHOD method_31924 getElementFormat ()Lnet/minecraft/class_293$class_5595;
+		METHOD method_31925 (Ljava/nio/ByteBuffer;I)V
+			ARG 1 index
+		METHOD method_43409 isSizeLessThanOrEqual (I)Z
+			ARG 1 size
+		METHOD method_43410 bindAndGrow (I)V
+			ARG 1 newSize
 		CLASS class_5591 IndexMapper
 			METHOD accept (Lit/unimi/dsi/fastutil/ints/IntConsumer;I)V
 				ARG 1 indexConsumer

--- a/mappings/net/minecraft/client/gl/Framebuffer.mapping
+++ b/mappings/net/minecraft/client/gl/Framebuffer.mapping
@@ -18,6 +18,7 @@ CLASS net/minecraft/class_276 net/minecraft/client/gl/Framebuffer
 		ARG 2 height
 		ARG 3 getError
 	METHOD method_1232 setTexFilter (I)V
+		ARG 1 texFilter
 	METHOD method_1233 drawInternal (IIZ)V
 		ARG 1 width
 		ARG 2 height

--- a/mappings/net/minecraft/client/gl/GLImportProcessor.mapping
+++ b/mappings/net/minecraft/client/gl/GLImportProcessor.mapping
@@ -30,6 +30,13 @@ CLASS net/minecraft/class_5913 net/minecraft/client/gl/GLImportProcessor
 		COMMENT Called to load an import reference's source code.
 		ARG 1 inline
 		ARG 2 name
+	METHOD method_36423 isLineValid (Ljava/lang/String;Ljava/util/regex/Matcher;)Z
+		ARG 0 line
+		ARG 1 matcher
+	METHOD method_36424 hasBogusString (Ljava/lang/String;Ljava/util/regex/Matcher;I)Z
+		ARG 0 string
+		ARG 1 matcher
+		ARG 2 matchEnd
 	CLASS class_5914 Context
 		COMMENT A context for the parser to keep track of its current line and caret position in the file.
 		FIELD field_29202 column I

--- a/mappings/net/minecraft/client/gl/GlBlendState.mapping
+++ b/mappings/net/minecraft/client/gl/GlBlendState.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_277 net/minecraft/client/gl/GlBlendState
 	FIELD field_1484 activeBlendState Lnet/minecraft/class_277;
 	FIELD field_1485 blendDisabled Z
-	FIELD field_1486 func I
+	FIELD field_1486 mode I
 	FIELD field_1487 separateBlend Z
 	FIELD field_1488 dstAlpha I
 	FIELD field_1489 dstRgb I
@@ -24,12 +24,12 @@ CLASS net/minecraft/class_277 net/minecraft/client/gl/GlBlendState
 		ARG 4 dstRgb
 		ARG 5 srcAlpha
 		ARG 6 dstAlpha
-		ARG 7 func
+		ARG 7 mode
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o
-	METHOD method_1243 getComponentFromString (Ljava/lang/String;)I
+	METHOD method_1243 getFactorFromString (Ljava/lang/String;)I
 		ARG 0 expression
 	METHOD method_1244 enable ()V
 	METHOD method_1245 isBlendDisabled ()Z
-	METHOD method_1247 getFuncFromString (Ljava/lang/String;)I
+	METHOD method_1247 getModeFromString (Ljava/lang/String;)I
 		ARG 0 name

--- a/mappings/net/minecraft/client/gl/Program.mapping
+++ b/mappings/net/minecraft/client/gl/Program.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/class_281 net/minecraft/client/gl/Program
 	FIELD field_1523 shaderRef I
 	FIELD field_1524 shaderType Lnet/minecraft/class_281$class_282;
 	FIELD field_1525 name Ljava/lang/String;
+	FIELD field_32037 MAX_SHADER_INFO_LOG_LENGTH I
 	METHOD <init> (Lnet/minecraft/class_281$class_282;ILjava/lang/String;)V
 		ARG 1 shaderType
 		ARG 2 shaderRef

--- a/mappings/net/minecraft/client/gl/ShaderEffect.mapping
+++ b/mappings/net/minecraft/client/gl/ShaderEffect.mapping
@@ -15,10 +15,10 @@ CLASS net/minecraft/class_279 net/minecraft/client/gl/ShaderEffect
 		ARG 1 textureManager
 		ARG 2 resourceManager
 		ARG 3 framebuffer
-		ARG 4 location
+		ARG 4 id
 	METHOD method_1256 parseEffect (Lnet/minecraft/class_1060;Lnet/minecraft/class_2960;)V
 		ARG 1 textureManager
-		ARG 2 location
+		ARG 2 id
 	METHOD method_1257 parsePass (Lnet/minecraft/class_1060;Lcom/google/gson/JsonElement;)V
 		ARG 1 textureManager
 		ARG 2 jsonPass

--- a/mappings/net/minecraft/client/gl/Uniform.mapping
+++ b/mappings/net/minecraft/client/gl/Uniform.mapping
@@ -19,7 +19,7 @@ CLASS net/minecraft/class_278 net/minecraft/client/gl/Uniform
 		ARG 4 value4
 	METHOD method_1253 set ([F)V
 		ARG 1 values
-	METHOD method_1254 set (FFFF)V
+	METHOD method_1254 setAndFlip (FFFF)V
 		ARG 1 value1
 		ARG 2 value2
 		ARG 3 value3
@@ -130,8 +130,10 @@ CLASS net/minecraft/class_278 net/minecraft/client/gl/Uniform
 		ARG 2 value2
 		ARG 3 value3
 		ARG 4 value4
-	METHOD method_35657 (FFFF)V
+	METHOD method_35657 set (FFFF)V
 		ARG 1 value1
 		ARG 2 value2
 		ARG 3 value3
 		ARG 4 value4
+	METHOD method_39978 set (Lnet/minecraft/class_4581;)V
+		ARG 1 values

--- a/mappings/net/minecraft/client/gl/VertexBuffer.mapping
+++ b/mappings/net/minecraft/client/gl/VertexBuffer.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/class_291 net/minecraft/client/gl/VertexBuffer
 	FIELD field_27368 drawMode Lnet/minecraft/class_293$class_5596;
 	FIELD field_29338 vertexArrayId I
 	FIELD field_29339 vertexFormat Lnet/minecraft/class_293;
+	FIELD field_38983 indexBuffer Lcom/mojang/blaze3d/systems/RenderSystem$class_5590;
 	METHOD method_1352 upload (Lnet/minecraft/class_287;)V
 		ARG 1 buffer
 	METHOD method_1353 bind ()V
@@ -13,15 +14,27 @@ CLASS net/minecraft/class_291 net/minecraft/client/gl/VertexBuffer
 	METHOD method_22643 submitUpload (Lnet/minecraft/class_287;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 buffer
 	METHOD method_22644 uploadInternal (Lnet/minecraft/class_287;)V
-	METHOD method_34427 setShader (Lnet/minecraft/class_1159;Lnet/minecraft/class_1159;Lnet/minecraft/class_5944;)V
+		ARG 1 builder
+	METHOD method_34427 draw (Lnet/minecraft/class_1159;Lnet/minecraft/class_1159;Lnet/minecraft/class_5944;)V
 		ARG 1 viewMatrix
 		ARG 2 projectionMatrix
 		ARG 3 shader
 	METHOD method_34429 (Ljava/lang/Runnable;)V
 		ARG 0 action
-	METHOD method_34431 innerSetShader (Lnet/minecraft/class_1159;Lnet/minecraft/class_1159;Lnet/minecraft/class_5944;)V
+	METHOD method_34431 drawInternal (Lnet/minecraft/class_1159;Lnet/minecraft/class_1159;Lnet/minecraft/class_5944;)V
 		ARG 1 viewMatrix
 		ARG 2 projectionMatrix
 		ARG 3 shader
 	METHOD method_34435 getVertexFormat ()Lnet/minecraft/class_293;
 	METHOD method_35665 drawElements ()V
+	METHOD method_43441 setFromParameters (Lnet/minecraft/class_287$class_4574;Ljava/nio/ByteBuffer;)V
+		ARG 1 parameters
+		ARG 2 data
+	METHOD method_43442 configureVertexFormat (Lnet/minecraft/class_287$class_4574;Ljava/nio/ByteBuffer;)Lnet/minecraft/class_293;
+		ARG 1 parameters
+		ARG 2 data
+	METHOD method_43443 configureIndexBuffer (Lnet/minecraft/class_287$class_4574;Ljava/nio/ByteBuffer;)Lcom/mojang/blaze3d/systems/RenderSystem$class_5590;
+		ARG 1 parameters
+		ARG 2 data
+	METHOD method_43444 isClosed ()Z
+	METHOD method_43445 getElementFormat ()Lnet/minecraft/class_293$class_5595;

--- a/mappings/net/minecraft/client/gl/WindowFramebuffer.mapping
+++ b/mappings/net/minecraft/client/gl/WindowFramebuffer.mapping
@@ -5,9 +5,9 @@ CLASS net/minecraft/class_6364 net/minecraft/client/gl/WindowFramebuffer
 	METHOD <init> (II)V
 		ARG 1 width
 		ARG 2 height
-	METHOD method_36801 supportColor (Lnet/minecraft/class_6364$class_6366;)Z
+	METHOD method_36801 supportsColor (Lnet/minecraft/class_6364$class_6366;)Z
 		ARG 1 size
-	METHOD method_36802 initSize (II)V
+	METHOD method_36802 init (II)V
 		ARG 1 width
 		ARG 2 height
 	METHOD method_36803 supportsDepth (Lnet/minecraft/class_6364$class_6366;)Z

--- a/mappings/net/minecraft/client/render/BackgroundRenderer.mapping
+++ b/mappings/net/minecraft/client/render/BackgroundRenderer.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_758 net/minecraft/client/render/BackgroundRenderer
+	FIELD field_38338 FOG_MODIFIERS Ljava/util/List;
 	FIELD field_4031 waterFogColor I
 	FIELD field_4032 blue F
 	FIELD field_4033 green F
@@ -21,8 +22,13 @@ CLASS net/minecraft/class_758 net/minecraft/client/render/BackgroundRenderer
 		ARG 1 fogType
 		ARG 2 viewDistance
 		ARG 3 thickFog
+		ARG 4 tickDelta
 	METHOD method_3212 setFogBlack ()V
 	METHOD method_42588 getFogModifier (Lnet/minecraft/class_1297;F)Lnet/minecraft/class_758$class_7286;
+		ARG 0 entity
+		ARG 1 tickDelta
+	METHOD method_42589 (Lnet/minecraft/class_1309;FLnet/minecraft/class_758$class_7286;)Z
+		ARG 2 modifier
 	CLASS class_4596 FogType
 	CLASS class_7283 BlindnessFogModifier
 	CLASS class_7284 DarknessFogModifier
@@ -30,8 +36,21 @@ CLASS net/minecraft/class_758 net/minecraft/client/render/BackgroundRenderer
 		FIELD field_38339 fogType Lnet/minecraft/class_758$class_4596;
 		FIELD field_38340 fogStart F
 		FIELD field_38341 fogEnd F
+		FIELD field_38342 fogShape Lnet/minecraft/class_6854;
+		METHOD <init> (Lnet/minecraft/class_758$class_4596;)V
+			ARG 1 fogType
 	CLASS class_7286 StatusEffectFogModifier
 		METHOD method_42590 getStatusEffect ()Lnet/minecraft/class_1291;
 		METHOD method_42591 applyStartEndModifier (Lnet/minecraft/class_758$class_7285;Lnet/minecraft/class_1309;Lnet/minecraft/class_1293;FF)V
+			ARG 1 fogData
+			ARG 2 entity
+			ARG 3 effect
+			ARG 4 viewDistance
+			ARG 5 tickDelta
 		METHOD method_42592 applyColorModifier (Lnet/minecraft/class_1309;Lnet/minecraft/class_1293;FF)F
+			ARG 1 entity
+			ARG 2 effect
+			ARG 4 tickDelta
 		METHOD method_42593 shouldApply (Lnet/minecraft/class_1309;F)Z
+			ARG 1 entity
+			ARG 2 tickDelta

--- a/mappings/net/minecraft/client/render/BufferBuilder.mapping
+++ b/mappings/net/minecraft/client/render/BufferBuilder.mapping
@@ -34,6 +34,9 @@ CLASS net/minecraft/class_287 net/minecraft/client/render/BufferBuilder
 	METHOD method_1343 clear ()V
 	METHOD method_16005 roundBufferSize (I)I
 		ARG 0 amount
+	METHOD method_22625 ([FII)I
+		ARG 1 a
+		ARG 2 b
 	METHOD method_22632 popData ()Lcom/mojang/datafixers/util/Pair;
 	METHOD method_22892 grow ()V
 	METHOD method_22893 isBuilding ()Z
@@ -81,6 +84,10 @@ CLASS net/minecraft/class_287 net/minecraft/client/render/BufferBuilder
 		METHOD method_31959 hasNoVertexBuffer ()Z
 		METHOD method_31960 hasNoIndexBuffer ()Z
 		METHOD method_31961 getIndexBufferLength ()I
+		METHOD method_43429 getVertexBufferPosition ()I
+		METHOD method_43430 getVertexBufferLimit ()I
+		METHOD method_43431 getIndexBufferPosition ()I
+		METHOD method_43432 getIndexBufferLimit ()I
 	CLASS class_5594 State
 		FIELD field_27358 drawMode Lnet/minecraft/class_293$class_5596;
 		FIELD field_27359 vertexCount I

--- a/mappings/net/minecraft/client/render/BufferRenderer.mapping
+++ b/mappings/net/minecraft/client/render/BufferRenderer.mapping
@@ -1,16 +1,16 @@
 CLASS net/minecraft/class_286 net/minecraft/client/render/BufferRenderer
 	FIELD field_38982 currentVertexBuffer Lnet/minecraft/class_291;
 	METHOD method_34420 unbindAll ()V
-	METHOD method_43433 draw (Lnet/minecraft/class_287;)V
+	METHOD method_43433 drawWithShader (Lnet/minecraft/class_287;)V
 		ARG 0 builder
 	METHOD method_43434 bindAndSet (Lnet/minecraft/class_291;)V
 		ARG 0 vertexBuffer
 	METHOD method_43435 bindAndSet (Lnet/minecraft/class_293;)Lnet/minecraft/class_291;
 		ARG 0 vertexFormat
 	METHOD method_43436 resetCurrentVertexBuffer ()V
-	METHOD method_43437 postDraw (Lnet/minecraft/class_287;)V
+	METHOD method_43437 drawWithoutShader (Lnet/minecraft/class_287;)V
 		ARG 0 builder
-	METHOD method_43438 drawInternal (Lnet/minecraft/class_287;)V
+	METHOD method_43438 drawWithShaderInternal (Lnet/minecraft/class_287;)V
 		ARG 0 builder
 	METHOD method_43439 getVertexBuffer (Lnet/minecraft/class_287;)Lnet/minecraft/class_291;
 		ARG 0 builder

--- a/mappings/net/minecraft/client/render/BufferRenderer.mapping
+++ b/mappings/net/minecraft/client/render/BufferRenderer.mapping
@@ -1,2 +1,16 @@
 CLASS net/minecraft/class_286 net/minecraft/client/render/BufferRenderer
+	FIELD field_38982 currentVertexBuffer Lnet/minecraft/class_291;
 	METHOD method_34420 unbindAll ()V
+	METHOD method_43433 draw (Lnet/minecraft/class_287;)V
+		ARG 0 builder
+	METHOD method_43434 bindAndSet (Lnet/minecraft/class_291;)V
+		ARG 0 vertexBuffer
+	METHOD method_43435 bindAndSet (Lnet/minecraft/class_293;)Lnet/minecraft/class_291;
+		ARG 0 vertexFormat
+	METHOD method_43436 resetCurrentVertexBuffer ()V
+	METHOD method_43437 postDraw (Lnet/minecraft/class_287;)V
+		ARG 0 builder
+	METHOD method_43438 drawInternal (Lnet/minecraft/class_287;)V
+		ARG 0 builder
+	METHOD method_43439 getVertexBuffer (Lnet/minecraft/class_287;)Lnet/minecraft/class_291;
+		ARG 0 builder

--- a/mappings/net/minecraft/client/render/Frustum.mapping
+++ b/mappings/net/minecraft/client/render/Frustum.mapping
@@ -3,6 +3,11 @@ CLASS net/minecraft/class_4604 net/minecraft/client/render/Frustum
 	FIELD field_20995 x D
 	FIELD field_20996 y D
 	FIELD field_20997 z D
+	METHOD <init> (Lnet/minecraft/class_1159;Lnet/minecraft/class_1159;)V
+		ARG 1 positionMatrix
+		ARG 2 projectionMatrix
+	METHOD <init> (Lnet/minecraft/class_4604;)V
+		ARG 1 frustum
 	METHOD method_23088 setPosition (DDD)V
 		ARG 1 cameraX
 		ARG 3 cameraY
@@ -28,5 +33,7 @@ CLASS net/minecraft/class_4604 net/minecraft/client/render/Frustum
 		ARG 4 z
 		ARG 5 index
 	METHOD method_23092 init (Lnet/minecraft/class_1159;Lnet/minecraft/class_1159;)V
+		ARG 1 positionMatrix
+		ARG 2 projectionMatrix
 	METHOD method_23093 isVisible (Lnet/minecraft/class_238;)Z
 		ARG 1 box

--- a/mappings/net/minecraft/client/render/GameRenderer.mapping
+++ b/mappings/net/minecraft/client/render/GameRenderer.mapping
@@ -296,12 +296,16 @@ CLASS net/minecraft/class_757 net/minecraft/client/render/GameRenderer
 		ARG 0 shader
 	METHOD method_36511 (Lnet/minecraft/class_5944;)V
 		ARG 0 shader
+	METHOD method_36512 (Lcom/mojang/datafixers/util/Pair;)V
+		ARG 1 pair
 	METHOD method_36513 (Lnet/minecraft/class_5944;)V
 		ARG 0 shader
 	METHOD method_36514 (Lnet/minecraft/class_5944;)V
 		ARG 0 shader
 	METHOD method_36515 (Lnet/minecraft/class_5944;)V
 		ARG 0 shader
+	METHOD method_36516 (Lcom/mojang/datafixers/util/Pair;)V
+		ARG 0 pair
 	METHOD method_36517 (Lnet/minecraft/class_5944;)V
 		ARG 0 shader
 	METHOD method_36518 (Lnet/minecraft/class_5944;)V

--- a/mappings/net/minecraft/client/render/LightmapTextureManager.mapping
+++ b/mappings/net/minecraft/client/render/LightmapTextureManager.mapping
@@ -23,6 +23,8 @@ CLASS net/minecraft/class_765 net/minecraft/client/render/LightmapTextureManager
 		ARG 1 renderer
 		ARG 2 client
 	METHOD method_23284 getBrightness (Lnet/minecraft/class_2874;I)F
+		ARG 0 type
+		ARG 1 lightLevel
 	METHOD method_23687 pack (II)I
 		ARG 0 block
 		ARG 1 sky
@@ -46,4 +48,8 @@ CLASS net/minecraft/class_765 net/minecraft/client/render/LightmapTextureManager
 	METHOD method_3315 disable ()V
 	METHOD method_3316 enable ()V
 	METHOD method_42596 getDarkness (Lnet/minecraft/class_1309;FF)F
+		ARG 1 entity
+		ARG 2 factor
+		ARG 3 delta
 	METHOD method_42597 getDarknessFactor (F)F
+		ARG 1 delta

--- a/mappings/net/minecraft/client/render/MapRenderer.mapping
+++ b/mappings/net/minecraft/client/render/MapRenderer.mapping
@@ -18,6 +18,9 @@ CLASS net/minecraft/class_330 net/minecraft/client/render/MapRenderer
 		ARG 4 state
 		ARG 5 hidePlayerIcons
 		ARG 6 light
+	METHOD method_32600 (Lnet/minecraft/class_22;Ljava/lang/Integer;Lnet/minecraft/class_330$class_331;)Lnet/minecraft/class_330$class_331;
+		ARG 2 id2
+		ARG 3 texture
 	METHOD method_32601 getMapTexture (ILnet/minecraft/class_22;)Lnet/minecraft/class_330$class_331;
 		ARG 1 id
 		ARG 2 state

--- a/mappings/net/minecraft/client/render/RenderLayer.mapping
+++ b/mappings/net/minecraft/client/render/RenderLayer.mapping
@@ -34,6 +34,7 @@ CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 	FIELD field_34002 TEXT_POLYGON_OFFSET Ljava/util/function/Function;
 	FIELD field_34003 TEXT_INTENSITY_POLYGON_OFFSET Ljava/util/function/Function;
 	FIELD field_38345 ENTITY_TRANSLUCENT_EMISSIVE Ljava/util/function/BiFunction;
+	FIELD field_39002 BLOCK_LAYERS Lcom/google/common/collect/ImmutableList;
 	METHOD <init> (Ljava/lang/String;Lnet/minecraft/class_293;Lnet/minecraft/class_293$class_5596;IZZLjava/lang/Runnable;Ljava/lang/Runnable;)V
 		ARG 1 name
 		ARG 2 vertexFormat
@@ -211,6 +212,7 @@ CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 		ARG 1 affectsOutline
 	METHOD method_42600 getEntityTranslucentEmissive (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
 		ARG 0 texture
+	METHOD method_43332 isNotStrip ()Z
 	CLASS class_4687 MultiPhase
 		FIELD field_21403 phases Lnet/minecraft/class_1921$class_4688;
 		FIELD field_21697 affectedOutline Ljava/util/Optional;

--- a/mappings/net/minecraft/client/render/RenderLayer.mapping
+++ b/mappings/net/minecraft/client/render/RenderLayer.mapping
@@ -212,7 +212,7 @@ CLASS net/minecraft/class_1921 net/minecraft/client/render/RenderLayer
 		ARG 1 affectsOutline
 	METHOD method_42600 getEntityTranslucentEmissive (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1921;
 		ARG 0 texture
-	METHOD method_43332 isNotStrip ()Z
+	METHOD method_43332 areVerticesNotShared ()Z
 	CLASS class_4687 MultiPhase
 		FIELD field_21403 phases Lnet/minecraft/class_1921$class_4688;
 		FIELD field_21697 affectedOutline Ljava/util/Optional;

--- a/mappings/net/minecraft/client/render/RenderPhase.mapping
+++ b/mappings/net/minecraft/client/render/RenderPhase.mapping
@@ -154,6 +154,8 @@ CLASS net/minecraft/class_4668 net/minecraft/client/render/RenderPhase
 		METHOD method_23564 getId ()Ljava/util/Optional;
 	CLASS class_5940 Textures
 		FIELD field_29453 id Ljava/util/Optional;
+		METHOD <init> (Lcom/google/common/collect/ImmutableList;)V
+			ARG 1 textures
 		METHOD method_34560 create ()Lnet/minecraft/class_4668$class_5940$class_5941;
 		CLASS class_5941 Builder
 			FIELD field_29454 textures Lcom/google/common/collect/ImmutableList$Builder;

--- a/mappings/net/minecraft/client/render/VertexFormat.mapping
+++ b/mappings/net/minecraft/client/render/VertexFormat.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/class_293 net/minecraft/client/render/VertexFormat
 	FIELD field_1600 size I
 	FIELD field_1602 elements Lcom/google/common/collect/ImmutableList;
 	FIELD field_29340 elementMap Lcom/google/common/collect/ImmutableMap;
+	FIELD field_38984 buffer Lnet/minecraft/class_291;
 	METHOD <init> (Lcom/google/common/collect/ImmutableMap;)V
 		ARG 1 elementMap
 	METHOD equals (Ljava/lang/Object;)Z
@@ -15,6 +16,7 @@ CLASS net/minecraft/class_293 net/minecraft/client/render/VertexFormat
 	METHOD method_34445 getShaderAttributes ()Lcom/google/common/collect/ImmutableList;
 	METHOD method_34449 innerStartDrawing ()V
 	METHOD method_34450 innerEndDrawing ()V
+	METHOD method_43446 getBuffer ()Lnet/minecraft/class_291;
 	CLASS class_5595 IntType
 		FIELD field_27374 type I
 		FIELD field_27375 size I
@@ -31,9 +33,11 @@ CLASS net/minecraft/class_293 net/minecraft/client/render/VertexFormat
 		FIELD field_27383 mode I
 		FIELD field_27384 vertexCount I
 		FIELD field_27385 size I
+		FIELD field_38878 strip Z
 		METHOD <init> (Ljava/lang/String;IIIIZ)V
 			ARG 3 mode
 			ARG 4 vertexCount
 			ARG 5 size
+			ARG 6 strip
 		METHOD method_31973 getSize (I)I
 			ARG 1 vertexCount

--- a/mappings/net/minecraft/client/render/VertexFormat.mapping
+++ b/mappings/net/minecraft/client/render/VertexFormat.mapping
@@ -33,11 +33,11 @@ CLASS net/minecraft/class_293 net/minecraft/client/render/VertexFormat
 		FIELD field_27383 mode I
 		FIELD field_27384 vertexCount I
 		FIELD field_27385 size I
-		FIELD field_38878 strip Z
+		FIELD field_38878 shareVertices Z
 		METHOD <init> (Ljava/lang/String;IIIIZ)V
 			ARG 3 mode
 			ARG 4 vertexCount
 			ARG 5 size
-			ARG 6 strip
+			ARG 6 shareVertices
 		METHOD method_31973 getSize (I)I
 			ARG 1 vertexCount

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -115,9 +115,9 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	METHOD method_22714 renderWeather (Lnet/minecraft/class_765;FDDD)V
 		ARG 1 manager
 		ARG 2 tickDelta
-		ARG 3 x
-		ARG 5 y
-		ARG 7 z
+		ARG 3 cameraX
+		ARG 5 cameraY
+		ARG 7 cameraZ
 	METHOD method_22977 renderEntity (Lnet/minecraft/class_1297;DDDFLnet/minecraft/class_4587;Lnet/minecraft/class_4597;)V
 		ARG 1 entity
 		ARG 2 cameraX

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
+	FIELD field_20793 rainSoundCounter I
 	FIELD field_20797 RAIN Lnet/minecraft/class_2960;
 	FIELD field_20798 SNOW Lnet/minecraft/class_2960;
 	FIELD field_20950 blockBreakingProgressions Lit/unimi/dsi/fastutil/longs/Long2ObjectMap;
@@ -13,7 +14,12 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	FIELD field_27740 frustum Lnet/minecraft/class_4604;
 	FIELD field_27741 blockEntityRenderDispatcher Lnet/minecraft/class_824;
 	FIELD field_34807 chunkInfos Lit/unimi/dsi/fastutil/objects/ObjectArrayList;
+	FIELD field_34808 fullUpdateFuture Ljava/util/concurrent/Future;
+	FIELD field_34809 updateFinished Ljava/util/concurrent/atomic/AtomicBoolean;
+	FIELD field_34810 shouldUpdate Z
+	FIELD field_34811 nextUpdateTime Ljava/util/concurrent/atomic/AtomicLong;
 	FIELD field_34816 builtChunks Ljava/util/concurrent/BlockingQueue;
+	FIELD field_34817 renderableChunks Ljava/util/concurrent/atomic/AtomicReference;
 	FIELD field_4055 noCullingBlockEntities Ljava/util/Set;
 	FIELD field_4056 capturedFrustum Lnet/minecraft/class_4604;
 	FIELD field_4058 blockBreakingInfos Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
@@ -97,13 +103,21 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 		ARG 9 positionMatrix
 	METHOD method_22712 drawBlockOutline (Lnet/minecraft/class_4587;Lnet/minecraft/class_4588;Lnet/minecraft/class_1297;DDDLnet/minecraft/class_2338;Lnet/minecraft/class_2680;)V
 		ARG 1 matrices
+		ARG 2 vertexConsumer
 		ARG 3 entity
+		ARG 4 cameraX
+		ARG 6 cameraY
+		ARG 8 cameraZ
 		ARG 10 pos
 		ARG 11 state
 	METHOD method_22713 tickRainSplashing (Lnet/minecraft/class_4184;)V
 		ARG 1 camera
 	METHOD method_22714 renderWeather (Lnet/minecraft/class_765;FDDD)V
 		ARG 1 manager
+		ARG 2 tickDelta
+		ARG 3 x
+		ARG 5 y
+		ARG 7 z
 	METHOD method_22977 renderEntity (Lnet/minecraft/class_1297;DDDFLnet/minecraft/class_4587;Lnet/minecraft/class_4597;)V
 		ARG 1 entity
 		ARG 2 cameraX
@@ -161,6 +175,17 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 		ARG 4 green
 		ARG 5 blue
 		ARG 6 alpha
+	METHOD method_22983 drawShapeOutline (Lnet/minecraft/class_4587;Lnet/minecraft/class_4588;Lnet/minecraft/class_265;DDDFFFF)V
+		ARG 0 matrices
+		ARG 1 vertexConsumer
+		ARG 2 shape
+		ARG 3 offsetX
+		ARG 5 offsetY
+		ARG 7 offsetZ
+		ARG 9 red
+		ARG 10 green
+		ARG 11 blue
+		ARG 12 alpha
 	METHOD method_22986 (Lnet/minecraft/class_4597$class_4598;Lnet/minecraft/class_4588;Lnet/minecraft/class_1921;)Lnet/minecraft/class_4588;
 		ARG 2 renderLayer
 	METHOD method_22987 removeBlockBreakingInfo (Lnet/minecraft/class_3191;)V
@@ -216,6 +241,9 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	METHOD method_3251 renderLayer (Lnet/minecraft/class_1921;Lnet/minecraft/class_4587;DDDLnet/minecraft/class_1159;)V
 		ARG 1 renderLayer
 		ARG 2 matrices
+		ARG 3 cameraX
+		ARG 5 cameraY
+		ARG 7 cameraZ
 		ARG 9 positionMatrix
 	METHOD method_3252 tick ()V
 	METHOD method_3254 drawEntityOutlinesFramebuffer ()V
@@ -270,6 +298,13 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 		ARG 10 velocityY
 		ARG 12 velocityZ
 	METHOD method_3277 renderLightSky ()V
+	METHOD method_3278 (Lnet/minecraft/class_4588;Lnet/minecraft/class_4587$class_4665;DDDFFFFDDDDDD)V
+		ARG 12 minX
+		ARG 14 minY
+		ARG 16 minZ
+		ARG 18 maxX
+		ARG 20 maxY
+		ARG 22 maxZ
 	METHOD method_3279 reload ()V
 	METHOD method_3281 isTerrainRenderComplete ()Z
 	METHOD method_3282 spawnParticle (Lnet/minecraft/class_2394;ZDDDDDD)Lnet/minecraft/class_703;
@@ -292,8 +327,17 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 		ARG 12 velocityY
 		ARG 14 velocityZ
 	METHOD method_3289 getChunksDebugString ()Ljava/lang/String;
-	METHOD method_3291 drawShapeOutline (Lnet/minecraft/class_4587;Lnet/minecraft/class_4588;Lnet/minecraft/class_265;DDDFFFF)V
+	METHOD method_3291 drawCuboidShapeOutline (Lnet/minecraft/class_4587;Lnet/minecraft/class_4588;Lnet/minecraft/class_265;DDDFFFF)V
 		ARG 0 matrices
+		ARG 1 vertexConsumer
+		ARG 2 shape
+		ARG 3 offsetX
+		ARG 5 offsetY
+		ARG 7 offsetZ
+		ARG 9 red
+		ARG 10 green
+		ARG 11 blue
+		ARG 12 alpha
 	METHOD method_3292 scheduleTerrainUpdate ()V
 	METHOD method_3293 renderStars ()V
 	METHOD method_3295 scheduleChunkRender (IIIZ)V
@@ -304,6 +348,12 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	METHOD method_3296 loadEntityOutlineShader ()V
 	METHOD method_34550 renderSky (Lnet/minecraft/class_287;F)V
 		ARG 0 builder
+	METHOD method_34808 collectRenderableChunks (Ljava/util/LinkedHashSet;Lnet/minecraft/class_761$class_5972;Lnet/minecraft/class_243;Ljava/util/Queue;Z)V
+		ARG 1 chunks
+		ARG 2 chunkInfoList
+		ARG 3 cameraPos
+		ARG 4 queue
+		ARG 5 chunkCullingEnabled
 	METHOD method_34810 getChunkBuilder ()Lnet/minecraft/class_846;
 	METHOD method_34811 getChunkCount ()D
 	METHOD method_34812 getViewDistance ()D
@@ -323,14 +373,20 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	METHOD method_35774 reloadTransparencyShader ()V
 	METHOD method_35775 captureFrustum ()V
 	METHOD method_35776 killFrustum ()V
-	METHOD method_38549 (Lnet/minecraft/class_4184;Ljava/util/Queue;)V
+	METHOD method_38549 enqueueChunksInViewDistance (Lnet/minecraft/class_4184;Ljava/util/Queue;)V
 		ARG 1 camera
+		ARG 2 queue
 	METHOD method_38550 addBuiltChunk (Lnet/minecraft/class_846$class_851;)V
 		ARG 1 chunk
 	METHOD method_38551 applyFrustum (Lnet/minecraft/class_4604;)V
 		ARG 1 frustum
-	METHOD method_38553 (Lnet/minecraft/class_2338;Lnet/minecraft/class_846$class_851;)Z
+	METHOD method_38552 (Lnet/minecraft/class_2338;Lnet/minecraft/class_761$class_762;)D
+		ARG 1 chunkInfo
+	METHOD method_38553 isOutsideViewDistance (Lnet/minecraft/class_2338;Lnet/minecraft/class_846$class_851;)Z
 		ARG 1 pos
+		ARG 2 chunk
+	METHOD method_38554 (J)J
+		ARG 1 nextUpdateTime
 	METHOD method_40050 isRenderingReady (Lnet/minecraft/class_2338;)Z
 		ARG 1 pos
 	METHOD method_8562 playSong (Lnet/minecraft/class_3414;Lnet/minecraft/class_2338;)V
@@ -351,6 +407,9 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 		ARG 2 pos
 		ARG 3 data
 	METHOD method_8567 processWorldEvent (ILnet/minecraft/class_2338;I)V
+		ARG 1 eventId
+		ARG 2 pos
+		ARG 3 data
 	METHOD method_8568 addParticle (Lnet/minecraft/class_2394;ZDDDDDD)V
 		ARG 1 parameters
 		ARG 2 shouldAlwaysSpawn
@@ -383,6 +442,8 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 			ARG 1 chunk
 			ARG 2 direction
 			ARG 3 propagationLevel
+		METHOD equals (Ljava/lang/Object;)Z
+			ARG 1 o
 		METHOD method_3298 canCull (Lnet/minecraft/class_2350;)Z
 			ARG 1 from
 		METHOD method_3299 updateCullingState (BLnet/minecraft/class_2350;)V
@@ -406,3 +467,8 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 		METHOD method_34821 setInfo (Lnet/minecraft/class_846$class_851;Lnet/minecraft/class_761$class_762;)V
 			ARG 1 chunk
 			ARG 2 info
+	CLASS class_6600 RenderableChunks
+		FIELD field_34818 chunkInfoList Lnet/minecraft/class_761$class_5972;
+		FIELD field_34819 chunks Ljava/util/LinkedHashSet;
+		METHOD <init> (I)V
+			ARG 1 chunkCount

--- a/mappings/net/minecraft/client/render/block/BlockModelRenderer.mapping
+++ b/mappings/net/minecraft/client/render/block/BlockModelRenderer.mapping
@@ -54,6 +54,7 @@ CLASS net/minecraft/class_778 net/minecraft/client/render/block/BlockModelRender
 		ARG 6 box
 		ARG 7 flags
 	METHOD method_3365 renderQuads (Lnet/minecraft/class_4587$class_4665;Lnet/minecraft/class_4588;FFFLjava/util/List;II)V
+		ARG 0 entry
 		ARG 1 vertexConsumer
 		ARG 2 red
 		ARG 3 green
@@ -62,6 +63,7 @@ CLASS net/minecraft/class_778 net/minecraft/client/render/block/BlockModelRender
 		ARG 6 light
 		ARG 7 overlay
 	METHOD method_3367 render (Lnet/minecraft/class_4587$class_4665;Lnet/minecraft/class_4588;Lnet/minecraft/class_2680;Lnet/minecraft/class_1087;FFFII)V
+		ARG 1 entry
 		ARG 2 vertexConsumer
 		ARG 3 state
 		ARG 4 bakedModel
@@ -103,14 +105,21 @@ CLASS net/minecraft/class_778 net/minecraft/client/render/block/BlockModelRender
 		ARG 8 random
 		ARG 9 seed
 		ARG 11 overlay
+	METHOD method_43333 isOpaqueFullCube (Lnet/minecraft/class_1920;Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;)Z
+		ARG 0 world
+		ARG 1 state
+		ARG 2 pos
 	CLASS class_779 NeighborData
 		FIELD field_4189 nonCubicWeight Z
+		FIELD field_4190 VALUES [Lnet/minecraft/class_778$class_779;
 		FIELD field_4191 faces [Lnet/minecraft/class_2350;
 		METHOD <init> (Ljava/lang/String;I[Lnet/minecraft/class_2350;FZ[Lnet/minecraft/class_778$class_782;[Lnet/minecraft/class_778$class_782;[Lnet/minecraft/class_778$class_782;[Lnet/minecraft/class_778$class_782;)V
 			ARG 3 faces
 			ARG 5 nonCubicWeight
 		METHOD method_3378 getData (Lnet/minecraft/class_2350;)Lnet/minecraft/class_778$class_779;
 			ARG 0 direction
+		METHOD method_3383 ([Lnet/minecraft/class_778$class_779;)V
+			ARG 0 values
 	CLASS class_780 AmbientOcclusionCalculator
 		FIELD field_4194 light [I
 		FIELD field_4196 brightness [F
@@ -135,6 +144,8 @@ CLASS net/minecraft/class_778 net/minecraft/client/render/block/BlockModelRender
 			ARG 4 secondCorner
 			ARG 5 thirdCorner
 			ARG 6 fourthCorner
+		METHOD method_3390 ([Lnet/minecraft/class_778$class_781;)V
+			ARG 0 values
 		METHOD method_3394 getTranslations (Lnet/minecraft/class_2350;)Lnet/minecraft/class_778$class_781;
 			ARG 0 direction
 	CLASS class_782 NeighborOrientation
@@ -156,3 +167,9 @@ CLASS net/minecraft/class_778 net/minecraft/client/render/block/BlockModelRender
 			ARG 1 state
 			ARG 2 blockView
 			ARG 3 pos
+		CLASS 1
+			METHOD rehash (I)V
+				ARG 1 newN
+		CLASS 2
+			METHOD rehash (I)V
+				ARG 1 newN

--- a/mappings/net/minecraft/client/render/block/BlockRenderManager.mapping
+++ b/mappings/net/minecraft/client/render/block/BlockRenderManager.mapping
@@ -23,6 +23,8 @@ CLASS net/minecraft/class_776 net/minecraft/client/render/block/BlockRenderManag
 		ARG 1 pos
 		ARG 2 world
 		ARG 3 vertexConsumer
+		ARG 4 blockState
+		ARG 5 fluidState
 	METHOD method_3353 renderBlockAsEntity (Lnet/minecraft/class_2680;Lnet/minecraft/class_4587;Lnet/minecraft/class_4597;II)V
 		ARG 1 state
 		ARG 2 matrices

--- a/mappings/net/minecraft/client/render/block/FluidRenderer.mapping
+++ b/mappings/net/minecraft/client/render/block/FluidRenderer.mapping
@@ -15,9 +15,11 @@ CLASS net/minecraft/class_775 net/minecraft/client/render/block/FluidRenderer
 		ARG 13 light
 	METHOD method_29708 shouldRenderSide (Lnet/minecraft/class_1920;Lnet/minecraft/class_2338;Lnet/minecraft/class_3610;Lnet/minecraft/class_2680;Lnet/minecraft/class_2350;Lnet/minecraft/class_3610;)Z
 		ARG 0 world
+		ARG 1 pos
 		ARG 2 fluidState
 		ARG 3 blockState
 		ARG 4 direction
+		ARG 5 neighborFluidState
 	METHOD method_29709 isOppositeSideCovered (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2350;)Z
 		ARG 0 world
 		ARG 1 pos
@@ -26,17 +28,45 @@ CLASS net/minecraft/class_775 net/minecraft/client/render/block/FluidRenderer
 	METHOD method_29710 isSideCovered (Lnet/minecraft/class_1922;Lnet/minecraft/class_2350;FLnet/minecraft/class_2338;Lnet/minecraft/class_2680;)Z
 		ARG 0 world
 		ARG 1 direction
+		ARG 2 height
 		ARG 3 pos
 		ARG 4 state
 	METHOD method_3343 getLight (Lnet/minecraft/class_1920;Lnet/minecraft/class_2338;)I
 		ARG 1 world
 		ARG 2 pos
 	METHOD method_3344 isSideCovered (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;FLnet/minecraft/class_2680;)Z
+		ARG 0 world
+		ARG 1 pos
 		ARG 2 direction
 		ARG 3 maxDeviation
+		ARG 4 state
 	METHOD method_3345 onResourceReload ()V
 	METHOD method_3347 render (Lnet/minecraft/class_1920;Lnet/minecraft/class_2338;Lnet/minecraft/class_4588;Lnet/minecraft/class_2680;Lnet/minecraft/class_3610;)Z
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 vertexConsumer
+		ARG 4 blockState
+		ARG 5 fluidState
 	METHOD method_3348 isSameFluid (Lnet/minecraft/class_3610;Lnet/minecraft/class_3610;)Z
+		ARG 0 a
+		ARG 1 b
+	METHOD method_40077 calculateFluidHeight (Lnet/minecraft/class_1920;Lnet/minecraft/class_3611;FFFLnet/minecraft/class_2338;)F
+		ARG 1 world
+		ARG 2 fluid
+		ARG 3 originHeight
+		ARG 4 northSouthHeight
+		ARG 5 eastWestHeight
+		ARG 6 pos
+	METHOD method_40078 getFluidHeight (Lnet/minecraft/class_1920;Lnet/minecraft/class_3611;Lnet/minecraft/class_2338;)F
+		ARG 1 world
+		ARG 2 fluid
+		ARG 3 pos
+	METHOD method_40079 getFluidHeight (Lnet/minecraft/class_1920;Lnet/minecraft/class_3611;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_3610;)F
+		ARG 1 world
+		ARG 2 fluid
+		ARG 3 pos
+		ARG 4 blockState
+		ARG 5 fluidState
+	METHOD method_40080 addHeight ([FF)V
+		ARG 1 heights
+		ARG 2 height

--- a/mappings/net/minecraft/client/render/block/FluidRenderer.mapping
+++ b/mappings/net/minecraft/client/render/block/FluidRenderer.mapping
@@ -68,5 +68,5 @@ CLASS net/minecraft/class_775 net/minecraft/client/render/block/FluidRenderer
 		ARG 4 blockState
 		ARG 5 fluidState
 	METHOD method_40080 addHeight ([FF)V
-		ARG 1 heights
+		ARG 1 weightedAverageHeight
 		ARG 2 height

--- a/mappings/net/minecraft/client/render/block/entity/CampfireBlockEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/block/entity/CampfireBlockEntityRenderer.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_3941 net/minecraft/client/render/block/entity/CampfireBlockEntityRenderer
 	FIELD field_32824 SCALE F
+	FIELD field_38884 itemRenderer Lnet/minecraft/class_918;
 	METHOD <init> (Lnet/minecraft/class_5614$class_5615;)V
 		ARG 1 ctx

--- a/mappings/net/minecraft/client/render/block/entity/MobSpawnerBlockEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/block/entity/MobSpawnerBlockEntityRenderer.mapping
@@ -1,3 +1,4 @@
 CLASS net/minecraft/class_839 net/minecraft/client/render/block/entity/MobSpawnerBlockEntityRenderer
+	FIELD field_38885 entityRenderDispatcher Lnet/minecraft/class_898;
 	METHOD <init> (Lnet/minecraft/class_5614$class_5615;)V
 		ARG 1 ctx

--- a/mappings/net/minecraft/client/render/chunk/ChunkBuilder.mapping
+++ b/mappings/net/minecraft/client/render/chunk/ChunkBuilder.mapping
@@ -27,6 +27,8 @@ CLASS net/minecraft/class_846 net/minecraft/client/render/chunk/ChunkBuilder
 	METHOD method_19420 getCameraPosition ()Lnet/minecraft/class_243;
 	METHOD method_22752 setWorld (Lnet/minecraft/class_638;)V
 		ARG 1 world
+	METHOD method_22753 (Lnet/minecraft/class_287;Lnet/minecraft/class_291;Ljava/lang/Void;)Ljava/util/concurrent/CompletionStage;
+		ARG 3 void_
 	METHOD method_22755 (Lnet/minecraft/class_750;Lnet/minecraft/class_846$class_4690;Ljava/lang/Throwable;)V
 		ARG 2 result
 		ARG 3 throwable
@@ -107,6 +109,8 @@ CLASS net/minecraft/class_846 net/minecraft/client/render/chunk/ChunkBuilder
 		METHOD method_3656 getBuffer (Lnet/minecraft/class_1921;)Lnet/minecraft/class_291;
 			ARG 1 layer
 		METHOD method_3659 delete ()V
+		METHOD method_3660 ([Lnet/minecraft/class_2338$class_2339;)V
+			ARG 0 neighborPositions
 		METHOD method_3661 needsImportantRebuild ()Z
 		METHOD method_3662 cancelRebuild ()V
 		METHOD method_3663 cancel ()Z
@@ -145,6 +149,7 @@ CLASS net/minecraft/class_846 net/minecraft/client/render/chunk/ChunkBuilder
 				ARG 2 cameraY
 				ARG 3 cameraZ
 				ARG 4 data
+				ARG 5 builderStorage
 			METHOD method_22788 (Ljava/util/List;Lnet/minecraft/class_750;Lnet/minecraft/class_1921;)V
 				ARG 3 renderLayer
 			METHOD method_23087 addBlockEntity (Lnet/minecraft/class_846$class_849;Ljava/util/Set;Lnet/minecraft/class_2586;)V

--- a/mappings/net/minecraft/client/render/chunk/ChunkOcclusionDataBuilder.mapping
+++ b/mappings/net/minecraft/client/render/chunk/ChunkOcclusionDataBuilder.mapping
@@ -7,6 +7,8 @@ CLASS net/minecraft/class_852 net/minecraft/client/render/chunk/ChunkOcclusionDa
 	FIELD field_4478 closed Ljava/util/BitSet;
 	FIELD field_4479 DIRECTIONS [Lnet/minecraft/class_2350;
 	METHOD method_3679 build ()Lnet/minecraft/class_854;
+	METHOD method_3680 ([I)V
+		ARG 0 edgePoints
 	METHOD method_3681 pack (III)I
 		ARG 0 x
 		ARG 1 y

--- a/mappings/net/minecraft/client/render/debug/BeeDebugRenderer.mapping
+++ b/mappings/net/minecraft/client/render/debug/BeeDebugRenderer.mapping
@@ -62,6 +62,10 @@ CLASS net/minecraft/class_4703 net/minecraft/client/render/debug/BeeDebugRendere
 		ARG 1 pos
 		ARG 2 line
 		ARG 3 color
+	METHOD method_23817 (Ljava/util/Map$Entry;)V
+		ARG 0 entry
+	METHOD method_23818 (Ljava/util/Map;Lnet/minecraft/class_4703$class_5243;)V
+		ARG 1 bee
 	METHOD method_23819 removeOutdatedHives ()V
 	METHOD method_23820 drawPath (Lnet/minecraft/class_4703$class_5243;)V
 		ARG 1 bee
@@ -90,7 +94,13 @@ CLASS net/minecraft/class_4703 net/minecraft/client/render/debug/BeeDebugRendere
 		ARG 1 bee
 	METHOD method_24082 (Ljava/util/Map;Lnet/minecraft/class_4703$class_5243;)V
 		ARG 1 bee
+	METHOD method_24083 (Ljava/util/Map;Lnet/minecraft/class_4703$class_5243;Lnet/minecraft/class_2338;)V
+		ARG 2 pos
 	METHOD method_24084 getBlacklistingBees ()Ljava/util/Map;
+	METHOD method_30109 (Lnet/minecraft/class_2338;)Ljava/util/List;
+		ARG 0 hive
+	METHOD method_30110 (Lnet/minecraft/class_2338;)Ljava/util/Set;
+		ARG 0 flower
 	METHOD method_35794 removeBee (I)V
 		ARG 1 id
 	METHOD method_35795 (ILnet/minecraft/class_4703$class_5243;)Z

--- a/mappings/net/minecraft/client/render/debug/GameEventDebugRenderer.mapping
+++ b/mappings/net/minecraft/client/render/debug/GameEventDebugRenderer.mapping
@@ -8,6 +8,7 @@ CLASS net/minecraft/class_5739 net/minecraft/client/render/debug/GameEventDebugR
 		ARG 2 listener
 	METHOD method_33087 addEvent (Lnet/minecraft/class_5712;Lnet/minecraft/class_243;)V
 		ARG 1 event
+		ARG 2 pos
 	METHOD method_33088 addListener (Lnet/minecraft/class_5716;I)V
 		ARG 1 positionSource
 		ARG 2 range
@@ -17,6 +18,12 @@ CLASS net/minecraft/class_5739 net/minecraft/client/render/debug/GameEventDebugR
 		ARG 2 green
 		ARG 3 blue
 		ARG 4 alpha
+	METHOD method_33090 (Lnet/minecraft/class_287;DDDLnet/minecraft/class_243;)V
+		ARG 7 pos
+	METHOD method_33091 (Lnet/minecraft/class_5739$class_5741;Lnet/minecraft/class_4587;Lnet/minecraft/class_4588;DDDLnet/minecraft/class_243;)V
+		ARG 9 pos
+	METHOD method_33092 (Lnet/minecraft/class_243;)V
+		ARG 0 pos
 	CLASS class_5740 Entry
 		FIELD comp_678 startingMs J
 		FIELD comp_679 event Lnet/minecraft/class_5712;
@@ -39,3 +46,6 @@ CLASS net/minecraft/class_5739 net/minecraft/client/render/debug/GameEventDebugR
 			ARG 1 world
 		METHOD method_33095 isTooFar (Lnet/minecraft/class_1937;Lnet/minecraft/class_243;)Z
 			ARG 1 world
+			ARG 2 pos
+		METHOD method_42601 (Lnet/minecraft/class_243;Lnet/minecraft/class_243;)Z
+			ARG 1 pos2

--- a/mappings/net/minecraft/client/render/debug/GameTestDebugRenderer.mapping
+++ b/mappings/net/minecraft/client/render/debug/GameTestDebugRenderer.mapping
@@ -6,6 +6,8 @@ CLASS net/minecraft/class_4503 net/minecraft/client/render/debug/GameTestDebugRe
 		ARG 2 color
 		ARG 3 message
 		ARG 4 duration
+	METHOD method_23110 (JLjava/util/Map$Entry;)Z
+		ARG 2 entry
 	METHOD method_23111 renderMarker (Lnet/minecraft/class_2338;Lnet/minecraft/class_4503$class_4504;)V
 		ARG 1 pos
 		ARG 2 marker

--- a/mappings/net/minecraft/client/render/debug/GoalSelectorDebugRenderer.mapping
+++ b/mappings/net/minecraft/client/render/debug/GoalSelectorDebugRenderer.mapping
@@ -7,6 +7,9 @@ CLASS net/minecraft/class_4205 net/minecraft/client/render/debug/GoalSelectorDeb
 	METHOD method_19430 setGoalSelectorList (ILjava/util/List;)V
 		ARG 1 index
 		ARG 2 selectors
+	METHOD method_23116 (Lnet/minecraft/class_2338;Ljava/lang/Integer;Ljava/util/List;)V
+		ARG 1 index
+		ARG 2 selectors
 	METHOD method_35799 removeGoalSelectorList (I)V
 		ARG 1 index
 	CLASS class_4206 GoalSelector

--- a/mappings/net/minecraft/client/render/debug/NeighborUpdateDebugRenderer.mapping
+++ b/mappings/net/minecraft/client/render/debug/NeighborUpdateDebugRenderer.mapping
@@ -3,6 +3,8 @@ CLASS net/minecraft/class_869 net/minecraft/client/render/debug/NeighborUpdateDe
 	FIELD field_4623 neighborUpdates Ljava/util/Map;
 	METHOD <init> (Lnet/minecraft/class_310;)V
 		ARG 1 client
+	METHOD method_30113 (Ljava/lang/Long;)Ljava/util/Map;
+		ARG 0 time2
 	METHOD method_3870 addNeighborUpdate (JLnet/minecraft/class_2338;)V
 		ARG 1 time
 		ARG 3 pos

--- a/mappings/net/minecraft/client/render/debug/VillageDebugRenderer.mapping
+++ b/mappings/net/minecraft/client/render/debug/VillageDebugRenderer.mapping
@@ -94,6 +94,8 @@ CLASS net/minecraft/class_4207 net/minecraft/client/render/debug/VillageDebugRen
 		ARG 1 potentialJobSite
 	METHOD method_29386 getBrainsContainingPotentialJobSite (Lnet/minecraft/class_2338;)Ljava/util/Collection;
 		ARG 1 potentialJobSite
+	METHOD method_30112 (Lnet/minecraft/class_2338;)Ljava/util/List;
+		ARG 0 pos
 	METHOD method_35797 removeBrain (I)V
 		ARG 1 entityId
 	METHOD method_35798 (ILnet/minecraft/class_4207$class_4232;)Z
@@ -116,6 +118,7 @@ CLASS net/minecraft/class_4207 net/minecraft/client/render/debug/VillageDebugRen
 		FIELD field_22406 health F
 		FIELD field_22407 maxHealth F
 		FIELD field_25287 potentialJobSites Ljava/util/Set;
+		FIELD field_38348 angerLevel I
 		METHOD <init> (Ljava/util/UUID;ILjava/lang/String;Ljava/lang/String;IFFLnet/minecraft/class_2374;Ljava/lang/String;Lnet/minecraft/class_11;ZI)V
 			ARG 1 uuid
 			ARG 2 entityId
@@ -128,6 +131,7 @@ CLASS net/minecraft/class_4207 net/minecraft/client/render/debug/VillageDebugRen
 			ARG 9 inventory
 			ARG 10 path
 			ARG 11 wantsGolem
+			ARG 12 angerLevel
 		METHOD method_23149 getUuid ()Ljava/util/UUID;
 		METHOD method_23151 isPointOfInterest (Lnet/minecraft/class_2338;)Z
 			ARG 1 pos

--- a/mappings/net/minecraft/client/render/entity/EntityRenderers.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderers.mapping
@@ -63,3 +63,7 @@ CLASS net/minecraft/class_5619 net/minecraft/client/render/entity/EntityRenderer
 		ARG 0 context
 	METHOD method_33430 (Lnet/minecraft/class_5617$class_5618;)Lnet/minecraft/class_897;
 		ARG 0 context
+	METHOD method_42604 (Lnet/minecraft/class_5617$class_5618;)Lnet/minecraft/class_897;
+		ARG 0 context
+	METHOD method_42605 (Lnet/minecraft/class_5617$class_5618;)Lnet/minecraft/class_897;
+		ARG 0 context

--- a/mappings/net/minecraft/client/render/entity/FallingBlockEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/FallingBlockEntityRenderer.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_901 net/minecraft/client/render/entity/FallingBlockEntityRenderer
+	FIELD field_38890 blockRenderManager Lnet/minecraft/class_776;

--- a/mappings/net/minecraft/client/render/entity/HorseEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/HorseEntityRenderer.mapping
@@ -1,2 +1,4 @@
 CLASS net/minecraft/class_910 net/minecraft/client/render/entity/HorseEntityRenderer
 	FIELD field_4714 TEXTURES Ljava/util/Map;
+	METHOD method_27151 (Ljava/util/EnumMap;)V
+		ARG 0 map

--- a/mappings/net/minecraft/client/render/entity/MinecartEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/MinecartEntityRenderer.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_925 net/minecraft/client/render/entity/MinecartEntityRenderer
+	FIELD field_38892 blockRenderManager Lnet/minecraft/class_776;
 	FIELD field_4746 TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_4747 model Lnet/minecraft/class_583;
 	METHOD <init> (Lnet/minecraft/class_5617$class_5618;Lnet/minecraft/class_5601;)V

--- a/mappings/net/minecraft/client/render/entity/MooshroomEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/MooshroomEntityRenderer.mapping
@@ -1,2 +1,4 @@
 CLASS net/minecraft/class_926 net/minecraft/client/render/entity/MooshroomEntityRenderer
 	FIELD field_4748 TEXTURES Ljava/util/Map;
+	METHOD method_18657 (Ljava/util/HashMap;)V
+		ARG 0 map

--- a/mappings/net/minecraft/client/render/entity/PandaEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/PandaEntityRenderer.mapping
@@ -1,3 +1,5 @@
 CLASS net/minecraft/class_931 net/minecraft/client/render/entity/PandaEntityRenderer
 	FIELD field_17595 TEXTURES Ljava/util/Map;
+	METHOD method_17796 (Ljava/util/EnumMap;)V
+		ARG 0 map
 	METHOD method_4086 getAngle (FFIFF)F

--- a/mappings/net/minecraft/client/render/entity/TntEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/TntEntityRenderer.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_956 net/minecraft/client/render/entity/TntEntityRenderer
+	FIELD field_38894 blockRenderManager Lnet/minecraft/class_776;

--- a/mappings/net/minecraft/client/render/entity/TntMinecartEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/TntMinecartEntityRenderer.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_957 net/minecraft/client/render/entity/TntMinecartEntityRenderer
-	FIELD field_38893 blockRenderManager Lnet/minecraft/class_776;
+	FIELD field_38893 tntBlockRenderManager Lnet/minecraft/class_776;
 	METHOD method_23190 renderFlashingBlock (Lnet/minecraft/class_776;Lnet/minecraft/class_2680;Lnet/minecraft/class_4587;Lnet/minecraft/class_4597;IZ)V
 		COMMENT Renders a given block state into the given buffers either normally or with a bright white overlay.
 		COMMENT Used for rendering primed TNT either standalone or as part of a TNT minecart.

--- a/mappings/net/minecraft/client/render/entity/feature/DolphinHeldItemFeatureRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/DolphinHeldItemFeatureRenderer.mapping
@@ -1,1 +1,5 @@
 CLASS net/minecraft/class_977 net/minecraft/client/render/entity/feature/DolphinHeldItemFeatureRenderer
+	FIELD field_38898 heldItemRenderer Lnet/minecraft/class_759;
+	METHOD <init> (Lnet/minecraft/class_3883;Lnet/minecraft/class_759;)V
+		ARG 1 context
+		ARG 2 heldItemRenderer

--- a/mappings/net/minecraft/client/render/entity/feature/EndermanBlockFeatureRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/EndermanBlockFeatureRenderer.mapping
@@ -1,1 +1,5 @@
 CLASS net/minecraft/class_975 net/minecraft/client/render/entity/feature/EndermanBlockFeatureRenderer
+	FIELD field_38895 blockRenderManager Lnet/minecraft/class_776;
+	METHOD <init> (Lnet/minecraft/class_3883;Lnet/minecraft/class_776;)V
+		ARG 1 context
+		ARG 2 blockRenderManager

--- a/mappings/net/minecraft/client/render/entity/feature/FoxHeldItemFeatureRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/FoxHeldItemFeatureRenderer.mapping
@@ -1,1 +1,5 @@
 CLASS net/minecraft/class_4043 net/minecraft/client/render/entity/feature/FoxHeldItemFeatureRenderer
+	FIELD field_38899 heldItemRenderer Lnet/minecraft/class_759;
+	METHOD <init> (Lnet/minecraft/class_3883;Lnet/minecraft/class_759;)V
+		ARG 1 context
+		ARG 2 heldItemRenderer

--- a/mappings/net/minecraft/client/render/entity/feature/HeldItemFeatureRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/HeldItemFeatureRenderer.mapping
@@ -1,4 +1,8 @@
 CLASS net/minecraft/class_989 net/minecraft/client/render/entity/feature/HeldItemFeatureRenderer
+	FIELD field_38901 heldItemRenderer Lnet/minecraft/class_759;
+	METHOD <init> (Lnet/minecraft/class_3883;Lnet/minecraft/class_759;)V
+		ARG 1 context
+		ARG 2 playerHeldItemRenderer
 	METHOD method_4192 renderItem (Lnet/minecraft/class_1309;Lnet/minecraft/class_1799;Lnet/minecraft/class_809$class_811;Lnet/minecraft/class_1306;Lnet/minecraft/class_4587;Lnet/minecraft/class_4597;I)V
 		ARG 1 entity
 		ARG 2 stack

--- a/mappings/net/minecraft/client/render/entity/feature/HeldItemFeatureRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/HeldItemFeatureRenderer.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_989 net/minecraft/client/render/entity/feature/HeldIte
 	FIELD field_38901 heldItemRenderer Lnet/minecraft/class_759;
 	METHOD <init> (Lnet/minecraft/class_3883;Lnet/minecraft/class_759;)V
 		ARG 1 context
-		ARG 2 playerHeldItemRenderer
+		ARG 2 heldItemRenderer
 	METHOD method_4192 renderItem (Lnet/minecraft/class_1309;Lnet/minecraft/class_1799;Lnet/minecraft/class_809$class_811;Lnet/minecraft/class_1306;Lnet/minecraft/class_4587;Lnet/minecraft/class_4597;I)V
 		ARG 1 entity
 		ARG 2 stack

--- a/mappings/net/minecraft/client/render/entity/feature/IronGolemFlowerFeatureRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/IronGolemFlowerFeatureRenderer.mapping
@@ -1,1 +1,5 @@
 CLASS net/minecraft/class_986 net/minecraft/client/render/entity/feature/IronGolemFlowerFeatureRenderer
+	FIELD field_38900 blockRenderManager Lnet/minecraft/class_776;
+	METHOD <init> (Lnet/minecraft/class_3883;Lnet/minecraft/class_776;)V
+		ARG 1 context
+		ARG 2 blockRenderManager

--- a/mappings/net/minecraft/client/render/entity/feature/PandaHeldItemFeatureRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/PandaHeldItemFeatureRenderer.mapping
@@ -1,1 +1,5 @@
 CLASS net/minecraft/class_990 net/minecraft/client/render/entity/feature/PandaHeldItemFeatureRenderer
+	FIELD field_38903 heldItemRenderer Lnet/minecraft/class_759;
+	METHOD <init> (Lnet/minecraft/class_3883;Lnet/minecraft/class_759;)V
+		ARG 1 context
+		ARG 2 heldItemRenderer

--- a/mappings/net/minecraft/client/render/entity/feature/PlayerHeldItemFeatureRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/PlayerHeldItemFeatureRenderer.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_5697 net/minecraft/client/render/entity/feature/PlayerHeldItemFeatureRenderer
 	FIELD field_32944 HEAD_YAW F
 	FIELD field_32945 HEAD_ROLL F
+	FIELD field_38904 playerHeldItemRenderer Lnet/minecraft/class_759;
 	METHOD method_32799 renderSpyglass (Lnet/minecraft/class_1309;Lnet/minecraft/class_1799;Lnet/minecraft/class_1306;Lnet/minecraft/class_4587;Lnet/minecraft/class_4597;I)V
 		ARG 1 entity
 		ARG 2 stack

--- a/mappings/net/minecraft/client/render/entity/feature/SnowmanPumpkinFeatureRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/SnowmanPumpkinFeatureRenderer.mapping
@@ -1,1 +1,7 @@
 CLASS net/minecraft/class_996 net/minecraft/client/render/entity/feature/SnowmanPumpkinFeatureRenderer
+	FIELD field_38905 blockRenderManager Lnet/minecraft/class_776;
+	FIELD field_38906 itemRenderer Lnet/minecraft/class_918;
+	METHOD <init> (Lnet/minecraft/class_3883;Lnet/minecraft/class_776;Lnet/minecraft/class_918;)V
+		ARG 1 context
+		ARG 2 blockRenderManager
+		ARG 3 itemRenderer

--- a/mappings/net/minecraft/client/render/entity/feature/VillagerHeldItemFeatureRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/VillagerHeldItemFeatureRenderer.mapping
@@ -1,1 +1,5 @@
 CLASS net/minecraft/class_4004 net/minecraft/client/render/entity/feature/VillagerHeldItemFeatureRenderer
+	FIELD field_38896 heldItemRenderer Lnet/minecraft/class_759;
+	METHOD <init> (Lnet/minecraft/class_3883;Lnet/minecraft/class_759;)V
+		ARG 1 context
+		ARG 2 heldItemRenderer

--- a/mappings/net/minecraft/client/render/entity/model/FrogEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/FrogEntityModel.mapping
@@ -8,6 +8,7 @@ CLASS net/minecraft/class_7198 net/minecraft/client/render/entity/model/FrogEnti
 	FIELD field_37925 rightArm Lnet/minecraft/class_630;
 	FIELD field_37926 leftLeg Lnet/minecraft/class_630;
 	FIELD field_37927 rightLeg Lnet/minecraft/class_630;
+	FIELD field_38448 croakingBody Lnet/minecraft/class_630;
 	METHOD <init> (Lnet/minecraft/class_630;)V
 		ARG 1 root
 	METHOD method_41905 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/item/BuiltinModelItemRenderer.mapping
+++ b/mappings/net/minecraft/client/render/item/BuiltinModelItemRenderer.mapping
@@ -22,3 +22,5 @@ CLASS net/minecraft/class_756 net/minecraft/client/render/item/BuiltinModelItemR
 		ARG 4 vertexConsumers
 		ARG 5 light
 		ARG 6 overlay
+	METHOD method_37310 (Lnet/minecraft/class_2487;Lcom/mojang/authlib/GameProfile;)V
+		ARG 1 profile

--- a/mappings/net/minecraft/client/render/model/CubeFace.mapping
+++ b/mappings/net/minecraft/client/render/model/CubeFace.mapping
@@ -3,6 +3,8 @@ CLASS net/minecraft/class_753 net/minecraft/client/render/model/CubeFace
 	FIELD field_3959 corners [Lnet/minecraft/class_753$class_755;
 	METHOD <init> (Ljava/lang/String;I[Lnet/minecraft/class_753$class_755;)V
 		ARG 3 corners
+	METHOD method_3161 ([Lnet/minecraft/class_753;)V
+		ARG 0 lookup
 	METHOD method_3162 getCorner (I)Lnet/minecraft/class_753$class_755;
 		ARG 1 corner
 	METHOD method_3163 getFace (Lnet/minecraft/class_2350;)Lnet/minecraft/class_753;

--- a/mappings/net/minecraft/client/render/model/ModelLoader.mapping
+++ b/mappings/net/minecraft/client/render/model/ModelLoader.mapping
@@ -43,7 +43,7 @@ CLASS net/minecraft/class_1088 net/minecraft/client/render/model/ModelLoader
 		ARG 1 resourceManager
 		ARG 2 blockColors
 		ARG 3 profiler
-		ARG 4 mipmapLevels
+		ARG 4 mipmapLevel
 	METHOD method_15878 bake (Lnet/minecraft/class_2960;Lnet/minecraft/class_3665;)Lnet/minecraft/class_1087;
 		ARG 1 id
 		ARG 2 settings

--- a/mappings/net/minecraft/client/render/model/ModelLoader.mapping
+++ b/mappings/net/minecraft/client/render/model/ModelLoader.mapping
@@ -42,27 +42,52 @@ CLASS net/minecraft/class_1088 net/minecraft/client/render/model/ModelLoader
 	METHOD <init> (Lnet/minecraft/class_3300;Lnet/minecraft/class_324;Lnet/minecraft/class_3695;I)V
 		ARG 1 resourceManager
 		ARG 2 blockColors
+		ARG 3 profiler
+		ARG 4 mipmapLevels
 	METHOD method_15878 bake (Lnet/minecraft/class_2960;Lnet/minecraft/class_3665;)Lnet/minecraft/class_1087;
 		ARG 1 id
 		ARG 2 settings
 	METHOD method_18177 upload (Lnet/minecraft/class_1060;Lnet/minecraft/class_3695;)Lnet/minecraft/class_4724;
 		ARG 1 textureManager
 		ARG 2 profiler
+	METHOD method_21597 (ILnet/minecraft/class_2680;)V
+		ARG 2 state
+	METHOD method_21600 (Lnet/minecraft/class_1088$class_4455;)Ljava/util/Set;
+		ARG 0 definition
+	METHOD method_21601 (Lnet/minecraft/class_1088$class_4455;Ljava/util/Set;)V
+		ARG 1 definition
+		ARG 2 states
+	METHOD method_21602 (Lit/unimi/dsi/fastutil/objects/Object2IntOpenHashMap;)V
+		ARG 0 map
 	METHOD method_21603 addStates (Ljava/lang/Iterable;)V
 		ARG 1 states
 	METHOD method_21604 (Ljava/util/Map;Lnet/minecraft/class_2960;Lcom/mojang/datafixers/util/Pair;Ljava/util/Map;Lnet/minecraft/class_1091;Lnet/minecraft/class_2680;)V
 		ARG 5 id
+		ARG 6 state
 	METHOD method_21605 getStateLookup ()Lit/unimi/dsi/fastutil/objects/Object2IntMap;
 	METHOD method_22820 (I)Lnet/minecraft/class_2960;
 		ARG 0 stage
 	METHOD method_23216 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_2960;
 		ARG 0 id
+	METHOD method_24149 (Lcom/mojang/datafixers/util/Pair;)V
+		ARG 0 pair
+	METHOD method_24150 (Ljava/util/HashSet;)V
+		ARG 0 textures
 	METHOD method_4715 loadModel (Lnet/minecraft/class_2960;)V
 		ARG 1 id
+	METHOD method_4716 (Lnet/minecraft/class_2680;)V
+		ARG 1 state
+	METHOD method_4717 (Lnet/minecraft/class_2960;Lnet/minecraft/class_2680;)V
+		ARG 2 state
 	METHOD method_4718 loadModelFromJson (Lnet/minecraft/class_2960;)Lnet/minecraft/class_793;
 		ARG 1 id
 	METHOD method_4720 (Ljava/util/Map;Lnet/minecraft/class_2960;Lnet/minecraft/class_2680;)V
 		ARG 2 state
+	METHOD method_4722 (Ljava/util/Map;Lnet/minecraft/class_807;Ljava/util/List;Lnet/minecraft/class_816;Lcom/mojang/datafixers/util/Pair;Lnet/minecraft/class_790;Lnet/minecraft/class_2680;)V
+		ARG 6 state
+	METHOD method_4723 (Lnet/minecraft/class_2960;Lnet/minecraft/class_2689;)V
+		ARG 1 id
+		ARG 2 stateManager
 	METHOD method_4724 getPropertyValue (Lnet/minecraft/class_2769;Ljava/lang/String;)Ljava/lang/Comparable;
 		ARG 0 property
 		ARG 1 string
@@ -76,9 +101,20 @@ CLASS net/minecraft/class_1088 net/minecraft/client/render/model/ModelLoader
 	METHOD method_4729 putModel (Lnet/minecraft/class_2960;Lnet/minecraft/class_1100;)V
 		ARG 1 id
 		ARG 2 unbakedModel
+	METHOD method_4730 (Lcom/mojang/datafixers/util/Pair;Ljava/util/Map$Entry;)Z
+		ARG 1 entry
+	METHOD method_4731 (Lcom/google/common/collect/ImmutableList;Lnet/minecraft/class_2689;Ljava/util/Map;Ljava/util/List;Lnet/minecraft/class_816;Lcom/mojang/datafixers/util/Pair;Lnet/minecraft/class_790;Lnet/minecraft/class_2960;Lcom/mojang/datafixers/util/Pair;Ljava/lang/String;Lnet/minecraft/class_807;)V
+		ARG 9 key
+		ARG 10 model
+	METHOD method_4732 (Ljava/util/Set;Lnet/minecraft/class_1100;)Ljava/util/stream/Stream;
+		ARG 2 model
 	METHOD method_4733 (Lnet/minecraft/class_2960;)V
 		ARG 1 id
 	METHOD method_4734 getBakedModelMap ()Ljava/util/Map;
+	METHOD method_4737 (Lnet/minecraft/class_2960;Lnet/minecraft/class_3298;)Lcom/mojang/datafixers/util/Pair;
+		ARG 2 resource
+	METHOD method_4738 (Ljava/util/Map;Lnet/minecraft/class_816;Ljava/util/List;Lnet/minecraft/class_2680;)V
+		ARG 3 state
 	METHOD method_4739 (Lnet/minecraft/class_2248;Ljava/util/Map;Lnet/minecraft/class_2680;)Z
 		ARG 2 state
 	CLASS class_1089 ModelLoaderException

--- a/mappings/net/minecraft/client/render/model/json/AndMultipartModelSelector.mapping
+++ b/mappings/net/minecraft/client/render/model/json/AndMultipartModelSelector.mapping
@@ -3,3 +3,9 @@ CLASS net/minecraft/class_812 net/minecraft/client/render/model/json/AndMultipar
 	FIELD field_4324 selectors Ljava/lang/Iterable;
 	METHOD <init> (Ljava/lang/Iterable;)V
 		ARG 1 selectors
+	METHOD method_3506 (Ljava/util/List;Lnet/minecraft/class_2680;)Z
+		ARG 1 state
+	METHOD method_3507 (Lnet/minecraft/class_2680;Ljava/util/function/Predicate;)Z
+		ARG 1 predicate
+	METHOD method_3508 (Lnet/minecraft/class_2689;Lnet/minecraft/class_815;)Ljava/util/function/Predicate;
+		ARG 1 selector

--- a/mappings/net/minecraft/client/render/model/json/JsonUnbakedModel.mapping
+++ b/mappings/net/minecraft/client/render/model/json/JsonUnbakedModel.mapping
@@ -33,6 +33,8 @@ CLASS net/minecraft/class_793 net/minecraft/client/render/model/json/JsonUnbaked
 		ARG 1 name
 	METHOD method_3433 getElements ()Ljava/util/List;
 	METHOD method_3434 getOverrides ()Ljava/util/List;
+	METHOD method_3435 (Ljava/util/Set;Ljava/lang/String;)V
+		ARG 2 layer
 	METHOD method_3437 deserialize (Ljava/io/Reader;)Lnet/minecraft/class_793;
 		ARG 0 input
 	METHOD method_3438 getTransformation (Lnet/minecraft/class_809$class_811;)Lnet/minecraft/class_804;
@@ -42,6 +44,8 @@ CLASS net/minecraft/class_793 net/minecraft/client/render/model/json/JsonUnbaked
 	METHOD method_3440 compileOverrides (Lnet/minecraft/class_1088;Lnet/minecraft/class_793;)Lnet/minecraft/class_806;
 		ARG 1 modelLoader
 		ARG 2 parent
+	METHOD method_3441 (Ljava/util/function/Function;Ljava/util/Set;Ljava/util/Set;Lnet/minecraft/class_799;)V
+		ARG 4 override
 	METHOD method_3442 resolveTexture (Ljava/lang/String;)Lcom/mojang/datafixers/util/Either;
 		ARG 1 name
 	METHOD method_3443 getTransformations ()Lnet/minecraft/class_809;
@@ -96,3 +100,5 @@ CLASS net/minecraft/class_793 net/minecraft/client/render/model/json/JsonUnbaked
 			ARG 0 value
 	CLASS class_6246 UncheckedModelException
 		COMMENT An unused unchecked exception. Probably related to unbaked models.
+		METHOD <init> (Ljava/lang/String;)V
+			ARG 1 message

--- a/mappings/net/minecraft/client/render/model/json/MultipartModelComponent.mapping
+++ b/mappings/net/minecraft/client/render/model/json/MultipartModelComponent.mapping
@@ -10,9 +10,17 @@ CLASS net/minecraft/class_819 net/minecraft/client/render/model/json/MultipartMo
 	METHOD method_3530 getPredicate (Lnet/minecraft/class_2689;)Ljava/util/function/Predicate;
 		ARG 1 stateFactory
 	CLASS class_820 Deserializer
+		METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
+			ARG 1 json
+			ARG 2 type
+			ARG 3 context
 		METHOD method_3531 deserializeSelectorOrDefault (Lcom/google/gson/JsonObject;)Lnet/minecraft/class_815;
 			ARG 1 object
 		METHOD method_3533 createStatePropertySelector (Ljava/util/Map$Entry;)Lnet/minecraft/class_815;
 			ARG 0 entry
+		METHOD method_3534 (Lcom/google/gson/JsonElement;)Lnet/minecraft/class_815;
+			ARG 0 json
 		METHOD method_3536 deserializeSelector (Lcom/google/gson/JsonObject;)Lnet/minecraft/class_815;
 			ARG 0 object
+		METHOD method_3537 (Lcom/google/gson/JsonElement;)Lnet/minecraft/class_815;
+			ARG 0 json

--- a/mappings/net/minecraft/client/render/model/json/MultipartModelSelector.mapping
+++ b/mappings/net/minecraft/client/render/model/json/MultipartModelSelector.mapping
@@ -3,3 +3,11 @@ CLASS net/minecraft/class_815 net/minecraft/client/render/model/json/MultipartMo
 	FIELD field_16901 FALSE Lnet/minecraft/class_815;
 	METHOD getPredicate (Lnet/minecraft/class_2689;)Ljava/util/function/Predicate;
 		ARG 1 stateFactory
+	METHOD method_16808 (Lnet/minecraft/class_2689;)Ljava/util/function/Predicate;
+		ARG 0 stateFactory
+	METHOD method_16809 (Lnet/minecraft/class_2680;)Z
+		ARG 0 state
+	METHOD method_16810 (Lnet/minecraft/class_2689;)Ljava/util/function/Predicate;
+		ARG 0 stateFactory
+	METHOD method_16811 (Lnet/minecraft/class_2680;)Z
+		ARG 0 state

--- a/mappings/net/minecraft/client/render/model/json/OrMultipartModelSelector.mapping
+++ b/mappings/net/minecraft/client/render/model/json/OrMultipartModelSelector.mapping
@@ -3,3 +3,9 @@ CLASS net/minecraft/class_821 net/minecraft/client/render/model/json/OrMultipart
 	FIELD field_4337 selectors Ljava/lang/Iterable;
 	METHOD <init> (Ljava/lang/Iterable;)V
 		ARG 1 selectors
+	METHOD method_3538 (Ljava/util/List;Lnet/minecraft/class_2680;)Z
+		ARG 1 state
+	METHOD method_3539 (Lnet/minecraft/class_2680;Ljava/util/function/Predicate;)Z
+		ARG 1 predicate
+	METHOD method_3540 (Lnet/minecraft/class_2689;Lnet/minecraft/class_815;)Ljava/util/function/Predicate;
+		ARG 1 selector

--- a/mappings/net/minecraft/client/render/model/json/SimpleMultipartModelSelector.mapping
+++ b/mappings/net/minecraft/client/render/model/json/SimpleMultipartModelSelector.mapping
@@ -5,7 +5,15 @@ CLASS net/minecraft/class_818 net/minecraft/client/render/model/json/SimpleMulti
 	METHOD <init> (Ljava/lang/String;Ljava/lang/String;)V
 		ARG 1 key
 		ARG 2 valueString
+	METHOD method_3524 (Ljava/util/List;Lnet/minecraft/class_2680;)Z
+		ARG 1 state
 	METHOD method_3525 createPredicate (Lnet/minecraft/class_2689;Lnet/minecraft/class_2769;Ljava/lang/String;)Ljava/util/function/Predicate;
 		ARG 1 stateFactory
 		ARG 2 property
 		ARG 3 valueString
+	METHOD method_3526 (Lnet/minecraft/class_2689;Lnet/minecraft/class_2769;Ljava/lang/String;)Ljava/util/function/Predicate;
+		ARG 3 value
+	METHOD method_3527 (Lnet/minecraft/class_2680;Ljava/util/function/Predicate;)Z
+		ARG 1 predicate
+	METHOD method_3528 (Lnet/minecraft/class_2769;Ljava/util/Optional;Lnet/minecraft/class_2680;)Z
+		ARG 2 state

--- a/mappings/net/minecraft/client/util/Clipboard.mapping
+++ b/mappings/net/minecraft/client/util/Clipboard.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_3674 net/minecraft/client/util/Clipboard
 	FIELD field_16236 clipboardBuffer Ljava/nio/ByteBuffer;
+	FIELD field_31905 GLFW_FORMAT_UNAVAILABLE I
 	METHOD method_15977 getClipboard (JLorg/lwjgl/glfw/GLFWErrorCallbackI;)Ljava/lang/String;
 		ARG 1 window
 		ARG 3 errorCallback

--- a/unpick-definitions/gl.unpick
+++ b/unpick-definitions/gl.unpick
@@ -313,7 +313,7 @@ target_method org/lwjgl/opengl/GL32C glBeginQuery (II)V
 target_method org/lwjgl/opengl/GL32C glEndQuery (I)V
 	param 0 gl_query_target
 
-target_method org/lwjgl/opengl/ARBTimerQuery glGetQueryObjecti (II)I
+target_method org/lwjgl/opengl/GL32C glGetQueryObjecti (II)I
 	param 1 gl_query_object_pname
 target_method org/lwjgl/opengl/ARBTimerQuery glGetQueryObjecti64 (II)J
 	param 1 gl_query_object_pname
@@ -330,7 +330,7 @@ target_method com/mojang/blaze3d/platform/GlStateManager _glBindBuffer (II)V
 	param 0 gl_bind_buffer_target
 target_method com/mojang/blaze3d/platform/GlStateManager _glBufferData (IJI)V
 	param 0 gl_bind_buffer_target
-	param 3 gl_buffer_data_usage
+	param 2 gl_buffer_data_usage
 target_method com/mojang/blaze3d/platform/GlStateManager mapBuffer (II)Ljava/nio/ByteBuffer;
 	param 0 gl_bind_buffer_target
 	param 1 gl_map_buffer_access
@@ -343,7 +343,7 @@ target_method org/lwjgl/opengl/GL32C glBindBuffer (II)V
 	param 0 gl_bind_buffer_target
 target_method org/lwjgl/opengl/GL32C glBufferData (IJI)V
 	param 0 gl_bind_buffer_target
-	param 3 gl_buffer_data_usage
+	param 2 gl_buffer_data_usage
 
 target_method com/mojang/blaze3d/platform/GlStateManager _getError ()I
 	return gl_error

--- a/unpick-definitions/gl.unpick
+++ b/unpick-definitions/gl.unpick
@@ -1,0 +1,374 @@
+v2
+
+# Unpick definition for GL
+
+# Editing Note:
+# This file sorts constant declarations by the class name it is
+# most frequently used in. Lines declaring or using the same constants
+# are grouped.
+
+# Where possible, this will unpick the constant using values from
+# the game jar (usually GlConst in Blaze3D.) If there is no applicable
+# field there, this will use the value from GLxx class in LWJGL,
+# where XX is the lowest version the constant is available in.
+
+# This does not unpick all constants in LWJGL; that'd become
+# too big and target methods become harder to maintain.
+# Only constants that need unpicking in vanilla are listed.
+
+# Framebuffer
+
+constant gl_framebuffer_target com/mojang/blaze3d/platform/GlConst GL_FRAMEBUFFER
+constant gl_framebuffer_target com/mojang/blaze3d/platform/GlConst GL_READ_FRAMEBUFFER
+constant gl_framebuffer_target com/mojang/blaze3d/platform/GlConst GL_DRAW_FRAMEBUFFER
+
+constant gl_filter com/mojang/blaze3d/platform/GlConst GL_NEAREST
+constant gl_filter com/mojang/blaze3d/platform/GlConst GL_LINEAR
+
+constant gl_tex_target com/mojang/blaze3d/platform/GlConst GL_TEXTURE_2D
+constant gl_tex_target com/mojang/blaze3d/platform/GlConst GL_PROXY_TEXTURE_2D
+
+constant gl_tex_parameter_pname com/mojang/blaze3d/platform/GlConst GL_TEXTURE_MAG_FILTER
+constant gl_tex_parameter_pname com/mojang/blaze3d/platform/GlConst GL_TEXTURE_MIN_FILTER
+constant gl_tex_parameter_pname com/mojang/blaze3d/platform/GlConst GL_TEXTURE_COMPARE_MODE
+constant gl_tex_parameter_pname com/mojang/blaze3d/platform/GlConst GL_TEXTURE_WRAP_S
+constant gl_tex_parameter_pname com/mojang/blaze3d/platform/GlConst GL_TEXTURE_WRAP_T
+constant gl_tex_parameter_pname org/lwjgl/opengl/GL12 GL_TEXTURE_MAX_LEVEL
+constant gl_tex_parameter_pname org/lwjgl/opengl/GL12 GL_TEXTURE_MAX_LOD
+constant gl_tex_parameter_pname org/lwjgl/opengl/GL12 GL_TEXTURE_MIN_LOD
+constant gl_tex_parameter_pname org/lwjgl/opengl/GL14 GL_TEXTURE_LOD_BIAS
+
+constant gl_tex_parameter_value com/mojang/blaze3d/platform/GlConst GL_NEAREST
+constant gl_tex_parameter_value com/mojang/blaze3d/platform/GlConst GL_LINEAR
+constant gl_tex_parameter_value com/mojang/blaze3d/platform/GlConst GL_CLAMP_TO_EDGE
+constant gl_tex_parameter_value com/mojang/blaze3d/platform/GlConst GL_NEAREST_MIPMAP_LINEAR
+constant gl_tex_parameter_value com/mojang/blaze3d/platform/GlConst GL_LINEAR_MIPMAP_LINEAR
+
+constant gl_tex_format com/mojang/blaze3d/platform/GlConst GL_DEPTH_COMPONENT
+constant gl_tex_format com/mojang/blaze3d/platform/GlConst GL_RGBA8
+constant gl_tex_format com/mojang/blaze3d/platform/GlConst GL_RGBA
+constant gl_tex_format com/mojang/blaze3d/platform/GlConst GL_BGR
+constant gl_tex_format com/mojang/blaze3d/platform/GlConst GL_RG
+constant gl_tex_format com/mojang/blaze3d/platform/GlConst GL_RGB
+constant gl_tex_format com/mojang/blaze3d/platform/GlConst GL_RED
+constant gl_tex_format org/lwjgl/opengl/GL12 GL_BGRA
+
+constant gl_type com/mojang/blaze3d/platform/GlConst GL_BYTE
+constant gl_type com/mojang/blaze3d/platform/GlConst GL_UNSIGNED_BYTE
+constant gl_type com/mojang/blaze3d/platform/GlConst GL_SHORT
+constant gl_type com/mojang/blaze3d/platform/GlConst GL_UNSIGNED_SHORT
+constant gl_type com/mojang/blaze3d/platform/GlConst GL_INT
+constant gl_type com/mojang/blaze3d/platform/GlConst GL_UNSIGNED_INT
+constant gl_type com/mojang/blaze3d/platform/GlConst GL_FLOAT
+constant gl_type com/mojang/blaze3d/platform/GlConst GL_UNSIGNED_INT_8_8_8_8_REV
+
+constant gl_framebuffer_attachment com/mojang/blaze3d/platform/GlConst GL_COLOR_ATTACHMENT0
+constant gl_framebuffer_attachment com/mojang/blaze3d/platform/GlConst GL_DEPTH_ATTACHMENT
+
+constant gl_framebuffer_status com/mojang/blaze3d/platform/GlConst GL_FRAMEBUFFER_COMPLETE
+constant gl_framebuffer_status com/mojang/blaze3d/platform/GlConst GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT
+constant gl_framebuffer_status com/mojang/blaze3d/platform/GlConst GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT
+constant gl_framebuffer_status com/mojang/blaze3d/platform/GlConst GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER
+constant gl_framebuffer_status com/mojang/blaze3d/platform/GlConst GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER
+constant gl_framebuffer_status com/mojang/blaze3d/platform/GlConst GL_FRAMEBUFFER_UNSUPPORTED
+constant gl_framebuffer_status com/mojang/blaze3d/platform/GlConst GL_OUT_OF_MEMORY
+
+# GlBlendState
+
+constant gl_blend_equation_mode com/mojang/blaze3d/platform/GlConst GL_FUNC_ADD
+constant gl_blend_equation_mode com/mojang/blaze3d/platform/GlConst GL_MIN
+constant gl_blend_equation_mode com/mojang/blaze3d/platform/GlConst GL_MAX
+constant gl_blend_equation_mode com/mojang/blaze3d/platform/GlConst GL_FUNC_SUBTRACT
+constant gl_blend_equation_mode com/mojang/blaze3d/platform/GlConst GL_FUNC_REVERSE_SUBTRACT
+
+# GlDebug - Does not have blaze3d const
+constant gl_debug_source org/lwjgl/opengl/GL43 GL_DEBUG_SOURCE_API
+constant gl_debug_source org/lwjgl/opengl/GL43 GL_DEBUG_SOURCE_WINDOW_SYSTEM
+constant gl_debug_source org/lwjgl/opengl/GL43 GL_DEBUG_SOURCE_SHADER_COMPILER
+constant gl_debug_source org/lwjgl/opengl/GL43 GL_DEBUG_SOURCE_THIRD_PARTY
+constant gl_debug_source org/lwjgl/opengl/GL43 GL_DEBUG_SOURCE_APPLICATION
+constant gl_debug_source org/lwjgl/opengl/GL43 GL_DEBUG_SOURCE_OTHER
+
+constant gl_debug_type org/lwjgl/opengl/GL43 GL_DEBUG_TYPE_ERROR
+constant gl_debug_type org/lwjgl/opengl/GL43 GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR
+constant gl_debug_type org/lwjgl/opengl/GL43 GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR
+constant gl_debug_type org/lwjgl/opengl/GL43 GL_DEBUG_TYPE_PORTABILITY
+constant gl_debug_type org/lwjgl/opengl/GL43 GL_DEBUG_TYPE_PERFORMANCE
+constant gl_debug_type org/lwjgl/opengl/GL43 GL_DEBUG_TYPE_OTHER
+constant gl_debug_type org/lwjgl/opengl/GL43 GL_DEBUG_TYPE_MARKER
+
+constant gl_debug_severity org/lwjgl/opengl/GL43 GL_DEBUG_SEVERITY_HIGH
+constant gl_debug_severity org/lwjgl/opengl/GL43 GL_DEBUG_SEVERITY_MEDIUM
+constant gl_debug_severity org/lwjgl/opengl/GL43 GL_DEBUG_SEVERITY_LOW
+constant gl_debug_severity org/lwjgl/opengl/GL43 GL_DEBUG_SEVERITY_NOTIFICATION
+
+constant gl_enable_state org/lwjgl/opengl/GL11 GL_BLEND
+constant gl_enable_state org/lwjgl/opengl/GL11 GL_DEPTH_TEST
+constant gl_enable_state org/lwjgl/opengl/GL11 GL_CULL_FACE
+constant gl_enable_state org/lwjgl/opengl/GL11 GL_POLYGON_OFFSET_FULL
+constant gl_enable_state org/lwjgl/opengl/GL11 GL_POLYGON_OFFSET_LINE
+constant gl_enable_state org/lwjgl/opengl/GL11 GL_COLOR_LOGIC_OP
+constant gl_enable_state org/lwjgl/opengl/GL11 GL_SCISSOR_TEST
+constant gl_enable_state org/lwjgl/opengl/GL43 GL_DEBUG_OUTPUT
+constant gl_enable_state org/lwjgl/opengl/GL43 GL_DEBUG_OUTPUT_SYNCHRONOUS
+
+constant gl_hint_mode org/lwjgl/opengl/GL11 GL_DONT_CARE
+
+# GlProgramManager
+
+constant gl_program_pname com/mojang/blaze3d/platform/GlConst GL_LINK_STATUS
+constant gl_program_pname com/mojang/blaze3d/platform/GlConst GL_COMPILE_STATUS
+
+# note: glGetProgramInfoLog 32768 is not a const or flag
+
+# GlTimer
+
+constant gl_query_target org/lwjgl/opengl/GL33 GL_TIME_ELAPSED
+
+constant gl_query_object_pname org/lwjgl/opengl/GL15 GL_QUERY_RESULT
+constant gl_query_object_pname org/lwjgl/opengl/GL15 GL_QUERY_RESULT_AVAILABLE
+
+# JsonEffectGlShader etc
+constant gl_texture com/mojang/blaze3d/platform/GlConst GL_TEXTURE0
+constant gl_texture com/mojang/blaze3d/platform/GlConst GL_TEXTURE1
+constant gl_texture com/mojang/blaze3d/platform/GlConst GL_TEXTURE2
+
+# Program
+constant gl_program_type com/mojang/blaze3d/platform/GlConst GL_VERTEX_SHADER
+constant gl_program_type com/mojang/blaze3d/platform/GlConst GL_FRAGMENT_SHADER
+
+# VertexBuffer
+constant gl_bind_buffer_target com/mojang/blaze3d/platform/GlConst GL_ARRAY_BUFFER
+constant gl_bind_buffer_target com/mojang/blaze3d/platform/GlConst GL_ELEMENT_ARRAY_BUFFER
+
+constant gl_buffer_data_usage com/mojang/blaze3d/platform/GlConst GL_STATIC_DRAW
+constant gl_buffer_data_usage com/mojang/blaze3d/platform/GlConst GL_DYNAMIC_DRAW
+
+constant gl_error com/mojang/blaze3d/platform/GlConst GL_OUT_OF_MEMORY
+
+# GlDebugInfo
+constant gl_get_string_name org/lwjgl/opengl/GL11 GL_VENDOR
+constant gl_get_string_name org/lwjgl/opengl/GL11 GL_RENDERER
+constant gl_get_string_name org/lwjgl/opengl/GL11 GL_VERSION
+constant gl_get_string_name org/lwjgl/opengl/GL11 GL_EXTENSIONS
+
+# GlStateManager
+
+constant gl_get_integer_pname org/lwjgl/opengl/GL11 GL_DRAW_FRAMEBUFFER_BINDING
+constant gl_get_integer_pname org/lwjgl/opengl/GL11 GL_MAX_TEXTURE_SIZE
+
+constant gl_logic_op org/lwjgl/opengl/GL11 GL_CLEAR
+constant gl_logic_op org/lwjgl/opengl/GL11 GL_AND
+constant gl_logic_op org/lwjgl/opengl/GL11 GL_AND_REVERSE
+constant gl_logic_op org/lwjgl/opengl/GL11 GL_COPY
+constant gl_logic_op org/lwjgl/opengl/GL11 GL_AND_INVERTED
+constant gl_logic_op org/lwjgl/opengl/GL11 GL_NOOP
+constant gl_logic_op org/lwjgl/opengl/GL11 GL_XOR
+constant gl_logic_op org/lwjgl/opengl/GL11 GL_OR
+constant gl_logic_op org/lwjgl/opengl/GL11 GL_NOR
+constant gl_logic_op org/lwjgl/opengl/GL11 GL_EQUIV
+constant gl_logic_op org/lwjgl/opengl/GL11 GL_INVERT
+constant gl_logic_op org/lwjgl/opengl/GL11 GL_OR_REVERSE
+constant gl_logic_op org/lwjgl/opengl/GL11 GL_COPY_INVERTED
+constant gl_logic_op org/lwjgl/opengl/GL11 GL_OR_INVERTED
+constant gl_logic_op org/lwjgl/opengl/GL11 GL_NAND
+constant gl_logic_op org/lwjgl/opengl/GL11 GL_SET
+
+constant gl_blend_func_factor org/lwjgl/opengl/GL14 GL_CONSTANT_ALPHA
+constant gl_blend_func_factor org/lwjgl/opengl/GL14 GL_CONSTANT_COLOR
+constant gl_blend_func_factor org/lwjgl/opengl/GL14 GL_ONE_MINUS_CONSTANT_ALPHA
+constant gl_blend_func_factor org/lwjgl/opengl/GL14 GL_ONE_MINUS_CONSTANT_COLOR
+constant gl_blend_func_factor com/mojang/blaze3d/platform/GlConst GL_DST_ALPHA
+constant gl_blend_func_factor com/mojang/blaze3d/platform/GlConst GL_DST_COLOR
+constant gl_blend_func_factor com/mojang/blaze3d/platform/GlConst GL_ONE_MINUS_DST_ALPHA
+constant gl_blend_func_factor com/mojang/blaze3d/platform/GlConst GL_ONE_MINUS_DST_COLOR
+constant gl_blend_func_factor com/mojang/blaze3d/platform/GlConst GL_SRC_ALPHA
+constant gl_blend_func_factor com/mojang/blaze3d/platform/GlConst GL_SRC_COLOR
+constant gl_blend_func_factor com/mojang/blaze3d/platform/GlConst GL_ONE_MINUS_SRC_ALPHA
+constant gl_blend_func_factor com/mojang/blaze3d/platform/GlConst GL_ONE_MINUS_SRC_COLOR
+
+# TextureUtil
+constant gl_pixel_store_pname com/mojang/blaze3d/platform/GlConst GL_UNPACK_SWAP_BYTES
+constant gl_pixel_store_pname com/mojang/blaze3d/platform/GlConst GL_UNPACK_LSB_FIRST
+constant gl_pixel_store_pname com/mojang/blaze3d/platform/GlConst GL_UNPACK_ROW_LENGTH
+constant gl_pixel_store_pname com/mojang/blaze3d/platform/GlConst GL_UNPACK_SKIP_ROWS
+constant gl_pixel_store_pname com/mojang/blaze3d/platform/GlConst GL_UNPACK_SKIP_PIXELS
+constant gl_pixel_store_pname com/mojang/blaze3d/platform/GlConst GL_UNPACK_ALIGNMENT
+constant gl_pixel_store_pname com/mojang/blaze3d/platform/GlConst GL_PACK_ALIGNMENT
+
+constant gl_map_buffer_access com/mojang/blaze3d/platform/GlConst GL_WRITE_ONLY
+
+# MinecraftClient
+flag gl_clear_mask com/mojang/blaze3d/platform/GlConst GL_DEPTH_BUFFER_BIT
+flag gl_clear_mask com/mojang/blaze3d/platform/GlConst GL_COLOR_BUFFER_BIT
+
+# Target definition
+
+target_method com/mojang/blaze3d/platform/GlStateManager _glBindFramebuffer (II)V
+	param 0 gl_framebuffer_target
+target_method com/mojang/blaze3d/platform/GlStateManager _glFramebufferTexture2D (IIIII)V
+	param 0 gl_framebuffer_target
+	param 1 gl_framebuffer_attachment
+	param 2 gl_tex_target
+target_method com/mojang/blaze3d/platform/GlStateManager glCheckFramebufferStatus (I)I
+	param 0 gl_framebuffer_target
+	return gl_framebuffer_status
+
+target_method com/mojang/blaze3d/platform/GlStateManager _glBlitFrameBuffer (IIIIIIIIII)V
+	param 9 gl_filter
+target_method net/minecraft/client/gl/Framebuffer setTexFilter (I)V
+	param 0 gl_filter
+
+target_method com/mojang/blaze3d/platform/GlStateManager _texParameter (III)V
+	param 0 gl_tex_target
+	param 1 gl_tex_parameter_pname
+	param 2 gl_tex_parameter_value
+target_method com/mojang/blaze3d/platform/GlStateManager _texParameter (IIF)V
+	param 0 gl_tex_target
+	param 1 gl_tex_parameter_pname
+target_method com/mojang/blaze3d/platform/GlStateManager _texImage2D (IIIIIIIILjava/nio/IntBuffer;)V
+	param 0 gl_tex_target
+	param 2 gl_tex_format
+	param 6 gl_tex_format
+	param 7 gl_type
+
+target_method com/mojang/blaze3d/systems/RenderSystem texParameter (III)V
+	param 0 gl_tex_target
+	param 1 gl_tex_parameter_pname
+	param 2 gl_tex_parameter_value
+target_method com/mojang/blaze3d/platform/GlStateManager _texSubImage2D (IIIIIIIIJ)V
+	param 0 gl_tex_target
+	param 6 gl_tex_format
+	param 7 gl_type
+target_method com/mojang/blaze3d/platform/GlStateManager _getTexImage (IIIIJ)V
+	param 0 gl_tex_target
+target_method org/lwjgl/opengl/GL11 glBindTexture (II)V
+	param 0 gl_tex_target
+target_method org/lwjgl/opengl/GL11 glTexImage2D (IIIIIIIILjava/nio/IntBuffer;)V
+	param 0 gl_tex_target
+	param 2 gl_tex_format
+	param 6 gl_tex_format
+target_method org/lwjgl/opengl/GL11 glTexParameteri (III)V
+	param 0 gl_tex_target
+
+target_method com/mojang/blaze3d/platform/GlStateManager _readPixels (IIIIIIJ)V
+	param 4 gl_tex_format
+	param 5 gl_type
+target_method com/mojang/blaze3d/platform/GlStateManager _glDrawPixels (IIIIJ)V
+	param 2 gl_tex_format
+	param 3 gl_type
+target_method net/minecraft/client/texture/NativeImage$Format <init> (Ljava/lang/String;IIIZZZZZIIIIIZ)V
+	param 3 gl_tex_format
+target_method net/minecraft/client/texture/NativeImage$InternalFormat <init> (Ljava/lang/String;II)V
+	param 2 gl_tex_format
+
+target_method net/minecraft/client/render/VertexFormatElement$DataType <init> (Ljava/lang/String;IILjava/lang/String;I)V
+	param 4 gl_type
+target_method net/minecraft/client/render/VertexFormat$IntType <init> (Ljava/lang/String;III)V
+	param 2 gl_type
+
+target_method net/minecraft/client/gl/GlBlendState <init> (ZZIIIII)V
+	param 6 gl_blend_equation_mode
+target_method net/minecraft/client/gl/GlBlendState <init> (III)V
+	param 2 gl_blend_equation_mode
+target_method net/minecraft/client/gl/GlBlendState getModeFromString (Ljava/lang/String;)I
+	return gl_blend_equation_mode
+
+target_method net/minecraft/client/gl/GlDebug getSource (I)Ljava/lang/String;
+	param 0 gl_debug_source
+target_method net/minecraft/client/gl/GlDebug info (IIIIIJJ)V
+	param 0 gl_debug_source
+	param 1 gl_debug_type
+	param 3 gl_debug_severity
+target_method net/minecraft/client/gl/GlDebug$DebugMessage <init> (IIIILjava/lang/String;)V
+	param 0 gl_debug_source
+	param 1 gl_debug_type
+	param 3 gl_debug_severity
+
+target_method net/minecraft/client/gl/GlDebug getType (I)Ljava/lang/String;
+	param 0 gl_debug_type
+
+target_method net/minecraft/client/gl/GlDebug getSeverity (I)Ljava/lang/String;
+	param 0 gl_debug_severity
+
+target_method com/mojang/blaze3d/platform/GlStateManager$CapabilityTracker <init> (I)V
+	param 0 gl_enable_state
+target_method org/lwjgl/opengl/GL11 glEnable (I)V
+	param 0 gl_enable_state
+
+target_method org/lwjgl/opengl/KHRDebug glDebugMessageControl (III[IZ)V
+	param 0 gl_hint_mode
+	param 1 gl_hint_mode
+target_method org/lwjgl/opengl/ARBDebugOutput glDebugMessageControlARB (III[IZ)V
+	param 0 gl_hint_mode
+	param 1 gl_hint_mode
+
+target_method com/mojang/blaze3d/platform/GlStateManager glGetProgrami (II)I
+	param 1 gl_program_pname
+target_method com/mojang/blaze3d/platform/GlStateManager glGetShaderi (II)I
+	param 1 gl_program_pname
+
+target_method org/lwjgl/opengl/GL32C glBeginQuery (II)V
+	param 0 gl_query_target
+target_method org/lwjgl/opengl/GL32C glEndQuery (I)V
+	param 0 gl_query_target
+
+target_method org/lwjgl/opengl/ARBTimerQuery glGetQueryObjecti (II)I
+	param 1 gl_query_object_pname
+target_method org/lwjgl/opengl/ARBTimerQuery glGetQueryObjecti64 (II)J
+	param 1 gl_query_object_pname
+
+target_method com/mojang/blaze3d/platform/GlStateManager _activeTexture (I)V
+	param 0 gl_texture
+target_method com/mojang/blaze3d/systems/RenderSystem activeTexture (I)V
+	param 0 gl_texture
+
+target_method net/minecraft/client/gl/Program$Type <init> (Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;I)V
+	param 4 gl_program_type
+
+target_method com/mojang/blaze3d/platform/GlStateManager _glBindBuffer (II)V
+	param 0 gl_bind_buffer_target
+target_method com/mojang/blaze3d/platform/GlStateManager _glBufferData (IJI)V
+	param 0 gl_bind_buffer_target
+	param 3 gl_buffer_data_usage
+target_method com/mojang/blaze3d/platform/GlStateManager mapBuffer (II)Ljava/nio/ByteBuffer;
+	param 0 gl_bind_buffer_target
+	param 1 gl_map_buffer_access
+target_method com/mojang/blaze3d/platform/GlStateManager _glUnmapBuffer (I)V
+	param 0 gl_bind_buffer_target
+target_method com/mojang/blaze3d/systems/RenderSystem glBufferData (ILjava/nio/ByteBuffer;I)V
+	param 0 gl_bind_buffer_target
+	param 2 gl_buffer_data_usage
+target_method org/lwjgl/opengl/GL32C glBindBuffer (II)V
+	param 0 gl_bind_buffer_target
+target_method org/lwjgl/opengl/GL32C glBufferData (IJI)V
+	param 0 gl_bind_buffer_target
+	param 3 gl_buffer_data_usage
+
+target_method com/mojang/blaze3d/platform/GlStateManager _getError ()I
+	return gl_error
+
+target_method com/mojang/blaze3d/platform/GlStateManager _getString (I)Ljava/lang/String;
+	param 0 gl_get_string_name
+
+target_method com/mojang/blaze3d/platform/GlStateManager _getInteger (I)I
+	param 0 gl_get_integer_pname
+
+target_method com/mojang/blaze3d/platform/GlStateManager$LogicOp <init> (Ljava/lang/String;II)V
+	param 2 gl_logic_op
+
+target_method com/mojang/blaze3d/platform/GlStateManager$SrcFactor <init> (Ljava/lang/String;II)V
+	param 2 gl_blend_func_factor
+target_method com/mojang/blaze3d/platform/GlStateManager$DstFactor <init> (Ljava/lang/String;II)V
+	param 2 gl_blend_func_factor
+target_method net/minecraft/client/gl/GlBlendState getFactorFromString (Ljava/lang/String;)I
+	return gl_blend_func_factor
+
+target_method com/mojang/blaze3d/platform/GlStateManager _pixelStore (II)V
+	param 0 gl_pixel_store_pname
+target_method org/lwjgl/opengl/GL11 glPixelStorei (II)V
+	param 0 gl_pixel_store_pname
+
+target_method com/mojang/blaze3d/systems/RenderSystem clear (IZ)V
+	param 0 gl_clear_mask
+

--- a/unpick-definitions/glfw.unpick
+++ b/unpick-definitions/glfw.unpick
@@ -23,13 +23,13 @@ constant glfw_window_hint_value org/lwjgl/glfw/GLFW GLFW_NATIVE_CONTEXT_API
 constant glfw_window_hint_value org/lwjgl/glfw/GLFW GLFW_OPENGL_CORE_PROFILE
 
 target_method org/lwjgl/glfw/GLFW glfwSetInputMode (JII)V
-	param 2 glfw_input_mode
+	param 1 glfw_input_mode
 
 target_method net/minecraft/client/util/InputUtil setCursorParameters (JIDD)V
-	param 2 glfw_input_mode_value
+	param 1 glfw_input_mode_value
 
 target_method net/minecraft/client/util/MonitorTracker handleMonitorEvent (JI)V
-	param 2 glfw_monitor_event
+	param 1 glfw_monitor_event
 
 target_method org/lwjgl/glfw/GLFW glfwWindowHint (II)V
 	param 0 glfw_window_hint

--- a/unpick-definitions/glfw.unpick
+++ b/unpick-definitions/glfw.unpick
@@ -1,0 +1,36 @@
+v2
+
+# InputUtil
+constant glfw_input_mode net/minecraft/client/util/InputUtil GLFW_CURSOR
+
+constant glfw_input_mode_value net/minecraft/client/util/InputUtil GLFW_CURSOR_DISABLED
+constant glfw_input_mode_value net/minecraft/client/util/InputUtil GLFW_CURSOR_NORMAL
+
+# MonitorTracker
+constant glfw_monitor_event org/lwjgl/glfw/GLFW GLFW_CONNECTED
+constant glfw_monitor_event org/lwjgl/glfw/GLFW GLFW_DISCONNECTED
+
+# Window
+constant glfw_window_hint org/lwjgl/glfw/GLFW GLFW_CLIENT_API
+constant glfw_window_hint org/lwjgl/glfw/GLFW GLFW_CONTEXT_CREATION_API
+constant glfw_window_hint org/lwjgl/glfw/GLFW GLFW_CONTEXT_VERSION_MAJOR
+constant glfw_window_hint org/lwjgl/glfw/GLFW GLFW_CONTEXT_VERSION_MINOR
+constant glfw_window_hint org/lwjgl/glfw/GLFW GLFW_OPENGL_FORWARD_COMPAT
+constant glfw_window_hint org/lwjgl/glfw/GLFW GLFW_OPENGL_PROFILE
+
+constant glfw_window_hint_value org/lwjgl/glfw/GLFW GLFW_OPENGL_API
+constant glfw_window_hint_value org/lwjgl/glfw/GLFW GLFW_NATIVE_CONTEXT_API
+constant glfw_window_hint_value org/lwjgl/glfw/GLFW GLFW_OPENGL_CORE_PROFILE
+
+target_method org/lwjgl/glfw/GLFW glfwSetInputMode (JII)V
+	param 2 glfw_input_mode
+
+target_method net/minecraft/client/util/InputUtil setCursorParameters (JIDD)V
+	param 2 glfw_input_mode_value
+
+target_method net/minecraft/client/util/MonitorTracker handleMonitorEvent (JI)V
+	param 2 glfw_monitor_event
+
+target_method org/lwjgl/glfw/GLFW glfwWindowHint (II)V
+	param 0 glfw_window_hint
+	param 1 glfw_window_hint_value


### PR DESCRIPTION
Big PR mapping rendering stuff.

# New Stuff
- 21w37a Priority Updates related stuff (`WorldRenderer`)
- 22w03a fog changes (`BackgroundRenderer`)
- 22w05a fluid rendering changes
- 22w16a rendering refactor stuff (`VertexBuffer` etc)
- `GlImportProcessor` methods (likely from 21w10a?)
- `blockRenderManager`/`heldItemRenderer`/etc fields
- Parameter mappings for Blaze3D and other stuff
- Unpick. Manually written, only contains the minimum required (does not unpick all LWJGL consts)

# Fixes
- `VertexBuffer`: incorrectly named `setShader` renamed to `draw`
- `ShaderEffect`: `location` -> `id`
- `Uniform`: `set` -> `setAndFlip` (to make `set` behavior consistent)
- `WindowFramebuffer`: `supportColor` -> `supportsColor`, `initSize` renamed to `init` because it initializes things that aren't size
- `WorldRenderer`: `drawShapeOutline` renamed to `drawCuboidShapeOutline`; `drawShapeOutline` is now assigned to a method that takes any shape (incl. non-cuboid)
- `TntMinecarftEntityRenderer`: `blockRenderManager` renamed to `tntBlockRenderManager` due to collision
- `GlBlendState`: uses `mode` and `factor` instead of `func` and `component` to match OpenGL terms
- `BufferRenderer`: method names now clarify whether it uses shaders, incorrectly named `postDraw` renamed to `drawWithoutShader`