### PR TITLE
Add `yarnCommon` task that opens enigma with only common classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Compared to launching Enigma externally, the gradle task adds a name guesser plu
 ### `yarnUnpicked`
 Same as above, but unpicks the constants and launches Enigma with them. Can be a little bit slower to get going.
 
+### `yarnCommon`
+Same as `yarn`, but will only show common classes.
 
 ### `build`
 Build a GZip'd archive containing a tiny mapping between official (obfuscated), [intermediary](https://github.com/FabricMC/intermediary), and yarn names ("named") and packages enigma mappings into a zip archive..

--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,7 @@ def clientJar = new File(cacheFilesMinecraft, "${minecraft_version}-client.jar")
 def serverBootstrapJar = new File(cacheFilesMinecraft, "${minecraft_version}-serverboostrap.jar")
 // The real server jar, expected from the bootstrap
 def serverJar = new File(cacheFilesMinecraft, "${minecraft_version}-server.jar")
+def serverIntermediaryJar = file("${minecraft_version}-server-intermediary.jar")
 def libraries = new File(cacheFilesMinecraft, "libraries")
 def libs = new File("build/libs/")
 
@@ -424,7 +425,6 @@ task mapIntermediaryJar(dependsOn: [downloadMcLibs, downloadIntermediary, mergeJ
 	//Force the task to always run
 	outputs.upToDateWhen { false }
 
-
 	doLast {
 		logger.lifecycle(":mapping minecraft to intermediary")
 		def tinyInput = downloadIntermediary.dest
@@ -432,36 +432,37 @@ task mapIntermediaryJar(dependsOn: [downloadMcLibs, downloadIntermediary, mergeJ
 	}
 }
 
-task yarnUnpicked(dependsOn: "unpickIntermediaryJar", type: JavaExec) {
-	group = yarnGroup
+task mapServerIntermediaryJar(dependsOn: [downloadMcLibs, downloadIntermediary, extractServerJar]) {
+	group = mapJarGroup
+	inputs.files downloadMcLibs.outputs.files.files
+	outputs.file(serverIntermediaryJar)
 
-	classpath = configurations.enigmaRuntime
-	mainClass = 'cuchaz.enigma.gui.Main'
+	//Force the task to always run
+	outputs.upToDateWhen { false }
 
-	args '-jar'
-	args unpickedJar.getAbsolutePath()
-	args '-mappings'
-	args mappingsDir.getAbsolutePath()
-	args '-profile'
-	args 'enigma_profile.json'
-
-	jvmArgs "-Xmx2048m"
+	doLast {
+		logger.lifecycle(":mapping minecraft server to intermediary")
+		def tinyInput = downloadIntermediary.dest
+		mapJar(serverIntermediaryJar, serverJar, tinyInput, libraries, "official", "intermediary")
+	}
 }
 
-task yarn(dependsOn: mapIntermediaryJar, type: JavaExec) {
+task yarnUnpicked(dependsOn: "unpickIntermediaryJar", type: EnigmaTask) {
 	group = yarnGroup
+	jar = unpickedJar
+	mappings = mappingsDir
+}
 
-	classpath = configurations.enigmaRuntime
-	mainClass = 'cuchaz.enigma.gui.Main'
+task yarn(dependsOn: mapIntermediaryJar, type: EnigmaTask) {
+	group = yarnGroup
+	jar = intermediaryJar
+	mappings = mappingsDir
+}
 
-	args '-jar'
-	args intermediaryJar.getAbsolutePath()
-	args '-mappings'
-	args mappingsDir.getAbsolutePath()
-	args '-profile'
-	args 'enigma_profile.json'
-
-	jvmArgs "-Xmx2048m"
+task yarnCommon(dependsOn: mapServerIntermediaryJar, type: EnigmaTask) {
+	group = yarnGroup
+	jar = serverIntermediaryJar
+	mappings = mappingsDir
 }
 
 task checkMappings(dependsOn: mapIntermediaryJar) {
@@ -1050,4 +1051,29 @@ class WithV2FileOutput extends DefaultTask {
 	File v1Output
 	@OutputFile
 	File v2Output
+}
+
+abstract class EnigmaTask extends JavaExec {
+	@Input
+	abstract Property<File> getJar()
+
+	@Input
+	abstract Property<File> getMappings()
+
+	EnigmaTask() {
+		classpath = project.configurations.enigmaRuntime
+		mainClass.set('cuchaz.enigma.gui.Main')
+	}
+
+	@TaskAction
+	void exec() {
+		args '-jar'
+		args jar.get().absolutePath
+		args '-mappings'
+		args mappings.get().absolutePath
+		args '-profile'
+		args 'enigma_profile.json'
+		jvmArgs "-Xmx2048m"
+		super.exec()
+	}
 }


### PR DESCRIPTION
Noticed that there are some classes that don't have `@Environment(EnvType.CLIENT)` in `net.minecraft.client` package, this would help find those.

I can't help naming these though, as I've been using mojmap.