### PR TITLE
Fix javadoc of NetworkEncryptionUtils.encodeRsaPublicKey

### DIFF
--- a/mappings/net/minecraft/network/encryption/NetworkEncryptionUtils.mapping
+++ b/mappings/net/minecraft/network/encryption/NetworkEncryptionUtils.mapping
@@ -146,8 +146,8 @@ CLASS net/minecraft/class_3515 net/minecraft/network/encryption/NetworkEncryptio
 	METHOD method_43522 encodeRsaPublicKey (Ljava/security/PublicKey;)Ljava/lang/String;
 		COMMENT Encodes an RSA public {@code key} to a PEM-formatted key string.
 		COMMENT
-		COMMENT <p>A PEM-formatted RSA private key is {@value #RSA_PRIVATE_KEY_PREFIX}, followed
-		COMMENT by Base64 encoded X.509 encoded key, followed by {@value #RSA_PRIVATE_KEY_SUFFIX}.
+		COMMENT <p>A PEM-formatted RSA public key is {@value #RSA_PUBLIC_KEY_PREFIX}, followed
+		COMMENT by Base64 encoded X.509 encoded key, followed by {@value #RSA_PUBLIC_KEY_SUFFIX}.
 		COMMENT
 		COMMENT @throws IllegalArgumentException when non-RSA key is passed
 		COMMENT


### PR DESCRIPTION
As requested by @apple502j in discord.
> when you're reading javadoc and you find a copy-paste from my just-merged PR: :ohno:
> could someone fix NetworkEncryptionUtils#encodeRsaPublicKey to mention the serialization steps of public keys, not private keys

https://discord.com/channels/507304429255393322/521545796882006027/970679530832420865