### PR TITLE
Rename LivingEntity#applyEnchantmentsToDamage

### DIFF
--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -416,7 +416,15 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6035 tickRiptide (Lnet/minecraft/class_238;Lnet/minecraft/class_238;)V
 		ARG 1 a
 		ARG 2 b
-	METHOD method_6036 applyEnchantmentsToDamage (Lnet/minecraft/class_1282;F)F
+	METHOD method_6036 modifyAppliedDamage (Lnet/minecraft/class_1282;F)F
+		COMMENT {@return the modified damage value for the applied {@code damage}}
+		COMMENT
+		COMMENT @apiNote Subclasses should override this to make the entity take reduced damage.
+		COMMENT
+		COMMENT @implNote This applies various {@linkplain net.minecraft.enchantment.ProtectionEnchantment
+		COMMENT protection enchantments} and the resistance effect. {@link
+		COMMENT net.minecraft.entity.mob.WitchEntity} uses this to negate their own damage and reduce the
+		COMMENT applied status effect damage.
 		ARG 1 source
 		ARG 2 amount
 	METHOD method_6037 spawnItemParticles (Lnet/minecraft/class_1799;I)V


### PR DESCRIPTION
This applies other damage modifiers, such as status effects. Did not use the word "modifier" itself since that sounds like the attribute modifier (which is not applied in this method.)