### PR TITLE
Map message type and format

### DIFF
--- a/mappings/net/minecraft/client/option/NarratorMode.mapping
+++ b/mappings/net/minecraft/client/option/NarratorMode.mapping
@@ -9,3 +9,5 @@ CLASS net/minecraft/class_4065 net/minecraft/client/option/NarratorMode
 	METHOD method_18510 byId (I)Lnet/minecraft/class_4065;
 		ARG 0 id
 	METHOD method_18511 getName ()Lnet/minecraft/class_2561;
+	METHOD method_43766 isCompatibleWith (Lnet/minecraft/class_2556$class_7466$class_7467;)Z
+		ARG 1 narrationKind

--- a/mappings/net/minecraft/network/MessageFormat.mapping
+++ b/mappings/net/minecraft/network/MessageFormat.mapping
@@ -1,0 +1,52 @@
+CLASS net/minecraft/class_7463 net/minecraft/network/MessageFormat
+	COMMENT A message format applies on a server-sent message and its sender to
+	COMMENT stylize it.
+	FIELD field_39219 CODEC Lcom/mojang/serialization/Codec;
+		COMMENT The codec for chat format.
+	METHOD method_43830 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance
+	METHOD method_43831 plain (Ljava/lang/String;)Lnet/minecraft/class_7463;
+		COMMENT {@return a message format that applies the translation key with the
+		COMMENT sender's name and the message content}
+		ARG 0 translationKey
+	METHOD method_43832 apply (Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)Lnet/minecraft/class_2561;
+		ARG 1 content
+		ARG 2 sender
+	METHOD method_43833 italicGray (Ljava/lang/String;)Lnet/minecraft/class_7463;
+		COMMENT {@return a message format that applies the translation key with the
+		COMMENT sender's name and the message content, and applies a gray, italic style}
+		ARG 0 translationKey
+	METHOD method_43834 getArgs (Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)[Lnet/minecraft/class_2561;
+		ARG 1 content
+		ARG 2 sender
+	METHOD method_43835 team (Ljava/lang/String;)Lnet/minecraft/class_7463;
+		COMMENT {@return a message format that applies the translation key with the
+		COMMENT sender's team name, the sender's name, and the message content}
+		ARG 0 translationKey
+	CLASS class_7464 Parameter
+		COMMENT A parameter for the translation text of a message format.
+		FIELD field_39223 CODEC Lcom/mojang/serialization/Codec;
+			COMMENT The codec for a message format parameter.
+		FIELD field_39224 name Ljava/lang/String;
+		FIELD field_39225 argumentFactory Lnet/minecraft/class_7463$class_7464$class_7465;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;Lnet/minecraft/class_7463$class_7464$class_7465;)V
+			ARG 3 name
+			ARG 4 factory
+		METHOD method_43837 getArgument (Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)Lnet/minecraft/class_2561;
+			COMMENT {@return an argument for this parameter given the message content and
+			COMMENT sender}
+			ARG 1 content
+			ARG 2 sender
+		METHOD method_43838 (Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)Lnet/minecraft/class_2561;
+			ARG 0 content
+			ARG 1 sender
+		METHOD method_43839 (Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)Lnet/minecraft/class_2561;
+			ARG 0 content
+			ARG 1 sender
+		METHOD method_43840 (Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)Lnet/minecraft/class_2561;
+			ARG 0 content
+			ARG 1 sender
+		CLASS class_7465 ArgumentFactory
+			METHOD select (Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)Lnet/minecraft/class_2561;
+				ARG 1 content
+				ARG 2 sender

--- a/mappings/net/minecraft/network/MessageType.mapping
+++ b/mappings/net/minecraft/network/MessageType.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_2556 net/minecraft/network/MessageType
 	COMMENT A message type, or chat type in registry, or chat style format per
 	COMMENT Minecraft blog, defines how a piece of text content should be rendered.
-	COMMENT It can direct messges to the chat hud, the in-game hud overlay, and the
+	COMMENT It can direct messages to the chat hud, the in-game hud overlay, and the
 	COMMENT narrator, and format them with the sender information.
 	FIELD comp_792 Ljava/util/Optional;
 		COMMENT the display rule of a message to the chat hud, or
@@ -10,14 +10,14 @@ CLASS net/minecraft/class_2556 net/minecraft/network/MessageType
 		COMMENT the display rule of a message to the in-game hud overlay, or
 		COMMENT {@code Optional.empty()} if it is not displayed
 	FIELD comp_794 Ljava/util/Optional;
-		COMMENT the narration rule of of a message, or {@code Optional.empty()} if it is
+		COMMENT the narration rule of a message, or {@code Optional.empty()} if it is
 		COMMENT not narrated
 	FIELD field_39227 CODEC Lcom/mojang/serialization/Codec;
 		COMMENT The codec for the message type.
 	METHOD method_43843 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 0 instance
 	METHOD method_43844 registerAndGetDefault (Lnet/minecraft/class_2378;)Lnet/minecraft/class_2556;
-		COMMENT Registers the built-in message types and return the default "chat" type.
+		COMMENT Registers the built-in message types and returns the default "chat" type.
 		ARG 0 registry
 	METHOD method_43845 getKey (Ljava/lang/String;)Lnet/minecraft/class_5321;
 		ARG 0 id
@@ -33,14 +33,14 @@ CLASS net/minecraft/class_2556 net/minecraft/network/MessageType
 		METHOD method_43846 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 			ARG 0 instance
 		METHOD method_43847 of (Lnet/minecraft/class_7463;Lnet/minecraft/class_2556$class_7466$class_7467;)Lnet/minecraft/class_2556$class_7466;
-			COMMENT {@return a rule that narrate a message after formatting} The message
-			COMMENT is narrated as the given {@code type}, and the narration can include
+			COMMENT {@return a rule that narrates a message after formatting} The message
+			COMMENT is narrated as the given {@code kind}, and the narration can include
 			COMMENT sender information in addition to the message content.
 			ARG 0 decoration
 			ARG 1 kind
 		METHOD method_43848 of (Lnet/minecraft/class_2556$class_7466$class_7467;)Lnet/minecraft/class_2556$class_7466;
-			COMMENT {@return a rule that narrate a message's content directly} The message
-			COMMENT is narrated as the given {@code type}, without any sender-related
+			COMMENT {@return a rule that narrates a message's content directly} The message
+			COMMENT is narrated as the given {@code kind}, without any sender-related
 			COMMENT information.
 			ARG 0 kind
 		METHOD method_43849 apply (Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)Lnet/minecraft/class_2561;

--- a/mappings/net/minecraft/network/MessageType.mapping
+++ b/mappings/net/minecraft/network/MessageType.mapping
@@ -1,1 +1,82 @@
 CLASS net/minecraft/class_2556 net/minecraft/network/MessageType
+	COMMENT A message type, or chat type in registry, or chat style format per
+	COMMENT Minecraft blog, defines how a piece of text content should be rendered.
+	COMMENT It can direct messges to the chat hud, the in-game hud overlay, and the
+	COMMENT narrator, and format them with the sender information.
+	FIELD comp_792 Ljava/util/Optional;
+		COMMENT the display rule of a message to the chat hud, or
+		COMMENT {@code Optional.empty()} if it is not displayed
+	FIELD comp_793 Ljava/util/Optional;
+		COMMENT the display rule of a message to the in-game hud overlay, or
+		COMMENT {@code Optional.empty()} if it is not displayed
+	FIELD comp_794 Ljava/util/Optional;
+		COMMENT the narration rule of of a message, or {@code Optional.empty()} if it is
+		COMMENT not narrated
+	FIELD field_39227 CODEC Lcom/mojang/serialization/Codec;
+		COMMENT The codec for the message type.
+	METHOD method_43843 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance
+	METHOD method_43844 registerAndGetDefault (Lnet/minecraft/class_2378;)Lnet/minecraft/class_2556;
+		COMMENT Registers the built-in message types and return the default "chat" type.
+		ARG 0 registry
+	METHOD method_43845 getKey (Ljava/lang/String;)Lnet/minecraft/class_5321;
+		ARG 0 id
+	CLASS class_7466 NarrationRule
+		COMMENT A narration rule for a message.
+		FIELD comp_795 Ljava/util/Optional;
+			COMMENT the formatting of a message, or {@code Optional.empty()} if the content
+			COMMENT is displayed directly
+		FIELD comp_796 Lnet/minecraft/class_2556$class_7466$class_7467;
+			COMMENT the narration kind, and if this narration can interrupt other ones
+		FIELD field_39233 CODEC Lcom/mojang/serialization/Codec;
+			COMMENT The codec for the message narraton rule.
+		METHOD method_43846 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+			ARG 0 instance
+		METHOD method_43847 of (Lnet/minecraft/class_7463;Lnet/minecraft/class_2556$class_7466$class_7467;)Lnet/minecraft/class_2556$class_7466;
+			COMMENT {@return a rule that narrate a message after formatting} The message
+			COMMENT is narrated as the given {@code type}, and the narration can include
+			COMMENT sender information in addition to the message content.
+			ARG 0 decoration
+			ARG 1 kind
+		METHOD method_43848 of (Lnet/minecraft/class_2556$class_7466$class_7467;)Lnet/minecraft/class_2556$class_7466;
+			COMMENT {@return a rule that narrate a message's content directly} The message
+			COMMENT is narrated as the given {@code type}, without any sender-related
+			COMMENT information.
+			ARG 0 kind
+		METHOD method_43849 apply (Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)Lnet/minecraft/class_2561;
+			COMMENT {@return the text to narrate after applying this rule on the given
+			COMMENT content and sender}
+			ARG 1 content
+			ARG 2 sender
+		CLASS class_7467 Kind
+			COMMENT The narration kind. It also determines if the narration can interrupt
+			COMMENT previous ones.
+			FIELD field_39236 CODEC Lcom/mojang/serialization/Codec;
+				COMMENT The codec for the narration kind.
+			FIELD field_39237 name Ljava/lang/String;
+			FIELD field_39238 interrupt Z
+			METHOD <init> (Ljava/lang/String;ILjava/lang/String;Z)V
+				ARG 3 name
+				ARG 4 interrupt
+			METHOD method_43851 shouldInterrupt ()Z
+	CLASS class_7468 DisplayRule
+		COMMENT A display rule for a message.
+		FIELD comp_797 Ljava/util/Optional;
+			COMMENT the formatting of a message, or {@code Optional.empty()} if the content
+			COMMENT is displayed directly
+		FIELD field_39240 CODEC Lcom/mojang/serialization/Codec;
+			COMMENT The codec for the message display rule.
+		METHOD method_43853 of ()Lnet/minecraft/class_2556$class_7468;
+			COMMENT {@return a rule that displays a message's content directly} The message
+			COMMENT is displayed without any sender-related information.
+		METHOD method_43854 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+			ARG 0 instance
+		METHOD method_43855 of (Lnet/minecraft/class_7463;)Lnet/minecraft/class_2556$class_7468;
+			COMMENT {@return a rule to format the message} It allows displaying the sender
+			COMMENT information in addition to the message content.
+			ARG 0 format
+		METHOD method_43856 apply (Lnet/minecraft/class_2561;Lnet/minecraft/class_7436;)Lnet/minecraft/class_2561;
+			COMMENT {@return the text to display after applying this rule on the given
+			COMMENT content and sender}
+			ARG 1 content
+			ARG 2 sender


### PR DESCRIPTION
Mojang calls it "chat format" in its registry and "chat style format" in the blog, but I think `MessageType` and `MessageFormat` fits better.

Since this name differs from what's in the registry, I didn't map the key and the registry in the Registry class. In addition, we should consider making new packages for these chat stuff, such as a `chat` package. The `network` package is more for network infrastructures, while the `text` package is text infrastructures so I oppose a move to there.