### PR TITLE
Small amount of Block Mappings + Game Events

### DIFF
--- a/mappings/net/minecraft/block/CandleBlock.mapping
+++ b/mappings/net/minecraft/block/CandleBlock.mapping
@@ -8,6 +8,7 @@ CLASS net/minecraft/class_5544 net/minecraft/block/CandleBlock
 	FIELD field_27180 TWO_CANDLES_SHAPE Lnet/minecraft/class_265;
 	FIELD field_27181 THREE_CANDLES_SHAPE Lnet/minecraft/class_265;
 	FIELD field_27182 FOUR_CANDLES_SHAPE Lnet/minecraft/class_265;
+	FIELD field_31051 MAX_CANDLE_AMOUNT I
 	METHOD method_31628 (Lnet/minecraft/class_4970$class_4971;)Z
 		ARG 0 state
 	METHOD method_31630 canBeLit (Lnet/minecraft/class_2680;)Z

--- a/mappings/net/minecraft/block/Material.mapping
+++ b/mappings/net/minecraft/block/Material.mapping
@@ -79,6 +79,7 @@ CLASS net/minecraft/class_3614 net/minecraft/block/Material
 	FIELD field_27890 POWDER_SNOW Lnet/minecraft/class_3614;
 	FIELD field_28242 SCULK Lnet/minecraft/class_3614;
 	FIELD field_37828 FROGSPAWN Lnet/minecraft/class_3614;
+	FIELD field_38977 FROGLIGHT Lnet/minecraft/class_3614;
 	METHOD <init> (Lnet/minecraft/class_3620;ZZZZZZLnet/minecraft/class_3619;)V
 		ARG 1 color
 		ARG 2 liquid

--- a/mappings/net/minecraft/block/PropaguleBlock.mapping
+++ b/mappings/net/minecraft/block/PropaguleBlock.mapping
@@ -8,5 +8,5 @@ CLASS net/minecraft/class_7115 net/minecraft/block/PropaguleBlock
 		ARG 0 state
 	METHOD method_41436 isFullyGrown (Lnet/minecraft/class_2680;)Z
 		ARG 0 state
-	METHOD method_43130 getAgeState (I)Lnet/minecraft/class_2680;
+	METHOD method_43130 getHangingState (I)Lnet/minecraft/class_2680;
 		ARG 0 age

--- a/mappings/net/minecraft/block/PropaguleBlock.mapping
+++ b/mappings/net/minecraft/block/PropaguleBlock.mapping
@@ -8,3 +8,5 @@ CLASS net/minecraft/class_7115 net/minecraft/block/PropaguleBlock
 		ARG 0 state
 	METHOD method_41436 isFullyGrown (Lnet/minecraft/class_2680;)Z
 		ARG 0 state
+	METHOD method_43130 getAgeState (I)Lnet/minecraft/class_2680;
+		ARG 0 age

--- a/mappings/net/minecraft/block/SculkSpreadable.mapping
+++ b/mappings/net/minecraft/block/SculkSpreadable.mapping
@@ -12,6 +12,10 @@ CLASS net/minecraft/class_7124 net/minecraft/block/SculkSpreadable
 		ARG 3 state
 		ARG 4 directions
 		ARG 5 markForPostProcessing
+	METHOD method_41470 (Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;Lnet/minecraft/class_5819;)Z
+		ARG 1 world
+		ARG 2 pos
+		ARG 3 random
 	METHOD method_41471 spread (Lnet/minecraft/class_7128$class_7129;Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;Lnet/minecraft/class_5819;Lnet/minecraft/class_7128;Z)I
 		ARG 1 cursor
 		ARG 2 world

--- a/mappings/net/minecraft/block/entity/EnchantingTableBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/EnchantingTableBlockEntity.mapping
@@ -3,9 +3,14 @@ CLASS net/minecraft/class_2605 net/minecraft/block/entity/EnchantingTableBlockEn
 	FIELD field_11959 customName Lnet/minecraft/class_2561;
 	FIELD field_11960 pageAngle F
 	FIELD field_11961 ticks I
+	FIELD field_11962 offset F
+	FIELD field_11963 bookRotationPrev F
+	FIELD field_11964 bookRotation F
 	FIELD field_11965 pageTurningSpeed F
 	FIELD field_11966 nextPageTurningSpeed F
+	FIELD field_11967 flipTurn F
 	FIELD field_11968 RANDOM Lnet/minecraft/class_5819;
+	FIELD field_11969 flipRandom F
 	METHOD <init> (Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)V
 		ARG 1 pos
 		ARG 2 state

--- a/mappings/net/minecraft/block/entity/EnchantingTableBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/EnchantingTableBlockEntity.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_2605 net/minecraft/block/entity/EnchantingTableBlockEn
 	FIELD field_11960 pageAngle F
 	FIELD field_11961 ticks I
 	FIELD field_11962 offset F
-	FIELD field_11963 bookRotationPrev F
+	FIELD field_11963 lastBookRotation F
 	FIELD field_11964 bookRotation F
 	FIELD field_11965 pageTurningSpeed F
 	FIELD field_11966 nextPageTurningSpeed F

--- a/mappings/net/minecraft/block/entity/EnchantingTableBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/EnchantingTableBlockEntity.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_2605 net/minecraft/block/entity/EnchantingTableBlockEn
 	FIELD field_11959 customName Lnet/minecraft/class_2561;
 	FIELD field_11960 pageAngle F
 	FIELD field_11961 ticks I
-	FIELD field_11962 offset F
+	FIELD field_11962 targetBookRotation F
 	FIELD field_11963 lastBookRotation F
 	FIELD field_11964 bookRotation F
 	FIELD field_11965 pageTurningSpeed F

--- a/mappings/net/minecraft/server/world/ServerWorld.mapping
+++ b/mappings/net/minecraft/server/world/ServerWorld.mapping
@@ -29,6 +29,7 @@ CLASS net/minecraft/class_3218 net/minecraft/server/world/ServerWorld
 	FIELD field_35565 blockEventQueue Ljava/util/List;
 	FIELD field_36208 structureLocator Lnet/minecraft/class_6832;
 	FIELD field_36317 duringListenerUpdate Z
+	FIELD field_39095 globalListeners Ljava/util/List;
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;Ljava/util/concurrent/Executor;Lnet/minecraft/class_32$class_5143;Lnet/minecraft/class_5268;Lnet/minecraft/class_5321;Lnet/minecraft/class_5363;Lnet/minecraft/class_3949;ZJLjava/util/List;Z)V
 		ARG 1 server
 		ARG 2 workerExecutor
@@ -351,6 +352,12 @@ CLASS net/minecraft/class_3218 net/minecraft/server/world/ServerWorld
 		ARG 3 radius
 		ARG 4 horizontalBlockCheckInterval
 		ARG 5 verticalBlockCheckInterval
+	METHOD method_43663 activateGameEventListeners (Ljava/util/List;)V
+		ARG 1 listenerInfos
+	METHOD method_43664 (Ljava/util/List;Lnet/minecraft/class_5712;Lnet/minecraft/class_243;Lnet/minecraft/class_5712$class_7397;Lnet/minecraft/class_5714;Lnet/minecraft/class_243;)V
+		ARG 5 listener
+		ARG 6 listenerPos
+	METHOD method_43665 activateGameEventListeners ()V
 	METHOD method_8448 updateSleepingPlayers ()V
 	METHOD method_8487 locateStructure (Lnet/minecraft/class_6862;Lnet/minecraft/class_2338;IZ)Lnet/minecraft/class_2338;
 		COMMENT Tries to find the closest structure of a given type near a given block.

--- a/mappings/net/minecraft/server/world/ServerWorld.mapping
+++ b/mappings/net/minecraft/server/world/ServerWorld.mapping
@@ -29,7 +29,6 @@ CLASS net/minecraft/class_3218 net/minecraft/server/world/ServerWorld
 	FIELD field_35565 blockEventQueue Ljava/util/List;
 	FIELD field_36208 structureLocator Lnet/minecraft/class_6832;
 	FIELD field_36317 duringListenerUpdate Z
-	FIELD field_39095 globalListeners Ljava/util/List;
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;Ljava/util/concurrent/Executor;Lnet/minecraft/class_32$class_5143;Lnet/minecraft/class_5268;Lnet/minecraft/class_5321;Lnet/minecraft/class_5363;Lnet/minecraft/class_3949;ZJLjava/util/List;Z)V
 		ARG 1 server
 		ARG 2 workerExecutor
@@ -352,12 +351,7 @@ CLASS net/minecraft/class_3218 net/minecraft/server/world/ServerWorld
 		ARG 3 radius
 		ARG 4 horizontalBlockCheckInterval
 		ARG 5 verticalBlockCheckInterval
-	METHOD method_43663 activateGameEventListeners (Ljava/util/List;)V
-		ARG 1 listenerInfos
 	METHOD method_43664 (Ljava/util/List;Lnet/minecraft/class_5712;Lnet/minecraft/class_243;Lnet/minecraft/class_5712$class_7397;Lnet/minecraft/class_5714;Lnet/minecraft/class_243;)V
-		ARG 5 listener
-		ARG 6 listenerPos
-	METHOD method_43665 activateGameEventListeners ()V
 	METHOD method_8448 updateSleepingPlayers ()V
 	METHOD method_8487 locateStructure (Lnet/minecraft/class_6862;Lnet/minecraft/class_2338;IZ)Lnet/minecraft/class_2338;
 		COMMENT Tries to find the closest structure of a given type near a given block.

--- a/mappings/net/minecraft/server/world/ServerWorld.mapping
+++ b/mappings/net/minecraft/server/world/ServerWorld.mapping
@@ -351,7 +351,6 @@ CLASS net/minecraft/class_3218 net/minecraft/server/world/ServerWorld
 		ARG 3 radius
 		ARG 4 horizontalBlockCheckInterval
 		ARG 5 verticalBlockCheckInterval
-	METHOD method_43664 (Ljava/util/List;Lnet/minecraft/class_5712;Lnet/minecraft/class_243;Lnet/minecraft/class_5712$class_7397;Lnet/minecraft/class_5714;Lnet/minecraft/class_243;)V
 	METHOD method_8448 updateSleepingPlayers ()V
 	METHOD method_8487 locateStructure (Lnet/minecraft/class_6862;Lnet/minecraft/class_2338;IZ)Lnet/minecraft/class_2338;
 		COMMENT Tries to find the closest structure of a given type near a given block.

--- a/mappings/net/minecraft/world/WorldAccess.mapping
+++ b/mappings/net/minecraft/world/WorldAccess.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/class_1936 net/minecraft/world/WorldAccess
 	METHOD method_32888 emitGameEvent (Lnet/minecraft/class_5712;Lnet/minecraft/class_243;Lnet/minecraft/class_5712$class_7397;)V
 		COMMENT Emits an game event.
 		ARG 1 event
-		ARG 2 pos
+		ARG 2 emitterPos
 		ARG 3 emitter
 	METHOD method_33596 emitGameEvent (Lnet/minecraft/class_1297;Lnet/minecraft/class_5712;Lnet/minecraft/class_2338;)V
 		ARG 1 entity

--- a/mappings/net/minecraft/world/event/GameEvent.mapping
+++ b/mappings/net/minecraft/world/event/GameEvent.mapping
@@ -24,3 +24,21 @@ CLASS net/minecraft/class_5712 net/minecraft/world/event/GameEvent
 			ARG 1 affectedState
 		METHOD method_43287 of (Lnet/minecraft/class_2680;)Lnet/minecraft/class_5712$class_7397;
 			ARG 0 affectedState
+	CLASS class_7447 Info
+		FIELD field_39177 gameEvent Lnet/minecraft/class_5712;
+		FIELD field_39178 emitterPos Lnet/minecraft/class_243;
+		FIELD field_39179 emitter Lnet/minecraft/class_5712$class_7397;
+		FIELD field_39180 listener Lnet/minecraft/class_5714;
+		FIELD field_39181 listenerPos D
+		METHOD <init> (Lnet/minecraft/class_5712;Lnet/minecraft/class_243;Lnet/minecraft/class_5712$class_7397;Lnet/minecraft/class_5714;Lnet/minecraft/class_243;)V
+			ARG 1 gameEvent
+			ARG 2 emitterPos
+			ARG 3 emitter
+			ARG 4 listener
+			ARG 5 listenerPos
+		METHOD compareTo (Ljava/lang/Object;)I
+			ARG 1 info
+		METHOD method_43724 getGameEvent ()Lnet/minecraft/class_5712;
+		METHOD method_43726 getEmitterPos ()Lnet/minecraft/class_243;
+		METHOD method_43727 getEmitter ()Lnet/minecraft/class_5712$class_7397;
+		METHOD method_43728 getListener ()Lnet/minecraft/class_5714;

--- a/mappings/net/minecraft/world/event/listener/GameEventDispatcher.mapping
+++ b/mappings/net/minecraft/world/event/listener/GameEventDispatcher.mapping
@@ -10,6 +10,7 @@ CLASS net/minecraft/class_5713 net/minecraft/world/event/listener/GameEventDispa
 			COMMENT the event
 		ARG 2 pos
 		ARG 3 emitter
+		ARG 4 onListenerAccept
 	METHOD method_32944 addListener (Lnet/minecraft/class_5714;)V
 		COMMENT Adds a listener to this dispatcher.
 		ARG 1 listener

--- a/mappings/net/minecraft/world/event/listener/GameEventListener.mapping
+++ b/mappings/net/minecraft/world/event/listener/GameEventListener.mapping
@@ -7,5 +7,7 @@ CLASS net/minecraft/class_5714 net/minecraft/world/event/listener/GameEventListe
 		COMMENT
 		COMMENT @return {@code true} if the game event has been accepted by this listener
 		ARG 1 world
+		ARG 2 info
 	METHOD method_32948 getRange ()I
 		COMMENT Returns the range, in blocks, of the listener.
+	METHOD method_43723 isGameEventLocal ()Z

--- a/mappings/net/minecraft/world/event/listener/GameEventListener.mapping
+++ b/mappings/net/minecraft/world/event/listener/GameEventListener.mapping
@@ -10,4 +10,3 @@ CLASS net/minecraft/class_5714 net/minecraft/world/event/listener/GameEventListe
 		ARG 2 info
 	METHOD method_32948 getRange ()I
 		COMMENT Returns the range, in blocks, of the listener.
-	METHOD method_43723 isGameEventLocal ()Z

--- a/mappings/net/minecraft/world/event/listener/SimpleGameEventDispatcher.mapping
+++ b/mappings/net/minecraft/world/event/listener/SimpleGameEventDispatcher.mapping
@@ -12,3 +12,5 @@ CLASS net/minecraft/class_5711 net/minecraft/world/event/listener/SimpleGameEven
 		ARG 1 world
 	METHOD method_32936 dispatchTo (Lnet/minecraft/class_3218;Lnet/minecraft/class_243;Lnet/minecraft/class_5714;)Ljava/util/Optional;
 		ARG 0 world
+		ARG 1 listenerPos
+		ARG 2 listener

--- a/mappings/net/minecraft/world/event/listener/VibrationListener.mapping
+++ b/mappings/net/minecraft/world/event/listener/VibrationListener.mapping
@@ -68,6 +68,7 @@ CLASS net/minecraft/class_5718 net/minecraft/world/event/listener/VibrationListe
 			ARG 1 gameEvent
 			ARG 2 emitter
 		METHOD method_42672 onListen ()V
+		METHOD method_43695 canAvoidVibrations ()Z
 	CLASS class_7269 Vibration
 		FIELD field_38245 CODEC Lcom/mojang/serialization/Codec;
 		METHOD <init> (Lnet/minecraft/class_5712;ILnet/minecraft/class_243;Ljava/util/UUID;Ljava/util/UUID;)V


### PR DESCRIPTION
I did a run through Block code. I decided that since a lot of the constants were unmappable, I skipped a lot of them in the net.minecraft.block class. Then, as I went into new blocks like Skulk and such, I found that some of the GameEvent code was unmapped. 

Most importantly I guess this maps GameEvent#Info, which seems to be some sort of data class that implements Comparable. 

I went back to finish some block code here and there, and made sure most of the methods were mapped. 