### PR TITLE
Refactor vertex format stuff

### DIFF
--- a/mappings/com/mojang/blaze3d/systems/RenderSystem.mapping
+++ b/mappings/com/mojang/blaze3d/systems/RenderSystem.mapping
@@ -257,7 +257,7 @@ CLASS com/mojang/blaze3d/systems/RenderSystem
 		FIELD field_27333 increment I
 		FIELD field_27334 indexMapper Lcom/mojang/blaze3d/systems/RenderSystem$class_5590$class_5591;
 		FIELD field_27335 id I
-		FIELD field_27336 elementFormat Lnet/minecraft/class_293$class_5595;
+		FIELD field_27336 indexType Lnet/minecraft/class_293$class_5595;
 		FIELD field_27337 size I
 		METHOD <init> (IILcom/mojang/blaze3d/systems/RenderSystem$class_5590$class_5591;)V
 			ARG 1 sizeMultiplier
@@ -269,7 +269,7 @@ CLASS com/mojang/blaze3d/systems/RenderSystem
 			ARG 1 indicesBuffer
 		METHOD method_31923 (Ljava/nio/ByteBuffer;I)V
 			ARG 1 index
-		METHOD method_31924 getElementFormat ()Lnet/minecraft/class_293$class_5595;
+		METHOD method_31924 getIndexType ()Lnet/minecraft/class_293$class_5595;
 		METHOD method_31925 (Ljava/nio/ByteBuffer;I)V
 			ARG 1 index
 		METHOD method_43409 isSizeLessThanOrEqual (I)Z

--- a/mappings/net/minecraft/client/gl/VertexBuffer.mapping
+++ b/mappings/net/minecraft/client/gl/VertexBuffer.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_291 net/minecraft/client/gl/VertexBuffer
 	FIELD field_1593 vertexCount I
 	FIELD field_1594 vertexBufferId I
 	FIELD field_27366 indexBufferId I
-	FIELD field_27367 elementFormat Lnet/minecraft/class_293$class_5595;
+	FIELD field_27367 indexType Lnet/minecraft/class_293$class_5595;
 	FIELD field_27368 drawMode Lnet/minecraft/class_293$class_5596;
 	FIELD field_29338 vertexArrayId I
 	FIELD field_29339 vertexFormat Lnet/minecraft/class_293;
@@ -27,4 +27,4 @@ CLASS net/minecraft/class_291 net/minecraft/client/gl/VertexBuffer
 		ARG 1 parameters
 		ARG 2 data
 	METHOD method_43444 isClosed ()Z
-	METHOD method_43445 getElementFormat ()Lnet/minecraft/class_293$class_5595;
+	METHOD method_43445 getIndexType ()Lnet/minecraft/class_293$class_5595;

--- a/mappings/net/minecraft/client/render/BufferBuilder.mapping
+++ b/mappings/net/minecraft/client/render/BufferBuilder.mapping
@@ -46,28 +46,6 @@ CLASS net/minecraft/class_287 net/minecraft/client/render/BufferBuilder
 	METHOD method_31950 writeSortedIndices (Lnet/minecraft/class_293$class_5595;)V
 	METHOD method_31954 buildPrimitiveCenters ()[Lnet/minecraft/class_1160;
 	CLASS class_4574 DrawArrayParameters
-		FIELD comp_749 vertexFormat Lnet/minecraft/class_293;
-		FIELD comp_750 count I
-		FIELD comp_751 vertexCount I
-		FIELD comp_752 mode Lnet/minecraft/class_293$class_5596;
-		FIELD comp_753 elementFormat Lnet/minecraft/class_293$class_5595;
-		FIELD comp_754 hasNoVertexBuffer Z
-		FIELD comp_755 hasNoIndexBuffer Z
-		METHOD <init> (Lnet/minecraft/class_293;IILnet/minecraft/class_293$class_5596;Lnet/minecraft/class_293$class_5595;ZZ)V
-			ARG 1 vertexFormat
-			ARG 2 count
-			ARG 3 vertexCount
-			ARG 4 mode
-			ARG 5 elementFormat
-			ARG 6 hasNoVertexBuffer
-			ARG 7 hasNoIndexBuffer
-		METHOD comp_749 vertexFormat ()Lnet/minecraft/class_293;
-		METHOD comp_750 count ()I
-		METHOD comp_751 vertexCount ()I
-		METHOD comp_752 mode ()Lnet/minecraft/class_293$class_5596;
-		METHOD comp_753 elementFormat ()Lnet/minecraft/class_293$class_5595;
-		METHOD comp_754 hasNoVertexBuffer ()Z
-		METHOD comp_755 hasNoIndexBuffer ()Z
 		METHOD method_31957 getIndexBufferStart ()I
 		METHOD method_31958 getIndexBufferEnd ()I
 		METHOD method_31961 getIndexBufferLength ()I

--- a/mappings/net/minecraft/client/render/VertexFormat.mapping
+++ b/mappings/net/minecraft/client/render/VertexFormat.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_293 net/minecraft/client/render/VertexFormat
 	FIELD field_1597 offsets Lit/unimi/dsi/fastutil/ints/IntList;
-	FIELD field_1600 size I
+	FIELD field_1600 vertexSizeByte I
 	FIELD field_1602 elements Lcom/google/common/collect/ImmutableList;
 	FIELD field_29340 elementMap Lcom/google/common/collect/ImmutableMap;
 	FIELD field_38984 buffer Lnet/minecraft/class_291;
@@ -10,34 +10,37 @@ CLASS net/minecraft/class_293 net/minecraft/client/render/VertexFormat
 		ARG 1 o
 	METHOD method_1357 getElements ()Lcom/google/common/collect/ImmutableList;
 	METHOD method_1359 getVertexSizeInteger ()I
-	METHOD method_1362 getVertexSize ()I
-	METHOD method_22649 startDrawing ()V
-	METHOD method_22651 endDrawing ()V
-	METHOD method_34445 getShaderAttributes ()Lcom/google/common/collect/ImmutableList;
-	METHOD method_34449 innerStartDrawing ()V
-	METHOD method_34450 innerEndDrawing ()V
+	METHOD method_1362 getVertexSizeByte ()I
+	METHOD method_22649 setupState ()V
+		COMMENT Specifies for OpenGL how the vertex data should be interpreted.
+	METHOD method_22651 clearState ()V
+	METHOD method_34445 getAttributeNames ()Lcom/google/common/collect/ImmutableList;
+	METHOD method_34449 setupStateInternal ()V
+	METHOD method_34450 clearStateInternal ()V
 	METHOD method_43446 getBuffer ()Lnet/minecraft/class_291;
-	CLASS class_5595 IntType
-		FIELD field_27374 type I
+	CLASS class_5595 IndexType
+		FIELD field_27374 glType I
 		FIELD field_27375 size I
 		METHOD <init> (Ljava/lang/String;III)V
-			ARG 3 type
+			ARG 3 glType
 			ARG 4 size
-		METHOD method_31972 getSmallestTypeFor (I)Lnet/minecraft/class_293$class_5595;
-			COMMENT Gets the smallest type in which the given number fits.
-			COMMENT
-			COMMENT @return the smallest type
-			ARG 0 number
-				COMMENT a number from 8 to 32 bits of memory
+		METHOD method_31972 smallestFor (I)Lnet/minecraft/class_293$class_5595;
+			COMMENT {@return the smallest type in which {@code indexCount} fits}
+			ARG 0 indexCount
 	CLASS class_5596 DrawMode
-		FIELD field_27383 mode I
-		FIELD field_27384 vertexCount I
-		FIELD field_27385 size I
+		FIELD field_27383 glMode I
+		FIELD field_27384 firstVertexCount I
+			COMMENT The number of vertices needed to form a first shape.
+		FIELD field_27385 additionalVertexCount I
+			COMMENT The number of vertices needed to form an additional shape. In other
+			COMMENT words, it's {@code firstVertexCount - s} where {@code s} is the number
+			COMMENT of vertices shared with the previous shape.
 		FIELD field_38878 shareVertices Z
+			COMMENT Whether there are shared vertices in consecutive shapes.
 		METHOD <init> (Ljava/lang/String;IIIIZ)V
-			ARG 3 mode
-			ARG 4 vertexCount
-			ARG 5 size
+			ARG 3 glMode
+			ARG 4 firstVertexCount
+			ARG 5 additionalVertexCount
 			ARG 6 shareVertices
-		METHOD method_31973 getSize (I)I
+		METHOD method_31973 getIndexCount (I)I
 			ARG 1 vertexCount

--- a/mappings/net/minecraft/client/render/VertexFormatElement.mapping
+++ b/mappings/net/minecraft/client/render/VertexFormatElement.mapping
@@ -1,135 +1,154 @@
 CLASS net/minecraft/class_296 net/minecraft/client/render/VertexFormatElement
-	COMMENT Represents a singular field within a larger vertex format.
-	COMMENT <p>
-	COMMENT This element comprises a data type, a field length,
-	COMMENT and the corresponding GL element type to which this field corresponds.
-	FIELD field_1612 length I
-	FIELD field_1613 textureIndex I
+	COMMENT Represents a singular field within a larger {@link
+	COMMENT net.minecraft.client.render.VertexFormat vertex format}.
+	COMMENT
+	COMMENT <p>This element comprises a component type, the number of components,
+	COMMENT and a type that describes how the components should be interpreted.
+	FIELD field_1612 componentCount I
+	FIELD field_1613 uvIndex I
 	FIELD field_1614 type Lnet/minecraft/class_296$class_298;
-	FIELD field_1615 dataType Lnet/minecraft/class_296$class_297;
+	FIELD field_1615 componentType Lnet/minecraft/class_296$class_297;
 	FIELD field_21329 byteLength I
 		COMMENT The total length of this element (in bytes).
 	METHOD <init> (ILnet/minecraft/class_296$class_297;Lnet/minecraft/class_296$class_298;I)V
-		ARG 1 textureIndex
-		ARG 2 dataType
+		ARG 1 uvIndex
+		ARG 2 componentType
 		ARG 3 type
-		ARG 4 length
+		ARG 4 componentCount
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o
 	METHOD method_1382 getType ()Lnet/minecraft/class_296$class_298;
 	METHOD method_1383 isValidType (ILnet/minecraft/class_296$class_298;)Z
-		ARG 1 index
+		ARG 1 uvIndex
 		ARG 2 type
-	METHOD method_1385 getTextureIndex ()I
-	METHOD method_1386 getDataType ()Lnet/minecraft/class_296$class_297;
+	METHOD method_1385 getUvIndex ()I
+	METHOD method_1386 getComponentType ()Lnet/minecraft/class_296$class_297;
 	METHOD method_1387 getByteLength ()I
-	METHOD method_22652 startDrawing (IJI)V
+	METHOD method_22652 setupState (IJI)V
+		COMMENT Specifies for OpenGL how the vertex data corresponding to this element
+		COMMENT should be interpreted.
 		ARG 1 elementIndex
-		ARG 2 pointer
+			COMMENT the index of the element in a vertex format
+		ARG 2 offset
+			COMMENT the distance between the start of the buffer and the first instance of
+			COMMENT the element in the buffer
 		ARG 4 stride
-	METHOD method_22653 endDrawing (I)V
+			COMMENT the distance between consecutive instances of the element in the buffer
+	METHOD method_22653 clearState (I)V
 		ARG 1 elementIndex
-	METHOD method_34451 getLength ()I
+	METHOD method_34451 getComponentCount ()I
 	METHOD method_35667 isPosition ()Z
-	CLASS class_297 DataType
+	CLASS class_297 ComponentType
+		COMMENT Represents a type of components in an element.
 		FIELD field_1618 byteLength I
 		FIELD field_1626 name Ljava/lang/String;
-		FIELD field_1627 id I
+		FIELD field_1627 glType I
 		METHOD <init> (Ljava/lang/String;IILjava/lang/String;I)V
-			ARG 3 byteCount
+			ARG 3 byteLength
 			ARG 4 name
-			ARG 5 id
+			ARG 5 glType
 		METHOD method_1389 getName ()Ljava/lang/String;
-		METHOD method_1390 getId ()I
+		METHOD method_1390 getGlType ()I
 		METHOD method_1391 getByteLength ()I
 	CLASS class_298 Type
+		COMMENT Describes how the components should be interpreted.
 		FIELD field_1630 name Ljava/lang/String;
-		FIELD field_20783 starter Lnet/minecraft/class_296$class_298$class_4575;
-		FIELD field_20784 finisher Lnet/minecraft/class_296$class_298$class_5938;
+		FIELD field_20783 setupTask Lnet/minecraft/class_296$class_298$class_4575;
+		FIELD field_20784 clearTask Lnet/minecraft/class_296$class_298$class_5938;
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;Lnet/minecraft/class_296$class_298$class_4575;Lnet/minecraft/class_296$class_298$class_5938;)V
 			ARG 3 name
-			ARG 4 starter
-			ARG 5 finisher
+			ARG 4 setupTask
+			ARG 5 clearTask
 		METHOD method_1392 getName ()Ljava/lang/String;
-		METHOD method_22654 endDrawing (II)V
-			ARG 1 textureIndex
+		METHOD method_22654 clearState (II)V
+			ARG 1 uvIndex
 			ARG 2 elementIndex
-		METHOD method_22655 startDrawing (IIIJII)V
-			ARG 1 size
-			ARG 2 type
+		METHOD method_22655 setupState (IIIJII)V
+			ARG 1 componentCount
+			ARG 2 componentType
 			ARG 3 stride
-			ARG 4 pointer
-			ARG 6 textureIndex
+			ARG 4 offset
+			ARG 6 uvIndex
 			ARG 7 elementIndex
 		METHOD method_22657 (II)V
-			ARG 0 textureIndex
+			ARG 0 uvIndex
 			ARG 1 elementIndex
 		METHOD method_22658 (IIIJII)V
-			ARG 0 size
-			ARG 1 type
+			ARG 0 componentCount
+			ARG 1 componentType
 			ARG 2 stride
-			ARG 3 pointer
-			ARG 5 textureIndex
+			ARG 3 offset
+			ARG 5 uvIndex
 			ARG 6 elementIndex
 		METHOD method_22659 (II)V
-			ARG 0 textureIndex
+			ARG 0 uvIndex
 			ARG 1 elementIndex
 		METHOD method_22660 (IIIJII)V
-			ARG 0 size
-			ARG 1 type
+			ARG 0 componentCount
+			ARG 1 componentType
 			ARG 2 stride
-			ARG 3 pointer
-			ARG 5 textureIndex
+			ARG 3 offset
+			ARG 5 uvIndex
 			ARG 6 elementIndex
 		METHOD method_22661 (II)V
-			ARG 0 textureIndex
+			ARG 0 uvIndex
 			ARG 1 elementIndex
 		METHOD method_22662 (IIIJII)V
-			ARG 0 size
-			ARG 1 type
+			ARG 0 componentCount
+			ARG 1 componentType
 			ARG 2 stride
-			ARG 3 pointer
-			ARG 5 textureIndex
+			ARG 3 offset
+			ARG 5 uvIndex
 			ARG 6 elementIndex
 		METHOD method_22663 (II)V
-			ARG 0 textureIndex
+			ARG 0 uvIndex
 			ARG 1 elementIndex
 		METHOD method_22664 (IIIJII)V
-			ARG 0 size
-			ARG 1 type
+			ARG 0 componentCount
+			ARG 1 componentType
 			ARG 2 stride
-			ARG 3 pointer
-			ARG 5 textureIndex
+			ARG 3 offset
+			ARG 5 uvIndex
 			ARG 6 elementIndex
 		METHOD method_22665 (II)V
-			ARG 0 textureIndex
+			ARG 0 uvIndex
 			ARG 1 elementIndex
 		METHOD method_22666 (IIIJII)V
-			ARG 0 size
-			ARG 1 type
+			ARG 0 componentCount
+			ARG 1 componentType
 			ARG 2 stride
-			ARG 3 pointer
-			ARG 5 textureIndex
+			ARG 3 offset
+			ARG 5 uvIndex
 			ARG 6 elementIndex
 		METHOD method_22667 (IIIJII)V
-			ARG 0 size
-			ARG 1 type
+			ARG 0 componentCount
+			ARG 1 componentType
 			ARG 2 stride
-			ARG 3 pointer
-			ARG 5 textureIndex
+			ARG 3 offset
+			ARG 5 uvIndex
 			ARG 6 elementIndex
 		METHOD method_34452 (II)V
-			ARG 0 textureIndex
+			ARG 0 uvIndex
 			ARG 1 elementIndex
-		CLASS class_4575 Starter
+		CLASS class_4575 SetupTask
 			METHOD setupBufferState (IIIJII)V
-				ARG 1 size
-				ARG 2 type
+				COMMENT Specifies for OpenGL how the vertex data corresponding to the element
+				COMMENT should be interpreted.
+				ARG 1 componentCount
+					COMMENT the number of components in the element
+				ARG 2 componentType
+					COMMENT the GL type of components in the element
 				ARG 3 stride
-				ARG 4 pointer
-				ARG 6 textureIndex
+					COMMENT the distance between consecutive instances of the element in the buffer
+				ARG 4 offset
+					COMMENT the distance between the start of the buffer and the first instance of
+					COMMENT the element in the buffer; be aware that {@code pointer} is a legacy
+					COMMENT name from OpenGL 2
+				ARG 6 uvIndex
 				ARG 7 elementIndex
-		CLASS class_5938 Finisher
+					COMMENT the index of the element in a vertex format
+		CLASS class_5938 ClearTask
 			METHOD clearBufferState (II)V
-				ARG 1 textureIndex
+				ARG 1 uvIndex
 				ARG 2 elementIndex
+					COMMENT the index of the element in a vertex format

--- a/mappings/net/minecraft/client/render/VertexFormats.mapping
+++ b/mappings/net/minecraft/client/render/VertexFormats.mapping
@@ -12,12 +12,12 @@ CLASS net/minecraft/class_290 net/minecraft/client/render/VertexFormats
 	FIELD field_1586 POSITION_TEXTURE_LIGHT_COLOR Lnet/minecraft/class_293;
 	FIELD field_1587 POSITION_ELEMENT Lnet/minecraft/class_296;
 	FIELD field_1590 POSITION_COLOR_TEXTURE_LIGHT_NORMAL Lnet/minecraft/class_293;
-	FIELD field_1591 TEXTURE_0_ELEMENT Lnet/minecraft/class_296;
+	FIELD field_1591 TEXTURE_ELEMENT Lnet/minecraft/class_296;
 	FIELD field_1592 POSITION Lnet/minecraft/class_293;
 	FIELD field_20886 LIGHT_ELEMENT Lnet/minecraft/class_296;
 	FIELD field_20887 POSITION_COLOR_TEXTURE Lnet/minecraft/class_293;
 	FIELD field_20888 POSITION_COLOR_TEXTURE_LIGHT Lnet/minecraft/class_293;
 	FIELD field_21468 POSITION_COLOR_LIGHT Lnet/minecraft/class_293;
-	FIELD field_29335 TEXTURE_ELEMENT Lnet/minecraft/class_296;
+	FIELD field_29335 UV_ELEMENT Lnet/minecraft/class_296;
 	FIELD field_29336 BLIT_SCREEN Lnet/minecraft/class_293;
 	FIELD field_29337 LINES Lnet/minecraft/class_293;

--- a/unpick-definitions/gl.unpick
+++ b/unpick-definitions/gl.unpick
@@ -262,9 +262,9 @@ target_method net/minecraft/client/texture/NativeImage$Format <init> (Ljava/lang
 target_method net/minecraft/client/texture/NativeImage$InternalFormat <init> (Ljava/lang/String;II)V
 	param 2 gl_tex_format
 
-target_method net/minecraft/client/render/VertexFormatElement$DataType <init> (Ljava/lang/String;IILjava/lang/String;I)V
+target_method net/minecraft/client/render/VertexFormatElement$ComponentType <init> (Ljava/lang/String;IILjava/lang/String;I)V
 	param 4 gl_type
-target_method net/minecraft/client/render/VertexFormat$IntType <init> (Ljava/lang/String;III)V
+target_method net/minecraft/client/render/VertexFormat$IndexType <init> (Ljava/lang/String;III)V
 	param 2 gl_type
 
 target_method net/minecraft/client/gl/GlBlendState <init> (ZZIIIII)V


### PR DESCRIPTION
The main renames are

* `VertexFormat.IntType` → `IndexType`: It's exclusively used as a type of indices in an index buffer. Mojang refactored `BufferBuilder.DrawArrayParameters` and made it into a record in 22w17a. Its exposed name is `indexType`, which verifies this rename.
* `VertexFormat#startDrawing` → `setupState`: `startDrawing` does not describe its purpose.
* `VertexFormatElement.DataType` → `ComponentType`: `DataType` is not clear what data mean.

See also my javadoc for reasoning.