### PR TITLE
Add and fix mappings for structure placements

### DIFF
--- a/mappings/net/minecraft/world/gen/chunk/placement/RandomSpreadStructurePlacement.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/placement/RandomSpreadStructurePlacement.mapping
@@ -1,13 +1,30 @@
 CLASS net/minecraft/class_6872 net/minecraft/world/gen/chunk/placement/RandomSpreadStructurePlacement
 	FIELD field_36420 CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_37772 spacing I
+	FIELD field_37773 separation I
+	FIELD field_37774 spreadType Lnet/minecraft/class_6873;
 	METHOD <init> (IILnet/minecraft/class_6873;I)V
 		ARG 1 spacing
+		ARG 2 separation
 		ARG 3 spreadType
+		ARG 4 salt
+	METHOD <init> (Lnet/minecraft/class_2382;Lnet/minecraft/class_6874$class_7154;FILjava/util/Optional;IILnet/minecraft/class_6873;)V
+		ARG 1 locateOffset
+		ARG 2 frequencyReductionMethod
+		ARG 3 frequency
+		ARG 4 salt
+		ARG 5 exclusionZone
+		ARG 6 spacing
+		ARG 7 separation
+		ARG 8 spreadType
 	METHOD method_40169 getStartChunk (JII)Lnet/minecraft/class_1923;
 		ARG 1 seed
-		ARG 3 x
-		ARG 4 z
+		ARG 3 chunkX
+		ARG 4 chunkZ
 	METHOD method_40170 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 0 instance
 	METHOD method_40171 (Lnet/minecraft/class_6872;)Lcom/mojang/serialization/DataResult;
 		ARG 0 placement
+	METHOD method_41632 getSpacing ()I
+	METHOD method_41633 getSeparation ()I
+	METHOD method_41634 getSpreadType ()Lnet/minecraft/class_6873;

--- a/mappings/net/minecraft/world/gen/chunk/placement/StructurePlacement.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/placement/StructurePlacement.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_6874 net/minecraft/world/gen/chunk/placement/StructurePlacement
 	FIELD field_36428 TYPE_CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_37775 ARBITRARY_SALT I
 	FIELD field_37776 locateOffset Lnet/minecraft/class_2382;
 	FIELD field_37777 frequencyReductionMethod Lnet/minecraft/class_6874$class_7154;
 	FIELD field_37778 frequency F
@@ -16,18 +17,19 @@ CLASS net/minecraft/class_6874 net/minecraft/world/gen/chunk/placement/Structure
 		ARG 1 chunkGenerator
 		ARG 2 noiseConfig
 		ARG 3 seed
-		ARG 5 x
-		ARG 6 z
+		ARG 5 chunkX
+		ARG 6 chunkZ
 	METHOD method_41635 defaultShouldGenerate (JIIIF)Z
 		ARG 0 seed
-		ARG 2 regionX
-		ARG 3 regionZ
-		ARG 4 salt
+		ARG 2 salt
+		ARG 3 chunkX
+		ARG 4 chunkZ
 		ARG 5 frequency
 	METHOD method_41636 getLocatePos (Lnet/minecraft/class_1923;)Lnet/minecraft/class_2338;
 		ARG 1 chunkPos
 	METHOD method_41638 legacyType3ShouldGenerate (JIIIF)Z
 		ARG 0 seed
+		ARG 2 salt
 		ARG 3 chunkX
 		ARG 4 chunkZ
 		ARG 5 frequency
@@ -35,15 +37,19 @@ CLASS net/minecraft/class_6874 net/minecraft/world/gen/chunk/placement/Structure
 		ARG 1 chunkGenerator
 		ARG 2 noiseConfig
 		ARG 3 seed
-		ARG 5 x
-		ARG 6 z
+		ARG 5 chunkX
+		ARG 6 chunkZ
 	METHOD method_41640 legacyType2ShouldGenerate (JIIIF)Z
 		ARG 0 seed
-		ARG 3 regionX
-		ARG 4 regionZ
+		ARG 2 salt
+		ARG 3 chunkX
+		ARG 4 chunkZ
 		ARG 5 frequency
 	METHOD method_41641 legacyType1ShouldGenerate (JIIIF)Z
 		ARG 0 seed
+		ARG 2 salt
+		ARG 3 chunkX
+		ARG 4 chunkZ
 		ARG 5 frequency
 	METHOD method_41642 getLocateOffset ()Lnet/minecraft/class_2382;
 	METHOD method_41643 getFrequencyReductionMethod ()Lnet/minecraft/class_6874$class_7154;
@@ -59,8 +65,11 @@ CLASS net/minecraft/class_6874 net/minecraft/world/gen/chunk/placement/Structure
 			ARG 5 x
 			ARG 6 z
 	CLASS class_7153 GenerationPredicate
-		METHOD shouldGenerate (JIIIF)Z
+		METHOD shouldGenerate shouldGenerate (JIIIF)Z
 			ARG 1 seed
+			ARG 3 salt
+			ARG 4 chunkX
+			ARG 5 chunkZ
 			ARG 6 chance
 	CLASS class_7154 FrequencyReductionMethod
 		FIELD field_37786 CODEC Lcom/mojang/serialization/Codec;
@@ -71,4 +80,7 @@ CLASS net/minecraft/class_6874 net/minecraft/world/gen/chunk/placement/Structure
 			ARG 4 generationPredicate
 		METHOD method_41650 shouldGenerate (JIIIF)Z
 			ARG 1 seed
+			ARG 3 salt
+			ARG 4 chunkX
+			ARG 5 chunkZ
 			ARG 6 chance

--- a/mappings/net/minecraft/world/gen/chunk/placement/StructurePlacement.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/placement/StructurePlacement.mapping
@@ -65,7 +65,7 @@ CLASS net/minecraft/class_6874 net/minecraft/world/gen/chunk/placement/Structure
 			ARG 5 x
 			ARG 6 z
 	CLASS class_7153 GenerationPredicate
-		METHOD shouldGenerate shouldGenerate (JIIIF)Z
+		METHOD shouldGenerate (JIIIF)Z
 			ARG 1 seed
 			ARG 3 salt
 			ARG 4 chunkX


### PR DESCRIPTION
Something odd is going on with `StructurePlacement#defaultShouldGenerate`
All those private static methods should have the exact same param names, and its very clear that the order is `seed, salt, chunkX, chunkZ, frequency` based on the call to `FrequencyReductionMethod#shouldGenerate`. But inside defaultShouldGenerate the params are put in the wrong order into the `ChunkRandom#setRegionSeed`. setRegionSeed might be misnamed, but I think its params are in the right order based on a call to it in `RandomSpreadStructurePlacement#getStartChunk`. 