### PR TITLE
22w19a networking

### DIFF
--- a/mappings/net/minecraft/client/font/MultilineText.mapping
+++ b/mappings/net/minecraft/client/font/MultilineText.mapping
@@ -32,6 +32,8 @@ CLASS net/minecraft/class_5489 net/minecraft/client/font/MultilineText
 	METHOD method_30894 (Lnet/minecraft/class_327;Lnet/minecraft/class_5481;)Lnet/minecraft/class_5489$class_5490;
 		ARG 1 text
 	METHOD method_30895 create (Lnet/minecraft/class_327;Ljava/util/List;)Lnet/minecraft/class_5489;
+		ARG 0 textRenderer
+		ARG 1 lines
 	METHOD method_30896 draw (Lnet/minecraft/class_4587;IIII)I
 		ARG 1 matrices
 		ARG 2 x
@@ -54,8 +56,12 @@ CLASS net/minecraft/class_5489 net/minecraft/client/font/MultilineText
 		ARG 4 lineHeight
 		ARG 5 padding
 		ARG 6 color
+	METHOD method_44048 getMaxWidth ()I
 	CLASS 2
+		FIELD field_39338 maxWidth I
 		METHOD method_41155 (Lnet/minecraft/class_5489$class_5490;)I
+			ARG 0 line
+		METHOD method_44049 (Lnet/minecraft/class_5489$class_5490;)I
 			ARG 0 line
 	CLASS class_5490 Line
 		FIELD field_26531 text Lnet/minecraft/class_5481;

--- a/mappings/net/minecraft/client/gui/hud/ChatHud.mapping
+++ b/mappings/net/minecraft/client/gui/hud/ChatHud.mapping
@@ -42,7 +42,7 @@ CLASS net/minecraft/class_338 net/minecraft/client/gui/hud/ChatHud
 		ARG 2 messageId
 		ARG 3 timestamp
 		ARG 4 refresh
-	METHOD method_1816 getText (DD)Lnet/minecraft/class_2583;
+	METHOD method_1816 getTextStyleAt (DD)Lnet/minecraft/class_2583;
 		ARG 1 x
 		ARG 3 y
 	METHOD method_1817 reset ()V
@@ -65,3 +65,4 @@ CLASS net/minecraft/class_338 net/minecraft/client/gui/hud/ChatHud
 	METHOD method_30885 (ILnet/minecraft/class_303;)Z
 		ARG 1 message
 	METHOD method_41831 getDefaultUnfocusedHeight ()D
+	METHOD method_44047 getChatScreen ()Lnet/minecraft/class_408;

--- a/mappings/net/minecraft/client/gui/screen/ChatScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ChatScreen.mapping
@@ -55,7 +55,8 @@ CLASS net/minecraft/class_408 net/minecraft/client/gui/screen/ChatScreen
 		COMMENT
 		COMMENT <p>To check if the client allows chat previews, check the {@linkplain
 		COMMENT net.minecraft.client.option.GameOptions#getChatPreview the chat preview option},
-		COMMENT and to check if the server allows chat previews, check {@link ServerInfo#shouldPreviewChat}.
+		COMMENT and to check if the server allows chat previews, check {@link
+		COMMENT net.minecraft.client.network.ServerInfo#shouldPreviewChat}.
 	METHOD method_44062 getPreviewText ()Ljava/util/List;
 	METHOD method_44063 getPreviewWidth ()I
 	METHOD method_44064 getPreviewBottom ()I

--- a/mappings/net/minecraft/client/gui/screen/ChatScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ChatScreen.mapping
@@ -43,7 +43,7 @@ CLASS net/minecraft/class_408 net/minecraft/client/gui/screen/ChatScreen
 		ARG 1 chatText
 		ARG 2 addToHistory
 	METHOD method_44057 getPreviewHeight (Ljava/util/List;)I
-		ARG 1 texts
+		ARG 1 lines
 	METHOD method_44058 getPreviewTextStyleAt (DD)Lnet/minecraft/class_2583;
 		ARG 1 x
 		ARG 3 y
@@ -51,11 +51,11 @@ CLASS net/minecraft/class_408 net/minecraft/client/gui/screen/ChatScreen
 		ARG 1 chatText
 	METHOD method_44060 getChatPreviewer ()Lnet/minecraft/class_7479;
 	METHOD method_44061 shouldPreviewChat ()Z
-		COMMENT {@return whether the client and the server both allows chat previews}
+		COMMENT {@return whether the client and the server both allow chat previews}
 		COMMENT
-		COMMENT <p>To check if the client allows chat previews, check the {@linkplain
-		COMMENT net.minecraft.client.option.GameOptions#getChatPreview the chat preview option},
-		COMMENT and to check if the server allows chat previews, check {@link
+		COMMENT <p>To check if the client allows chat previews, check {@linkplain
+		COMMENT net.minecraft.client.option.GameOptions#getChatPreview the chat preview option}.
+		COMMENT To check if the server allows chat previews, check {@link
 		COMMENT net.minecraft.client.network.ServerInfo#shouldPreviewChat}.
 	METHOD method_44062 getPreviewText ()Ljava/util/List;
 	METHOD method_44063 getPreviewWidth ()I

--- a/mappings/net/minecraft/client/gui/screen/ChatScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ChatScreen.mapping
@@ -12,6 +12,9 @@ CLASS net/minecraft/class_408 net/minecraft/client/gui/screen/ChatScreen
 	FIELD field_2389 chatLastMessage Ljava/lang/String;
 	FIELD field_32237 SHIFT_SCROLL_AMOUNT D
 	FIELD field_33953 USAGE_TEXT Lnet/minecraft/class_2561;
+	FIELD field_39344 CHAT_PREVIEW_WARNING_TOAST_TITLE Lnet/minecraft/class_2561;
+	FIELD field_39345 CHAT_PREVIEW_WARNING_TOAST_TEXT Lnet/minecraft/class_2561;
+	FIELD field_39346 CHAT_PREVIEW_TEXT Lnet/minecraft/class_2561;
 	METHOD <init> (Ljava/lang/String;)V
 		ARG 1 originalChatText
 	METHOD method_2108 setText (Ljava/lang/String;)V

--- a/mappings/net/minecraft/client/gui/screen/ChatScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ChatScreen.mapping
@@ -12,9 +12,13 @@ CLASS net/minecraft/class_408 net/minecraft/client/gui/screen/ChatScreen
 	FIELD field_2389 chatLastMessage Ljava/lang/String;
 	FIELD field_32237 SHIFT_SCROLL_AMOUNT D
 	FIELD field_33953 USAGE_TEXT Lnet/minecraft/class_2561;
+	FIELD field_39341 PREVIEW_LEFT_MARGIN I
+	FIELD field_39342 PREVIEW_RIGHT_MARGIN I
+	FIELD field_39343 PREVIEW_BOTTOM_MARGIN I
 	FIELD field_39344 CHAT_PREVIEW_WARNING_TOAST_TITLE Lnet/minecraft/class_2561;
 	FIELD field_39345 CHAT_PREVIEW_WARNING_TOAST_TEXT Lnet/minecraft/class_2561;
-	FIELD field_39346 CHAT_PREVIEW_TEXT Lnet/minecraft/class_2561;
+	FIELD field_39346 CHAT_PREVIEW_PLACEHOLDER_TEXT Lnet/minecraft/class_2561;
+	FIELD field_39347 chatPreviewer Lnet/minecraft/class_7479;
 	METHOD <init> (Ljava/lang/String;)V
 		ARG 1 originalChatText
 	METHOD method_2108 setText (Ljava/lang/String;)V
@@ -23,3 +27,35 @@ CLASS net/minecraft/class_408 net/minecraft/client/gui/screen/ChatScreen
 		ARG 1 offset
 	METHOD method_23945 onChatFieldUpdate (Ljava/lang/String;)V
 		ARG 1 chatText
+	METHOD method_44050 getPreviewLeft ()I
+	METHOD method_44051 getPreviewRight ()I
+	METHOD method_44052 getTextStyleAt (DD)Lnet/minecraft/class_2583;
+		ARG 1 x
+		ARG 3 y
+	METHOD method_44053 renderChatPreview (Lnet/minecraft/class_4587;)V
+		ARG 1 matrices
+	METHOD method_44054 normalize (Ljava/lang/String;)Ljava/lang/String;
+		COMMENT {@return the {@code message} normalized by trimming it and then normalizing spaces}
+		ARG 1 chatText
+	METHOD method_44055 getPreviewTop (I)I
+		ARG 1 previewHeight
+	METHOD method_44056 sendMessage (Ljava/lang/String;Z)V
+		ARG 1 chatText
+		ARG 2 addToHistory
+	METHOD method_44057 getPreviewHeight (Ljava/util/List;)I
+		ARG 1 texts
+	METHOD method_44058 getPreviewTextStyleAt (DD)Lnet/minecraft/class_2583;
+		ARG 1 x
+		ARG 3 y
+	METHOD method_44059 updatePreviewer (Ljava/lang/String;)V
+		ARG 1 chatText
+	METHOD method_44060 getChatPreviewer ()Lnet/minecraft/class_7479;
+	METHOD method_44061 shouldPreviewChat ()Z
+		COMMENT {@return whether the client and the server both allows chat previews}
+		COMMENT
+		COMMENT <p>To check if the client allows chat previews, check the {@linkplain
+		COMMENT net.minecraft.client.option.GameOptions#getChatPreview the chat preview option},
+		COMMENT and to check if the server allows chat previews, check {@link ServerInfo#shouldPreviewChat}.
+	METHOD method_44062 getPreviewText ()Ljava/util/List;
+	METHOD method_44063 getPreviewWidth ()I
+	METHOD method_44064 getPreviewBottom ()I

--- a/mappings/net/minecraft/client/gui/screen/WarningScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/WarningScreen.mapping
@@ -12,3 +12,4 @@ CLASS net/minecraft/class_7065 net/minecraft/client/gui/screen/WarningScreen
 		ARG 4 narratedText
 	METHOD method_41160 initButtons (I)V
 		ARG 1 yOffset
+	METHOD method_44068 getLineHeight ()I

--- a/mappings/net/minecraft/client/gui/screen/multiplayer/ChatPreviewWarningScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/multiplayer/ChatPreviewWarningScreen.mapping
@@ -1,0 +1,13 @@
+CLASS net/minecraft/class_7483 net/minecraft/client/gui/screen/multiplayer/ChatPreviewWarningScreen
+	FIELD field_39348 TITLE Lnet/minecraft/class_2561;
+	FIELD field_39349 CONTENT Lnet/minecraft/class_2561;
+	FIELD field_39350 CHECK_MESSAGE Lnet/minecraft/class_2561;
+	FIELD field_39351 NARRATED_TEXT Lnet/minecraft/class_2561;
+	FIELD field_39352 serverInfo Lnet/minecraft/class_642;
+	METHOD <init> (Lnet/minecraft/class_642;)V
+		ARG 1 serverInfo
+	METHOD method_44066 (Lnet/minecraft/class_4185;)V
+		ARG 1 button
+	METHOD method_44067 (Lnet/minecraft/class_4185;)V
+		ARG 1 button
+	METHOD method_44069 acknowledge ()V

--- a/mappings/net/minecraft/client/gui/screen/multiplayer/MultiplayerWarningScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/multiplayer/MultiplayerWarningScreen.mapping
@@ -3,3 +3,6 @@ CLASS net/minecraft/class_4749 net/minecraft/client/gui/screen/multiplayer/Multi
 	FIELD field_21844 MESSAGE Lnet/minecraft/class_2561;
 	FIELD field_21845 CHECK_MESSAGE Lnet/minecraft/class_2561;
 	FIELD field_21846 NARRATED_TEXT Lnet/minecraft/class_2561;
+	FIELD field_39354 parent Lnet/minecraft/class_437;
+	METHOD <init> (Lnet/minecraft/class_437;)V
+		ARG 1 parent

--- a/mappings/net/minecraft/client/network/ChatPreviewer.mapping
+++ b/mappings/net/minecraft/client/network/ChatPreviewer.mapping
@@ -1,0 +1,40 @@
+CLASS net/minecraft/class_7479 net/minecraft/client/network/ChatPreviewer
+	FIELD field_39326 QUERY_INTERVAL J
+	FIELD field_39327 FORCE_QUERY_INTERVAL J
+	FIELD field_39329 client Lnet/minecraft/class_310;
+	FIELD field_39331 nextQuery Lnet/minecraft/class_7479$class_7480;
+	FIELD field_39332 lastQuery Lnet/minecraft/class_7479$class_7480;
+	FIELD field_39333 queryTime J
+	FIELD field_39334 lastResponse Lnet/minecraft/class_7479$class_7481;
+	METHOD <init> (Lnet/minecraft/class_310;)V
+		ARG 1 client
+	METHOD method_44031 tryQuery ()V
+	METHOD method_44032 onResponse (ILnet/minecraft/class_2561;)V
+		ARG 1 id
+		ARG 2 response
+	METHOD method_44033 shouldQuery (J)Z
+		ARG 1 currentTime
+	METHOD method_44034 query (Lnet/minecraft/class_7479$class_7480;J)V
+		ARG 1 query
+		ARG 2 currentTime
+	METHOD method_44035 onInput (Ljava/lang/String;)V
+		ARG 1 query
+	METHOD method_44036 clear ()V
+	METHOD method_44037 tryConsumeResponse (Ljava/lang/String;)Lnet/minecraft/class_2561;
+		ARG 1 message
+	METHOD method_44038 getLastResponseText ()Lnet/minecraft/class_2561;
+	METHOD method_44039 normalize (Ljava/lang/String;)Ljava/lang/String;
+		ARG 0 message
+	METHOD method_44040 hasQueryOrResponse ()Z
+	METHOD method_44041 getNextQueryTime ()J
+	METHOD method_44042 getNextForcedQueryTime ()J
+	CLASS class_7480 Query
+		METHOD method_44043 idEquals (I)Z
+			ARG 1 id
+		METHOD method_44044 queryEquals (Ljava/lang/String;)Z
+			ARG 1 query
+	CLASS class_7481 Response
+		METHOD method_44045 canConsume (Ljava/lang/String;)Z
+			ARG 1 message
+	CLASS class_7482
+		FIELD field_39336 random Lnet/minecraft/class_5819;

--- a/mappings/net/minecraft/client/network/ChatPreviewer.mapping
+++ b/mappings/net/minecraft/client/network/ChatPreviewer.mapping
@@ -4,6 +4,9 @@ CLASS net/minecraft/class_7479 net/minecraft/client/network/ChatPreviewer
 	COMMENT reopening it would create a new chat previewer.
 	COMMENT
 	COMMENT <p>A <strong>query</strong> is a request to the server to send the chat message preview.
+	COMMENT The previewer only sends the query if there is no query that is waiting for the response,
+	COMMENT or if the last query took more than {@value #LATEST_NEXT_QUERY_DELAY} milliseconds to
+	COMMENT respond. A query can be sent at most every {@value #EARLIEST_NEXT_QUERY_DELAY} milliseconds.
 	COMMENT
 	COMMENT <p>The response to the query can be "consumed" by calling {@link #tryConsumeResponse}.
 	COMMENT If the response is still valid (i.e. the input has not changed since the query was sent),
@@ -12,10 +15,16 @@ CLASS net/minecraft/class_7479 net/minecraft/client/network/ChatPreviewer
 	COMMENT can only be consumed after the cooldown (by default, {@value #CONSUME_COOLDOWN} milliseconds)
 	COMMENT has passed. It is also possible to get the response text without consuming by calling
 	COMMENT {@link #getPreviewText}.
-	FIELD field_39326 J
+	FIELD field_39326 EARLIEST_NEXT_QUERY_DELAY J
+		COMMENT How long the previewer should wait at a minimum before sending the next
+		COMMENT query in milliseconds. Is {@value}.
 		COMMENT
-	FIELD field_39327 J
+		COMMENT @see #getEarliestNextQueryTime
+	FIELD field_39327 LATEST_NEXT_QUERY_DELAY J
+		COMMENT How long the previewer can wait for the response at most before sending the next
+		COMMENT query in milliseconds. Is {@value}.
 		COMMENT
+		COMMENT @see #getLatestNextQueryTime
 	FIELD field_39328 CONSUME_COOLDOWN J
 		COMMENT How long the previewer should wait before consuming the response since the response
 		COMMENT arrived at the client in milliseconds. Is {@value}.
@@ -23,10 +32,18 @@ CLASS net/minecraft/class_7479 net/minecraft/client/network/ChatPreviewer
 		COMMENT @see #tryConsumeResponse
 	FIELD field_39329 client Lnet/minecraft/class_310;
 	FIELD field_39330 idIncrementor Lnet/minecraft/class_7479$class_7482;
-	FIELD field_39331 pendingQuery Lnet/minecraft/class_7479$class_7480;
-	FIELD field_39332 lastQuery Lnet/minecraft/class_7479$class_7480;
+	FIELD field_39331 pendingRequestQuery Lnet/minecraft/class_7479$class_7480;
+		COMMENT The query that is waiting for the previewer to request (i.e. the next query to be sent).
+		COMMENT Can be {@code null} if there is no such query.
+	FIELD field_39332 pendingResponseQuery Lnet/minecraft/class_7479$class_7480;
+		COMMENT The query that is waiting for the server to respond (i.e. the last query).
+		COMMENT Can be {@code null} if there is no such query.
 	FIELD field_39333 queryTime J
 		COMMENT The last time a query was sent.
+		COMMENT
+		COMMENT <p>The next query will be sent after {@value #EARLIEST_NEXT_QUERY_DELAY} to
+		COMMENT {@value #LATEST_NEXT_QUERY_DELAY} milliseconds; the actual delay depends on
+		COMMENT when the server responds to the query.
 	FIELD field_39334 lastResponse Lnet/minecraft/class_7479$class_7481;
 	METHOD <init> (Lnet/minecraft/class_310;)V
 		ARG 1 client
@@ -35,11 +52,16 @@ CLASS net/minecraft/class_7479 net/minecraft/client/network/ChatPreviewer
 	METHOD method_44032 onResponse (ILnet/minecraft/class_2561;)V
 		COMMENT Called when the preview response was received.
 		COMMENT
-		COMMENT @implNote This sets the last response if the last query ID equals {@code id}.
+		COMMENT @implNote This sets the last response and clears {@link #pendingResponseQuery}
+		COMMENT if the pending query ID equals {@code id}
 		ARG 1 id
 		ARG 2 response
 	METHOD method_44033 shouldQuery (J)Z
 		COMMENT {@return whether the delay for querying has passed}
+		COMMENT
+		COMMENT <p>The previewer only sends the query if there is no query that is waiting for the response,
+		COMMENT or if the last query took more than {@value #LATEST_NEXT_QUERY_DELAY} milliseconds to
+		COMMENT respond. A query can be sent at most every {@value #EARLIEST_NEXT_QUERY_DELAY} milliseconds.
 		ARG 1 currentTime
 	METHOD method_44034 query (Lnet/minecraft/class_7479$class_7480;J)V
 		COMMENT Sends {@code query} to the server.
@@ -77,10 +99,14 @@ CLASS net/minecraft/class_7479 net/minecraft/client/network/ChatPreviewer
 		COMMENT
 		COMMENT @implNote A preview should be rendered if there is a response, a pending query, or
 		COMMENT a query waiting for the response.
-	METHOD method_44041 ()J
+	METHOD method_44041 getEarliestNextQueryTime ()J
+		COMMENT {@return the earliest time the next query can be sent}
 		COMMENT
-	METHOD method_44042 ()J
+		COMMENT @implNote This is {@value #EARLIEST_NEXT_QUERY_DELAY} milliseconds after the last query.
+	METHOD method_44042 getLatestNextQueryTime ()J
+		COMMENT {@return the latest time the next query should be sent}
 		COMMENT
+		COMMENT @implNote This is {@value #LATEST_NEXT_QUERY_DELAY} milliseconds after the last query.
 	CLASS class_7480 Query
 		COMMENT A query, or a request, to the server to send the chat message preview.
 		FIELD comp_825 Ljava/lang/String;

--- a/mappings/net/minecraft/client/network/ChatPreviewer.mapping
+++ b/mappings/net/minecraft/client/network/ChatPreviewer.mapping
@@ -123,7 +123,7 @@ CLASS net/minecraft/class_7479 net/minecraft/client/network/ChatPreviewer
 		METHOD method_44045 canConsume (Ljava/lang/String;)Z
 			COMMENT {@return whether the response can be consumed for the {@code message}}
 			COMMENT
-			COMMENT <p>This returns {@code true} if the message equals the queried message and
+			COMMENT <p>This returns {@code true} if the {@code message} equals the queried message and
 			COMMENT the cooldown has passed.
 			ARG 1 message
 	CLASS class_7482 IdIncrementor

--- a/mappings/net/minecraft/client/network/ChatPreviewer.mapping
+++ b/mappings/net/minecraft/client/network/ChatPreviewer.mapping
@@ -4,12 +4,6 @@ CLASS net/minecraft/class_7479 net/minecraft/client/network/ChatPreviewer
 	COMMENT reopening it would create a new chat previewer.
 	COMMENT
 	COMMENT <p>A <strong>query</strong> is a request to the server to send the chat message preview.
-	COMMENT If the chat screen's input was previously empty, the next query sent is called
-	COMMENT "initial query", since there is no {@linkplain #lastQuery last query}. This is not
-	COMMENT the first query that the chat previewer sends, though, since the last query is cleared
-	COMMENT whenever the chat screen's input gets empty - for example, by the player pressing Delete.
-	COMMENT This distinction between the initial query and the subsequent query is important, because
-	COMMENT the initial query has a shorter delay.
 	COMMENT
 	COMMENT <p>The response to the query can be "consumed" by calling {@link #tryConsumeResponse}.
 	COMMENT If the response is still valid (i.e. the input has not changed since the query was sent),
@@ -18,16 +12,10 @@ CLASS net/minecraft/class_7479 net/minecraft/client/network/ChatPreviewer
 	COMMENT can only be consumed after the cooldown (by default, {@value #CONSUME_COOLDOWN} milliseconds)
 	COMMENT has passed. It is also possible to get the response text without consuming by calling
 	COMMENT {@link #getPreviewText}.
-	FIELD field_39326 INITIAL_QUERY_DELAY J
-		COMMENT How long the previewer should wait before sending the initial query in milliseconds
-		COMMENT since the last query was sent. Is {@value}.
+	FIELD field_39326 J
 		COMMENT
-		COMMENT @see #getInitialQueryTime
-	FIELD field_39327 QUERY_DELAY J
-		COMMENT How long the previewer should wait before sending the non-initial query in milliseconds
-		COMMENT since the last query was sent. Is {@value}.
+	FIELD field_39327 J
 		COMMENT
-		COMMENT @see #getQueryTime
 	FIELD field_39328 CONSUME_COOLDOWN J
 		COMMENT How long the previewer should wait before consuming the response since the response
 		COMMENT arrived at the client in milliseconds. Is {@value}.
@@ -39,9 +27,6 @@ CLASS net/minecraft/class_7479 net/minecraft/client/network/ChatPreviewer
 	FIELD field_39332 lastQuery Lnet/minecraft/class_7479$class_7480;
 	FIELD field_39333 queryTime J
 		COMMENT The last time a query was sent.
-		COMMENT
-		COMMENT @implNote This is {@code 0} by default and is set when the first query is sent. This
-		COMMENT causes {@link #getInitialQueryTime} to not respect the delay for the first query.
 	FIELD field_39334 lastResponse Lnet/minecraft/class_7479$class_7481;
 	METHOD <init> (Lnet/minecraft/class_310;)V
 		ARG 1 client
@@ -55,9 +40,6 @@ CLASS net/minecraft/class_7479 net/minecraft/client/network/ChatPreviewer
 		ARG 2 response
 	METHOD method_44033 shouldQuery (J)Z
 		COMMENT {@return whether the delay for querying has passed}
-		COMMENT
-		COMMENT @see #getInitialQueryTime
-		COMMENT @see #getQueryTime
 		ARG 1 currentTime
 	METHOD method_44034 query (Lnet/minecraft/class_7479$class_7480;J)V
 		COMMENT Sends {@code query} to the server.
@@ -95,18 +77,10 @@ CLASS net/minecraft/class_7479 net/minecraft/client/network/ChatPreviewer
 		COMMENT
 		COMMENT @implNote A preview should be rendered if there is a response, a pending query, or
 		COMMENT a query waiting for the response.
-	METHOD method_44041 getInitialQueryTime ()J
-		COMMENT {@return the next time the initial query should be sent, in milliseconds}
+	METHOD method_44041 ()J
 		COMMENT
-		COMMENT <p>In vanilla, this is {@value #INITIAL_QUERY_DELAY} milliseconds after the query time.
+	METHOD method_44042 ()J
 		COMMENT
-		COMMENT @implNote This must be smaller than {@link #getQueryTime}. Also, this is ignored for the
-		COMMENT first query sent after the chat screen was created. (See the implementation note for
-		COMMENT {@link #queryTime} for details.)
-	METHOD method_44042 getQueryTime ()J
-		COMMENT {@return the next time the non-initial query should be sent, in milliseconds}
-		COMMENT
-		COMMENT <p>In vanilla, this is {@value #QUERY_DELAY} milliseconds after the query time.
 	CLASS class_7480 Query
 		COMMENT A query, or a request, to the server to send the chat message preview.
 		FIELD comp_825 Ljava/lang/String;

--- a/mappings/net/minecraft/client/network/ChatPreviewer.mapping
+++ b/mappings/net/minecraft/client/network/ChatPreviewer.mapping
@@ -109,17 +109,20 @@ CLASS net/minecraft/class_7479 net/minecraft/client/network/ChatPreviewer
 		COMMENT @implNote This is {@value #LATEST_NEXT_QUERY_DELAY} milliseconds after the last query.
 	CLASS class_7480 Query
 		COMMENT A query, or a request, to the server to send the chat message preview.
-		FIELD comp_825 Ljava/lang/String;
+		FIELD comp_825 message Ljava/lang/String;
 			COMMENT the queried message to preview
+		METHOD comp_825 message ()Ljava/lang/String;
 		METHOD method_44043 idEquals (I)Z
 			ARG 1 id
-		METHOD method_44044 queryEquals (Ljava/lang/String;)Z
-			COMMENT {@return whether the query's queried message equals {@code query}}
-			ARG 1 query
+		METHOD method_44044 messageEquals (Ljava/lang/String;)Z
+			COMMENT {@return whether the query's queried message equals {@code message}}
+			ARG 1 message
 	CLASS class_7481 Response
 		COMMENT A response to the preview query.
 		FIELD comp_827 Ljava/lang/String;
 			COMMENT the message that was queried to preview
+		FIELD comp_828 previewText Lnet/minecraft/class_2561;
+		METHOD comp_828 previewText ()Lnet/minecraft/class_2561;
 		METHOD method_44045 canConsume (Ljava/lang/String;)Z
 			COMMENT {@return whether the response can be consumed for the {@code message}}
 			COMMENT

--- a/mappings/net/minecraft/client/network/ChatPreviewer.mapping
+++ b/mappings/net/minecraft/client/network/ChatPreviewer.mapping
@@ -1,40 +1,135 @@
 CLASS net/minecraft/class_7479 net/minecraft/client/network/ChatPreviewer
-	FIELD field_39326 QUERY_INTERVAL J
-	FIELD field_39327 FORCE_QUERY_INTERVAL J
+	COMMENT Chat previewer manages the chat preview. Chat previewer is created per
+	COMMENT {@link net.minecraft.client.gui.screen.ChatScreen}, so closing the chat screen and
+	COMMENT reopening it would create a new chat previewer.
+	COMMENT
+	COMMENT <p>A <strong>query</strong> is a request to the server to send the chat message preview.
+	COMMENT If the chat screen's input was previously empty, the next query sent is called
+	COMMENT "initial query", since there is no {@linkplain #lastQuery last query}. This is not
+	COMMENT the first query that the chat previewer sends, though, since the last query is cleared
+	COMMENT whenever the chat screen's input gets empty - for example, by the player pressing Delete.
+	COMMENT This distinction between the initial query and the subsequent query is important, because
+	COMMENT the initial query has a shorter delay.
+	COMMENT
+	COMMENT <p>The response to the query can be "consumed" by calling {@link #tryConsumeResponse}.
+	COMMENT If the response is still valid (i.e. the input has not changed since the query was sent),
+	COMMENT consuming the response will return the response and clear it. Note that to prevent race
+	COMMENT condition between the player sending the chat message and the response's arrival, responses
+	COMMENT can only be consumed after the cooldown (by default, {@value #CONSUME_COOLDOWN} milliseconds)
+	COMMENT has passed. It is also possible to get the response text without consuming by calling
+	COMMENT {@link #getPreviewText}.
+	FIELD field_39326 INITIAL_QUERY_DELAY J
+		COMMENT How long the previewer should wait before sending the initial query in milliseconds
+		COMMENT since the last query was sent. Is {@value}.
+		COMMENT
+		COMMENT @see #getInitialQueryTime
+	FIELD field_39327 QUERY_DELAY J
+		COMMENT How long the previewer should wait before sending the non-initial query in milliseconds
+		COMMENT since the last query was sent. Is {@value}.
+		COMMENT
+		COMMENT @see #getQueryTime
+	FIELD field_39328 CONSUME_COOLDOWN J
+		COMMENT How long the previewer should wait before consuming the response since the response
+		COMMENT arrived at the client in milliseconds. Is {@value}.
+		COMMENT
+		COMMENT @see #tryConsumeResponse
 	FIELD field_39329 client Lnet/minecraft/class_310;
-	FIELD field_39331 nextQuery Lnet/minecraft/class_7479$class_7480;
+	FIELD field_39330 idIncrementor Lnet/minecraft/class_7479$class_7482;
+	FIELD field_39331 pendingQuery Lnet/minecraft/class_7479$class_7480;
 	FIELD field_39332 lastQuery Lnet/minecraft/class_7479$class_7480;
 	FIELD field_39333 queryTime J
+		COMMENT The last time a query was sent.
+		COMMENT
+		COMMENT @implNote This is {@code 0} by default and is set when the first query is sent. This
+		COMMENT causes {@link #getInitialQueryTime} to not respect the delay for the first query.
 	FIELD field_39334 lastResponse Lnet/minecraft/class_7479$class_7481;
 	METHOD <init> (Lnet/minecraft/class_310;)V
 		ARG 1 client
 	METHOD method_44031 tryQuery ()V
+		COMMENT Sends the pending query, if it exists and the delay has passed.
 	METHOD method_44032 onResponse (ILnet/minecraft/class_2561;)V
+		COMMENT Called when the preview response was received.
+		COMMENT
+		COMMENT @implNote This sets the last response if the last query ID equals {@code id}.
 		ARG 1 id
 		ARG 2 response
 	METHOD method_44033 shouldQuery (J)Z
+		COMMENT {@return whether the delay for querying has passed}
+		COMMENT
+		COMMENT @see #getInitialQueryTime
+		COMMENT @see #getQueryTime
 		ARG 1 currentTime
 	METHOD method_44034 query (Lnet/minecraft/class_7479$class_7480;J)V
+		COMMENT Sends {@code query} to the server.
 		ARG 1 query
 		ARG 2 currentTime
 	METHOD method_44035 onInput (Ljava/lang/String;)V
+		COMMENT Called when {@code query} was input into the chat screen.
+		COMMENT
+		COMMENT @implNote If the {@linkplain #normalize normalized} query is empty, the queries are cleared
+		COMMENT and the empty response is set by the client; otherwise it sets the pending query.
 		ARG 1 query
 	METHOD method_44036 clear ()V
+		COMMENT Clears the last response and the queries (but not the query time).
 	METHOD method_44037 tryConsumeResponse (Ljava/lang/String;)Lnet/minecraft/class_2561;
+		COMMENT {@return the consumed response text, or {@code null} if the server responded as such, or
+		COMMENT if the response could not be consumed}
+		COMMENT
+		COMMENT <p>If the response is still valid (i.e. the input has not changed since the query was sent),
+		COMMENT consuming the response will return the response and clear it. Note that to prevent race
+		COMMENT condition between the player sending the chat message and the response's arrival, responses
+		COMMENT can only be consumed after the cooldown (by default, {@value #CONSUME_COOLDOWN} milliseconds)
+		COMMENT has passed. It is also possible to get the response text without consuming by calling
+		COMMENT {@link #getPreviewText}.
 		ARG 1 message
-	METHOD method_44038 getLastResponseText ()Lnet/minecraft/class_2561;
+	METHOD method_44038 getPreviewText ()Lnet/minecraft/class_2561;
+		COMMENT {@return the preview text (also known as the last response text), or {@code null}
+		COMMENT if the server responded as such}
+		COMMENT
+		COMMENT <p>This does not consume the response.
 	METHOD method_44039 normalize (Ljava/lang/String;)Ljava/lang/String;
+		COMMENT {@return the {@code message} normalized by trimming it and then normalizing spaces}
 		ARG 0 message
-	METHOD method_44040 hasQueryOrResponse ()Z
-	METHOD method_44041 getNextQueryTime ()J
-	METHOD method_44042 getNextForcedQueryTime ()J
+	METHOD method_44040 shouldRenderPreview ()Z
+		COMMENT {@return whether the preview should be rendered}
+		COMMENT
+		COMMENT @implNote A preview should be rendered if there is a response, a pending query, or
+		COMMENT a query waiting for the response.
+	METHOD method_44041 getInitialQueryTime ()J
+		COMMENT {@return the next time the initial query should be sent, in milliseconds}
+		COMMENT
+		COMMENT <p>In vanilla, this is {@value #INITIAL_QUERY_DELAY} milliseconds after the query time.
+		COMMENT
+		COMMENT @implNote This must be smaller than {@link #getQueryTime}. Also, this is ignored for the
+		COMMENT first query sent after the chat screen was created. (See the implementation note for
+		COMMENT {@link #queryTime} for details.)
+	METHOD method_44042 getQueryTime ()J
+		COMMENT {@return the next time the non-initial query should be sent, in milliseconds}
+		COMMENT
+		COMMENT <p>In vanilla, this is {@value #QUERY_DELAY} milliseconds after the query time.
 	CLASS class_7480 Query
+		COMMENT A query, or a request, to the server to send the chat message preview.
+		FIELD comp_825 Ljava/lang/String;
+			COMMENT the queried message to preview
 		METHOD method_44043 idEquals (I)Z
 			ARG 1 id
 		METHOD method_44044 queryEquals (Ljava/lang/String;)Z
+			COMMENT {@return whether the query's queried message equals {@code query}}
 			ARG 1 query
 	CLASS class_7481 Response
+		COMMENT A response to the preview query.
+		FIELD comp_827 Ljava/lang/String;
+			COMMENT the message that was queried to preview
 		METHOD method_44045 canConsume (Ljava/lang/String;)Z
+			COMMENT {@return whether the response can be consumed for the {@code message}}
+			COMMENT
+			COMMENT <p>This returns {@code true} if the message equals the queried message and
+			COMMENT the cooldown has passed.
 			ARG 1 message
-	CLASS class_7482
+	CLASS class_7482 IdIncrementor
+		COMMENT A utility class that increments the ID by a random number from 0 to 99.
+		FIELD field_39335 MAX_INCREMENT I
 		FIELD field_39336 random Lnet/minecraft/class_5819;
+		FIELD field_39337 current I
+		METHOD method_44046 next ()I
+			COMMENT {@return the next ID}

--- a/mappings/net/minecraft/client/network/ClientPlayNetworkHandler.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayNetworkHandler.mapping
@@ -112,6 +112,16 @@ CLASS net/minecraft/class_634 net/minecraft/client/network/ClientPlayNetworkHand
 	METHOD method_43331 resolveUrl (Ljava/lang/String;)Ljava/net/URL;
 		ARG 0 url
 	METHOD method_43597 isSignatureValid (Lnet/minecraft/class_7471;)Z
-		COMMENT {@return whether the chat message packet has a valid signature}
+		COMMENT {@return whether the chat message has a valid signature}
 		COMMENT
 		COMMENT <p>This returns {@code false} when the chat sender is unknown.
+		ARG 1 message
+	METHOD method_44071 (Lnet/minecraft/class_642;Ljava/lang/String;)V
+		ARG 1 favicon
+	METHOD method_44072 (Lnet/minecraft/class_642;Lnet/minecraft/class_2561;)V
+		ARG 1 description
+	METHOD method_44073 handleMessage (Lnet/minecraft/class_2556;Lnet/minecraft/class_7471;Lnet/minecraft/class_7436;)V
+		COMMENT Handles an incoming chat message.
+		ARG 1 type
+		ARG 2 message
+		ARG 3 sender

--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -117,7 +117,7 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 		ARG 2 message
 	METHOD method_43786 signArguments (Lnet/minecraft/class_7470;Lcom/mojang/brigadier/ParseResults;)Lnet/minecraft/class_7450;
 		COMMENT Signs the command arguments. If the arguments cannot be signed or if there is no
-		COMMENT arguments to sign, this will return {@link ArgumentSignatures#none()}.
+		COMMENT arguments to sign, this will return {@link ArgumentSignatureDatas#none()}.
 		ARG 1 signer
 		ARG 2 parseResults
 	METHOD method_43787 sendCommand (Lnet/minecraft/class_7470;Ljava/lang/String;Lnet/minecraft/class_2561;)V

--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -116,8 +116,8 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 		ARG 1 signer
 		ARG 2 message
 	METHOD method_43786 signArguments (Lnet/minecraft/class_7470;Lcom/mojang/brigadier/ParseResults;)Lnet/minecraft/class_7450;
-		COMMENT Signs the command arguments. If the arguments cannot be signed, this will return
-		COMMENT {@link ArgumentSignatures#none()}.
+		COMMENT Signs the command arguments. If the arguments cannot be signed or if there is no
+		COMMENT arguments to sign, this will return {@link ArgumentSignatures#none()}.
 		ARG 1 signer
 		ARG 2 parseResults
 	METHOD method_43787 sendCommand (Lnet/minecraft/class_7470;Ljava/lang/String;Lnet/minecraft/class_2561;)V
@@ -125,9 +125,34 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 		ARG 1 signer
 		ARG 2 command
 			COMMENT the command (excluding the leading slash)
+		ARG 3 preview
+	METHOD method_44096 sendChatMessage (Ljava/lang/String;Lnet/minecraft/class_2561;)V
+		COMMENT Sends a chat message with the preview to the server. If the server could not
+		COMMENT reproduce the preview based on {@code message}, the server rejects the message.
+		COMMENT
+		COMMENT <p>The message will be truncated to at most 256 characters before
+		COMMENT sending to the server.
+		COMMENT
+		COMMENT <p>If the message contains an invalid character (see {@link
+		COMMENT net.minecraft.SharedConstants#isValidChar isValidChar}), the server will
+		COMMENT reject the message and disconnect the client.
+		COMMENT
+		COMMENT @apiNote This method is used to send a message typed in {@linkplain
+		COMMENT net.minecraft.client.gui.screen the chat screen} that has a preview.
+		ARG 1 message
+		ARG 2 preview
+	METHOD method_44097 sendChatMessagePacket (Lnet/minecraft/class_7470;Ljava/lang/String;Lnet/minecraft/class_2561;)V
+		ARG 1 signer
+		ARG 2 message
+		ARG 3 preview
 	METHOD method_44098 sendCommand (Ljava/lang/String;Lnet/minecraft/class_2561;)V
+		COMMENT Sends a command to the server.
 		ARG 1 command
+			COMMENT the command (excluding the leading slash)
+		ARG 2 preview
 	METHOD method_44099 sendCommand (Ljava/lang/String;)V
+		COMMENT Sends a command to the server.
 		ARG 1 command
+			COMMENT the command (excluding the leading slash)
 	METHOD method_7290 dropSelectedItem (Z)Z
 		ARG 1 entireStack

--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -125,5 +125,9 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 		ARG 1 signer
 		ARG 2 command
 			COMMENT the command (excluding the leading slash)
+	METHOD method_44098 sendCommand (Ljava/lang/String;Lnet/minecraft/class_2561;)V
+		ARG 1 command
+	METHOD method_44099 sendCommand (Ljava/lang/String;)V
+		ARG 1 command
 	METHOD method_7290 dropSelectedItem (Z)Z
 		ARG 1 entireStack

--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -124,7 +124,7 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 		COMMENT Signs and sends {@code command} to the server.
 		ARG 1 signer
 		ARG 2 command
-			COMMENT the command (excluding the leading slash)
+			COMMENT the command (can have the leading slash)
 		ARG 3 preview
 	METHOD method_44096 sendChatMessage (Ljava/lang/String;Lnet/minecraft/class_2561;)V
 		COMMENT Sends a chat message with the preview to the server. If the server could not
@@ -148,11 +148,11 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 	METHOD method_44098 sendCommand (Ljava/lang/String;Lnet/minecraft/class_2561;)V
 		COMMENT Sends a command to the server.
 		ARG 1 command
-			COMMENT the command (excluding the leading slash)
+			COMMENT the command (can have the leading slash)
 		ARG 2 preview
 	METHOD method_44099 sendCommand (Ljava/lang/String;)V
 		COMMENT Sends a command to the server.
 		ARG 1 command
-			COMMENT the command (excluding the leading slash)
+			COMMENT the command (can have the leading slash)
 	METHOD method_7290 dropSelectedItem (Z)Z
 		ARG 1 entireStack

--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -117,7 +117,7 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 		ARG 2 message
 	METHOD method_43786 signArguments (Lnet/minecraft/class_7470;Lcom/mojang/brigadier/ParseResults;)Lnet/minecraft/class_7450;
 		COMMENT Signs the command arguments. If the arguments cannot be signed or if there is no
-		COMMENT arguments to sign, this will return {@link ArgumentSignatureDatas#none()}.
+		COMMENT arguments to sign, this will return {@link ArgumentSignatureDataMap#empty()}.
 		ARG 1 signer
 		ARG 2 parseResults
 	METHOD method_43787 sendCommand (Lnet/minecraft/class_7470;Ljava/lang/String;Lnet/minecraft/class_2561;)V

--- a/mappings/net/minecraft/client/network/MultiplayerServerListPinger.mapping
+++ b/mappings/net/minecraft/client/network/MultiplayerServerListPinger.mapping
@@ -12,6 +12,7 @@ CLASS net/minecraft/class_644 net/minecraft/client/network/MultiplayerServerList
 		ARG 2 info
 	METHOD method_3003 add (Lnet/minecraft/class_642;Ljava/lang/Runnable;)V
 		ARG 1 entry
+		ARG 2 saver
 	METHOD method_3004 cancel ()V
 	METHOD method_36897 showError (Lnet/minecraft/class_2561;Lnet/minecraft/class_642;)V
 		ARG 1 error
@@ -29,3 +30,6 @@ CLASS net/minecraft/class_644 net/minecraft/client/network/MultiplayerServerList
 			METHOD channelRead0 (Lio/netty/channel/ChannelHandlerContext;Ljava/lang/Object;)V
 				ARG 1 context
 				ARG 2 buf
+			METHOD exceptionCaught (Lio/netty/channel/ChannelHandlerContext;Ljava/lang/Throwable;)V
+				ARG 1 context
+				ARG 2 throwable

--- a/mappings/net/minecraft/client/network/ServerInfo.mapping
+++ b/mappings/net/minecraft/client/network/ServerInfo.mapping
@@ -14,6 +14,8 @@ CLASS net/minecraft/class_642 net/minecraft/client/network/ServerInfo
 	FIELD field_3761 address Ljava/lang/String;
 	FIELD field_3762 playerListSummary Ljava/util/List;
 	FIELD field_3763 local Z
+	FIELD field_39355 LOGGER Lorg/slf4j/Logger;
+	FIELD field_39356 chatPreview Lnet/minecraft/class_642$class_7484;
 	METHOD <init> (Ljava/lang/String;Ljava/lang/String;Z)V
 		ARG 1 name
 		ARG 2 address
@@ -35,6 +37,17 @@ CLASS net/minecraft/class_642 net/minecraft/client/network/ServerInfo
 		ARG 1 resourcePackPolicy
 	METHOD method_2996 copyFrom (Lnet/minecraft/class_642;)V
 		ARG 1 serverInfo
+	METHOD method_44077 (Lnet/minecraft/class_642;Lnet/minecraft/class_642$class_7484;)V
+		ARG 1 chatPreview
+	METHOD method_44078 parseFavicon (Ljava/lang/String;)Ljava/lang/String;
+		ARG 0 favicon
+	METHOD method_44079 (Lnet/minecraft/class_2487;Lnet/minecraft/class_2520;)V
+		ARG 1 chatPreview
+	METHOD method_44080 setPreviewsChat (Z)V
+		COMMENT Sets whether the chat preview is enabled.
+		ARG 1 enabled
+	METHOD method_44081 getChatPreview ()Lnet/minecraft/class_642$class_7484;
+	METHOD method_44082 shouldPreviewChat ()Z
 	CLASS class_643 ResourcePackPolicy
 		COMMENT The policy of the client when this server sends a {@linkplain
 		COMMENT net.minecraft.network.packet.s2c.play.ResourcePackSendS2CPacket server
@@ -53,3 +66,23 @@ CLASS net/minecraft/class_642 net/minecraft/client/network/ServerInfo
 		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
 			ARG 3 name
 		METHOD method_2997 getName ()Lnet/minecraft/class_2561;
+	CLASS class_7484 ChatPreview
+		FIELD field_39357 CODEC Lcom/mojang/serialization/Codec;
+		FIELD field_39358 acknowledged Z
+		FIELD field_39359 toastShown Z
+		METHOD <init> (ZZ)V
+			ARG 1 acknowledged
+			ARG 2 toastShown
+		METHOD method_44083 setAcknowledged ()V
+		METHOD method_44084 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+			ARG 0 instance
+		METHOD method_44085 (Lnet/minecraft/class_642$class_7484;)Ljava/lang/Boolean;
+			ARG 0 chatPreview
+		METHOD method_44086 showToast ()Z
+			COMMENT If the chat preview toast is never shown, returns {@code true} and marks that the
+			COMMENT toast was shown; otherwise, returns {@code false}.
+		METHOD method_44087 (Lnet/minecraft/class_642$class_7484;)Ljava/lang/Boolean;
+			ARG 0 chatPreview
+		METHOD method_44088 isAcknowledged ()Z
+			COMMENT {@return whether the player acknowledged the chat preview warning}
+		METHOD method_44089 copy ()Lnet/minecraft/class_642$class_7484;

--- a/mappings/net/minecraft/client/option/GameOptions.mapping
+++ b/mappings/net/minecraft/client/option/GameOptions.mapping
@@ -205,6 +205,10 @@ CLASS net/minecraft/class_315 net/minecraft/client/option/GameOptions
 	FIELD field_38298 HOLD_KEY_TEXT Lnet/minecraft/class_2561;
 	FIELD field_38299 HIDE_MATCHED_NAMES_TOOLTIP Lnet/minecraft/class_2561;
 	FIELD field_38300 MAX_FRAMERATE I
+	FIELD field_39318 CHAT_PREVIEW_TOOLTIP Lnet/minecraft/class_2561;
+	FIELD field_39319 chatPreview Lnet/minecraft/class_7172;
+	FIELD field_39320 ONLY_SHOW_SIGNED_CHAT_TOOLTIP Lnet/minecraft/class_2561;
+	FIELD field_39321 onlyShowSignedChat Lnet/minecraft/class_7172;
 	METHOD <init> (Lnet/minecraft/class_310;Ljava/io/File;)V
 		ARG 1 client
 		ARG 2 optionsFile
@@ -557,6 +561,8 @@ CLASS net/minecraft/class_315 net/minecraft/client/option/GameOptions
 	METHOD method_42728 (Lnet/minecraft/class_2561;Ljava/lang/Double;)Lnet/minecraft/class_2561;
 		ARG 0 optionText
 		ARG 1 value
+	METHOD method_44025 getChatPreview ()Lnet/minecraft/class_7172;
+	METHOD method_44026 getOnlyShowSignedChat ()Lnet/minecraft/class_7172;
 	CLASS 2
 		METHOD method_33676 find (Ljava/lang/String;)Ljava/lang/String;
 			ARG 1 key

--- a/mappings/net/minecraft/client/option/ServerList.mapping
+++ b/mappings/net/minecraft/client/option/ServerList.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/class_641 net/minecraft/client/option/ServerList
 	FIELD field_3749 servers Ljava/util/List;
 	FIELD field_3750 client Lnet/minecraft/class_310;
 	FIELD field_3751 LOGGER Lorg/slf4j/Logger;
+	FIELD field_39360 SERVER_LIST_EXECUTOR Lnet/minecraft/class_3846;
 	METHOD <init> (Lnet/minecraft/class_310;)V
 		ARG 1 client
 	METHOD method_2980 set (ILnet/minecraft/class_642;)V

--- a/mappings/net/minecraft/client/option/ServerList.mapping
+++ b/mappings/net/minecraft/client/option/ServerList.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_641 net/minecraft/client/option/ServerList
 	FIELD field_3749 servers Ljava/util/List;
 	FIELD field_3750 client Lnet/minecraft/class_310;
 	FIELD field_3751 LOGGER Lorg/slf4j/Logger;
-	FIELD field_39360 SERVER_LIST_EXECUTOR Lnet/minecraft/class_3846;
+	FIELD field_39360 IO_EXECUTOR Lnet/minecraft/class_3846;
 	METHOD <init> (Lnet/minecraft/class_310;)V
 		ARG 1 client
 	METHOD method_2980 set (ILnet/minecraft/class_642;)V

--- a/mappings/net/minecraft/client/toast/SystemToast.mapping
+++ b/mappings/net/minecraft/client/toast/SystemToast.mapping
@@ -52,3 +52,6 @@ CLASS net/minecraft/class_370 net/minecraft/client/toast/SystemToast
 		ARG 0 client
 		ARG 1 directory
 	CLASS class_371 Type
+		FIELD field_39340 displayDuration J
+		METHOD <init> (Ljava/lang/String;IJ)V
+			ARG 3 displayDuration

--- a/mappings/net/minecraft/client/util/ProfileKeys.mapping
+++ b/mappings/net/minecraft/client/util/ProfileKeys.mapping
@@ -48,3 +48,8 @@ CLASS net/minecraft/class_7434 net/minecraft/client/util/ProfileKeys
 		COMMENT {@return the private key, or {@code null} if there is no private key associated
 		COMMENT with the profile}
 	METHOD method_43784 getPublicKeyData ()Ljava/util/Optional;
+	METHOD method_44076 decodeKeyPairResponse (Lcom/mojang/authlib/yggdrasil/response/KeyPairResponse;)Lnet/minecraft/class_7428$class_7443;
+		COMMENT {@return {@code keyPairResponse} decoded to {@link PlayerPublicKey.PublicKeyData}}
+		COMMENT
+		COMMENT @throws NetworkEncryptionException when the response is malformed
+		ARG 0 keyPairResponse

--- a/mappings/net/minecraft/network/ChatDecorator.mapping
+++ b/mappings/net/minecraft/network/ChatDecorator.mapping
@@ -1,13 +1,46 @@
 CLASS net/minecraft/class_7492 net/minecraft/network/ChatDecorator
+	COMMENT Chat decorator decorates the chat server-side. Currently, only one chat decorator
+	COMMENT can exist at a time. The chat decorator that is currently used can be ontained by
+	COMMENT {@link net.minecraft.server.MinecraftServer#getChatDecorator}.
+	COMMENT
+	COMMENT <p>For the chat decorator to produce a signed message, <strong>both the server
+	COMMENT and the sender's client need to have chat previews enabled</strong>, Otherwise, the decorated
+	COMMENT content is considered unsigned, and if the clients require chat messages to be signed
+	COMMENT via the {@linkplain net.minecraft.client.option.GameOptions#getOnlyShowSignedChat
+	COMMENT "Only Show Signed Chat" option}, they will see the undecorated message. Therefore,
+	COMMENT chat decorator is <strong>not recommended for censoring messages</strong>.
+	COMMENT
+	COMMENT <p>It is <strong>very important that the decorator return the same text when previewed
+	COMMENT and sent</strong>. If this is not followed correctly, the server detects that the client
+	COMMENT sent a forged text and discards the message. For example, a decorator that appends the
+	COMMENT time the decoration was applied would be likely to fail, since there is usually a delay
+	COMMENT between the previewing and the submission. One way to solve this issue is to make it
+	COMMENT cache the result on preview, so that when the sent message needs decorating, the cached
+	COMMENT value can be used.
 	FIELD field_39384 NOOP Lnet/minecraft/class_7492;
+		COMMENT An empty chat decorator that does not decorate anything.
 	METHOD decorate (Lnet/minecraft/class_3222;Lnet/minecraft/class_2561;)Lnet/minecraft/class_2561;
+		COMMENT {@return the decorated {@code message}}
 		ARG 1 sender
 		ARG 2 message
 	METHOD decorate (Lnet/minecraft/class_3222;Lnet/minecraft/class_2561;Lnet/minecraft/class_7469;Z)Lnet/minecraft/class_7471;
+		COMMENT {@return the decorated signed chat message from undecorated {@code message}}
+		COMMENT
+		COMMENT <p>If {@code previewed} is false, the returned message will have the original
+		COMMENT content as signed and the decorated content as unsigned. This means that if the
+		COMMENT received player requires signed chat message, they will see the original content.
 		ARG 1 sender
 		ARG 2 message
 		ARG 3 signature
+		ARG 4 previewed
+			COMMENT whether the decoration was previewed by the sender's client
 	METHOD decorate (Lnet/minecraft/class_3222;Lnet/minecraft/class_7471;)Lnet/minecraft/class_7471;
+		COMMENT {@return the signed chat message with unsigned content set as decorated {@code message}}
+		COMMENT
+		COMMENT @apiNote This is used by various commands that send messages, such as {@link
+		COMMENT net.minecraft.server.command.MeCommand}.
+		COMMENT
+		COMMENT <p>If the received player requires signed chat message, they will see the original content.
 		ARG 1 sender
 		ARG 2 message
 	METHOD method_44120 (Lnet/minecraft/class_3222;Lnet/minecraft/class_2561;)Lnet/minecraft/class_2561;

--- a/mappings/net/minecraft/network/ChatDecorator.mapping
+++ b/mappings/net/minecraft/network/ChatDecorator.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_7492 net/minecraft/network/ChatDecorator
 	COMMENT Chat decorator decorates the chat server-side. Currently, only one chat decorator
-	COMMENT can exist at a time. The chat decorator that is currently used can be ontained by
+	COMMENT can exist at a time. The chat decorator that is currently used can be obtained by
 	COMMENT {@link net.minecraft.server.MinecraftServer#getChatDecorator}.
 	COMMENT
 	COMMENT <p>For the chat decorator to produce a signed message, <strong>both the server

--- a/mappings/net/minecraft/network/ChatDecorator.mapping
+++ b/mappings/net/minecraft/network/ChatDecorator.mapping
@@ -1,0 +1,18 @@
+CLASS net/minecraft/class_7492 net/minecraft/network/ChatDecorator
+	FIELD field_39384 NOOP Lnet/minecraft/class_7492;
+	METHOD decorate (Lnet/minecraft/class_3222;Lnet/minecraft/class_2561;)Lnet/minecraft/class_2561;
+		ARG 1 sender
+		ARG 2 message
+	METHOD decorate (Lnet/minecraft/class_3222;Lnet/minecraft/class_2561;Lnet/minecraft/class_7469;Z)Lnet/minecraft/class_7471;
+		ARG 1 sender
+		ARG 2 message
+		ARG 3 signature
+	METHOD decorate (Lnet/minecraft/class_3222;Lnet/minecraft/class_7471;)Lnet/minecraft/class_7471;
+		ARG 1 sender
+		ARG 2 message
+	METHOD method_44120 (Lnet/minecraft/class_3222;Lnet/minecraft/class_2561;)Lnet/minecraft/class_2561;
+		ARG 0 sender
+		ARG 1 message
+	METHOD method_44121 (Lnet/minecraft/class_3222;Lnet/minecraft/class_2561;)Lnet/minecraft/class_2561;
+		ARG 0 sender
+		ARG 1 message

--- a/mappings/net/minecraft/network/MessageType.mapping
+++ b/mappings/net/minecraft/network/MessageType.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_2556 net/minecraft/network/MessageType
 	COMMENT A message type (also known as "chat type") controls whether to display or narrate
 	COMMENT the messages sent to the clients, and if so, how. Message types are registered
-	COMMENT at {@link Registry#MESSAGE_TYPE}. When sending a message, the registry key of the
+	COMMENT at {@link BuiltinRegistries#MESSAGE_TYPE}. When sending a message, the registry key of the
 	COMMENT message type can be passed to indicate which message type should be used.
 	COMMENT
 	COMMENT <p>Message type has three fields, all of which are optional. If the field is empty,

--- a/mappings/net/minecraft/network/MessageType.mapping
+++ b/mappings/net/minecraft/network/MessageType.mapping
@@ -1,8 +1,9 @@
 CLASS net/minecraft/class_2556 net/minecraft/network/MessageType
 	COMMENT A message type (also known as "chat type") controls whether to display or narrate
 	COMMENT the messages sent to the clients, and if so, how. Message types are registered
-	COMMENT at {@link BuiltinRegistries#MESSAGE_TYPE}. When sending a message, the registry key of the
-	COMMENT message type can be passed to indicate which message type should be used.
+	COMMENT at {@link net.minecraft.util.registry.BuiltinRegistries#MESSAGE_TYPE}. When
+	COMMENT sending a message, the registry key of the message type can be passed to indicate
+	COMMENT which message type should be used.
 	COMMENT
 	COMMENT <p>Message type has three fields, all of which are optional. If the field is empty,
 	COMMENT the message is not displayed or narrated there.

--- a/mappings/net/minecraft/network/MessageType.mapping
+++ b/mappings/net/minecraft/network/MessageType.mapping
@@ -75,7 +75,7 @@ CLASS net/minecraft/class_2556 net/minecraft/network/MessageType
 		COMMENT does not have a decoration.
 	METHOD method_43843 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 0 instance
-	METHOD method_43844 registerAndGetDefault (Lnet/minecraft/class_2378;)Lnet/minecraft/class_6880;
+	METHOD method_43844 initialize (Lnet/minecraft/class_2378;)Lnet/minecraft/class_6880;
 		ARG 0 registry
 	METHOD method_43845 register (Ljava/lang/String;)Lnet/minecraft/class_5321;
 		ARG 0 id

--- a/mappings/net/minecraft/network/PacketByteBuf.mapping
+++ b/mappings/net/minecraft/network/PacketByteBuf.mapping
@@ -42,6 +42,9 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 	COMMENT  <td>{@link ChunkSectionPos}</td><td>{@link #readChunkSectionPos()}</td><td>{@link #writeChunkSectionPos(ChunkSectionPos)}</td>
 	COMMENT </tr>
 	COMMENT <tr>
+	COMMENT  <td>{@link GlobalPos}</td><td>{@link #readGlobalPos()}</td><td>{@link #writeGlobalPos(GlobalPos)}</td>
+	COMMENT </tr>
+	COMMENT <tr>
 	COMMENT  <td>{@link Text}</td><td>{@link #readText()}</td><td>{@link #writeText(Text)}</td>
 	COMMENT </tr>
 	COMMENT <tr>
@@ -75,7 +78,16 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 	COMMENT  <td>{@link Identifier}</td><td>{@link #readIdentifier()}</td><td>{@link #writeIdentifier(Identifier)}</td>
 	COMMENT </tr>
 	COMMENT <tr>
+	COMMENT  <td>{@link RegistryKey}</td><td>{@link #readRegistryKey(RegistryKey)}</td><td>{@link #writeRegistryKey(RegistryKey)}</td>
+	COMMENT </tr>
+	COMMENT <tr>
 	COMMENT  <td>{@link Date}</td><td>{@link #readDate()}</td><td>{@link #writeDate(Date)}</td>
+	COMMENT </tr>
+	COMMENT <tr>
+	COMMENT  <td>{@link Instant}</td><td>{@link #readInstant()}</td><td>{@link #writeInstant(Instant)}</td>
+	COMMENT </tr>
+	COMMENT <tr>
+	COMMENT  <td>{@link PublicKey}</td><td>{@link #readPublicKey()}</td><td>{@link #writePublicKey(PublicKey)}</td>
 	COMMENT </tr>
 	COMMENT <tr>
 	COMMENT  <td>{@link BlockHitResult}</td><td>{@link #readBlockHitResult()}</td><td>{@link #writeBlockHitResult(BlockHitResult)}</td>
@@ -935,6 +947,60 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 		COMMENT @return the read nullable value
 		COMMENT @see #writeNullable(Object, PacketByteBuf.PacketWriter)
 		ARG 1 reader
+	METHOD method_44112 readRegistryKey (Lnet/minecraft/class_5321;)Lnet/minecraft/class_5321;
+		COMMENT Reads a registry key from this buf. A registry key is represented by its
+		COMMENT {@linkplain #readIdentifier value as an identifier}.
+		COMMENT
+		COMMENT @return the read registry key
+		COMMENT @see #writeRegistryKey(RegistryKey)
+		ARG 1 registryRef
+			COMMENT the registry key of the registry the read registry key belongs to
+	METHOD method_44113 writeGlobalPos (Lnet/minecraft/class_4208;)V
+		COMMENT Writes a global position to this buf. A global position is represented by
+		COMMENT {@linkplain #writeRegistryKey the registry key} of the dimension followed by
+		COMMENT {@linkplain #writeBlockPos the block position}.
+		COMMENT
+		COMMENT @see #readGlobalPos()
+		ARG 1 pos
+	METHOD method_44114 writePublicKey (Ljava/security/PublicKey;)Lnet/minecraft/class_2540;
+		COMMENT Writes a public key to this buf. A public key is represented by a {@linkplain
+		COMMENT #writeByteArray byte array} of X.509-encoded payload.
+		COMMENT
+		COMMENT @return his buf, for chaining
+		COMMENT @see #readPublicKey()
+		ARG 1 publicKey
+	METHOD method_44115 writeInstant (Ljava/time/Instant;)V
+		COMMENT Writes an instant to this buf. An instance is represented by the milliseconds
+		COMMENT since the epoch.
+		COMMENT
+		COMMENT @see #readInstant()
+		ARG 1 instant
+	METHOD method_44116 writeRegistryKey (Lnet/minecraft/class_5321;)V
+		COMMENT Writes a registry key to this buf. A registry key is represented by its
+		COMMENT {@linkplain #writeIdentifier value as an identifier}.
+		COMMENT
+		COMMENT @see #readRegistryKey(RegistryKey)
+		ARG 1 key
+	METHOD method_44117 readGlobalPos ()Lnet/minecraft/class_4208;
+		COMMENT Reads a global position from this buf. A global position is represented by
+		COMMENT {@linkplain #readRegistryKey the registry key} of the dimension followed by
+		COMMENT {@linkplain #readBlockPos the block position}.
+		COMMENT
+		COMMENT @return the read global pos
+		COMMENT @see #writeGlobalPos(GlobalPos)
+	METHOD method_44118 readInstant ()Ljava/time/Instant;
+		COMMENT Reads an instant from this buf. An instance is represented by the milliseconds
+		COMMENT since the epoch.
+		COMMENT
+		COMMENT @return the read instant
+		COMMENT @see #writeInstant(Instant)
+	METHOD method_44119 readPublicKey ()Ljava/security/PublicKey;
+		COMMENT Reads a public key from this buf. A public key is represented by a {@linkplain
+		COMMENT #readByteArray byte array} of X.509-encoded payload.
+		COMMENT
+		COMMENT @return the read public key
+		COMMENT @throws o.netty.handler.codec.DecoderException if the public key is malformed
+		COMMENT @see #writePublicKey(PublicKey)
 	METHOD nioBuffer (II)Ljava/nio/ByteBuffer;
 		ARG 1 index
 		ARG 2 length

--- a/mappings/net/minecraft/network/PacketByteBuf.mapping
+++ b/mappings/net/minecraft/network/PacketByteBuf.mapping
@@ -999,7 +999,7 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 		COMMENT #readByteArray byte array} of X.509-encoded payload.
 		COMMENT
 		COMMENT @return the read public key
-		COMMENT @throws o.netty.handler.codec.DecoderException if the public key is malformed
+		COMMENT @throws io.netty.handler.codec.DecoderException if the public key is malformed
 		COMMENT @see #writePublicKey(PublicKey)
 	METHOD nioBuffer (II)Ljava/nio/ByteBuffer;
 		ARG 1 index

--- a/mappings/net/minecraft/network/PacketByteBuf.mapping
+++ b/mappings/net/minecraft/network/PacketByteBuf.mapping
@@ -966,7 +966,7 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 		COMMENT Writes a public key to this buf. A public key is represented by a {@linkplain
 		COMMENT #writeByteArray byte array} of X.509-encoded payload.
 		COMMENT
-		COMMENT @return his buf, for chaining
+		COMMENT @return this buf, for chaining
 		COMMENT @see #readPublicKey()
 		ARG 1 publicKey
 	METHOD method_44115 writeInstant (Ljava/time/Instant;)V

--- a/mappings/net/minecraft/network/PacketByteBuf.mapping
+++ b/mappings/net/minecraft/network/PacketByteBuf.mapping
@@ -970,7 +970,7 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 		COMMENT @see #readPublicKey()
 		ARG 1 publicKey
 	METHOD method_44115 writeInstant (Ljava/time/Instant;)V
-		COMMENT Writes an instant to this buf. An instance is represented by the milliseconds
+		COMMENT Writes an instant to this buf. An instant is represented by the milliseconds
 		COMMENT since the epoch.
 		COMMENT
 		COMMENT @see #readInstant()
@@ -989,7 +989,7 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 		COMMENT @return the read global pos
 		COMMENT @see #writeGlobalPos(GlobalPos)
 	METHOD method_44118 readInstant ()Ljava/time/Instant;
-		COMMENT Reads an instant from this buf. An instance is represented by the milliseconds
+		COMMENT Reads an instant from this buf. An instant is represented by the milliseconds
 		COMMENT since the epoch.
 		COMMENT
 		COMMENT @return the read instant

--- a/mappings/net/minecraft/network/encryption/ArgumentSignatureDataMap.mapping
+++ b/mappings/net/minecraft/network/encryption/ArgumentSignatureDataMap.mapping
@@ -1,10 +1,10 @@
-CLASS net/minecraft/class_7450 net/minecraft/network/encryption/ArgumentSignatureDatas
+CLASS net/minecraft/class_7450 net/minecraft/network/encryption/ArgumentSignatureDataMap
 	COMMENT A record holding the salt and signatures for all signable arguments of an executed command.
 	FIELD field_39185 MAX_ARGUMENT_NAME_LENGTH I
 	METHOD <init> (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
-	METHOD method_43745 none ()Lnet/minecraft/class_7450;
-		COMMENT {@return a "none" signature datas that has no signed arguments}
+	METHOD method_43745 empty ()Lnet/minecraft/class_7450;
+		COMMENT {@return an empty signature data map that has no signed arguments}
 		COMMENT
 		COMMENT @apiNote This is used when there is no argument to sign, or when the signing fails.
 	METHOD method_43746 collectArguments (Lcom/mojang/brigadier/context/CommandContextBuilder;)Ljava/util/Map;
@@ -13,7 +13,7 @@ CLASS net/minecraft/class_7450 net/minecraft/network/encryption/ArgumentSignatur
 	METHOD method_43747 resultToText (Lnet/minecraft/class_7451;Lcom/mojang/brigadier/context/ParsedArgument;)Lnet/minecraft/class_2561;
 		ARG 0 type
 		ARG 1 argument
-	METHOD method_43748 createSignatureData (Ljava/lang/String;)Lnet/minecraft/class_3515$class_7425;
+	METHOD method_43748 get (Ljava/lang/String;)Lnet/minecraft/class_3515$class_7425;
 		COMMENT {@return the signature data for {@code argumentName}, or {@code null} if the
 		COMMENT argument name is not present in this signatures}
 		ARG 1 argumentName

--- a/mappings/net/minecraft/network/encryption/ArgumentSignatureDatas.mapping
+++ b/mappings/net/minecraft/network/encryption/ArgumentSignatureDatas.mapping
@@ -1,14 +1,21 @@
-CLASS net/minecraft/class_7450 net/minecraft/network/encryption/ArgumentSignatures
+CLASS net/minecraft/class_7450 net/minecraft/network/encryption/ArgumentSignatureDatas
+	COMMENT A record holding the salt and signatures for all signable arguments of an executed command.
 	FIELD field_39185 MAX_ARGUMENT_NAME_LENGTH I
 	METHOD <init> (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD method_43745 none ()Lnet/minecraft/class_7450;
+		COMMENT {@return a "none" signature datas that has no signed arguments}
+		COMMENT
+		COMMENT @apiNote This is used when there is no argument to sign, or when the signing fails.
 	METHOD method_43746 collectArguments (Lcom/mojang/brigadier/context/CommandContextBuilder;)Ljava/util/Map;
+		COMMENT {@return the signable argument names and their values from {@code builder}}
 		ARG 0 builder
 	METHOD method_43747 resultToText (Lnet/minecraft/class_7451;Lcom/mojang/brigadier/context/ParsedArgument;)Lnet/minecraft/class_2561;
 		ARG 0 type
 		ARG 1 argument
 	METHOD method_43748 createSignatureData (Ljava/lang/String;)Lnet/minecraft/class_3515$class_7425;
+		COMMENT {@return the signature data for {@code argumentName}, or {@code null} if the
+		COMMENT argument name is not present in this signatures}
 		ARG 1 argumentName
 	METHOD method_43749 write (Lnet/minecraft/class_2540;)V
 		ARG 1 buf

--- a/mappings/net/minecraft/network/encryption/ChatMessageSignature.mapping
+++ b/mappings/net/minecraft/network/encryption/ChatMessageSignature.mapping
@@ -4,6 +4,7 @@ CLASS net/minecraft/class_7469 net/minecraft/network/encryption/ChatMessageSigna
 		ARG 1 signature
 		ARG 2 message
 	METHOD method_43861 verify (Ljava/security/Signature;Lnet/minecraft/class_2561;)Z
+		ARG 1 signature
 		ARG 2 message
 	METHOD method_43862 updateSignature (Ljava/security/Signature;Lnet/minecraft/class_2561;Ljava/util/UUID;Ljava/time/Instant;J)V
 		ARG 0 signature
@@ -13,3 +14,4 @@ CLASS net/minecraft/class_7469 net/minecraft/network/encryption/ChatMessageSigna
 		ARG 4 salt
 	METHOD method_43863 toByteArray (Lnet/minecraft/class_2561;)[B
 		ARG 0 message
+	METHOD method_44124 canVerify ()Z

--- a/mappings/net/minecraft/network/encryption/ChatMessageSignature.mapping
+++ b/mappings/net/minecraft/network/encryption/ChatMessageSignature.mapping
@@ -1,12 +1,33 @@
 CLASS net/minecraft/class_7469 net/minecraft/network/encryption/ChatMessageSignature
+	COMMENT A signature for chat messages, consisting of the sender, the timestamp, and the signature data.
+	FIELD comp_799 timestamp Ljava/time/Instant;
+	METHOD comp_799 timestamp ()Ljava/time/Instant;
 	METHOD method_43859 none ()Lnet/minecraft/class_7469;
 	METHOD method_43860 verify (Ljava/security/Signature;Ljava/lang/String;)Z
+		COMMENT {@return whether {@code message} can be verified with this signature}
+		COMMENT
+		COMMENT @throws SignatureException when verifying fails
 		ARG 1 signature
 		ARG 2 message
+			COMMENT the message to verify
 	METHOD method_43861 verify (Ljava/security/Signature;Lnet/minecraft/class_2561;)Z
+		COMMENT {@return whether {@code message} can be verified with this signature}
+		COMMENT
+		COMMENT @throws SignatureException when verifying fails
 		ARG 1 signature
 		ARG 2 message
+			COMMENT the message to verify
 	METHOD method_43862 updateSignature (Ljava/security/Signature;Lnet/minecraft/class_2561;Ljava/util/UUID;Ljava/time/Instant;J)V
+		COMMENT Updates {@code signature} with the passed parameters.
+		COMMENT
+		COMMENT @implNote The data to be signed is {@code salt}, followed by big-endian ordered
+		COMMENT {@code uuid}, followed by {@code time} as seconds from the UTC epoch, followed by
+		COMMENT UTF-8 encoded {@code message} bytes.
+		COMMENT
+		COMMENT @throws SignatureException when updating signature fails
+		COMMENT
+		COMMENT @see ChatMessageSigner#sign
+		COMMENT @see #verify
 		ARG 0 signature
 		ARG 1 message
 		ARG 2 sender
@@ -15,3 +36,7 @@ CLASS net/minecraft/class_7469 net/minecraft/network/encryption/ChatMessageSigna
 	METHOD method_43863 toByteArray (Lnet/minecraft/class_2561;)[B
 		ARG 0 message
 	METHOD method_44124 canVerify ()Z
+		COMMENT {@return whether the signature can be verified}
+		COMMENT
+		COMMENT <p>Verifiable signature is not the same as verified signature. Signatures are verifiable
+		COMMENT if it has proper sender UUID and signature data. However, they can still fail to verify.

--- a/mappings/net/minecraft/network/encryption/ChatMessageSigner.mapping
+++ b/mappings/net/minecraft/network/encryption/ChatMessageSigner.mapping
@@ -1,9 +1,13 @@
 CLASS net/minecraft/class_7470 net/minecraft/network/encryption/ChatMessageSigner
+	COMMENT A signer for chat messages that produces {@link ChatMessageSignature}.
 	METHOD method_43864 sign (Ljava/security/Signature;Ljava/lang/String;)Lnet/minecraft/class_7469;
+		COMMENT {@return the chat message signature obtained by signing {@code message} with {@code signature}}
 		ARG 1 signature
 		ARG 2 message
 	METHOD method_43865 sign (Ljava/security/Signature;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7469;
+		COMMENT {@return the chat message signature obtained by signing {@code message} with {@code signature}}
 		ARG 1 signature
 		ARG 2 message
 	METHOD method_43866 create (Ljava/util/UUID;)Lnet/minecraft/class_7470;
+		COMMENT {@return a new signer instance}
 		ARG 0 sender

--- a/mappings/net/minecraft/network/encryption/CommandArgumentSigner.mapping
+++ b/mappings/net/minecraft/network/encryption/CommandArgumentSigner.mapping
@@ -1,13 +1,17 @@
 CLASS net/minecraft/class_7448 net/minecraft/network/encryption/CommandArgumentSigner
+	COMMENT A signer for command arguments.
 	FIELD field_39182 NONE Lnet/minecraft/class_7448;
 	METHOD method_43731 (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7471;
 		ARG 0 context
 		ARG 1 argumentName
 		ARG 2 value
 	METHOD signArgument (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7471;
+		COMMENT {@return the signed argument's message from the argument name and value}
 		ARG 1 context
 		ARG 2 argumentName
 		ARG 3 value
 	CLASS class_7449 Signatures
-		FIELD comp_776 time Ljava/time/Instant;
-		METHOD comp_776 time ()Ljava/time/Instant;
+		COMMENT A signature for command arguments, consisting of the sender, the timestamp,
+		COMMENT and the signature datas for the arguments.
+		FIELD comp_776 timestamp Ljava/time/Instant;
+		METHOD comp_776 timestamp ()Ljava/time/Instant;

--- a/mappings/net/minecraft/network/encryption/NetworkEncryptionUtils.mapping
+++ b/mappings/net/minecraft/network/encryption/NetworkEncryptionUtils.mapping
@@ -11,7 +11,7 @@ CLASS net/minecraft/class_3515 net/minecraft/network/encryption/NetworkEncryptio
 	FIELD field_29834 ISO_8859_1 Ljava/lang/String;
 	FIELD field_29835 SHA1 Ljava/lang/String;
 	FIELD field_39033 RSA_PUBLIC_KEY_PREFIX Ljava/lang/String;
-	FIELD field_39034 CRLF Ljava/lang/String;
+	FIELD field_39034 LINEBREAK Ljava/lang/String;
 	FIELD field_39035 RSA_PUBLIC_KEY_CODEC Lcom/mojang/serialization/Codec;
 		COMMENT The codec for RSA public keys.
 		COMMENT
@@ -30,6 +30,7 @@ CLASS net/minecraft/class_3515 net/minecraft/network/encryption/NetworkEncryptio
 	FIELD field_39038 RSA_PRIVATE_KEY_SUFFIX Ljava/lang/String;
 	FIELD field_39039 RSA_PUBLIC_KEY_SUFFIX Ljava/lang/String;
 	FIELD field_39109 SHA256_WITH_RSA Ljava/lang/String;
+	FIELD field_39272 BASE64_ENCODER Ljava/util/Base64$Encoder;
 	METHOD method_15234 decryptSecretKey (Ljava/security/PrivateKey;[B)Ljavax/crypto/SecretKey;
 		COMMENT Decrypts RSA-encrypted AES secret key.
 		COMMENT
@@ -199,6 +200,8 @@ CLASS net/minecraft/class_3515 net/minecraft/network/encryption/NetworkEncryptio
 			COMMENT
 			COMMENT @apiNote This <strong>does not validate</strong> the signature itself.
 		METHOD method_43529 write (Lnet/minecraft/class_2540;Lnet/minecraft/class_3515$class_7425;)V
+			ARG 0 buf
+			ARG 1 signatureData
 		METHOD method_43530 getSalt ()[B
 	CLASS class_7426 SecureRandomUtil
 		COMMENT Utilities for working with a secure random number generator.

--- a/mappings/net/minecraft/network/encryption/PlayerPublicKey.mapping
+++ b/mappings/net/minecraft/network/encryption/PlayerPublicKey.mapping
@@ -26,8 +26,13 @@ CLASS net/minecraft/class_7428 net/minecraft/network/encryption/PlayerPublicKey
 		ARG 0 publicKeyData
 	CLASS class_7443 PublicKeyData
 		FIELD field_39119 CODEC Lcom/mojang/serialization/Codec;
+		FIELD field_39309 KEY_SIGNATURE_MAX_SIZE I
+		METHOD <init> (Lnet/minecraft/class_2540;)V
+			ARG 1 buf
 		METHOD method_43700 toProperty ()Lcom/mojang/authlib/properties/Property;
 		METHOD method_43701 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 			ARG 0 instance
 		METHOD method_43702 toSerializedString ()Ljava/lang/String;
 		METHOD method_43704 isExpired ()Z
+		METHOD method_44011 write (Lnet/minecraft/class_2540;)V
+			ARG 1 buf

--- a/mappings/net/minecraft/network/encryption/SignedChatMessage.mapping
+++ b/mappings/net/minecraft/network/encryption/SignedChatMessage.mapping
@@ -1,4 +1,20 @@
 CLASS net/minecraft/class_7471 net/minecraft/network/encryption/SignedChatMessage
+	FIELD comp_804 signedMessage Lnet/minecraft/class_2561;
+	FIELD comp_830 unsignedMessage Ljava/util/Optional;
+	METHOD comp_804 signedMessage ()Lnet/minecraft/class_2561;
+	METHOD comp_830 unsignedMessage ()Ljava/util/Optional;
 	METHOD method_43867 verify (Lnet/minecraft/class_7428;)Z
+		ARG 1 key
 	METHOD method_43868 verify (Ljava/security/Signature;)Z
 		ARG 1 signature
+	METHOD method_44125 getMessage ()Lnet/minecraft/class_2561;
+	METHOD method_44126 of (Ljava/lang/String;Lnet/minecraft/class_7469;)Lnet/minecraft/class_7471;
+		ARG 0 signedMessage
+		ARG 1 signature
+	METHOD method_44127 of (Lnet/minecraft/class_2561;)Lnet/minecraft/class_7471;
+		ARG 0 message
+	METHOD method_44128 of (Lnet/minecraft/class_2561;Lnet/minecraft/class_7469;)Lnet/minecraft/class_7471;
+		ARG 0 signedMessage
+		ARG 1 signature
+	METHOD method_44129 withUnsigned (Lnet/minecraft/class_2561;)Lnet/minecraft/class_7471;
+		ARG 1 unsignedMessage

--- a/mappings/net/minecraft/network/encryption/SignedChatMessage.mapping
+++ b/mappings/net/minecraft/network/encryption/SignedChatMessage.mapping
@@ -1,20 +1,36 @@
 CLASS net/minecraft/class_7471 net/minecraft/network/encryption/SignedChatMessage
-	FIELD comp_804 signedMessage Lnet/minecraft/class_2561;
-	FIELD comp_830 unsignedMessage Ljava/util/Optional;
-	METHOD comp_804 signedMessage ()Lnet/minecraft/class_2561;
-	METHOD comp_830 unsignedMessage ()Ljava/util/Optional;
+	COMMENT A signed chat message, consisting of the signature, the signed content,
+	COMMENT and the optional unsigned content supplied when the chat decorator produced
+	COMMENT unsigned message due to the chat preview being disabled on either side.
+	COMMENT
+	COMMENT <p>Note that the signature itself might not be valid.
 	METHOD method_43867 verify (Lnet/minecraft/class_7428;)Z
+		COMMENT {@return whether the message can be verified using the public key}
 		ARG 1 key
 	METHOD method_43868 verify (Ljava/security/Signature;)Z
+		COMMENT {@return whether the message can be verified using {@code signature}}
+		COMMENT
+		COMMENT @throws SignatureException when verifying fails
 		ARG 1 signature
-	METHOD method_44125 getMessage ()Lnet/minecraft/class_2561;
+	METHOD method_44125 getContent ()Lnet/minecraft/class_2561;
+		COMMENT {@return the content of the message}
+		COMMENT
+		COMMENT <p>This returns the unsigned content if present, and fallbacks to the signed content.
 	METHOD method_44126 of (Ljava/lang/String;Lnet/minecraft/class_7469;)Lnet/minecraft/class_7471;
-		ARG 0 signedMessage
+		COMMENT {@return a new signed chat message with {@code signedContent} and {@code signature}}
+		ARG 0 signedContent
 		ARG 1 signature
 	METHOD method_44127 of (Lnet/minecraft/class_2561;)Lnet/minecraft/class_7471;
-		ARG 0 message
+		COMMENT {@return a new signed chat message with {@code signedContent} and "none" signature}
+		ARG 0 content
 	METHOD method_44128 of (Lnet/minecraft/class_2561;Lnet/minecraft/class_7469;)Lnet/minecraft/class_7471;
-		ARG 0 signedMessage
+		COMMENT {@return a new signed chat message with {@code signedContent} and {@code signature}}
+		ARG 0 signedContent
 		ARG 1 signature
 	METHOD method_44129 withUnsigned (Lnet/minecraft/class_2561;)Lnet/minecraft/class_7471;
-		ARG 1 unsignedMessage
+		COMMENT {@return the new signed chat message with {@code unsignedContent} added}
+		COMMENT
+		COMMENT @apiNote This is used in vanilla when chat decorator decorates the message without
+		COMMENT the client previewing it. In this case, the undecorated content is signed but the
+		COMMENT decorated content is unsigned.
+		ARG 1 unsignedContent

--- a/mappings/net/minecraft/network/listener/ClientPlayPacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ClientPlayPacketListener.mapping
@@ -201,4 +201,7 @@ CLASS net/minecraft/class_2602 net/minecraft/network/listener/ClientPlayPacketLi
 		ARG 1 packet
 	METHOD method_43596 onGameMessage (Lnet/minecraft/class_7439;)V
 		ARG 1 packet
-	METHOD method_44075 onChatPreview (Lnet/minecraft/class_7495;)V
+	METHOD method_44074 onChatPreview (Lnet/minecraft/class_7494;)V
+		ARG 1 packet
+	METHOD method_44075 onServerMetadata (Lnet/minecraft/class_7495;)V
+		ARG 1 packet

--- a/mappings/net/minecraft/network/listener/ClientPlayPacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ClientPlayPacketListener.mapping
@@ -201,3 +201,4 @@ CLASS net/minecraft/class_2602 net/minecraft/network/listener/ClientPlayPacketLi
 		ARG 1 packet
 	METHOD method_43596 onGameMessage (Lnet/minecraft/class_7439;)V
 		ARG 1 packet
+	METHOD method_44075 onChatPreview (Lnet/minecraft/class_7495;)V

--- a/mappings/net/minecraft/network/listener/ServerPlayPacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ServerPlayPacketListener.mapping
@@ -92,5 +92,5 @@ CLASS net/minecraft/class_2792 net/minecraft/network/listener/ServerPlayPacketLi
 		ARG 1 packet
 	METHOD method_43667 onCommandExecution (Lnet/minecraft/class_7472;)V
 		ARG 1 packet
-	METHOD method_43931 onQueryChatPreview (Lnet/minecraft/class_7496;)V
+	METHOD method_43931 onRequestChatPreview (Lnet/minecraft/class_7496;)V
 		ARG 1 packet

--- a/mappings/net/minecraft/network/listener/ServerPlayPacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ServerPlayPacketListener.mapping
@@ -92,3 +92,5 @@ CLASS net/minecraft/class_2792 net/minecraft/network/listener/ServerPlayPacketLi
 		ARG 1 packet
 	METHOD method_43667 onCommandExecution (Lnet/minecraft/class_7472;)V
 		ARG 1 packet
+	METHOD method_43931 onQueryChatPreview (Lnet/minecraft/class_7496;)V
+		ARG 1 packet

--- a/mappings/net/minecraft/network/packet/c2s/login/LoginHelloC2SPacket.mapping
+++ b/mappings/net/minecraft/network/packet/c2s/login/LoginHelloC2SPacket.mapping
@@ -1,3 +1,6 @@
 CLASS net/minecraft/class_2915 net/minecraft/network/packet/c2s/login/LoginHelloC2SPacket
 	METHOD <init> (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
+	METHOD method_43638 (Lnet/minecraft/class_2540;Lnet/minecraft/class_2540;Lnet/minecraft/class_7428$class_7443;)V
+		ARG 1 buf2
+		ARG 2 publicKey

--- a/mappings/net/minecraft/network/packet/c2s/play/ChatMessageC2SPacket.mapping
+++ b/mappings/net/minecraft/network/packet/c2s/play/ChatMessageC2SPacket.mapping
@@ -18,9 +18,11 @@ CLASS net/minecraft/class_2797 net/minecraft/network/packet/c2s/play/ChatMessage
 	FIELD field_39086 TIME_TO_LIVE Ljava/time/Duration;
 	FIELD field_39087 time Ljava/time/Instant;
 	FIELD field_39088 signature Lnet/minecraft/class_3515$class_7425;
+	FIELD field_39390 previewed Z
 	METHOD <init> (Ljava/lang/String;Lnet/minecraft/class_7469;Z)V
 		ARG 1 chatMessage
 		ARG 2 signature
+		ARG 3 previewed
 	METHOD <init> (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD method_12114 getChatMessage ()Ljava/lang/String;
@@ -31,3 +33,7 @@ CLASS net/minecraft/class_2797 net/minecraft/network/packet/c2s/play/ChatMessage
 		COMMENT {@return when the message is considered expired and should be discarded}
 	METHOD method_43899 createSignatureInstance (Ljava/util/UUID;)Lnet/minecraft/class_7469;
 		ARG 1 sender
+	METHOD method_44136 isPreviewed ()Z
+		COMMENT {@return whether the chat message was previewed before sending}
+		COMMENT
+		COMMENT @apiNote Chat decorators can produce signed decorated content only if it was previewed.

--- a/mappings/net/minecraft/network/packet/c2s/play/QueryChatPreviewC2SPacket.mapping
+++ b/mappings/net/minecraft/network/packet/c2s/play/QueryChatPreviewC2SPacket.mapping
@@ -1,3 +1,0 @@
-CLASS net/minecraft/class_7496 net/minecraft/network/packet/c2s/play/QueryChatPreviewC2SPacket
-	METHOD <init> (Lnet/minecraft/class_2540;)V
-		ARG 1 buf

--- a/mappings/net/minecraft/network/packet/c2s/play/QueryChatPreviewC2SPacket.mapping
+++ b/mappings/net/minecraft/network/packet/c2s/play/QueryChatPreviewC2SPacket.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_7496 net/minecraft/network/packet/c2s/play/QueryChatPreviewC2SPacket
+	METHOD <init> (Lnet/minecraft/class_2540;)V
+		ARG 1 buf

--- a/mappings/net/minecraft/network/packet/c2s/play/RequestChatPreviewC2SPacket.mapping
+++ b/mappings/net/minecraft/network/packet/c2s/play/RequestChatPreviewC2SPacket.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_7496 net/minecraft/network/packet/c2s/play/RequestChatPreviewC2SPacket
+	METHOD <init> (Lnet/minecraft/class_2540;)V
+		ARG 1 buf

--- a/mappings/net/minecraft/network/packet/s2c/play/ChatPreviewS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/ChatPreviewS2CPacket.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_7494 net/minecraft/network/packet/s2c/play/ChatPreviewS2CPacket
+	METHOD <init> (Lnet/minecraft/class_2540;)V
+		ARG 1 buf

--- a/mappings/net/minecraft/network/packet/s2c/play/PlayerListS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/PlayerListS2CPacket.mapping
@@ -37,3 +37,6 @@ CLASS net/minecraft/class_2703 net/minecraft/network/packet/s2c/play/PlayerListS
 			ARG 1 buf
 			ARG 2 entry
 		CLASS 1
+			METHOD method_43887 (Lnet/minecraft/class_2540;Lnet/minecraft/class_7428$class_7443;)V
+				ARG 0 buf2
+				ARG 1 publicKeyData

--- a/mappings/net/minecraft/network/packet/s2c/play/PlayerRespawnS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/PlayerRespawnS2CPacket.mapping
@@ -10,6 +10,7 @@ CLASS net/minecraft/class_2724 net/minecraft/network/packet/s2c/play/PlayerRespa
 	METHOD <init> (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD <init> (Lnet/minecraft/class_5321;Lnet/minecraft/class_5321;JLnet/minecraft/class_1934;Lnet/minecraft/class_1934;ZZZ)V
+		ARG 1 dimensionType
 		ARG 2 dimension
 		ARG 3 sha256Seed
 		ARG 5 gameMode

--- a/mappings/net/minecraft/network/packet/s2c/play/ServerMetadataS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/ServerMetadataS2CPacket.mapping
@@ -1,0 +1,10 @@
+CLASS net/minecraft/class_7495 net/minecraft/network/packet/s2c/play/ServerMetadataS2CPacket
+	FIELD field_39387 description Ljava/util/Optional;
+	FIELD field_39388 favicon Ljava/util/Optional;
+	METHOD <init> (Lnet/minecraft/class_2540;)V
+		ARG 1 buf
+	METHOD <init> (Lnet/minecraft/class_2561;Ljava/lang/String;Z)V
+		ARG 1 description
+		ARG 2 favicon
+	METHOD method_44132 getDescription ()Ljava/util/Optional;
+	METHOD method_44133 getFavicon ()Ljava/util/Optional;

--- a/mappings/net/minecraft/network/packet/s2c/play/ServerMetadataS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/ServerMetadataS2CPacket.mapping
@@ -1,10 +1,13 @@
 CLASS net/minecraft/class_7495 net/minecraft/network/packet/s2c/play/ServerMetadataS2CPacket
 	FIELD field_39387 description Ljava/util/Optional;
 	FIELD field_39388 favicon Ljava/util/Optional;
+	FIELD field_39389 previewsChat Z
 	METHOD <init> (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD <init> (Lnet/minecraft/class_2561;Ljava/lang/String;Z)V
 		ARG 1 description
 		ARG 2 favicon
+		ARG 3 previewsChat
 	METHOD method_44132 getDescription ()Ljava/util/Optional;
 	METHOD method_44133 getFavicon ()Ljava/util/Optional;
+	METHOD method_44134 shouldPreviewChat ()Z

--- a/mappings/net/minecraft/server/MinecraftServer.mapping
+++ b/mappings/net/minecraft/server/MinecraftServer.mapping
@@ -414,6 +414,8 @@ CLASS net/minecraft/server/MinecraftServer
 	METHOD method_43824 getHostProfile ()Lcom/mojang/authlib/GameProfile;
 	METHOD method_43825 setHostProfile (Lcom/mojang/authlib/GameProfile;)V
 		ARG 1 hostProfile
+	METHOD method_43928 canPreviewChat ()Z
+	METHOD method_43929 getChatDecorator ()Lnet/minecraft/class_7492;
 	METHOD method_5387 isMainThread ()Z
 	CLASS class_6414 DebugStart
 		FIELD field_33980 time J

--- a/mappings/net/minecraft/server/MinecraftServer.mapping
+++ b/mappings/net/minecraft/server/MinecraftServer.mapping
@@ -414,8 +414,11 @@ CLASS net/minecraft/server/MinecraftServer
 	METHOD method_43824 getHostProfile ()Lcom/mojang/authlib/GameProfile;
 	METHOD method_43825 setHostProfile (Lcom/mojang/authlib/GameProfile;)V
 		ARG 1 hostProfile
-	METHOD method_43928 canPreviewChat ()Z
+	METHOD method_43928 shouldPreviewChat ()Z
 	METHOD method_43929 getChatDecorator ()Lnet/minecraft/class_7492;
+		COMMENT {@return the chat decorator used by the server}
+		COMMENT
+		COMMENT <p>See the documentation of {@link ChatDecorator} for more information.
 	METHOD method_5387 isMainThread ()Z
 	CLASS class_6414 DebugStart
 		FIELD field_33980 time J

--- a/mappings/net/minecraft/server/PlayerManager.mapping
+++ b/mappings/net/minecraft/server/PlayerManager.mapping
@@ -100,6 +100,7 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 	METHOD method_14597 disconnectAllPlayers ()V
 	METHOD method_14599 reloadWhitelist ()V
 	METHOD method_14600 loadPlayerData (Lnet/minecraft/class_3222;)Lnet/minecraft/class_2487;
+		ARG 1 player
 	METHOD method_14601 updatePlayerLatency ()V
 	METHOD method_14602 getPlayer (Ljava/util/UUID;)Lnet/minecraft/class_3222;
 		ARG 1 uuid
@@ -127,6 +128,7 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		ARG 1 player
 	METHOD method_14613 createPlayer (Lcom/mojang/authlib/GameProfile;Lnet/minecraft/class_7428;)Lnet/minecraft/class_3222;
 		ARG 1 profile
+		ARG 2 publicKey
 	METHOD method_14614 isWhitelistEnabled ()Z
 	METHOD method_14617 saveAllPlayerData ()V
 	METHOD method_18241 (Lnet/minecraft/class_3218;Lnet/minecraft/class_1297;)Lnet/minecraft/class_1297;
@@ -143,8 +145,9 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		COMMENT message can be sent to a different player.
 		COMMENT
 		COMMENT @see #broadcast(Text, RegistryKey)
-		COMMENT @see #broadcast(SignedChatMessage, ChatMessageSender, RegistryKey)
-		COMMENT @see #broadcast(SignedChatMessage, Function, ChatMessageSender, RegistryKey)
+		COMMENT @see #broadcast(SignedChatMessage, TextStream.Message, ServerPlayerEntity, RegistryKey)
+		COMMENT @see #broadcast(SignedChatMessage, MessageSender, RegistryKey)
+		COMMENT @see #broadcast(SignedChatMessage, Function, MessageSender, RegistryKey)
 		ARG 1 message
 		ARG 2 playerMessageFactory
 			COMMENT a function that takes the player to send the message to
@@ -170,7 +173,8 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		COMMENT
 		COMMENT @see #broadcast(Text, RegistryKey)
 		COMMENT @see #broadcast(Text, Function, RegistryKey)
-		COMMENT @see #broadcast(SignedChatMessage, ChatMessageSender, RegistryKey)
+		COMMENT @see #broadcast(SignedChatMessage, TextStream.Message, ServerPlayerEntity, RegistryKey)
+		COMMENT @see #broadcast(SignedChatMessage, MessageSender, RegistryKey)
 		ARG 1 message
 		ARG 2 playerMessageFactory
 			COMMENT a function that takes the player to send the message to
@@ -185,10 +189,13 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		COMMENT message or a join/leave message.
 		COMMENT
 		COMMENT @see #broadcast(Text, Function, RegistryKey)
+		COMMENT @see #broadcast(SignedChatMessage, TextStream.Message, ServerPlayerEntity, RegistryKey)
 		COMMENT @see #broadcast(SignedChatMessage, MessageSender, RegistryKey)
 		COMMENT @see #broadcast(SignedChatMessage, Function, MessageSender, RegistryKey)
 		ARG 1 message
 		ARG 2 typeKey
+	METHOD method_43670 (Lnet/minecraft/class_3222;Lnet/minecraft/server/MinecraftServer$class_7460;)V
+		ARG 1 properties
 	METHOD method_43671 (Lnet/minecraft/class_3222;Lnet/minecraft/class_7471;Lnet/minecraft/class_7471;Lnet/minecraft/class_3222;)Lnet/minecraft/class_7471;
 		ARG 3 player
 	METHOD method_43672 (Lnet/minecraft/class_7471;Lnet/minecraft/class_3222;)Lnet/minecraft/class_7471;
@@ -211,9 +218,10 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		COMMENT
 		COMMENT @see #broadcast(Text, RegistryKey)
 		COMMENT @see #broadcast(Text, Function, RegistryKey)
-		COMMENT @see #broadcast(SignedChatMessage, ChatMessageSender, RegistryKey)
-		COMMENT @see #broadcast(SignedChatMessage, Function, ChatMessageSender, RegistryKey)
+		COMMENT @see #broadcast(SignedChatMessage, MessageSender, RegistryKey)
+		COMMENT @see #broadcast(SignedChatMessage, Function, MessageSender, RegistryKey)
 		ARG 1 message
+		ARG 2 filteredMessage
 		ARG 3 sender
 		ARG 4 typeKey
 	METHOD method_43674 broadcast (Lnet/minecraft/class_7471;Lnet/minecraft/class_7436;Lnet/minecraft/class_5321;)V
@@ -232,7 +240,17 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		COMMENT
 		COMMENT @see #broadcast(Text, RegistryKey)
 		COMMENT @see #broadcast(Text, Function, RegistryKey)
-		COMMENT @see #broadcast(SignedChatMessage, Function, ChatMessageSender, RegistryKey)
+		COMMENT @see #broadcast(SignedChatMessage, TextStream.Message, ServerPlayerEntity, RegistryKey)
+		COMMENT @see #broadcast(SignedChatMessage, Function, MessageSender, RegistryKey)
 		ARG 1 message
 		ARG 2 sender
 		ARG 3 typeKey
+	METHOD method_43934 decorateIfFiltered (Lnet/minecraft/class_3222;Lnet/minecraft/class_7471;Lnet/minecraft/class_5513$class_5837;)Lnet/minecraft/class_7471;
+		COMMENT {@return the decorated message, or {@code null} if the filtered message exists but
+		COMMENT is empty}
+		COMMENT
+		COMMENT <p>This only decorates the message if it is filtered, because the passed
+		COMMENT {@code message} is already decorated by the caller.
+		ARG 1 player
+		ARG 2 message
+		ARG 3 filteredMessage

--- a/mappings/net/minecraft/server/ServerMetadata.mapping
+++ b/mappings/net/minecraft/server/ServerMetadata.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/class_2926 net/minecraft/server/ServerMetadata
 	FIELD field_13286 version Lnet/minecraft/class_2926$class_2930;
 	FIELD field_33375 FAVICON_WIDTH I
 	FIELD field_33376 FAVICON_HEIGHT I
+	FIELD field_39391 previewsChat Z
 	METHOD method_12677 setFavicon (Ljava/lang/String;)V
 		ARG 1 favicon
 	METHOD method_12678 getFavicon ()Ljava/lang/String;
@@ -18,6 +19,9 @@ CLASS net/minecraft/class_2926 net/minecraft/server/ServerMetadata
 	METHOD method_12683 getVersion ()Lnet/minecraft/class_2926$class_2930;
 	METHOD method_12684 setDescription (Lnet/minecraft/class_2561;)V
 		ARG 1 description
+	METHOD method_44138 setPreviewsChat (Z)V
+		ARG 1 previewsChat
+	METHOD method_44139 shouldPreviewChat ()Z
 	CLASS class_2927 Players
 		FIELD field_13287 sample [Lcom/mojang/authlib/GameProfile;
 		FIELD field_13288 online I
@@ -33,6 +37,8 @@ CLASS net/minecraft/class_2926 net/minecraft/server/ServerMetadata
 		CLASS class_2928 Deserializer
 			METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 				ARG 1 json
+				ARG 2 type
+				ARG 3 context
 			METHOD serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 				ARG 1 entry
 				ARG 2 unused
@@ -44,6 +50,7 @@ CLASS net/minecraft/class_2926 net/minecraft/server/ServerMetadata
 			ARG 3 context
 		METHOD serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 			ARG 1 serverMetadata
+			ARG 2 type
 			ARG 3 context
 	CLASS class_2930 Version
 		FIELD field_13290 gameVersion Ljava/lang/String;
@@ -56,6 +63,7 @@ CLASS net/minecraft/class_2926 net/minecraft/server/ServerMetadata
 		CLASS class_2931 Serializer
 			METHOD deserialize (Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Ljava/lang/Object;
 				ARG 1 json
+				ARG 2 type
 				ARG 3 context
 			METHOD serialize (Ljava/lang/Object;Ljava/lang/reflect/Type;Lcom/google/gson/JsonSerializationContext;)Lcom/google/gson/JsonElement;
 				ARG 1 entry

--- a/mappings/net/minecraft/server/command/MessageCommand.mapping
+++ b/mappings/net/minecraft/server/command/MessageCommand.mapping
@@ -4,5 +4,6 @@ CLASS net/minecraft/class_3082 net/minecraft/server/command/MessageCommand
 	METHOD method_13462 execute (Lnet/minecraft/class_2168;Ljava/util/Collection;Lnet/minecraft/class_7471;)I
 		ARG 0 source
 		ARG 1 targets
+		ARG 2 message
 	METHOD method_13463 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context

--- a/mappings/net/minecraft/server/command/SayCommand.mapping
+++ b/mappings/net/minecraft/server/command/SayCommand.mapping
@@ -5,3 +5,5 @@ CLASS net/minecraft/class_3110 net/minecraft/server/command/SayCommand
 		ARG 0 context
 	METHOD method_13564 (Lnet/minecraft/class_2168;)Z
 		ARG 0 source
+	METHOD method_43657 (Lnet/minecraft/class_2168;Lnet/minecraft/class_3222;Lnet/minecraft/class_7471;Lnet/minecraft/class_3324;Lnet/minecraft/class_5513$class_5837;)V
+		ARG 4 message

--- a/mappings/net/minecraft/server/command/ServerCommandSource.mapping
+++ b/mappings/net/minecraft/server/command/ServerCommandSource.mapping
@@ -51,11 +51,11 @@ CLASS net/minecraft/class_2168 net/minecraft/server/command/ServerCommandSource
 	METHOD method_43736 getChatMessageSender ()Lnet/minecraft/class_7436;
 	METHOD method_43737 isExecutedByPlayer ()Z
 	METHOD method_43738 getSigner ()Lnet/minecraft/class_7448;
-	METHOD method_44023 getPlayerOrNull ()Lnet/minecraft/class_3222;
+	METHOD method_44023 getPlayer ()Lnet/minecraft/class_3222;
 		COMMENT {@return the player from this command source, or {@code null} if the source is not a player}
 	METHOD method_9206 withLevel (I)Lnet/minecraft/class_2168;
 		ARG 1 level
-	METHOD method_9207 getPlayer ()Lnet/minecraft/class_3222;
+	METHOD method_9207 getPlayerOrThrow ()Lnet/minecraft/class_3222;
 		COMMENT {@return the player from this command source}
 		COMMENT
 		COMMENT @throws CommandSyntaxException if this command source is not a player

--- a/mappings/net/minecraft/server/command/ServerCommandSource.mapping
+++ b/mappings/net/minecraft/server/command/ServerCommandSource.mapping
@@ -51,10 +51,14 @@ CLASS net/minecraft/class_2168 net/minecraft/server/command/ServerCommandSource
 	METHOD method_43736 getChatMessageSender ()Lnet/minecraft/class_7436;
 	METHOD method_43737 isExecutedByPlayer ()Z
 	METHOD method_43738 getSigner ()Lnet/minecraft/class_7448;
+	METHOD method_44023 getPlayerOrNull ()Lnet/minecraft/class_3222;
+		COMMENT {@return the player from this command source, or {@code null} if the source is not a player}
 	METHOD method_9206 withLevel (I)Lnet/minecraft/class_2168;
 		ARG 1 level
 	METHOD method_9207 getPlayer ()Lnet/minecraft/class_3222;
-		COMMENT Gets the player from this command source or throws a command syntax exception if this command source is not a player.
+		COMMENT {@return the player from this command source}
+		COMMENT
+		COMMENT @throws CommandSyntaxExcepption if this command source is not a player
 	METHOD method_9208 withPosition (Lnet/minecraft/class_243;)Lnet/minecraft/class_2168;
 		ARG 1 position
 	METHOD method_9209 mergeConsumers (Lcom/mojang/brigadier/ResultConsumer;Ljava/util/function/BinaryOperator;)Lnet/minecraft/class_2168;

--- a/mappings/net/minecraft/server/command/ServerCommandSource.mapping
+++ b/mappings/net/minecraft/server/command/ServerCommandSource.mapping
@@ -58,7 +58,7 @@ CLASS net/minecraft/class_2168 net/minecraft/server/command/ServerCommandSource
 	METHOD method_9207 getPlayer ()Lnet/minecraft/class_3222;
 		COMMENT {@return the player from this command source}
 		COMMENT
-		COMMENT @throws CommandSyntaxExcepption if this command source is not a player
+		COMMENT @throws CommandSyntaxException if this command source is not a player
 	METHOD method_9208 withPosition (Lnet/minecraft/class_243;)Lnet/minecraft/class_2168;
 		ARG 1 position
 	METHOD method_9209 mergeConsumers (Lcom/mojang/brigadier/ResultConsumer;Ljava/util/function/BinaryOperator;)Lnet/minecraft/class_2168;

--- a/mappings/net/minecraft/server/command/TeamMsgCommand.mapping
+++ b/mappings/net/minecraft/server/command/TeamMsgCommand.mapping
@@ -2,6 +2,8 @@ CLASS net/minecraft/class_3945 net/minecraft/server/command/TeamMsgCommand
 	FIELD field_17440 NO_TEAM_EXCEPTION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
 	FIELD field_24380 STYLE Lnet/minecraft/class_2583;
 	METHOD method_17599 execute (Lnet/minecraft/class_2168;Lnet/minecraft/class_7471;)I
+		ARG 0 source
+		ARG 1 message
 	METHOD method_17600 register (Lcom/mojang/brigadier/CommandDispatcher;)V
 		ARG 0 dispatcher
 	METHOD method_17601 (Lcom/mojang/brigadier/context/CommandContext;)I

--- a/mappings/net/minecraft/server/dedicated/MinecraftDedicatedServer.mapping
+++ b/mappings/net/minecraft/server/dedicated/MinecraftDedicatedServer.mapping
@@ -7,6 +7,7 @@ CLASS net/minecraft/class_3176 net/minecraft/server/dedicated/MinecraftDedicated
 	FIELD field_16799 propertiesLoader Lnet/minecraft/class_3807;
 	FIELD field_16800 gui Lnet/minecraft/class_3182;
 	FIELD field_26898 filterer Lnet/minecraft/class_5514;
+	FIELD field_39258 chatDecorator Lnet/minecraft/class_7492;
 	METHOD <init> (Ljava/lang/Thread;Lnet/minecraft/class_32$class_5143;Lnet/minecraft/class_3283;Lnet/minecraft/class_6904;Lnet/minecraft/class_3807;Lcom/mojang/datafixers/DataFixer;Lcom/mojang/authlib/minecraft/MinecraftSessionService;Lcom/mojang/authlib/GameProfileRepository;Lnet/minecraft/class_3312;Lnet/minecraft/class_3950;)V
 		ARG 1 serverThread
 		ARG 2 session

--- a/mappings/net/minecraft/server/dedicated/ServerPropertiesHandler.mapping
+++ b/mappings/net/minecraft/server/dedicated/ServerPropertiesHandler.mapping
@@ -50,6 +50,8 @@ CLASS net/minecraft/class_3806 net/minecraft/server/dedicated/ServerPropertiesHa
 	FIELD field_39018 enforceSecureProfile Z
 	FIELD field_39093 serverResourcePackProperties Ljava/util/Optional;
 	FIELD field_39094 SHA1_PATTERN Ljava/util/regex/Pattern;
+	FIELD field_39259 previewsChat Z
+	FIELD field_39260 testRainbowChat Z
 	METHOD method_16714 load (Ljava/nio/file/Path;)Lnet/minecraft/class_3806;
 		ARG 0 path
 	METHOD method_16715 (Ljava/lang/Integer;)Ljava/lang/Integer;

--- a/mappings/net/minecraft/server/filter/TextStream.mapping
+++ b/mappings/net/minecraft/server/filter/TextStream.mapping
@@ -19,3 +19,4 @@ CLASS net/minecraft/class_5513 net/minecraft/server/filter/TextStream
 		METHOD method_33803 getFiltered ()Ljava/lang/String;
 		METHOD method_33804 censored (Ljava/lang/String;)Lnet/minecraft/class_5513$class_5837;
 			ARG 0 raw
+		METHOD method_43933 hasFilteredText ()Z

--- a/mappings/net/minecraft/server/network/ServerPlayNetworkHandler.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayNetworkHandler.mapping
@@ -34,7 +34,9 @@ CLASS net/minecraft/class_3244 net/minecraft/server/network/ServerPlayNetworkHan
 	FIELD field_29778 KEEP_ALIVE_INTERVAL I
 	FIELD field_37280 MAX_BREAK_SQUARED_DISTANCE D
 	FIELD field_37282 sequence I
+	FIELD field_39261 previewTaskRunner Lnet/minecraft/class_7493;
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/class_2535;Lnet/minecraft/class_3222;)V
+		ARG 1 server
 		ARG 2 connection
 		ARG 3 player
 	METHOD method_14360 requestTeleport (DDDFFLjava/util/Set;)V

--- a/mappings/net/minecraft/server/network/ServerPlayNetworkHandler.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayNetworkHandler.mapping
@@ -110,6 +110,7 @@ CLASS net/minecraft/class_3244 net/minecraft/server/network/ServerPlayNetworkHan
 	METHOD method_31285 (Lnet/minecraft/class_2877;Ljava/util/List;)V
 		ARG 2 texts
 	METHOD method_31286 handleMessage (Lnet/minecraft/class_2797;Lnet/minecraft/class_5513$class_5837;)V
+		ARG 1 packet
 		ARG 2 message
 	METHOD method_33562 requestTeleportAndDismount (DDDFF)V
 		ARG 1 x

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -241,6 +241,8 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 		ARG 3 future
 	METHOD method_43666 getMessageTypeId (Lnet/minecraft/class_5321;)I
 		ARG 1 typeKey
+	METHOD method_43930 sendServerMetadata (Lnet/minecraft/class_2926;)V
+		ARG 1 metadata
 	METHOD method_7336 changeGameMode (Lnet/minecraft/class_1934;)Z
 		ARG 1 gameMode
 	CLASS 1

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -151,6 +151,8 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 			COMMENT the updated section position
 	METHOD method_18783 worldChanged (Lnet/minecraft/class_3218;)V
 		ARG 1 origin
+	METHOD method_19504 (Lnet/minecraft/class_3902;)V
+		ARG 1 unit
 	METHOD method_26280 getSpawnPointPosition ()Lnet/minecraft/class_2338;
 	METHOD method_26281 getSpawnPointDimension ()Lnet/minecraft/class_5321;
 	METHOD method_26282 isSpawnForced ()Z
@@ -207,6 +209,8 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 		ARG 1 player
 	METHOD method_34225 onSpawn ()V
 	METHOD method_34879 areClientChatColorsEnabled ()Z
+	METHOD method_37412 (Lnet/minecraft/class_1661;I)V
+		ARG 2 index
 	METHOD method_37413 dropSelectedItem (Z)Z
 		ARG 1 entireStack
 	METHOD method_38786 tickFallStartPos ()V
@@ -234,6 +238,7 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 		COMMENT @see #sendMessage(Text, RegistryKey)
 		ARG 1 message
 		ARG 2 sender
+		ARG 3 typeKey
 	METHOD method_43506 sendMessageDeliverError (Lnet/minecraft/class_2561;Lnet/minecraft/class_5321;)V
 		ARG 1 message
 		ARG 2 typeKey

--- a/mappings/net/minecraft/text/Texts.mapping
+++ b/mappings/net/minecraft/text/Texts.mapping
@@ -48,3 +48,4 @@ CLASS net/minecraft/class_2564 net/minecraft/text/Texts
 		ARG 0 texts
 		ARG 1 separator
 	METHOD method_43476 hasTranslation (Lnet/minecraft/class_2561;)Z
+		ARG 0 text

--- a/mappings/net/minecraft/util/PendingTaskRunner.mapping
+++ b/mappings/net/minecraft/util/PendingTaskRunner.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_7493 net/minecraft/util/thread/PendingTaskRunner
+CLASS net/minecraft/class_7493 net/minecraft/util/PendingTaskRunner
 	COMMENT A runner for tasks that have a running state and can hold one pending task.
 	COMMENT
 	COMMENT <p>If there is no running tasks, calling {@link #run} will run the passed task

--- a/mappings/net/minecraft/util/Util.mapping
+++ b/mappings/net/minecraft/util/Util.mapping
@@ -231,6 +231,22 @@ CLASS net/minecraft/class_156 net/minecraft/util/Util
 		COMMENT @implNote Unlike {@link java.util.List#lastIndexOf}, the returned function will
 		COMMENT return {@code 0} when given values not in the passed list.
 		ARG 0 values
+	METHOD method_43926 map (Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;
+		COMMENT {@return the {@code value} with {@code mapper} applied if the value is not {@code null},
+		COMMENT otherwise {@code null}}
+		COMMENT
+		COMMENT <p>This is the nullable equivalent to {@link Optional#map}.
+		ARG 0 value
+		ARG 1 mapper
+	METHOD method_43927 mapOrElse (Ljava/lang/Object;Ljava/util/function/Function;Ljava/lang/Object;)Ljava/lang/Object;
+		COMMENT {@return the {@code value} with {@code mapper} applied if the value is not {@code null},
+		COMMENT otherwise {@code other}}
+		COMMENT
+		COMMENT <p>This is the nullable equivalent to {@link Optional#map} chained with
+		COMMENT {@link Optional#orElse}.
+		ARG 0 value
+		ARG 1 mapper
+		ARG 2 other
 	METHOD method_645 previous (Ljava/lang/Iterable;Ljava/lang/Object;)Ljava/lang/Object;
 		ARG 0 iterable
 		ARG 1 object

--- a/mappings/net/minecraft/util/registry/BuiltinRegistries.mapping
+++ b/mappings/net/minecraft/util/registry/BuiltinRegistries.mapping
@@ -27,6 +27,7 @@ CLASS net/minecraft/class_5458 net/minecraft/util/registry/BuiltinRegistries
 	FIELD field_38009 DIMENSION_TYPE Lnet/minecraft/class_2378;
 	FIELD field_38010 WORLD_PRESET Lnet/minecraft/class_2378;
 	FIELD field_38011 FLAT_LEVEL_GENERATOR_PRESET Lnet/minecraft/class_2378;
+	FIELD field_39364 MESSAGE_TYPE Lnet/minecraft/class_2378;
 	METHOD method_30559 init ()V
 	METHOD method_30561 add (Lnet/minecraft/class_2378;Ljava/lang/String;Ljava/lang/Object;)Lnet/minecraft/class_6880;
 		ARG 0 registry
@@ -39,15 +40,22 @@ CLASS net/minecraft/class_5458 net/minecraft/util/registry/BuiltinRegistries
 	METHOD method_30563 addRegistry (Lnet/minecraft/class_5321;Lcom/mojang/serialization/Lifecycle;Lnet/minecraft/class_5458$class_7488;)Lnet/minecraft/class_2378;
 		ARG 0 registryRef
 		ARG 1 lifecycle
+		ARG 2 initializer
 	METHOD method_30564 addRegistry (Lnet/minecraft/class_5321;Lnet/minecraft/class_2385;Lnet/minecraft/class_5458$class_7488;Lcom/mojang/serialization/Lifecycle;)Lnet/minecraft/class_2385;
 		ARG 0 registryRef
 		ARG 1 registry
+		ARG 2 initializer
 		ARG 3 lifecycle
 	METHOD method_30565 addRegistry (Lnet/minecraft/class_5321;Lnet/minecraft/class_5458$class_7488;)Lnet/minecraft/class_2378;
 		ARG 0 registryRef
+		ARG 1 initializer
 	METHOD method_30566 (Lnet/minecraft/class_2960;Ljava/util/function/Supplier;)V
 		ARG 0 id
 		ARG 1 supplier
+	METHOD method_30569 (Lnet/minecraft/class_2378;)Lnet/minecraft/class_6880;
+		ARG 0 registry
+	METHOD method_30572 (Lnet/minecraft/class_2378;)Lnet/minecraft/class_6880;
+		ARG 0 registry
 	METHOD method_39203 add (Lnet/minecraft/class_2378;Lnet/minecraft/class_5321;Ljava/lang/Object;)Lnet/minecraft/class_6880;
 		ARG 0 registry
 		ARG 1 key
@@ -56,3 +64,7 @@ CLASS net/minecraft/class_5458 net/minecraft/util/registry/BuiltinRegistries
 		ARG 0 registry
 		ARG 1 id
 		ARG 2 value
+	CLASS class_7488 Initializer
+		COMMENT A functional interface that initializes the registry and returns the default value.
+		METHOD run (Lnet/minecraft/class_2378;)Lnet/minecraft/class_6880;
+			ARG 1 registry

--- a/mappings/net/minecraft/util/thread/PendingTaskRunner.mapping
+++ b/mappings/net/minecraft/util/thread/PendingTaskRunner.mapping
@@ -1,0 +1,15 @@
+CLASS net/minecraft/class_7493 net/minecraft/util/thread/PendingTaskRunner
+	COMMENT A runner for tasks that have a running state and can hold one pending task.
+	COMMENT
+	COMMENT <p>If there is no running tasks, calling {@link #run} will run the passed task
+	COMMENT and marks the runner as running. During this state, calling the run method will set
+	COMMENT the task as pending. If called multiple times, only the last task will be called.
+	COMMENT Calling {@link #runPending} forces it to run the pending task, if any.
+	FIELD field_39385 running Z
+	FIELD field_39386 pending Ljava/lang/Runnable;
+	METHOD method_44122 runPending ()V
+		COMMENT Runs the pending task, if any, and marks the runner as not running.
+	METHOD method_44123 run (Ljava/lang/Runnable;)V
+		COMMENT Runs the task and marks the runner as running if there is no running task,
+		COMMENT otherwise sets the task as the pending task. This overwrites the old pending task.
+		ARG 1 task


### PR DESCRIPTION
Contains mapping for new chat decorator, packets, server metadata, and client-side chat preview handling. Also mapped several things used by those along the way, such as `MultilineText` (used by warning screen), `Util#map`, registry changes, etc.

Renamed `ArgumentSignatures` because I completely misunderstood its functionality during the last review by liach. It is now `ArgumentSignatureDataMap`.