### PR TITLE
22w17a network stuff: part 2

### DIFF
--- a/mappings/net/minecraft/SharedConstants.mapping
+++ b/mappings/net/minecraft/SharedConstants.mapping
@@ -39,7 +39,7 @@ CLASS net/minecraft/class_155 net/minecraft/SharedConstants
 		COMMENT @apiNote This method is used to determine if the server should
 		COMMENT accept a chat message sent from client.
 		COMMENT
-		COMMENT @see net.minecraft.server.network.ServerPlayNetworkHandler#<p>hasIllegalCharacter
+		COMMENT @see net.minecraft.server.network.ServerPlayNetworkHandler#hasIllegalCharacter
 		ARG 0 chr
 	METHOD method_644 stripInvalidChars (Ljava/lang/String;)Ljava/lang/String;
 		ARG 0 s

--- a/mappings/net/minecraft/SharedConstants.mapping
+++ b/mappings/net/minecraft/SharedConstants.mapping
@@ -39,7 +39,7 @@ CLASS net/minecraft/class_155 net/minecraft/SharedConstants
 		COMMENT @apiNote This method is used to determine if the server should
 		COMMENT accept a chat message sent from client.
 		COMMENT
-		COMMENT @see net.minecraft.server.network.ServerPlayNetworkHandler#onChatMessage
+		COMMENT @see net.minecraft.server.network.ServerPlayNetworkHandler#<p>hasIllegalCharacter
 		ARG 0 chr
 	METHOD method_644 stripInvalidChars (Ljava/lang/String;)Ljava/lang/String;
 		ARG 0 s

--- a/mappings/net/minecraft/client/MinecraftClient.mapping
+++ b/mappings/net/minecraft/client/MinecraftClient.mapping
@@ -171,6 +171,7 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 	FIELD field_37855 metricsSampleDuration J
 	FIELD field_37856 gpuUtilizationPercentage D
 	FIELD field_37857 currentGlTimerQuery Lnet/minecraft/class_7168$class_7169;
+	FIELD field_39068 profileKeys Lnet/minecraft/class_7434;
 	METHOD <init> (Lnet/minecraft/class_542;)V
 		ARG 1 args
 	METHOD method_1476 checkIs64Bit ()Z
@@ -470,6 +471,7 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 	METHOD method_41733 forceStopRecorder ()V
 	METHOD method_41734 getGpuUtilizationPercentage ()D
 	METHOD method_41735 createIntegratedServerLoader ()Lnet/minecraft/class_7196;
+	METHOD method_43590 getProfileKeys ()Lnet/minecraft/class_7434;
 	CLASS class_5859 ChatRestriction
 		COMMENT Represents the restrictions on chat on a Minecraft client.
 		COMMENT

--- a/mappings/net/minecraft/client/gui/ClientChatListener.mapping
+++ b/mappings/net/minecraft/client/gui/ClientChatListener.mapping
@@ -4,8 +4,8 @@ CLASS net/minecraft/class_334 net/minecraft/client/gui/ClientChatListener
 	COMMENT <p>Listeners are registered at {@link net.minecraft.client.gui.hud.InGameHud#listeners}
 	COMMENT per message type.
 	COMMENT
-	COMMENT @see InGameHud#onChatMessage
-	COMMENT @see InGameHud#onGameMessage
+	COMMENT @see net.minecraft.client.gui.hud.InGameHud#onChatMessage
+	COMMENT @see net.minecraft.client.gui.hud.InGameHud#onGameMessage
 	METHOD method_1794 onChatMessage (Lnet/minecraft/class_2556;Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)V
 		COMMENT Called when a message is received.
 		ARG 1 type

--- a/mappings/net/minecraft/client/gui/ClientChatListener.mapping
+++ b/mappings/net/minecraft/client/gui/ClientChatListener.mapping
@@ -1,5 +1,14 @@
 CLASS net/minecraft/class_334 net/minecraft/client/gui/ClientChatListener
+	COMMENT A listener for received chat messages and game messages.
+	COMMENT
+	COMMENT <p>Listeners are registered at {@link net.minecraft.client.gui.hud.InGameHud#listeners}
+	COMMENT per message type.
+	COMMENT
+	COMMENT @see InGameHud#onChatMessage
+	COMMENT @see InGameHud#onGameMessage
 	METHOD method_1794 onChatMessage (Lnet/minecraft/class_2556;Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)V
+		COMMENT Called when a message is received.
 		ARG 1 type
 		ARG 2 message
 		ARG 3 sender
+			COMMENT the chat message's sender, {@code null} for game messages

--- a/mappings/net/minecraft/client/gui/ClientChatListener.mapping
+++ b/mappings/net/minecraft/client/gui/ClientChatListener.mapping
@@ -11,4 +11,4 @@ CLASS net/minecraft/class_334 net/minecraft/client/gui/ClientChatListener
 		ARG 1 type
 		ARG 2 message
 		ARG 3 sender
-			COMMENT the chat message's sender, {@code null} for game messages
+			COMMENT the chat message's sender, or {@code null} for game messages

--- a/mappings/net/minecraft/client/gui/ClientChatListener.mapping
+++ b/mappings/net/minecraft/client/gui/ClientChatListener.mapping
@@ -2,3 +2,4 @@ CLASS net/minecraft/class_334 net/minecraft/client/gui/ClientChatListener
 	METHOD method_1794 onChatMessage (Lnet/minecraft/class_2556;Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)V
 		ARG 1 type
 		ARG 2 message
+		ARG 3 sender

--- a/mappings/net/minecraft/client/gui/hud/ChatHudListener.mapping
+++ b/mappings/net/minecraft/client/gui/hud/ChatHudListener.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/class_335 net/minecraft/client/gui/hud/ChatHudListener
 	FIELD field_2056 client Lnet/minecraft/class_310;
 	METHOD <init> (Lnet/minecraft/class_310;)V
 		ARG 1 client
-	METHOD method_43594 toDisplayedText (Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)Lnet/minecraft/class_2561;
+	METHOD method_43594 format (Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)Lnet/minecraft/class_2561;
+		COMMENT {@return the text formatted for displaying in the chat hud}
 		ARG 0 message
 		ARG 1 sender

--- a/mappings/net/minecraft/client/gui/hud/ChatHudListener.mapping
+++ b/mappings/net/minecraft/client/gui/hud/ChatHudListener.mapping
@@ -2,3 +2,6 @@ CLASS net/minecraft/class_335 net/minecraft/client/gui/hud/ChatHudListener
 	FIELD field_2056 client Lnet/minecraft/class_310;
 	METHOD <init> (Lnet/minecraft/class_310;)V
 		ARG 1 client
+	METHOD method_43594 toDisplayedText (Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)Lnet/minecraft/class_2561;
+		ARG 0 message
+		ARG 1 sender

--- a/mappings/net/minecraft/client/gui/hud/InGameHud.mapping
+++ b/mappings/net/minecraft/client/gui/hud/InGameHud.mapping
@@ -159,6 +159,13 @@ CLASS net/minecraft/class_329 net/minecraft/client/gui/hud/InGameHud
 	METHOD method_39192 renderAutosaveIndicator (Lnet/minecraft/class_4587;)V
 		ARG 1 matrices
 	METHOD method_39193 tickAutosaveIndicator ()V
+	METHOD method_43591 onChatMessage (Lnet/minecraft/class_2556;Lnet/minecraft/class_2561;)V
+		ARG 1 type
+		ARG 2 message
+	METHOD method_43592 onChatMessage (Lnet/minecraft/class_2556;Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)V
+		ARG 1 type
+		ARG 2 message
+		ARG 3 sender
 	CLASS class_6411 HeartType
 		FIELD field_33950 textureIndex I
 		FIELD field_33951 hasBlinkingTexture Z

--- a/mappings/net/minecraft/client/gui/hud/InGameHud.mapping
+++ b/mappings/net/minecraft/client/gui/hud/InGameHud.mapping
@@ -163,7 +163,7 @@ CLASS net/minecraft/class_329 net/minecraft/client/gui/hud/InGameHud
 		COMMENT Handles a game message.
 		COMMENT
 		COMMENT @implNote This method discards the message if {@linkplain #extractSender the extracted
-		COMMENT sender} is blocked and calls {@link ClientChatListener#onChatMessage}.
+		COMMENT sender} is blocked. Otherwise, it calls {@link ClientChatListener#onChatMessage}.
 		COMMENT
 		COMMENT @see net.minecraft.client.network.ClientPlayNetworkHandler#onGameMessage
 		ARG 1 type
@@ -171,8 +171,8 @@ CLASS net/minecraft/class_329 net/minecraft/client/gui/hud/InGameHud
 	METHOD method_43592 onChatMessage (Lnet/minecraft/class_2556;Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)V
 		COMMENT Handles a chat message.
 		COMMENT
-		COMMENT @implNote This method discards the message if the sender is blocked and calls
-		COMMENT {@link ClientChatListener#onChatMessage}.
+		COMMENT @implNote This method discards the message if the sender is blocked.
+		COMMENT Otherwise, it calls {@link ClientChatListener#onChatMessage}.
 		COMMENT
 		COMMENT @see net.minecraft.client.network.ClientPlayNetworkHandler#onChatMessage
 		ARG 1 type

--- a/mappings/net/minecraft/client/gui/hud/InGameHud.mapping
+++ b/mappings/net/minecraft/client/gui/hud/InGameHud.mapping
@@ -162,7 +162,7 @@ CLASS net/minecraft/class_329 net/minecraft/client/gui/hud/InGameHud
 	METHOD method_43591 onGameMessage (Lnet/minecraft/class_2556;Lnet/minecraft/class_2561;)V
 		COMMENT Handles a game message.
 		COMMENT
-		COMMENT @implNote This method discard the message if {@linkplain #extractSender the extracted
+		COMMENT @implNote This method discards the message if {@linkplain #extractSender the extracted
 		COMMENT sender} is blocked and calls {@link ClientChatListener#onChatMessage}.
 		COMMENT
 		COMMENT @see net.minecraft.client.network.ClientPlayNetworkHandler#onGameMessage
@@ -171,7 +171,7 @@ CLASS net/minecraft/class_329 net/minecraft/client/gui/hud/InGameHud
 	METHOD method_43592 onChatMessage (Lnet/minecraft/class_2556;Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)V
 		COMMENT Handles a chat message.
 		COMMENT
-		COMMENT @implNote This method discard the message if the sender is blocked and calls
+		COMMENT @implNote This method discards the message if the sender is blocked and calls
 		COMMENT {@link ClientChatListener#onChatMessage}.
 		COMMENT
 		COMMENT @see net.minecraft.client.network.ClientPlayNetworkHandler#onChatMessage

--- a/mappings/net/minecraft/client/gui/hud/InGameHud.mapping
+++ b/mappings/net/minecraft/client/gui/hud/InGameHud.mapping
@@ -159,10 +159,22 @@ CLASS net/minecraft/class_329 net/minecraft/client/gui/hud/InGameHud
 	METHOD method_39192 renderAutosaveIndicator (Lnet/minecraft/class_4587;)V
 		ARG 1 matrices
 	METHOD method_39193 tickAutosaveIndicator ()V
-	METHOD method_43591 onChatMessage (Lnet/minecraft/class_2556;Lnet/minecraft/class_2561;)V
+	METHOD method_43591 onGameMessage (Lnet/minecraft/class_2556;Lnet/minecraft/class_2561;)V
+		COMMENT Handles a game message.
+		COMMENT
+		COMMENT @implNote This method discard the message if {@linkplain #extractSender the extracted
+		COMMENT sender} is blocked and calls {@link ClientChatListener#onChatMessage}.
+		COMMENT
+		COMMENT @see net.minecraft.client.network.ClientPlayNetworkHandler#onGameMessage
 		ARG 1 type
 		ARG 2 message
 	METHOD method_43592 onChatMessage (Lnet/minecraft/class_2556;Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)V
+		COMMENT Handles a chat message.
+		COMMENT
+		COMMENT @implNote This method discard the message if the sender is blocked and calls
+		COMMENT {@link ClientChatListener#onChatMessage}.
+		COMMENT
+		COMMENT @see net.minecraft.client.network.ClientPlayNetworkHandler#onChatMessage
 		ARG 1 type
 		ARG 2 message
 		ARG 3 sender

--- a/mappings/net/minecraft/client/network/ClientPlayNetworkHandler.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayNetworkHandler.mapping
@@ -111,3 +111,8 @@ CLASS net/minecraft/class_634 net/minecraft/client/network/ClientPlayNetworkHand
 		ARG 1 entity
 	METHOD method_43331 resolveUrl (Ljava/lang/String;)Ljava/net/URL;
 		ARG 0 url
+	METHOD method_43597 isSignatureValid (Lnet/minecraft/class_7438;)Z
+		COMMENT {@return whether the chat message packet has a valid signature}
+		COMMENT
+		COMMENT <p>This returns {@code false} when the chat sender is unknown.
+		ARG 1 packet

--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -112,7 +112,7 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 	METHOD method_33689 init ()V
 	METHOD method_43609 signChatMessage (Ljava/time/Instant;Ljava/lang/String;)Lnet/minecraft/class_3515$class_7425;
 		COMMENT Signs the chat message. If the chat message cannot be signed, this will return
-		COMMENT {@link NetworkEncryptionUtils.SignatureData.NONE}.
+		COMMENT {@link NetworkEncryptionUtils.SignatureData#NONE}.
 		ARG 1 time
 		ARG 2 message
 	METHOD method_7290 dropSelectedItem (Z)Z

--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -110,5 +110,8 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 	METHOD method_3149 isAutoJumpEnabled ()Z
 	METHOD method_3151 getMountJumpStrength ()F
 	METHOD method_33689 init ()V
+	METHOD method_43609 signChatMessage (Ljava/time/Instant;Ljava/lang/String;)Lnet/minecraft/class_3515$class_7425;
+		ARG 1 instant
+		ARG 2 message
 	METHOD method_7290 dropSelectedItem (Z)Z
 		ARG 1 entireStack

--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -111,7 +111,9 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 	METHOD method_3151 getMountJumpStrength ()F
 	METHOD method_33689 init ()V
 	METHOD method_43609 signChatMessage (Ljava/time/Instant;Ljava/lang/String;)Lnet/minecraft/class_3515$class_7425;
-		ARG 1 instant
+		COMMENT Signs the chat message. If the chat message cannot be signed, this will return
+		COMMENT {@link NetworkEncryptionUtils.SignatureData.NONE}.
+		ARG 1 time
 		ARG 2 message
 	METHOD method_7290 dropSelectedItem (Z)Z
 		ARG 1 entireStack

--- a/mappings/net/minecraft/client/network/PlayerListEntry.mapping
+++ b/mappings/net/minecraft/client/network/PlayerListEntry.mapping
@@ -12,7 +12,7 @@ CLASS net/minecraft/class_640 net/minecraft/client/network/PlayerListEntry
 	FIELD field_3746 showTime J
 	FIELD field_3747 blinkingHeartTime J
 	FIELD field_39072 LOGGER Lorg/slf4j/Logger;
-	FIELD field_39073 publicKey Lnet/minecraft/class_7428$class_7429;
+	FIELD field_39073 publicKeyInfo Lnet/minecraft/class_7428$class_7429;
 	METHOD <init> (Lnet/minecraft/class_2703$class_2705;Lcom/mojang/authlib/minecraft/MinecraftSessionService;)V
 		ARG 1 playerListPacketEntry
 	METHOD method_2955 getScoreboardTeam ()Lnet/minecraft/class_268;
@@ -55,4 +55,4 @@ CLASS net/minecraft/class_640 net/minecraft/client/network/PlayerListEntry
 		ARG 1 lastHealthTime
 	METHOD method_2979 getCapeTexture ()Lnet/minecraft/class_2960;
 	METHOD method_35757 hasCape ()Z
-	METHOD method_43598 getPublicKey ()Lnet/minecraft/class_7428$class_7429;
+	METHOD method_43598 getPublicKeyInfo ()Lnet/minecraft/class_7428$class_7429;

--- a/mappings/net/minecraft/client/network/PlayerListEntry.mapping
+++ b/mappings/net/minecraft/client/network/PlayerListEntry.mapping
@@ -12,9 +12,10 @@ CLASS net/minecraft/class_640 net/minecraft/client/network/PlayerListEntry
 	FIELD field_3746 showTime J
 	FIELD field_3747 blinkingHeartTime J
 	FIELD field_39072 LOGGER Lorg/slf4j/Logger;
-	FIELD field_39073 publicKeyInfo Lnet/minecraft/class_7428$class_7429;
+	FIELD field_39073 publicKeyData Lnet/minecraft/class_7428$class_7429;
 	METHOD <init> (Lnet/minecraft/class_2703$class_2705;Lcom/mojang/authlib/minecraft/MinecraftSessionService;)V
 		ARG 1 playerListPacketEntry
+		ARG 2 sessionService
 	METHOD method_2955 getScoreboardTeam ()Lnet/minecraft/class_268;
 	METHOD method_2956 (Lcom/mojang/authlib/minecraft/MinecraftProfileTexture$Type;Lnet/minecraft/class_2960;Lcom/mojang/authlib/minecraft/MinecraftProfileTexture;)V
 		ARG 1 type
@@ -55,4 +56,4 @@ CLASS net/minecraft/class_640 net/minecraft/client/network/PlayerListEntry
 		ARG 1 lastHealthTime
 	METHOD method_2979 getCapeTexture ()Lnet/minecraft/class_2960;
 	METHOD method_35757 hasCape ()Z
-	METHOD method_43598 getPublicKeyInfo ()Lnet/minecraft/class_7428$class_7429;
+	METHOD method_43598 getPublicKeyData ()Lnet/minecraft/class_7428$class_7429;

--- a/mappings/net/minecraft/client/network/PlayerListEntry.mapping
+++ b/mappings/net/minecraft/client/network/PlayerListEntry.mapping
@@ -11,6 +11,8 @@ CLASS net/minecraft/class_640 net/minecraft/client/network/PlayerListEntry
 	FIELD field_3745 model Ljava/lang/String;
 	FIELD field_3746 showTime J
 	FIELD field_3747 blinkingHeartTime J
+	FIELD field_39072 LOGGER Lorg/slf4j/Logger;
+	FIELD field_39073 publicKey Lnet/minecraft/class_7428$class_7429;
 	METHOD <init> (Lnet/minecraft/class_2703$class_2705;Lcom/mojang/authlib/minecraft/MinecraftSessionService;)V
 		ARG 1 playerListPacketEntry
 	METHOD method_2955 getScoreboardTeam ()Lnet/minecraft/class_268;
@@ -53,3 +55,4 @@ CLASS net/minecraft/class_640 net/minecraft/client/network/PlayerListEntry
 		ARG 1 lastHealthTime
 	METHOD method_2979 getCapeTexture ()Lnet/minecraft/class_2960;
 	METHOD method_35757 hasCape ()Z
+	METHOD method_43598 getPublicKey ()Lnet/minecraft/class_7428$class_7429;

--- a/mappings/net/minecraft/client/util/NarratorManager.mapping
+++ b/mappings/net/minecraft/client/util/NarratorManager.mapping
@@ -15,3 +15,7 @@ CLASS net/minecraft/class_333 net/minecraft/client/util/NarratorManager
 		ARG 1 text
 	METHOD method_37016 debugPrintMessage (Ljava/lang/String;)V
 		ARG 1 message
+	METHOD method_43593 toNarratedMessage (Lnet/minecraft/class_2556;Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)Lnet/minecraft/class_2561;
+		ARG 1 type
+		ARG 2 message
+		ARG 3 sender

--- a/mappings/net/minecraft/client/util/ProfileKeys.mapping
+++ b/mappings/net/minecraft/client/util/ProfileKeys.mapping
@@ -12,12 +12,12 @@ CLASS net/minecraft/class_7434 net/minecraft/client/util/ProfileKeys
 		COMMENT {@return the SHA1withRSA signature instance used for signing, or {@code null} if
 		COMMENT there is no private key associated with the profile}
 		COMMENT
-		COMMENT @apiNote Use {#link NetworkEncryptionUtils.SignatureData#createSignatureInstance()}
+		COMMENT @apiNote Use {#link PlayerPublicKey.PublicKeyData#createSignatureInstance()}
 		COMMENT to create the signature for verifying the signatures.
 		COMMENT
 		COMMENT @throws GeneralSecurityException when creation fails
 		COMMENT
-		COMMENT @see NetworkEncryptionUtils.SignatureData#createSignatureInstance()
+		COMMENT @see PlayerPublicKey.PublicKeyData#createSignatureInstance()
 	METHOD method_43600 saveKeyPairToFile (Lnet/minecraft/class_7427;)V
 		COMMENT Saves the {@code keyPair} to the cache file.
 		ARG 1 keyPair

--- a/mappings/net/minecraft/client/util/ProfileKeys.mapping
+++ b/mappings/net/minecraft/client/util/ProfileKeys.mapping
@@ -19,5 +19,5 @@ CLASS net/minecraft/class_7434 net/minecraft/client/util/ProfileKeys
 		ARG 0 keyPair
 	METHOD method_43605 fetchKeyPair (Lcom/mojang/authlib/minecraft/UserApiService;)Lnet/minecraft/class_7427;
 		ARG 1 userApiService
-	METHOD method_43606 loadKeyPairFileFile ()Ljava/util/Optional;
+	METHOD method_43606 loadKeyPairFromFile ()Ljava/util/Optional;
 	METHOD method_43608 getPrivateKey ()Ljava/security/PrivateKey;

--- a/mappings/net/minecraft/client/util/ProfileKeys.mapping
+++ b/mappings/net/minecraft/client/util/ProfileKeys.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_7434 net/minecraft/client/util/ProfileKeys
+	COMMENT A class to fetch, load, and save the player's public and private keys.
 	FIELD field_39074 LOGGER Lorg/slf4j/Logger;
 	FIELD field_39075 PROFILE_KEYS_PATH Ljava/nio/file/Path;
 	FIELD field_39076 jsonPath Ljava/nio/file/Path;
@@ -7,17 +8,42 @@ CLASS net/minecraft/class_7434 net/minecraft/client/util/ProfileKeys
 		ARG 1 userApiService
 		ARG 2 uuid
 		ARG 3 root
-	METHOD method_43599 getSignature ()Ljava/security/Signature;
+	METHOD method_43599 createSignatureInstance ()Ljava/security/Signature;
+		COMMENT {@return the SHA1withRSA signature instance used for signing, or {@code null} if
+		COMMENT there is no private key associated with the profile}
+		COMMENT
+		COMMENT @apiNote Use {#link NetworkEncryptionUtils.SignatureData#createSignatureInstance()}
+		COMMENT to create the signature for verifying the signatures.
+		COMMENT
+		COMMENT @throws GeneralSecurityException when creation fails
+		COMMENT
+		COMMENT @see NetworkEncryptionUtils.SignatureData#createSignatureInstance()
 	METHOD method_43600 saveKeyPairToFile (Lnet/minecraft/class_7427;)V
+		COMMENT Saves the {@code keyPair} to the cache file.
 		ARG 1 keyPair
 	METHOD method_43601 (Lcom/google/gson/JsonElement;)V
 		ARG 1 json
 	METHOD method_43602 getKeyPair (Lcom/mojang/authlib/minecraft/UserApiService;)Ljava/util/concurrent/CompletableFuture;
+		COMMENT Gets the key pair from the file cache, or if it is unavailable or expired,
+		COMMENT the Mojang server.
 		ARG 1 userApiService
 	METHOD method_43603 getPublicKey ()Lnet/minecraft/class_7428;
+		COMMENT {@return the public key, or {@code null} if there is no public key associated
+		COMMENT with the profile}
 	METHOD method_43604 (Lnet/minecraft/class_7427;)Z
 		ARG 0 keyPair
 	METHOD method_43605 fetchKeyPair (Lcom/mojang/authlib/minecraft/UserApiService;)Lnet/minecraft/class_7427;
+		COMMENT {@return the key pair fetched from Mojang's server}
+		COMMENT
+		COMMENT @throws NetworkEncryptionException when the fetched key is malformed
+		COMMENT @throws IOException when fetching fails
 		ARG 1 userApiService
 	METHOD method_43606 loadKeyPairFromFile ()Ljava/util/Optional;
+		COMMENT {@return the profile keys from the local cache}
+		COMMENT
+		COMMENT <p>This can return expired keys.
+		COMMENT
+		COMMENT @implNote The cache file is stored at {@code .minecraft/profilekeys/<uuid>,json}.
 	METHOD method_43608 getPrivateKey ()Ljava/security/PrivateKey;
+		COMMENT {@return the private key, or {@code null} if there is no private key associated
+		COMMENT with the profile}

--- a/mappings/net/minecraft/client/util/ProfileKeys.mapping
+++ b/mappings/net/minecraft/client/util/ProfileKeys.mapping
@@ -43,7 +43,7 @@ CLASS net/minecraft/class_7434 net/minecraft/client/util/ProfileKeys
 		COMMENT
 		COMMENT <p>This can return expired keys.
 		COMMENT
-		COMMENT @implNote The cache file is stored at {@code .minecraft/profilekeys/<uuid>,json}.
+		COMMENT @implNote The cache file is stored at {@code .minecraft/profilekeys/<uuid>.json}.
 	METHOD method_43608 getPrivateKey ()Ljava/security/PrivateKey;
 		COMMENT {@return the private key, or {@code null} if there is no private key associated
 		COMMENT with the profile}

--- a/mappings/net/minecraft/client/util/ProfileKeys.mapping
+++ b/mappings/net/minecraft/client/util/ProfileKeys.mapping
@@ -1,0 +1,23 @@
+CLASS net/minecraft/class_7434 net/minecraft/client/util/ProfileKeys
+	FIELD field_39074 LOGGER Lorg/slf4j/Logger;
+	FIELD field_39075 PROFILE_KEYS_PATH Ljava/nio/file/Path;
+	FIELD field_39076 jsonPath Ljava/nio/file/Path;
+	FIELD field_39077 keyPairFuture Ljava/util/concurrent/CompletableFuture;
+	METHOD <init> (Lcom/mojang/authlib/minecraft/UserApiService;Ljava/util/UUID;Ljava/nio/file/Path;)V
+		ARG 1 userApiService
+		ARG 2 uuid
+		ARG 3 root
+	METHOD method_43599 getSignature ()Ljava/security/Signature;
+	METHOD method_43600 saveKeyPairToFile (Lnet/minecraft/class_7427;)V
+		ARG 1 keyPair
+	METHOD method_43601 (Lcom/google/gson/JsonElement;)V
+		ARG 1 json
+	METHOD method_43602 getKeyPair (Lcom/mojang/authlib/minecraft/UserApiService;)Ljava/util/concurrent/CompletableFuture;
+		ARG 1 userApiService
+	METHOD method_43603 getPublicKey ()Lnet/minecraft/class_7428;
+	METHOD method_43604 (Lnet/minecraft/class_7427;)Z
+		ARG 0 keyPair
+	METHOD method_43605 fetchKeyPair (Lcom/mojang/authlib/minecraft/UserApiService;)Lnet/minecraft/class_7427;
+		ARG 1 userApiService
+	METHOD method_43606 loadKeyPairFileFile ()Ljava/util/Optional;
+	METHOD method_43608 getPrivateKey ()Ljava/security/PrivateKey;

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -115,6 +115,7 @@ CLASS net/minecraft/class_1657 net/minecraft/entity/player/PlayerEntity
 	METHOD method_43120 setLastDeathPos (Ljava/util/Optional;)V
 		ARG 1 lastDeathPos
 	METHOD method_43122 getLastDeathPos ()Ljava/util/Optional;
+	METHOD method_43545 asChatSender ()Lnet/minecraft/class_7436;
 	METHOD method_7254 unlockRecipes (Ljava/util/Collection;)I
 		ARG 1 recipes
 	METHOD method_7255 addExperience (I)V

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -115,7 +115,7 @@ CLASS net/minecraft/class_1657 net/minecraft/entity/player/PlayerEntity
 	METHOD method_43120 setLastDeathPos (Ljava/util/Optional;)V
 		ARG 1 lastDeathPos
 	METHOD method_43122 getLastDeathPos ()Ljava/util/Optional;
-	METHOD method_43545 asChatSender ()Lnet/minecraft/class_7436;
+	METHOD method_43545 asChatMessageSender ()Lnet/minecraft/class_7436;
 	METHOD method_7254 unlockRecipes (Ljava/util/Collection;)I
 		ARG 1 recipes
 	METHOD method_7255 addExperience (I)V

--- a/mappings/net/minecraft/network/ChatMessageSender.mapping
+++ b/mappings/net/minecraft/network/ChatMessageSender.mapping
@@ -1,4 +1,8 @@
 CLASS net/minecraft/class_7436 net/minecraft/network/ChatMessageSender
+	COMMENT The sender, or the source, of a chat message.
+	COMMENT
+	COMMENT <p>An instance can be obtained via
+	COMMENT {@link net.minecraft.entity.player.PlayerEntity#asChatMessageSender}.
 	METHOD <init> (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD method_43625 write (Lnet/minecraft/class_2540;)V

--- a/mappings/net/minecraft/network/PacketByteBuf.mapping
+++ b/mappings/net/minecraft/network/PacketByteBuf.mapping
@@ -876,7 +876,7 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 			COMMENT a value to write, must be in {@code registry}
 	METHOD method_43616 writeGameProfile (Lcom/mojang/authlib/GameProfile;)V
 		COMMENT Writes a game profile to this buf. A game profile is represented by a
-		COMMENT {@linkplain #writeUUID(UUID) uuid}, a username string, and a collection of
+		COMMENT {@linkplain #writeUuid(UUID) uuid}, a username string, and a collection of
 		COMMENT {@linkplain #writeProperty(Property) properties}.
 		COMMENT
 		COMMENT @see #readGameProfile()
@@ -915,7 +915,7 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 		ARG 2 rightParser
 	METHOD method_43623 readGameProfile ()Lcom/mojang/authlib/GameProfile;
 		COMMENT Reads a game profile from this buf. A game profile is represented by a
-		COMMENT {@linkplain #readUUID() uuid}, a username string, and a collection of
+		COMMENT {@linkplain #readUuid() uuid}, a username string, and a collection of
 		COMMENT {@linkplain #readProperty() properties}.
 		COMMENT
 		COMMENT @return the game profile

--- a/mappings/net/minecraft/network/PacketByteBuf.mapping
+++ b/mappings/net/minecraft/network/PacketByteBuf.mapping
@@ -12,7 +12,7 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 	COMMENT  <td>Codec-based</td><td>{@link #decode(Codec)}</td><td>{@link #encode(Codec, Object)}</td>
 	COMMENT </tr>
 	COMMENT <tr>
-	COMMENT  <td>{@link Registry} value</td><td>{@link #readRegistryValue(IndexedIterable)}</td><td>{@link #writeRegistryValue(IndexedIterable, Object)}</td>
+	COMMENT  <td>{@link net.minecraft.util.registry.Registry} value</td><td>{@link #readRegistryValue(IndexedIterable)}</td><td>{@link #writeRegistryValue(IndexedIterable, Object)}</td>
 	COMMENT </tr>
 	COMMENT <tr>
 	COMMENT  <td>{@link Collection}</td><td>{@link #readCollection(IntFunction, Function)}</td><td>{@link #writeCollection(Collection, BiConsumer)}</td>
@@ -57,6 +57,15 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 	COMMENT  <td>{@link UUID}</td><td>{@link #readUuid()}</td><td>{@link #writeUuid(UUID)}</td>
 	COMMENT </tr>
 	COMMENT <tr>
+	COMMENT  <td>{@index GameProfile}</td><td>{@link #readGameProfile()}</td><td>{@link #writeGameProfile(GameProfile)}</td>
+	COMMENT </tr>
+	COMMENT <tr>
+	COMMENT  <td>{@index Property}</td><td>{@link #readProperty()}</td><td>{@link #writeProperty(Property)}</td>
+	COMMENT </tr>
+	COMMENT <tr>
+	COMMENT  <td>{@link UUID}</td><td>{@link #readUuid()}</td><td>{@link #writeUuid(UUID)}</td>
+	COMMENT </tr>
+	COMMENT <tr>
 	COMMENT  <td>{@link NbtCompound}</td><td>{@link #readNbt()}</td><td>{@link #writeNbt(NbtCompound)}</td>
 	COMMENT </tr>
 	COMMENT <tr>
@@ -79,6 +88,9 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 	COMMENT </tr>
 	COMMENT <tr>
 	COMMENT  <td>{@link Optional}</td><td>{@link #readOptional(Function)}</td><td>{@link #writeOptional(Optional, BiConsumer)}</td>
+	COMMENT </tr>
+	COMMENT <tr>
+	COMMENT  <td>{@index Either}</td><td>{@link #readEither(Function, Function)}</td><td>{@link #writeEither(Either, BiConsumer, BiConsumer)}</td>
 	COMMENT </tr>
 	COMMENT </table></div>
 	COMMENT
@@ -862,6 +874,61 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 			COMMENT the registry (or an indexed iterable) that contains the value
 		ARG 2 value
 			COMMENT a value to write, must be in {@code registry}
+	METHOD method_43616 writeGameProfile (Lcom/mojang/authlib/GameProfile;)V
+		COMMENT Writes a game profile to this buf. A game profile is represented by a
+		COMMENT {@linkplain writeUUID(UUID) uuid}, a username string, and a collection of
+		COMMENT {@linkplain writeProperty(Property) properties}.
+		COMMENT
+		COMMENT @return the game profile
+		COMMENT @see #readGameProfile()
+		ARG 1 gameProfile
+	METHOD method_43617 writeProperty (Lcom/mojang/authlib/properties/Property;)V
+		COMMENT Writes a property to this buf. A property is represented by a string representing
+		COMMENT the property key, a string representing the property value, a boolean indicating
+		COMMENT whether the property is signed, and a string representing the signature (only
+		COMMENT exists if signed).
+		COMMENT
+		COMMENT @see #readProperty()
+		ARG 1 property
+	METHOD method_43618 (Lcom/mojang/authlib/properties/PropertyMap;Lnet/minecraft/class_2540;)V
+		ARG 2 buf
+	METHOD method_43619 writeEither (Lcom/mojang/datafixers/util/Either;Ljava/util/function/BiConsumer;Ljava/util/function/BiConsumer;)V
+		COMMENT Writes an {@code Either} to this buf. An either is represented by
+		COMMENT a boolean indicating if the left side or the right side of the either,
+		COMMENT followed by the value.
+		COMMENT
+		COMMENT @see #readEither(Function, Function)
+		ARG 1 either
+		ARG 2 leftSerializer
+		ARG 3 rightSerializer
+	METHOD method_43620 (Ljava/util/function/BiConsumer;Ljava/lang/Object;)V
+		ARG 2 object
+	METHOD method_43621 (Ljava/util/function/BiConsumer;Ljava/lang/Object;)V
+		ARG 2 object
+	METHOD method_43622 readEither (Ljava/util/function/Function;Ljava/util/function/Function;)Lcom/mojang/datafixers/util/Either;
+		COMMENT Reads an {@code Either} from this buf. An either is represented by
+		COMMENT a boolean indicating if the left side or the right side of the either,
+		COMMENT followed by the value.
+		COMMENT
+		COMMENT @return the read either
+		COMMENT @see #writeEither(Either, BiConsumer, BiConsumer)
+		ARG 1 leftParser
+		ARG 2 rightParser
+	METHOD method_43623 readGameProfile ()Lcom/mojang/authlib/GameProfile;
+		COMMENT Reads a game profile from this buf. A game profile is represented by a
+		COMMENT {@linkplain readUUID() uuid}, a username string, and a collection of
+		COMMENT {@linkplain readProperty() properties}.
+		COMMENT
+		COMMENT @return the game profile
+		COMMENT @see #writeGameProfile(GameProfile)
+	METHOD method_43624 readProperty ()Lcom/mojang/authlib/properties/Property;
+		COMMENT Reads a property from this buf. A property is represented by a string representing
+		COMMENT the property key, a string representing the property value, a boolean indicating
+		COMMENT whether the property is signed, and a string representing the signature (only
+		COMMENT exists if signed).
+		COMMENT
+		COMMENT @return the property
+		COMMENT @see #writeProperty(Property)
 	METHOD nioBuffer (II)Ljava/nio/ByteBuffer;
 		ARG 1 index
 		ARG 2 length

--- a/mappings/net/minecraft/network/PacketByteBuf.mapping
+++ b/mappings/net/minecraft/network/PacketByteBuf.mapping
@@ -876,10 +876,9 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 			COMMENT a value to write, must be in {@code registry}
 	METHOD method_43616 writeGameProfile (Lcom/mojang/authlib/GameProfile;)V
 		COMMENT Writes a game profile to this buf. A game profile is represented by a
-		COMMENT {@linkplain writeUUID(UUID) uuid}, a username string, and a collection of
-		COMMENT {@linkplain writeProperty(Property) properties}.
+		COMMENT {@linkplain #writeUUID(UUID) uuid}, a username string, and a collection of
+		COMMENT {@linkplain #writeProperty(Property) properties}.
 		COMMENT
-		COMMENT @return the game profile
 		COMMENT @see #readGameProfile()
 		ARG 1 gameProfile
 	METHOD method_43617 writeProperty (Lcom/mojang/authlib/properties/Property;)V
@@ -916,8 +915,8 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 		ARG 2 rightParser
 	METHOD method_43623 readGameProfile ()Lcom/mojang/authlib/GameProfile;
 		COMMENT Reads a game profile from this buf. A game profile is represented by a
-		COMMENT {@linkplain readUUID() uuid}, a username string, and a collection of
-		COMMENT {@linkplain readProperty() properties}.
+		COMMENT {@linkplain #readUUID() uuid}, a username string, and a collection of
+		COMMENT {@linkplain #readProperty() properties}.
 		COMMENT
 		COMMENT @return the game profile
 		COMMENT @see #writeGameProfile(GameProfile)

--- a/mappings/net/minecraft/network/encryption/KeyPair.mapping
+++ b/mappings/net/minecraft/network/encryption/KeyPair.mapping
@@ -1,5 +1,0 @@
-CLASS net/minecraft/class_7427 net/minecraft/network/encryption/KeyPair
-	FIELD field_39049 CODEC Lcom/mojang/serialization/Codec;
-	METHOD method_43546 isExpired ()Z
-	METHOD method_43547 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
-		ARG 0 instance

--- a/mappings/net/minecraft/network/encryption/KeyPair.mapping
+++ b/mappings/net/minecraft/network/encryption/KeyPair.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_7427 net/minecraft/network/encryption/KeyPair
+	FIELD field_39049 CODEC Lcom/mojang/serialization/Codec;
+	METHOD method_43546 isExpired ()Z
+	METHOD method_43547 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance

--- a/mappings/net/minecraft/network/encryption/NetworkEncryptionException.mapping
+++ b/mappings/net/minecraft/network/encryption/NetworkEncryptionException.mapping
@@ -1,3 +1,5 @@
 CLASS net/minecraft/class_5525 net/minecraft/network/encryption/NetworkEncryptionException
+	COMMENT A checked exception that wraps other exceptions, thrown
+	COMMENT when a cryptographic operation fails.
 	METHOD <init> (Ljava/lang/Throwable;)V
 		ARG 1 throwable

--- a/mappings/net/minecraft/network/encryption/NetworkEncryptionUtils.mapping
+++ b/mappings/net/minecraft/network/encryption/NetworkEncryptionUtils.mapping
@@ -1,49 +1,229 @@
 CLASS net/minecraft/class_3515 net/minecraft/network/encryption/NetworkEncryptionUtils
+	COMMENT Utilities for encryption, decryption, signing, and hashing of data.
+	COMMENT
+	COMMENT @apiNote Methods in this class usually throw {@link NetworkEncryptionException}
+	COMMENT when the operation fails. This is a checked exception and thus must be caught
+	COMMENT when using the methods.
 	FIELD field_29830 AES Ljava/lang/String;
 	FIELD field_29831 AES_KEY_LENGTH I
 	FIELD field_29832 RSA Ljava/lang/String;
 	FIELD field_29833 RSA_KEY_LENGTH I
 	FIELD field_29834 ISO_8859_1 Ljava/lang/String;
 	FIELD field_29835 SHA1 Ljava/lang/String;
+	FIELD field_39033 RSA_PUBLIC_KEY_PREFIX Ljava/lang/String;
+	FIELD field_39034 CRLF Ljava/lang/String;
+	FIELD field_39035 RSA_PUBLIC_KEY_CODEC Lcom/mojang/serialization/Codec;
+		COMMENT The codec for RSA public keys.
+		COMMENT
+		COMMENT @implNote The key is encoded using the PEM format.
+		COMMENT
+		COMMENT @see #encodeRsaPublicKeyPem(PublicKey)
+		COMMENT @see #decodeRsaPublicKeyPem(String)
+	FIELD field_39036 RSA_PRIVATE_KEY_CODEC Lcom/mojang/serialization/Codec;
+		COMMENT The codec for RSA private keys.
+		COMMENT
+		COMMENT @implNote The key is encoded using the PEM format.
+		COMMENT
+		COMMENT @see #encodeRsaPrivateKeyPem(PublicKey)
+		COMMENT @see #decodeRsaPrivateKeyPem(String)
+	FIELD field_39037 RSA_PRIVATE_KEY_PREFIX Ljava/lang/String;
+	FIELD field_39038 RSA_PRIVATE_KEY_SUFFIX Ljava/lang/String;
+	FIELD field_39039 RSA_PUBLIC_KEY_SUFFIX Ljava/lang/String;
 	METHOD method_15234 decryptSecretKey (Ljava/security/PrivateKey;[B)Ljavax/crypto/SecretKey;
+		COMMENT Decrypts RSA-encrypted AES secret key.
+		COMMENT
+		COMMENT @throws NetworkEncryptionException when the secret key is malformed
 		ARG 0 privateKey
 		ARG 1 encryptedSecretKey
 	METHOD method_15235 cipherFromKey (ILjava/security/Key;)Ljavax/crypto/Cipher;
+		COMMENT Creates an AES cipher from the key.
+		COMMENT
+		COMMENT @throws NetworkEncryptionException when creation fails, e.g. due to invalid key
 		ARG 0 opMode
 		ARG 1 key
+			COMMENT the AES secret key
 	METHOD method_15236 hash ([[B)[B
+		COMMENT {@return the SHA-1 hash of {@code bytes}}
 		ARG 0 bytes
 	METHOD method_15237 generateServerKeyPair ()Ljava/security/KeyPair;
+		COMMENT {@return a new {@value RSA_KEY_LENGTH} bit RSA public/private key pair}
+		COMMENT
+		COMMENT @throws NetworkEncryptionException when generation fails
 	METHOD method_15238 encrypt (Ljava/security/Key;[B)[B
+		COMMENT Encrypts a data. The algorithm is determined from the key used.
+		COMMENT
+		COMMENT @throws NetworkEncryptionException when encryption fails, e.g. due to invalid key
+		COMMENT
+		COMMENT @see #decrypt(Key, byte[])
 		ARG 0 key
+			COMMENT encryption key (e.g. AES secret key or RSA public key)
 		ARG 1 data
-	METHOD method_15239 generateKey ()Ljavax/crypto/SecretKey;
-	METHOD method_15240 generateServerId (Ljava/lang/String;Ljava/security/PublicKey;Ljavax/crypto/SecretKey;)[B
+	METHOD method_15239 generateSecretKey ()Ljavax/crypto/SecretKey;
+		COMMENT {@return a new {@value AES_KEY_LENGTH} bit AES secret key}
+		COMMENT
+		COMMENT @throws NetworkEncryptionException when generation fails
+	METHOD method_15240 computeServerId (Ljava/lang/String;Ljava/security/PublicKey;Ljavax/crypto/SecretKey;)[B
+		COMMENT {@return the computed server ID}
+		COMMENT
+		COMMENT @implNote The server ID is a SHA-1 hash of ISO-8859-1 encoded {@code baseServerId},
+		COMMENT {@code publicKey}, and {@code secretKey}.
+		COMMENT
+		COMMENT @throws NetworkEncryptionException when computation fails
 		ARG 0 baseServerId
 		ARG 1 publicKey
 		ARG 2 secretKey
-	METHOD method_15241 crypt (ILjava/lang/String;Ljava/security/Key;)Ljavax/crypto/Cipher;
+	METHOD method_15241 createCipher (ILjava/lang/String;Ljava/security/Key;)Ljavax/crypto/Cipher;
+		COMMENT Creates a cipher to perform encryption or decryption operation.
 		ARG 0 opMode
 		ARG 1 algorithm
 		ARG 2 key
-	METHOD method_15242 readEncodedPublicKey ([B)Ljava/security/PublicKey;
-		ARG 0 bytes
-	METHOD method_15243 decrypt (Ljava/security/Key;[B)[B
+	METHOD method_15242 decodeEncodedRsaPublicKey ([B)Ljava/security/PublicKey;
+		COMMENT Decodes a X.509-encoded RSA public key.
+		COMMENT
+		COMMENT @throws NetworkEncryptionException when the key is malformed
+		COMMENT
+		COMMENT @see #decodeRsaPublicKeyPem(String)
 		ARG 0 key
+	METHOD method_15243 decrypt (Ljava/security/Key;[B)[B
+		COMMENT Decrypts an encrypted data. The algorithm is determined from the key used.
+		COMMENT
+		COMMENT @throws NetworkEncryptionException when decryption fails, e.g. due to invalid key
+		COMMENT
+		COMMENT @see #encrypt(Key, byte[])
+		ARG 0 key
+			COMMENT decryption key (e.g. AES secret key or RSA private key)
 		ARG 1 data
 	METHOD method_15244 crypt (ILjava/security/Key;[B)[B
+		COMMENT Low-level API to perform encryption or decryption operation.
+		COMMENT
+		COMMENT @throws NetworkEncryptionException when the oprtation fails
 		ARG 0 opMode
 		ARG 1 key
 		ARG 2 data
+	METHOD method_43518 uuidToBytes (JJ)[B
+		COMMENT {@return the UUID converted to a big-endian byte array}
+		ARG 0 mostSignificant
+		ARG 2 leastSignificant
+	METHOD method_43519 decodeRsaPrivateKeyPem (Ljava/lang/String;)Ljava/security/PrivateKey;
+		COMMENT Decodes a PEM-formatted RSA private key.
+		COMMENT
+		COMMENT <p>A PEM-formatted RSA private key is {@value #RSA_PRIVATE_KEY_PREFIX}, followed
+		COMMENT by Base64 encoded PCKS #8 encoded key, followed by {@value #RSA_PRIVATE_KEY_SUFFIX}.
+		COMMENT Note that this method also allows Base64 encoded keys that have neither the prefix
+		COMMENT or the suffix.
+		COMMENT
+		COMMENT @throws NetworkEncryptionException when the key is malformed
+		COMMENT
+		COMMENT @see #encodeRsaPrivateKey(PrivateKey)
+		COMMENT @see #encodeRsaPublicKey(PublicKey)
+		COMMENT @see #decodeRsaPublicKeyPem(String)
+		ARG 0 key
+	METHOD method_43520 decodePem (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lnet/minecraft/class_3515$class_7424;)Ljava/security/Key;
+		COMMENT Decodes a PEM-formatted string key.
+		COMMENT
+		COMMENT <p>A PEM-formatted key is {@code prefix}, followed by Base64 encoded key,
+		COMMENT followed by {@code suffix}. Note that this method also allows Base64 encoded
+		COMMENT keys that have neither the prefix or the suffix.
+		COMMENT
+		COMMENT @throws NetworkEncryptionException when the {@code decoder} throws, e.g. due to
+		COMMENT invalid key content
+		ARG 0 key
+		ARG 1 prefix
+		ARG 2 suffix
+		ARG 3 decoder
+	METHOD method_43521 encodeRsaPrivateKey (Ljava/security/PrivateKey;)Ljava/lang/String;
+		COMMENT Encodes an RSA private {@code key} to a PEM-formatted key string.
+		COMMENT
+		COMMENT <p>A PEM-formatted RSA private key is {@value #RSA_PRIVATE_KEY_PREFIX}, followed
+		COMMENT by Base64 encoded PCKS #8 encoded key, followed by {@value #RSA_PRIVATE_KEY_SUFFIX}.
+		COMMENT
+		COMMENT @throws IllegalArgumentException when non-RSA key is passed
+		COMMENT
+		COMMENT @see #encodeRsaPublicKey(PublicKey)
+		COMMENT @see #decodeRsaPrivateKeyPem(String)
+		COMMENT @see #decodeRsaPublicKeyPem(String)
+		ARG 0 key
+	METHOD method_43522 encodeRsaPublicKey (Ljava/security/PublicKey;)Ljava/lang/String;
+		COMMENT Encodes an RSA public {@code key} to a PEM-formatted key string.
+		COMMENT
+		COMMENT <p>A PEM-formatted RSA private key is {@value #RSA_PRIVATE_KEY_PREFIX}, followed
+		COMMENT by Base64 encoded X.509 encoded key, followed by {@value #RSA_PRIVATE_KEY_SUFFIX}.
+		COMMENT
+		COMMENT @throws IllegalArgumentException when non-RSA key is passed
+		COMMENT
+		COMMENT @see #encodeRsaPrivateKey(PrivateKey)
+		COMMENT @see #decodeRsaPrivateKeyPem(String)
+		COMMENT @see #decodeRsaPublicKeyPem(String)
+		ARG 0 key
 	METHOD method_43523 updateSignature (Ljava/security/Signature;JLjava/util/UUID;Ljava/time/Instant;Ljava/lang/String;)V
+		COMMENT Updates {@code signature} with the passed parameters.
+		COMMENT
+		COMMENT @apiNote This is used when signing chat message contents.
+		COMMENT
+		COMMENT @implNote The data to be signed is {@code salt}, followed by big-endian ordered
+		COMMENT {@code uuid}, followed by {@code time} as seconds from the UTC epoch, followed by
+		COMMENT UTF-8 encoded {@code message} bytes.
+		COMMENT
+		COMMENT @throws SignatureException when updating signature fails
+		COMMENT
+		COMMENT @see net.minecraft.client.network.ClientPlayerEntity#signChatMessage(Instant, String)
 		ARG 0 signature
+		ARG 1 salt
 		ARG 3 uuid
 		ARG 4 time
 		ARG 5 message
+	METHOD method_43524 decodeRsaPublicKeyPem (Ljava/lang/String;)Ljava/security/PublicKey;
+		COMMENT Decodes a PEM-formatted RSA public key.
+		COMMENT
+		COMMENT <p>A PEM-formatted RSA public key is {@value #RSA_PUBLIC_KEY_PREFIX}, followed
+		COMMENT by Base64 encoded X.509 encoded key, followed by {@value #RSA_PUBLIC_KEY_SUFFIX}.
+		COMMENT Note that this method also allows Base64 encoded keys that have neither the prefix
+		COMMENT or the suffix.
+		COMMENT
+		COMMENT @throws NetworkEncryptionException when the key is malformed
+		COMMENT
+		COMMENT @see #encodeRsaPrivateKey(PrivateKey)
+		COMMENT @see #encodeRsaPublicKey(PublicKey)
+		COMMENT @see #decodeRsaPrivateKeyPem(String)
+		ARG 0 key
+	METHOD method_43525 decodeEncodedRsaPrivateKey ([B)Ljava/security/PrivateKey;
+		COMMENT Decodes a PCKS #8-encoded RSA private key.
+		COMMENT
+		COMMENT @throws NetworkEncryptionException when the key is malformed
+		COMMENT
+		COMMENT @see #decodeRsaPrivateKeyPem(String)
+		ARG 0 key
+	METHOD method_43526 (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 0 key
+	METHOD method_43527 (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 0 key
+	CLASS class_7424 KeyDecoder
+		COMMENT A functional interface that decodes an encoded key.
+		COMMENT
+		COMMENT @apiNote Implementations should throw {@link NetworkEncryptionException}
+		COMMENT when the key is malformed.
+		COMMENT
+		COMMENT @see NetworkEncryptionUtils#decodeEncodedRsaPrivateKey(byte[])
+		COMMENT @see NetworkEncryptionUtils#decodeEncodedRsaPublicKey(byte[])
+		METHOD apply ([B)Ljava/security/Key;
+			ARG 1 key
 	CLASS class_7425 SignatureData
+		COMMENT A record holding a signature of a data and the salt added while signing. Note that
+		COMMENT the signature might not be actually present.
+		FIELD field_39040 NONE Lnet/minecraft/class_3515$class_7425;
+			COMMENT The signature data for data without signatures.
+		METHOD <init> (Lnet/minecraft/class_2540;)V
+			ARG 1 buf
 		METHOD method_43528 isSignaturePresent ()Z
+			COMMENT {@return whether the signature data has a signature}
+			COMMENT
+			COMMENT @apiNote This <strong>does not validate</strong> the signature itself.
 		METHOD method_43529 write (Lnet/minecraft/class_2540;)V
 			ARG 1 buf
+		METHOD method_43530 getSalt ()[B
 	CLASS class_7426 SecureRandomUtil
+		COMMENT Utilities for working with a secure random number generator.
 		FIELD field_39041 SECURE_RANDOM Ljava/security/SecureRandom;
 		METHOD method_43531 nextLong ()J
+			COMMENT {@return a random number generated with a cryptograhically secure
+			COMMENT random number generator}

--- a/mappings/net/minecraft/network/encryption/NetworkEncryptionUtils.mapping
+++ b/mappings/net/minecraft/network/encryption/NetworkEncryptionUtils.mapping
@@ -96,7 +96,7 @@ CLASS net/minecraft/class_3515 net/minecraft/network/encryption/NetworkEncryptio
 	METHOD method_15244 crypt (ILjava/security/Key;[B)[B
 		COMMENT Low-level API to perform encryption or decryption operation.
 		COMMENT
-		COMMENT @throws NetworkEncryptionException when the oprtation fails
+		COMMENT @throws NetworkEncryptionException when the operation fails
 		ARG 0 opMode
 		ARG 1 key
 		ARG 2 data

--- a/mappings/net/minecraft/network/encryption/NetworkEncryptionUtils.mapping
+++ b/mappings/net/minecraft/network/encryption/NetworkEncryptionUtils.mapping
@@ -17,14 +17,14 @@ CLASS net/minecraft/class_3515 net/minecraft/network/encryption/NetworkEncryptio
 		COMMENT
 		COMMENT @implNote The key is encoded using the PEM format.
 		COMMENT
-		COMMENT @see #encodeRsaPublicKeyPem(PublicKey)
+		COMMENT @see #encodeRsaPublicKey(PublicKey)
 		COMMENT @see #decodeRsaPublicKeyPem(String)
 	FIELD field_39036 RSA_PRIVATE_KEY_CODEC Lcom/mojang/serialization/Codec;
 		COMMENT The codec for RSA private keys.
 		COMMENT
 		COMMENT @implNote The key is encoded using the PEM format.
 		COMMENT
-		COMMENT @see #encodeRsaPrivateKeyPem(PublicKey)
+		COMMENT @see #encodeRsaPrivateKey(PrivateKey)
 		COMMENT @see #decodeRsaPrivateKeyPem(String)
 	FIELD field_39037 RSA_PRIVATE_KEY_PREFIX Ljava/lang/String;
 	FIELD field_39038 RSA_PRIVATE_KEY_SUFFIX Ljava/lang/String;

--- a/mappings/net/minecraft/network/encryption/PlayerKeyPair.mapping
+++ b/mappings/net/minecraft/network/encryption/PlayerKeyPair.mapping
@@ -1,0 +1,15 @@
+CLASS net/minecraft/class_7427 net/minecraft/network/encryption/PlayerKeyPair
+	COMMENT An RSA key pair for a player.
+	COMMENT
+	COMMENT <p>Users cannot generate the keys themselves; this must be provided from Mojang's
+	COMMENT authentication server.
+	COMMENT
+	COMMENT @see net.minecraft.client.util.ProfileKeys
+	COMMENT @see PlayerPublicKey
+	FIELD comp_743 Ljava/time/Instant;
+		COMMENT the time when the keys must be refreshed, otherwise known as expiry time
+	FIELD field_39049 CODEC Lcom/mojang/serialization/Codec;
+	METHOD method_43546 isExpired ()Z
+		COMMENT {@return whether the keys are expired and can no longer be used}
+	METHOD method_43547 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance

--- a/mappings/net/minecraft/network/encryption/PlayerPublicKey.mapping
+++ b/mappings/net/minecraft/network/encryption/PlayerPublicKey.mapping
@@ -1,17 +1,63 @@
 CLASS net/minecraft/class_7428 net/minecraft/network/encryption/PlayerPublicKey
+	COMMENT An RSA public key for a player, signed by the Mojang's server.
+	COMMENT
+	COMMENT <p>Users cannot generate the keys themselves; this must be provided from Mojang's
+	COMMENT authentication server.
+	COMMENT
+	COMMENT @see net.minecraft.client.util.ProfileKeys
+	COMMENT @see PlayerKeyPair
+	FIELD comp_745 Ljava/lang/String;
+		COMMENT the PEM-formatted X.509 encoded key
+	FIELD comp_746 Ljava/lang/String;
+		COMMENT the signature certifying that this key is provided from Mojang's server
+	FIELD field_39050 CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_39051 PUBLIC_KEY Ljava/lang/String;
 	METHOD <init> (Lcom/mojang/datafixers/util/Pair;Ljava/lang/String;)V
 		ARG 1 expiresAtAndKey
 		ARG 2 signature
 	METHOD method_43548 toProperty ()Lcom/mojang/authlib/properties/Property;
-	METHOD method_43549 (Lcom/mojang/authlib/GameProfile;)Ljava/util/Optional;
+		COMMENT {@return the public key as an authlib {@code Property}}
+	METHOD method_43549 fromGameProfile (Lcom/mojang/authlib/GameProfile;)Ljava/util/Optional;
+		COMMENT {@return the public key extracted from the {@code gameProfile}}
+		COMMENT
+		COMMENT @apiNote This can return an {@linkplain java.util.Optional#empty() empty value}
+		COMMENT if the profile lacks the public key.
 		ARG 0 gameProfile
-	METHOD method_43550 (Lcom/mojang/authlib/minecraft/MinecraftSessionService;)Lnet/minecraft/class_7428$class_7429;
+	METHOD method_43550 verifyAndDecode (Lcom/mojang/authlib/minecraft/MinecraftSessionService;)Lnet/minecraft/class_7428$class_7429;
+		COMMENT Verifies the public key and decodes it.
+		COMMENT
+		COMMENT <p>The checks whether the public key is present, signed with the Mojang's private key,
+		COMMENT and not expired.
+		COMMENT
+		COMMENT @throws InsecurePublicKeyException.MissingException when the key is missing or empty
+		COMMENT @throws InsecurePublicKeyException.InvalidException when the key is unsigned or expired
+		COMMENT @throws NetworkEncryptionException when the key is malformed
 		ARG 1 sessionService
-	METHOD method_43552 (Ljava/lang/String;)Ljava/util/Optional;
-		ARG 0 key
+	METHOD method_43551 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance
+	METHOD method_43552 extract (Ljava/lang/String;)Ljava/util/Optional;
+		COMMENT Extracts the expiry time and the key content from {@code contents}.
+		ARG 0 contents
+	METHOD method_43553 (Ljava/lang/String;Lcom/mojang/datafixers/util/Pair;)Lnet/minecraft/class_7428;
+		ARG 1 pair
 	METHOD method_43554 isExpired ()Z
-	METHOD method_43555 (Lcom/mojang/authlib/GameProfile;)Lcom/mojang/authlib/GameProfile;
+		COMMENT {@return whether the key is expired and can no longer be used}
+	METHOD method_43555 write (Lcom/mojang/authlib/GameProfile;)Lcom/mojang/authlib/GameProfile;
+		COMMENT Writes the public key to the {@code gameProfile} properties under the
+		COMMENT {@value PUBLIC_KEY} key.
 		ARG 1 gameProfile
-	CLASS class_7429
+	CLASS class_7429 PublicKeyData
+		COMMENT A record holding a player's RSA public key data.
+		COMMENT
+		COMMENT <p>This should not be manually created. Use
+		COMMENT {@link PlayerPublicKey#verifyAndDecode(MinecraftSessionService)} to obtain an instance.
 		METHOD method_43557 createSignatureInstance ()Ljava/security/Signature;
+			COMMENT {@return the SHA1withRSA signature instance used for verifying signatures}
+			COMMENT
+			COMMENT @apiNote The returned signature cannot be used for signing. Use {#link
+			COMMENT net.minecraft.client.util.ProfileKeys#createSignatureInstance()} to create the
+			COMMENT signature for signing the data.
+			COMMENT
+			COMMENT @throws NetworkEncryptionException when creation fails
+			COMMENT
+			COMMENT @see net.minecraft.client.util.ProfileKeys#createSignatureInstance()

--- a/mappings/net/minecraft/network/encryption/PlayerPublicKey.mapping
+++ b/mappings/net/minecraft/network/encryption/PlayerPublicKey.mapping
@@ -35,8 +35,8 @@ CLASS net/minecraft/class_7428 net/minecraft/network/encryption/PlayerPublicKey
 		ARG 1 sessionService
 	METHOD method_43551 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 0 instance
-	METHOD method_43552 extract (Ljava/lang/String;)Ljava/util/Optional;
-		COMMENT Extracts the expiry time and the key content from {@code contents}.
+	METHOD method_43552 parse (Ljava/lang/String;)Ljava/util/Optional;
+		COMMENT {@return the expiry time and the key content parsed from {@code contents}}
 		ARG 0 contents
 	METHOD method_43553 (Ljava/lang/String;Lcom/mojang/datafixers/util/Pair;)Lnet/minecraft/class_7428;
 		ARG 1 pair

--- a/mappings/net/minecraft/network/packet/c2s/login/LoginKeyC2SPacket.mapping
+++ b/mappings/net/minecraft/network/packet/c2s/login/LoginKeyC2SPacket.mapping
@@ -30,7 +30,7 @@ CLASS net/minecraft/class_2917 net/minecraft/network/packet/c2s/login/LoginKeyC2
 		ARG 0 encrypted
 	METHOD method_43643 verifySignedNonce ([BLnet/minecraft/class_7428$class_7429;)Z
 		ARG 1 nonce
-		ARG 2 publicKey
+		ARG 2 publicKeyInfo
 	METHOD method_43644 verifyEncryptedNonce ([BLjava/security/PrivateKey;)Z
 		ARG 1 nonce
 		ARG 2 privateKey

--- a/mappings/net/minecraft/network/packet/c2s/login/LoginKeyC2SPacket.mapping
+++ b/mappings/net/minecraft/network/packet/c2s/login/LoginKeyC2SPacket.mapping
@@ -1,5 +1,18 @@
 CLASS net/minecraft/class_2917 net/minecraft/network/packet/c2s/login/LoginKeyC2SPacket
 	FIELD field_13274 encryptedSecretKey [B
+	FIELD field_39089 nonce Lcom/mojang/datafixers/util/Either;
+		COMMENT The nonce value.
+		COMMENT
+		COMMENT @implNote This value is either encrypted (the left side of {@code Either}) or signed
+		COMMENT (the right side). If encrypted, then it must be done so using the server's public key
+		COMMENT and the server verifies it by decrypting and comparing nonces. If signed, then it must
+		COMMENT be done so using the user's private key provided from Mojang's server, and the server
+		COMMENT verifies by checking if the reconstructed data can be verified using the public key.
+	METHOD <init> (Ljavax/crypto/SecretKey;Ljava/security/PublicKey;J[B)V
+		ARG 1 secretKey
+		ARG 2 publicKey
+		ARG 3 seed
+		ARG 5 signature
 	METHOD <init> (Ljavax/crypto/SecretKey;Ljava/security/PublicKey;[B)V
 		ARG 1 secretKey
 		ARG 2 publicKey
@@ -8,3 +21,16 @@ CLASS net/minecraft/class_2917 net/minecraft/network/packet/c2s/login/LoginKeyC2
 		ARG 1 buf
 	METHOD method_12654 decryptSecretKey (Ljava/security/PrivateKey;)Ljavax/crypto/SecretKey;
 		ARG 1 privateKey
+	METHOD method_43640 (Lnet/minecraft/class_7428$class_7429;[BLnet/minecraft/class_3515$class_7425;)Ljava/lang/Boolean;
+		ARG 2 signature
+	METHOD method_43641 (Lnet/minecraft/class_2540;Lnet/minecraft/class_3515$class_7425;)V
+		ARG 0 buf
+		ARG 1 signature
+	METHOD method_43642 ([B)Ljava/lang/Boolean;
+		ARG 0 encrypted
+	METHOD method_43643 verifySignedNonce ([BLnet/minecraft/class_7428$class_7429;)Z
+		ARG 1 nonce
+		ARG 2 publicKey
+	METHOD method_43644 verifyEncryptedNonce ([BLjava/security/PrivateKey;)Z
+		ARG 1 nonce
+		ARG 2 privateKey

--- a/mappings/net/minecraft/network/packet/c2s/play/ChatMessageC2SPacket.mapping
+++ b/mappings/net/minecraft/network/packet/c2s/play/ChatMessageC2SPacket.mapping
@@ -10,11 +10,14 @@ CLASS net/minecraft/class_2797 net/minecraft/network/packet/c2s/play/ChatMessage
 	COMMENT net.minecraft.SharedConstants#isValidChar isValidChar}), the server will
 	COMMENT reject the message and disconnect the client.
 	COMMENT
+	COMMENT <p>Messages that took more than {@link #TIME_TO_LIVE} to reach the server
+	COMMENT are considered expired and will be discarded.
+	COMMENT
 	COMMENT @see net.minecraft.client.network.ClientPlayerEntity#sendChatMessage
 	COMMENT @see net.minecraft.server.network.ServerPlayNetworkHandler#onChatMessage
 	FIELD field_12764 chatMessage Ljava/lang/String;
 	FIELD field_33359 MAX_LENGTH I
-	FIELD field_39086 TWO_MINUTES Ljava/time/Duration;
+	FIELD field_39086 TIME_TO_LIVE Ljava/time/Duration;
 	FIELD field_39087 time Ljava/time/Instant;
 	FIELD field_39088 signature Lnet/minecraft/class_3515$class_7425;
 	METHOD <init> (Ljava/time/Instant;Ljava/lang/String;Lnet/minecraft/class_3515$class_7425;)V
@@ -25,10 +28,15 @@ CLASS net/minecraft/class_2797 net/minecraft/network/packet/c2s/play/ChatMessage
 		ARG 1 buf
 	METHOD method_12114 getChatMessage ()Ljava/lang/String;
 	METHOD method_43632 truncateMessage (Ljava/lang/String;)Ljava/lang/String;
+		COMMENT {@return the message truncated to at most {@value #MAX_LENGTH} characters}
 		ARG 0 message
-	METHOD method_43633 (Ljava/time/Instant;)Z
-		ARG 1 time
+	METHOD method_43633 isExpired (Ljava/time/Instant;)Z
+		COMMENT {@return whether the message is considered expired and should be discarded}
+		ARG 1 currentTime
 	METHOD method_43634 getTime ()Ljava/time/Instant;
+		COMMENT {@return when the client sent the message to the server}
 	METHOD method_43635 getNormalizedChatMessage ()Ljava/lang/String;
+		COMMENT {@return the chat message with spaces normalized}
 	METHOD method_43636 getSignature ()Lnet/minecraft/class_3515$class_7425;
-	METHOD method_43637 offsetInstantTime ()Ljava/time/Instant;
+	METHOD method_43637 getExpiryTime ()Ljava/time/Instant;
+		COMMENT {@return when the message is considered expired and should be discarded}

--- a/mappings/net/minecraft/network/packet/s2c/play/ChatMessageS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/ChatMessageS2CPacket.mapping
@@ -1,6 +1,37 @@
 CLASS net/minecraft/class_7438 net/minecraft/network/packet/s2c/play/ChatMessageS2CPacket
+	COMMENT A packet used to send a chat message to the clients.
+	COMMENT
+	COMMENT <p>The content is not wrapped in any way (e.g. by {@code chat.type.text} text); the
+	COMMENT raw message content is sent to the clients, and they will wrap it (see {@link
+	COMMENT net.minecraft.client.gui.hud.ChatHudListener#format}.) If custom formats are needed,
+	COMMENT either send it as a {@link GameMessageS2CPacket game message} or use a server resource pack.
+	COMMENT
+	COMMENT <p>Messages that took more than {@link #TIME_TO_LIVE} to reach the clients are
+	COMMENT considered expired. This is measured from the time the client sent the chat message
+	COMMENT to the server. Note that unlike {@link
+	COMMENT net.minecraft.network.packet.c2s.play.ChatMessageC2SPacket} expired messages are not
+	COMMENT discarded by the clients; they instead log a warning.
+	COMMENT
+	COMMENT <p>Chat messages have signatures. It is possible to use a bogus signature - such as
+	COMMENT {@link NetworkEncryptionUtils.SignatureData#NONE} - to send a chat message; however
+	COMMENT if the signature is invalid (e.g. because the text's content differs from the one
+	COMMENT sent by the client, or because the passed signature is invalid) the client will
+	COMMENT log a warning. See {@link NetworkEncryptionUtils#updateSignature} for how the message
+	COMMENT is signed.
+	COMMENT
+	COMMENT @see net.minecraft.server.network.ServerPlayerEntity#sendChatMessage
+	COMMENT @see net.minecraft.client.network.ClientPlayNetworkHandler#onChatMessage
+	FIELD comp_758 Lnet/minecraft/class_2561;
+		COMMENT the unwrapped chat message
+	FIELD field_39085 TIME_TO_LIVE Ljava/time/Duration;
 	METHOD <init> (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD method_43627 isSignatureValid (Lnet/minecraft/class_7428$class_7429;)Z
-	METHOD method_43628 (Ljava/time/Instant;)Z
-		ARG 1 sendingTime
+		COMMENT {@return whether the chat message has a valid signature}
+		ARG 1 publicKey
+			COMMENT the sender's public key to use for verifying
+	METHOD method_43628 isExpired (Ljava/time/Instant;)Z
+		COMMENT {@return whether the message is considered expired}
+		ARG 1 currentTime
+	METHOD method_43630 getExpiryTime ()Ljava/time/Instant;
+		COMMENT {@return when the message is considered expired}

--- a/mappings/net/minecraft/server/MinecraftServer.mapping
+++ b/mappings/net/minecraft/server/MinecraftServer.mapping
@@ -434,6 +434,10 @@ CLASS net/minecraft/server/MinecraftServer
 		ARG 0 throwable
 	METHOD method_41239 getMaxChainedNeighborUpdates ()I
 	METHOD method_42062 forceStopRecorder ()V
+	METHOD method_43500 shouldEnforceSecureProfile ()Z
+	METHOD method_43614 logChatMessage (Lnet/minecraft/class_7436;Lnet/minecraft/class_2561;)V
+		ARG 1 sender
+		ARG 2 message
 	METHOD method_5387 isMainThread ()Z
 	CLASS class_6414 DebugStart
 		FIELD field_33980 time J

--- a/mappings/net/minecraft/server/PlayerManager.mapping
+++ b/mappings/net/minecraft/server/PlayerManager.mapping
@@ -137,3 +137,47 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 	METHOD method_38650 setSimulationDistance (I)V
 		ARG 1 simulationDistance
 	METHOD method_38651 getSimulationDistance ()I
+	METHOD method_43511 (Lnet/minecraft/class_2561;Lnet/minecraft/class_3222;)Lnet/minecraft/class_2561;
+		ARG 1 player
+	METHOD method_43512 broadcast (Lnet/minecraft/class_2561;Ljava/util/function/Function;Lnet/minecraft/class_2556;)V
+		COMMENT Broadcasts a message to all players and the server console. A different
+		COMMENT message can be sent to a different player.
+		COMMENT
+		COMMENT @apiNote This is used by {@link net.minecraft.server.command.MeCommand}
+		COMMENT and {@link net.minecraft.server.command.SayCommand}.
+		COMMENT
+		COMMENT @see #broadcast(Text, MessageType)
+		COMMENT @see #broadcast(Text, Function, MessageType, class_7436, Instant, NetworkEncryptionUtils.class_7425)
+		ARG 1 message
+		ARG 2 playerMessageFactory
+		ARG 3 type
+	METHOD method_43513 broadcast (Lnet/minecraft/class_2561;Ljava/util/function/Function;Lnet/minecraft/class_2556;Lnet/minecraft/class_7436;Ljava/time/Instant;Lnet/minecraft/class_3515$class_7425;)V
+		COMMENT Broadcasts a signed chat message to all players and the server console. A different
+		COMMENT message can be sent to a different player.
+		COMMENT
+		COMMENT @apiNote This method is used to broadcast a message sent by a player
+		COMMENT through {@linkplain net.minecraft.client.gui.screen.ChatScreen the chat screen}.
+		COMMENT
+		COMMENT @see #broadcast(Text, MessageType)
+		COMMENT @see #broadcast(Text, Function, MessageType)
+		ARG 1 message
+		ARG 2 playerMessageFactory
+		ARG 3 type
+		ARG 4 sender
+		ARG 5 instant
+		ARG 6 signature
+	METHOD method_43514 broadcast (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556;)V
+		COMMENT Broadcasts a message to all players and the server console.
+		COMMENT
+		COMMENT @apiNote This is used to send general messages such as a death
+		COMMENT message or a join/leave message. This is also used to send messages from
+		COMMENT non-player-executed commands, such as ones from a command block or the server console.
+		COMMENT
+		COMMENT @see #broadcast(Text, Function, MessageType)
+		COMMENT @see #broadcast(Text, Function, MessageType, class_7436, Instant, NetworkEncryptionUtils.class_7425)
+		ARG 1 message
+		ARG 2 uuid
+	METHOD method_43515 broadcast (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556;Ljava/util/UUID;)V
+		ARG 1 message
+		ARG 2 type
+		ARG 3 uuid

--- a/mappings/net/minecraft/server/PlayerManager.mapping
+++ b/mappings/net/minecraft/server/PlayerManager.mapping
@@ -189,7 +189,7 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		COMMENT @see #broadcast(Text, Function, MessageType)
 		COMMENT @see #broadcast(Text, Function, MessageType, ChatMessageSender, Instant, NetworkEncryptionUtils.SignatureData)
 		ARG 1 message
-		ARG 2 uuid
+		ARG 2 type
 	METHOD method_43515 broadcast (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556;Ljava/util/UUID;)V
 		ARG 1 message
 		ARG 2 type

--- a/mappings/net/minecraft/server/PlayerManager.mapping
+++ b/mappings/net/minecraft/server/PlayerManager.mapping
@@ -150,10 +150,20 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		COMMENT @see #broadcast(Text, Function, MessageType, class_7436, Instant, NetworkEncryptionUtils.class_7425)
 		ARG 1 message
 		ARG 2 playerMessageFactory
+			COMMENT a function that takes the player to send the message to
+			COMMENT and returns either the text to send to them or {@code null}
+			COMMENT to indicate the message should not be sent to them
 		ARG 3 type
 	METHOD method_43513 broadcast (Lnet/minecraft/class_2561;Ljava/util/function/Function;Lnet/minecraft/class_2556;Lnet/minecraft/class_7436;Ljava/time/Instant;Lnet/minecraft/class_3515$class_7425;)V
-		COMMENT Broadcasts a signed chat message to all players and the server console. A different
+		COMMENT Broadcasts a chat message to all players and the server console. A different
 		COMMENT message can be sent to a different player.
+		COMMENT
+		COMMENT <p>Chat messages have signatures. It is possible to use a bogus signature - such as
+		COMMENT {@link NetworkEncryptionUtils.SignatureData#NONE} - to send a chat message; however
+		COMMENT if the signature is invalid (e.g. because the text's content differs from the one
+		COMMENT sent by the client, or because the passed signature is invalid) the client will
+		COMMENT log a warning. See {@link NetworkEncryptionUtils#updateSignature} for how the message
+		COMMENT is signed.
 		COMMENT
 		COMMENT @apiNote This method is used to broadcast a message sent by a player
 		COMMENT through {@linkplain net.minecraft.client.gui.screen.ChatScreen the chat screen}.
@@ -162,6 +172,9 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		COMMENT @see #broadcast(Text, Function, MessageType)
 		ARG 1 message
 		ARG 2 playerMessageFactory
+			COMMENT a function that takes the player to send the message to
+			COMMENT and returns either the text to send to them or {@code null}
+			COMMENT to indicate the message should not be sent to them
 		ARG 3 type
 		ARG 4 sender
 		ARG 5 instant

--- a/mappings/net/minecraft/server/PlayerManager.mapping
+++ b/mappings/net/minecraft/server/PlayerManager.mapping
@@ -147,7 +147,7 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		COMMENT and {@link net.minecraft.server.command.SayCommand}.
 		COMMENT
 		COMMENT @see #broadcast(Text, MessageType)
-		COMMENT @see #broadcast(Text, Function, MessageType, class_7436, Instant, NetworkEncryptionUtils.class_7425)
+		COMMENT @see #broadcast(Text, Function, MessageType, ChatMessageSender, Instant, NetworkEncryptionUtils.SignatureData)
 		ARG 1 message
 		ARG 2 playerMessageFactory
 			COMMENT a function that takes the player to send the message to
@@ -187,7 +187,7 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		COMMENT non-player-executed commands, such as ones from a command block or the server console.
 		COMMENT
 		COMMENT @see #broadcast(Text, Function, MessageType)
-		COMMENT @see #broadcast(Text, Function, MessageType, class_7436, Instant, NetworkEncryptionUtils.class_7425)
+		COMMENT @see #broadcast(Text, Function, MessageType, ChatMessageSender, Instant, NetworkEncryptionUtils.SignatureData)
 		ARG 1 message
 		ARG 2 uuid
 	METHOD method_43515 broadcast (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556;Ljava/util/UUID;)V

--- a/mappings/net/minecraft/server/command/CommandOutput.mapping
+++ b/mappings/net/minecraft/server/command/CommandOutput.mapping
@@ -3,6 +3,10 @@ CLASS net/minecraft/class_2165 net/minecraft/server/command/CommandOutput
 	FIELD field_17395 DUMMY Lnet/minecraft/class_2165;
 	METHOD method_36320 cannotBeSilenced ()Z
 	METHOD method_43496 sendMessage (Lnet/minecraft/class_2561;)V
+		COMMENT Sends a system message.
+		COMMENT
+		COMMENT @implNote The output location depends on the implementation; players will
+		COMMENT use the in-game chat, and others will output to the log.
 		ARG 1 message
 	METHOD method_9200 shouldReceiveFeedback ()Z
 	METHOD method_9201 shouldBroadcastConsoleToOps ()Z

--- a/mappings/net/minecraft/server/command/CommandOutput.mapping
+++ b/mappings/net/minecraft/server/command/CommandOutput.mapping
@@ -2,6 +2,8 @@ CLASS net/minecraft/class_2165 net/minecraft/server/command/CommandOutput
 	COMMENT Represents a subject which can receive command feedback.
 	FIELD field_17395 DUMMY Lnet/minecraft/class_2165;
 	METHOD method_36320 cannotBeSilenced ()Z
+	METHOD method_43496 sendMessage (Lnet/minecraft/class_2561;)V
+		ARG 1 message
 	METHOD method_9200 shouldReceiveFeedback ()Z
 	METHOD method_9201 shouldBroadcastConsoleToOps ()Z
 	METHOD method_9202 shouldTrackOutput ()Z

--- a/mappings/net/minecraft/server/command/MeCommand.mapping
+++ b/mappings/net/minecraft/server/command/MeCommand.mapping
@@ -8,3 +8,5 @@ CLASS net/minecraft/class_3045 net/minecraft/server/command/MeCommand
 		ARG 1 arg
 	METHOD method_31374 (Lnet/minecraft/class_3222;Lnet/minecraft/class_2561;Lnet/minecraft/class_2561;Lnet/minecraft/class_3222;)Lnet/minecraft/class_2561;
 		ARG 3 player
+	METHOD method_31375 (Lcom/mojang/brigadier/context/CommandContext;Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/class_3222;Lnet/minecraft/class_5513$class_5837;)V
+		ARG 3 message

--- a/mappings/net/minecraft/server/dedicated/ServerPropertiesHandler.mapping
+++ b/mappings/net/minecraft/server/dedicated/ServerPropertiesHandler.mapping
@@ -52,6 +52,7 @@ CLASS net/minecraft/class_3806 net/minecraft/server/dedicated/ServerPropertiesHa
 	FIELD field_35564 hideOnlinePlayers Z
 	FIELD field_37039 worldGenProperties Lnet/minecraft/class_3806$class_7044;
 	FIELD field_37275 maxChainedNeighborUpdates I
+	FIELD field_39018 enforceSecureProfile Z
 	METHOD method_16714 load (Ljava/nio/file/Path;)Lnet/minecraft/class_3806;
 		ARG 0 path
 	METHOD method_16715 (Ljava/lang/Integer;)Ljava/lang/Integer;

--- a/mappings/net/minecraft/server/network/ServerLoginNetworkHandler.mapping
+++ b/mappings/net/minecraft/server/network/ServerLoginNetworkHandler.mapping
@@ -32,7 +32,7 @@ CLASS net/minecraft/class_3248 net/minecraft/server/network/ServerLoginNetworkHa
 	FIELD field_39020 MISSING_PUBLIC_KEY_TEXT Lnet/minecraft/class_2561;
 	FIELD field_39021 INVALID_PUBLIC_KEY_SIGNATURE_TEXT Lnet/minecraft/class_2561;
 	FIELD field_39022 INVALID_PUBLIC_KEY_TEXT Lnet/minecraft/class_2561;
-	FIELD field_39023 publicKey Lnet/minecraft/class_7428$class_7429;
+	FIELD field_39023 publicKeyInfo Lnet/minecraft/class_7428$class_7429;
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/class_2535;)V
 		ARG 1 server
 		ARG 2 connection

--- a/mappings/net/minecraft/server/network/ServerLoginNetworkHandler.mapping
+++ b/mappings/net/minecraft/server/network/ServerLoginNetworkHandler.mapping
@@ -29,6 +29,10 @@ CLASS net/minecraft/class_3248 net/minecraft/server/network/ServerLoginNetworkHa
 	FIELD field_14166 LOGGER Lorg/slf4j/Logger;
 	FIELD field_14167 nonce [B
 	FIELD field_29779 TIMEOUT_TICKS I
+	FIELD field_39020 MISSING_PUBLIC_KEY_TEXT Lnet/minecraft/class_2561;
+	FIELD field_39021 INVALID_PUBLIC_KEY_SIGNATURE_TEXT Lnet/minecraft/class_2561;
+	FIELD field_39022 INVALID_PUBLIC_KEY_TEXT Lnet/minecraft/class_2561;
+	FIELD field_39023 publicKey Lnet/minecraft/class_7428$class_7429;
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/class_2535;)V
 		ARG 1 server
 		ARG 2 connection
@@ -58,6 +62,11 @@ CLASS net/minecraft/class_3248 net/minecraft/server/network/ServerLoginNetworkHa
 		ARG 0 c
 	METHOD method_40085 isValidName (Ljava/lang/String;)Z
 		ARG 0 name
+	METHOD method_43510 getVerifiedPublicKey (Lnet/minecraft/class_2915;Lcom/mojang/authlib/minecraft/MinecraftSessionService;Z)Lnet/minecraft/class_7428$class_7429;
+		ARG 0 packet
+		ARG 1 minecraftSessionService
+		ARG 2 shouldThrowOnMissingKey
 	CLASS 1
 		METHOD method_14386 getClientAddress ()Ljava/net/InetAddress;
 	CLASS class_3249 State
+	CLASS class_7423 LoginException

--- a/mappings/net/minecraft/server/network/ServerPlayNetworkHandler.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayNetworkHandler.mapping
@@ -105,6 +105,8 @@ CLASS net/minecraft/class_3244 net/minecraft/server/network/ServerPlayNetworkHan
 		ARG 1 packet
 		ARG 2 signText
 	METHOD method_31286 handleMessage (Lnet/minecraft/class_2797;Lnet/minecraft/class_5513$class_5837;)V
+		ARG 1 packet
+		ARG 2 message
 	METHOD method_33562 requestTeleportAndDismount (DDDFF)V
 		ARG 1 x
 		ARG 3 y
@@ -133,6 +135,13 @@ CLASS net/minecraft/class_3244 net/minecraft/server/network/ServerPlayNetworkHan
 		ARG 0 d
 	METHOD method_41255 updateSequence (I)V
 		ARG 1 sequence
+	METHOD method_43508 hasIllegalCharacter (Ljava/lang/String;)Z
+		COMMENT {@return whether {@code message} contains an illegal character}
+		COMMENT
+		COMMENT @see SharedConstants#isValidChar(char)
+		ARG 0 message
+	METHOD method_43509 (Lnet/minecraft/class_2797;Lnet/minecraft/class_5513$class_5837;)V
+		ARG 2 message
 	CLASS 1
 		METHOD method_33897 processInteract (Lnet/minecraft/class_1268;Lnet/minecraft/class_3244$class_5860;)V
 			ARG 1 hand

--- a/mappings/net/minecraft/server/network/ServerPlayNetworkHandler.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayNetworkHandler.mapping
@@ -138,7 +138,7 @@ CLASS net/minecraft/class_3244 net/minecraft/server/network/ServerPlayNetworkHan
 	METHOD method_43508 hasIllegalCharacter (Ljava/lang/String;)Z
 		COMMENT {@return whether {@code message} contains an illegal character}
 		COMMENT
-		COMMENT @see SharedConstants#isValidChar(char)
+		COMMENT @see net.minecraft.SharedConstants#isValidChar(char)
 		ARG 0 message
 	METHOD method_43509 (Lnet/minecraft/class_2797;Lnet/minecraft/class_5513$class_5837;)V
 		ARG 2 message

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -209,6 +209,37 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	METHOD method_38786 tickFallStartPos ()V
 	METHOD method_38787 tickVehicleInLavaRiding ()V
 	METHOD method_39426 allowsServerListing ()Z
+	METHOD method_43501 sendMessage (Lnet/minecraft/class_2561;Ljava/util/UUID;)V
+		ARG 1 message
+		ARG 2 uuid
+	METHOD method_43502 sendMessage (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556;)V
+		COMMENT Sends a message to the player.
+		COMMENT
+		COMMENT @see #sendMessage(Text)
+		COMMENT @see #sendChatMessage(Text, MessageType, class_7436, Instant, NetworkEncryptionUtils.class_7425)
+		ARG 1 message
+		ARG 2 type
+	METHOD method_43503 (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556;Lio/netty/util/concurrent/Future;)V
+		ARG 3 future
+	METHOD method_43504 sendMessage (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556;Ljava/util/UUID;)V
+		ARG 1 message
+		ARG 2 type
+		ARG 3 uuid
+	METHOD method_43505 sendChatMessage (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556;Lnet/minecraft/class_7436;Ljava/time/Instant;Lnet/minecraft/class_3515$class_7425;)V
+		COMMENT Sends a signed chat message to the player.
+		COMMENT
+		COMMENT @see #sendMessage(Text)
+		COMMENT @see #sendMessage(Text, MessageType)
+		ARG 1 message
+		ARG 2 type
+		ARG 3 sender
+		ARG 4 instant
+		ARG 5 signature
+	METHOD method_43506 sendMessageDeliverError (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556;)V
+		ARG 1 message
+		ARG 2 type
+	METHOD method_43507 (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556;Lio/netty/util/concurrent/Future;)V
+		ARG 3 future
 	METHOD method_7336 changeGameMode (Lnet/minecraft/class_1934;)Z
 		ARG 1 gameMode
 	CLASS 1

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -216,7 +216,7 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 		COMMENT Sends a message to the player.
 		COMMENT
 		COMMENT @see #sendMessage(Text)
-		COMMENT @see #sendChatMessage(Text, MessageType, class_7436, Instant, NetworkEncryptionUtils.class_7425)
+		COMMENT @see #sendChatMessage(Text, MessageType, ChatMessageSender, Instant, NetworkEncryptionUtils.SignatureData)
 		ARG 1 message
 		ARG 2 type
 	METHOD method_43503 (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556;Lio/netty/util/concurrent/Future;)V

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -226,7 +226,14 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 		ARG 2 type
 		ARG 3 uuid
 	METHOD method_43505 sendChatMessage (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556;Lnet/minecraft/class_7436;Ljava/time/Instant;Lnet/minecraft/class_3515$class_7425;)V
-		COMMENT Sends a signed chat message to the player.
+		COMMENT Sends a chat message to the player.
+		COMMENT
+		COMMENT <p>Chat messages have signatures. It is possible to use a bogus signature - such as
+		COMMENT {@link NetworkEncryptionUtils.SignatureData#NONE} - to send a chat message; however
+		COMMENT if the signature is invalid (e.g. because the text's content differs from the one
+		COMMENT sent by the client, or because the passed signature is invalid) the client will
+		COMMENT log a warning. See {@link NetworkEncryptionUtils#updateSignature} for how the message
+		COMMENT is signed.
 		COMMENT
 		COMMENT @see #sendMessage(Text)
 		COMMENT @see #sendMessage(Text, MessageType)


### PR DESCRIPTION
See #3121

Contains mapping for networking, chat, and key management. Almost all methods related to them (both existing and new) are also documented. Also fixes various yarn bugs in the previous networking PR, and refactors some names to make their behavior more clear.