### PR TITLE
Remove broken "Iterator" mapping

### DIFF
--- a/mappings/net/minecraft/client/search/Iterator.mapping
+++ b/mappings/net/minecraft/client/search/Iterator.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/class_1122 net/minecraft/client/search/Iterator
-CLASS net/minecraft/class_1127 net/minecraft/client/search/Iterator


### PR DESCRIPTION
This is apparently causing yarn build failures and must be fixed.