### PR TITLE
Rename Text#copy and shallowCopy

### DIFF
--- a/mappings/net/minecraft/text/Text.mapping
+++ b/mappings/net/minecraft/text/Text.mapping
@@ -22,11 +22,11 @@ CLASS net/minecraft/class_2561 net/minecraft/text/Text
 		COMMENT Returns the style of this text.
 	METHOD method_27655 (ILjava/lang/StringBuilder;Ljava/lang/String;)Ljava/util/Optional;
 		ARG 2 string
-	METHOD method_27661 shallowCopy ()Lnet/minecraft/class_5250;
+	METHOD method_27661 copy ()Lnet/minecraft/class_5250;
 		COMMENT Copies the text itself, the style, and the siblings.
 		COMMENT
 		COMMENT <p>A shallow copy is made for the siblings.
-	METHOD method_27662 copy ()Lnet/minecraft/class_5250;
+	METHOD method_27662 copyContentOnly ()Lnet/minecraft/class_5250;
 		COMMENT Copies the text itself, excluding the styles or siblings.
 	METHOD method_30163 of (Ljava/lang/String;)Lnet/minecraft/class_2561;
 		COMMENT Creates a literal text with the given string as content.

--- a/mappings/net/minecraft/text/Text.mapping
+++ b/mappings/net/minecraft/text/Text.mapping
@@ -23,11 +23,11 @@ CLASS net/minecraft/class_2561 net/minecraft/text/Text
 	METHOD method_27655 (ILjava/lang/StringBuilder;Ljava/lang/String;)Ljava/util/Optional;
 		ARG 2 string
 	METHOD method_27661 copy ()Lnet/minecraft/class_5250;
-		COMMENT Copies the text itself, the style, and the siblings.
+		COMMENT Copies the text's content, the style, and the siblings.
 		COMMENT
 		COMMENT <p>A shallow copy is made for the siblings.
 	METHOD method_27662 copyContentOnly ()Lnet/minecraft/class_5250;
-		COMMENT Copies the text itself, excluding the styles or siblings.
+		COMMENT Copies the text's content, excluding the styles or siblings.
 	METHOD method_30163 of (Ljava/lang/String;)Lnet/minecraft/class_2561;
 		COMMENT Creates a literal text with the given string as content.
 		ARG 0 string


### PR DESCRIPTION
Screwed up multiple times myself, this rename should hopefully reduce amount of accidental style stripping while handling chat