### PR TITLE
1.19.1-pre4 stuff

### DIFF
--- a/mappings/net/minecraft/client/gui/EditBox.mapping
+++ b/mappings/net/minecraft/client/gui/EditBox.mapping
@@ -84,7 +84,7 @@ CLASS net/minecraft/class_7530 net/minecraft/client/gui/EditBox
 	METHOD method_44420 replaceSelection (Ljava/lang/String;)V
 		COMMENT Replaces the current selection with {@code string}. If there is no
 		COMMENT selection, this inserts the string at the cursor position. This removes
-		COMMENT {@linkplain SharedConstants#isValidChar invalid characters} and truncates
+		COMMENT {@linkplain net.minecraft.SharedConstants#isValidChar invalid characters} and truncates
 		COMMENT the passed string if necessary.
 		ARG 1 string
 	METHOD method_44421 getText ()Ljava/lang/String;

--- a/mappings/net/minecraft/client/gui/hud/ChatHud.mapping
+++ b/mappings/net/minecraft/client/gui/hud/ChatHud.mapping
@@ -37,6 +37,10 @@ CLASS net/minecraft/class_338 net/minecraft/client/gui/hud/ChatHud
 	METHOD method_1814 getChatScale ()D
 	METHOD method_1815 addMessage (Lnet/minecraft/class_2561;Lnet/minecraft/class_7469;ILnet/minecraft/class_7591;Z)V
 		ARG 1 message
+		ARG 2 signature
+		ARG 3 ticks
+		ARG 4 indicator
+		ARG 5 refresh
 	METHOD method_1816 getTextStyleAt (DD)Lnet/minecraft/class_2583;
 		ARG 1 x
 		ARG 3 y
@@ -74,3 +78,10 @@ CLASS net/minecraft/class_338 net/minecraft/client/gui/hud/ChatHud
 	METHOD method_44725 getMessageIndex (D)I
 		ARG 1 y
 	METHOD method_44752 getLineHeight ()I
+	METHOD method_44811 addMessage (Lnet/minecraft/class_2561;Lnet/minecraft/class_7469;Lnet/minecraft/class_7591;)V
+		ARG 1 message
+		ARG 2 signature
+		ARG 3 indicator
+	METHOD method_44812 hideMessage (Lnet/minecraft/class_7469;)V
+		ARG 1 signature
+	METHOD method_44813 refresh ()V

--- a/mappings/net/minecraft/client/network/ClientPlayNetworkHandler.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayNetworkHandler.mapping
@@ -20,7 +20,9 @@ CLASS net/minecraft/class_634 net/minecraft/client/network/ClientPlayNetworkHand
 	FIELD field_3699 world Lnet/minecraft/class_638;
 	FIELD field_3700 advancementHandler Lnet/minecraft/class_632;
 	FIELD field_3701 loginScreen Lnet/minecraft/class_437;
+	FIELD field_39808 messagePacker Lnet/minecraft/class_7610$class_7612;
 	METHOD <init> (Lnet/minecraft/class_310;Lnet/minecraft/class_437;Lnet/minecraft/class_2535;Lcom/mojang/authlib/GameProfile;Lnet/minecraft/class_6628;)V
+		ARG 1 client
 		ARG 2 screen
 		ARG 3 connection
 		ARG 4 profile
@@ -114,3 +116,4 @@ CLASS net/minecraft/class_634 net/minecraft/client/network/ClientPlayNetworkHand
 		ARG 1 favicon
 	METHOD method_44072 (Lnet/minecraft/class_642;Lnet/minecraft/class_2561;)V
 		ARG 1 description
+	METHOD method_44816 getMessagePacker ()Lnet/minecraft/class_7610$class_7612;

--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -97,15 +97,20 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 	METHOD method_33689 init ()V
 	METHOD method_43609 signChatMessage (Lnet/minecraft/class_7470;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7469;
 		COMMENT Signs the chat message. If the chat message cannot be signed, this will return
-		COMMENT {@link MessageSignature#none()}.
+		COMMENT {@link MessageSignatureData#EMPTY}.
+		ARG 1 metadata
+		ARG 2 preview
 	METHOD method_43786 signArguments (Lnet/minecraft/class_7470;Lcom/mojang/brigadier/ParseResults;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7450;
 		COMMENT Signs the command arguments. If the arguments cannot be signed or if there is no
-		COMMENT arguments to sign, this will return {@link ArgumentSignatureDataMap#empty()}.
+		COMMENT arguments to sign, this will return {@link ArgumentSignatureDataMap#EMPTY}.
 		ARG 1 signer
+		ARG 2 parseResults
 		ARG 3 preview
 			COMMENT the previewed argument value; if supplied, will be used for all signed arguments
-	METHOD method_43787 sendCommand (Ljava/lang/String;Lnet/minecraft/class_2561;)V
+	METHOD method_43787 sendCommandInternal (Ljava/lang/String;Lnet/minecraft/class_2561;)V
 		COMMENT Signs and sends {@code command} to the server.
+		ARG 1 command
+		ARG 2 preview
 	METHOD method_44096 sendChatMessage (Ljava/lang/String;Lnet/minecraft/class_2561;)V
 		COMMENT Sends a chat message with the preview to the server. If the server could not
 		COMMENT reproduce the preview based on {@code message}, the server rejects the message.
@@ -114,7 +119,7 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 		COMMENT sending to the server.
 		COMMENT
 		COMMENT <p>If the message contains an invalid character (see {@link
-		COMMENT net.minecraft.SharedConstants#isValidChar isValidChar}), the server will
+		COMMENT net.minecraft.SharedConstants#isValidChar}), the server will
 		COMMENT reject the message and disconnect the client.
 		COMMENT
 		COMMENT @apiNote This method is used to send a message typed in {@linkplain
@@ -122,12 +127,20 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 		ARG 1 message
 		ARG 2 preview
 	METHOD method_44097 sendChatMessagePacket (Ljava/lang/String;Lnet/minecraft/class_2561;)V
+		ARG 1 content
+		ARG 2 preview
+	METHOD method_44098 sendCommand (Ljava/lang/String;Lnet/minecraft/class_2561;)V
+		COMMENT Signs and sends {@code command} to the server.
+		ARG 1 command
+			COMMENT the command (without the leading slash)
+		ARG 2 preview
 	METHOD method_44099 sendCommand (Ljava/lang/String;)V
 		COMMENT Sends an unsigned command to the server.
 		ARG 1 command
-			COMMENT the command (can have the leading slash)
+			COMMENT the command (without the leading slash)
 	METHOD method_44297 (Lnet/minecraft/class_2561;Lnet/minecraft/class_7501;Lnet/minecraft/class_7470;Ljava/lang/String;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7469;
 		ARG 4 argumentName
 		ARG 5 value
+	METHOD method_44826 createMessageMetadata ()Lnet/minecraft/class_7470;
 	METHOD method_7290 dropSelectedItem (Z)Z
 		ARG 1 entireStack

--- a/mappings/net/minecraft/client/network/PlayerListEntry.mapping
+++ b/mappings/net/minecraft/client/network/PlayerListEntry.mapping
@@ -13,6 +13,7 @@ CLASS net/minecraft/class_640 net/minecraft/client/network/PlayerListEntry
 	FIELD field_3747 blinkingHeartTime J
 	FIELD field_39072 LOGGER Lorg/slf4j/Logger;
 	FIELD field_39073 publicKeyData Lnet/minecraft/class_7428;
+	FIELD field_39809 messageVerifier Lnet/minecraft/class_7615;
 	METHOD <init> (Lnet/minecraft/class_2703$class_2705;Lnet/minecraft/class_7500;)V
 		ARG 1 playerListPacketEntry
 		ARG 2 servicesSignatureVerifier
@@ -57,3 +58,4 @@ CLASS net/minecraft/class_640 net/minecraft/client/network/PlayerListEntry
 	METHOD method_2979 getCapeTexture ()Lnet/minecraft/class_2960;
 	METHOD method_35757 hasCape ()Z
 	METHOD method_43598 getPublicKeyData ()Lnet/minecraft/class_7428;
+	METHOD method_44817 getMessageVerifier ()Lnet/minecraft/class_7615;

--- a/mappings/net/minecraft/client/network/message/MessageHandler.mapping
+++ b/mappings/net/minecraft/client/network/message/MessageHandler.mapping
@@ -68,7 +68,7 @@ CLASS net/minecraft/class_7594 net/minecraft/client/network/message/MessageHandl
 	METHOD method_44821 processHeader (Lnet/minecraft/class_7614;Lnet/minecraft/class_7469;[B)Z
 		ARG 1 header
 		ARG 2 signature
-		ARG 3 bodyDiget
+		ARG 3 bodyDigest
 	METHOD method_44822 headerProcessed (Lnet/minecraft/class_7614;Lnet/minecraft/class_7469;[B)V
 		ARG 1 header
 		ARG 2 signatures

--- a/mappings/net/minecraft/client/network/message/MessageHandler.mapping
+++ b/mappings/net/minecraft/client/network/message/MessageHandler.mapping
@@ -6,6 +6,15 @@ CLASS net/minecraft/class_7594 net/minecraft/client/network/message/MessageHandl
 	FIELD field_39798 lastProcessTime J
 	METHOD <init> (Lnet/minecraft/class_310;)V
 		ARG 1 client
+	METHOD method_44731 getPlayerListEntry (Ljava/util/UUID;)Lnet/minecraft/class_640;
+		ARG 1 sender
+	METHOD method_44732 getStatus (Lnet/minecraft/class_7471;Lnet/minecraft/class_2561;Lnet/minecraft/class_640;)Lnet/minecraft/class_7595;
+		ARG 1 message
+		ARG 2 decorated
+		ARG 3 senderEntry
+	METHOD method_44733 onChatMessage (Lnet/minecraft/class_7471;Lnet/minecraft/class_2556$class_7602;)V
+		ARG 1 message
+		ARG 2 params
 	METHOD method_44734 extractSender (Lnet/minecraft/class_2561;)Ljava/util/UUID;
 		ARG 1 text
 	METHOD method_44735 addToChatLog (Lnet/minecraft/class_2561;Ljava/time/Instant;)V
@@ -16,8 +25,11 @@ CLASS net/minecraft/class_7594 net/minecraft/client/network/message/MessageHandl
 		ARG 2 overlay
 	METHOD method_44737 addToChatLog (Lnet/minecraft/class_7471;Lnet/minecraft/class_2556$class_7602;Lnet/minecraft/class_640;Lnet/minecraft/class_7595;)V
 		ARG 1 message
+		ARG 2 params
 		ARG 3 senderEntry
 		ARG 4 trustStatus
+	METHOD method_44738 isAlwaysTrusted (Ljava/util/UUID;)Z
+		ARG 1 sender
 	METHOD method_44765 processDelayedMessages ()V
 		COMMENT Processes all delayed messages until one of them fails to process if the delay
 		COMMENT has passed, and otherwise does nothing.
@@ -25,8 +37,44 @@ CLASS net/minecraft/class_7594 net/minecraft/client/network/message/MessageHandl
 		COMMENT Sets the chat delay to {@code chatDelay} seconds. If the chat delay was changed
 		COMMENT to {@code 0}, this also processes all queued messages.
 		ARG 1 chatDelay
+	METHOD method_44767 processProfilelessMessage (Lnet/minecraft/class_2556$class_7602;Lnet/minecraft/class_7471;Lnet/minecraft/class_2561;)Z
+		ARG 1 params
+		ARG 2 message
+		ARG 3 decorated
+	METHOD method_44768 processChatMessage (Lnet/minecraft/class_2556$class_7602;Lnet/minecraft/class_7471;Lnet/minecraft/class_2561;Lnet/minecraft/class_640;Lnet/minecraft/class_7595;)Z
+		ARG 1 params
+		ARG 2 message
+		ARG 3 decorated
+		ARG 4 senderEntry
+		ARG 5 trustStatus
 	METHOD method_44769 process ()V
 		COMMENT Processes one delayed message from the queue's beginning.
+	METHOD method_44772 narrate (Lnet/minecraft/class_2556$class_7602;Lnet/minecraft/class_7471;)V
+		ARG 1 params
+		ARG 2 message
 	METHOD method_44773 getDelayedMessages ()Ljava/util/Collection;
 	METHOD method_44775 shouldDelay ()Z
 		COMMENT {@return if the chat delay is set and the message should be delayed}
+	METHOD method_44818 process (Lnet/minecraft/class_7594$class_7601;)V
+		COMMENT Queues {@code processor} during {@linkplain #shouldDelay the chat delay},
+		COMMENT otherwise runs the processor.
+		ARG 1 processor
+	METHOD method_44819 removeDelayedMessage (Lnet/minecraft/class_7469;)Z
+		ARG 1 signature
+	METHOD method_44820 onMessageHeader (Lnet/minecraft/class_7614;Lnet/minecraft/class_7469;[B)V
+		ARG 1 header
+		ARG 2 signature
+		ARG 3 bodyDigest
+	METHOD method_44821 processHeader (Lnet/minecraft/class_7614;Lnet/minecraft/class_7469;[B)Z
+		ARG 1 header
+		ARG 2 signature
+		ARG 3 bodyDiget
+	METHOD method_44822 headerProcessed (Lnet/minecraft/class_7614;Lnet/minecraft/class_7469;[B)V
+		ARG 1 header
+		ARG 2 signatures
+		ARG 3 bodyDigest
+	CLASS class_7601 MessageProcessor
+		FIELD comp_917 processor Ljava/util/function/BooleanSupplier;
+		METHOD comp_917 processor ()Ljava/util/function/BooleanSupplier;
+		METHOD method_44824 process ()Z
+		METHOD method_44825 getHeaderSignature ()Lnet/minecraft/class_7469;

--- a/mappings/net/minecraft/client/texture/PlayerSkinProvider.mapping
+++ b/mappings/net/minecraft/client/texture/PlayerSkinProvider.mapping
@@ -13,8 +13,6 @@ CLASS net/minecraft/class_1071 net/minecraft/client/texture/PlayerSkinProvider
 	METHOD method_44705 loadSkin (Lcom/mojang/authlib/GameProfile;)Lnet/minecraft/class_2960;
 		COMMENT {@return the ID of {@code profile}'s skin, or the default skin for the profile's
 		COMMENT UUID if the skin is missing}
-		COMMENT
-		COMMENT @see DefaultSkinHelper#getTexture(java.util.UUID)
 		ARG 1 profile
 	METHOD method_4651 loadSkin (Lcom/mojang/authlib/minecraft/MinecraftProfileTexture;Lcom/mojang/authlib/minecraft/MinecraftProfileTexture$Type;Lnet/minecraft/class_1071$class_1072;)Lnet/minecraft/class_2960;
 		ARG 1 profileTexture

--- a/mappings/net/minecraft/command/argument/MessageArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/MessageArgumentType.mapping
@@ -49,3 +49,37 @@ CLASS net/minecraft/class_2196 net/minecraft/command/argument/MessageArgumentTyp
 	CLASS class_7515 SignedMessage
 		METHOD method_44262 decorate (Lnet/minecraft/class_2168;)Ljava/util/concurrent/CompletableFuture;
 			ARG 1 source
+		METHOD method_44801 (Lnet/minecraft/class_5837;Lnet/minecraft/class_5837;)Lnet/minecraft/class_5837;
+			ARG 1 decoratedMessage
+		METHOD method_44802 format (Lnet/minecraft/class_2168;Lnet/minecraft/class_5837;)Lnet/minecraft/class_5837;
+			COMMENT {@return the formatted {@code message}}
+			COMMENT
+			COMMENT <p>If the message contains a filtered part, that part is formatted by {@link
+			COMMENT #format(ServerCommandSource, String)}.
+			ARG 1 source
+			ARG 2 message
+		METHOD method_44803 decorate (Lnet/minecraft/class_2168;Lnet/minecraft/class_5837;Lnet/minecraft/class_5837;)Ljava/util/concurrent/CompletableFuture;
+			ARG 1 source
+			ARG 2 filtered
+			ARG 3 formatted
+		METHOD method_44804 format (Lnet/minecraft/class_2168;Ljava/lang/String;)Lnet/minecraft/class_2561;
+			COMMENT {@return the parsed and formatted {@code filteredText}, or {@code null} if it fails}
+			ARG 1 source
+			ARG 2 filteredText
+		METHOD method_44805 (Lnet/minecraft/class_7610$class_7611;Lnet/minecraft/class_7610$class_7613;Lnet/minecraft/class_7470;Lnet/minecraft/class_5837;)Lnet/minecraft/class_5837;
+			ARG 3 decoratedMessage
+		METHOD method_44806 sendHeader (Lnet/minecraft/class_2168;)V
+			COMMENT Sends the message's header to all players.
+			COMMENT
+			COMMENT <p>This should be called if the message could not be sent due to an exception.
+			COMMENT See {@link MessageCommand} for an example.
+			ARG 1 source
+		METHOD method_44807 (Lnet/minecraft/class_2168;Lnet/minecraft/class_5837;)V
+			ARG 1 decoratedMessage
+		METHOD method_44808 filterText (Lnet/minecraft/class_2168;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+			ARG 1 source
+			ARG 2 text
+		METHOD method_44809 (Lnet/minecraft/class_2168;Lnet/minecraft/class_5837;)V
+			ARG 1 message
+		METHOD method_44810 (Lnet/minecraft/class_2168;Lnet/minecraft/class_5837;)Ljava/util/concurrent/CompletionStage;
+			ARG 2 filtered

--- a/mappings/net/minecraft/command/argument/MessageArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/MessageArgumentType.mapping
@@ -72,7 +72,7 @@ CLASS net/minecraft/class_2196 net/minecraft/command/argument/MessageArgumentTyp
 			COMMENT Sends the message's header to all players.
 			COMMENT
 			COMMENT <p>This should be called if the message could not be sent due to an exception.
-			COMMENT See {@link MessageCommand} for an example.
+			COMMENT See {@link net.minecraft.server.command.MessageCommand} for an example.
 			ARG 1 source
 		METHOD method_44807 (Lnet/minecraft/class_2168;Lnet/minecraft/class_5837;)V
 			ARG 1 decoratedMessage

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -486,7 +486,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		ARG 1 x
 		ARG 3 y
 		ARG 5 z
-	METHOD method_43688 asMessageSender ()Lnet/minecraft/class_7436;
+	METHOD method_43688 asMessageSourceProfile ()Lnet/minecraft/class_7436;
 	METHOD method_44329 getEventSource ()Lnet/minecraft/class_1297;
 	METHOD method_5621 getMountedHeightOffset ()D
 	METHOD method_5622 onBlockCollision (Lnet/minecraft/class_2680;)V

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -486,7 +486,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		ARG 1 x
 		ARG 3 y
 		ARG 5 z
-	METHOD method_43688 asMessageSourceProfile ()Lnet/minecraft/class_7436;
+	METHOD method_43688 getMessageSourceProfile ()Lnet/minecraft/class_7436;
 	METHOD method_44329 getEventSource ()Lnet/minecraft/class_1297;
 	METHOD method_5621 getMountedHeightOffset ()D
 	METHOD method_5622 onBlockCollision (Lnet/minecraft/class_2680;)V

--- a/mappings/net/minecraft/network/listener/ClientPlayPacketListener.mapping
+++ b/mappings/net/minecraft/network/listener/ClientPlayPacketListener.mapping
@@ -209,3 +209,7 @@ CLASS net/minecraft/class_2602 net/minecraft/network/listener/ClientPlayPacketLi
 		ARG 1 packet
 	METHOD method_44763 onChatSuggestions (Lnet/minecraft/class_7597;)V
 		ARG 1 packet
+	METHOD method_44814 onHideMessage (Lnet/minecraft/class_7617;)V
+		ARG 1 packet
+	METHOD method_44815 onMessageHeader (Lnet/minecraft/class_7618;)V
+		ARG 1 packet

--- a/mappings/net/minecraft/network/message/ArgumentSignatureDataMap.mapping
+++ b/mappings/net/minecraft/network/message/ArgumentSignatureDataMap.mapping
@@ -1,5 +1,7 @@
 CLASS net/minecraft/class_7450 net/minecraft/network/message/ArgumentSignatureDataMap
 	COMMENT A record holding the signatures for all signable arguments of an executed command.
+	COMMENT
+	COMMENT @see SignedCommandArguments
 	FIELD field_39185 MAX_ARGUMENT_NAME_LENGTH I
 	FIELD field_39418 MAX_ARGUMENTS I
 	FIELD field_39807 EMPTY Lnet/minecraft/class_7450;

--- a/mappings/net/minecraft/network/message/ArgumentSignatureDataMap.mapping
+++ b/mappings/net/minecraft/network/message/ArgumentSignatureDataMap.mapping
@@ -27,8 +27,8 @@ CLASS net/minecraft/class_7450 net/minecraft/network/message/ArgumentSignatureDa
 	METHOD method_44798 (Lnet/minecraft/class_7450$class_7600;Lcom/mojang/datafixers/util/Pair;)Lnet/minecraft/class_7450$class_7599;
 		ARG 1 entry
 	METHOD method_44799 (Lnet/minecraft/class_2540;Lnet/minecraft/class_7450$class_7599;)V
-		ARG 0 entry
-		ARG 1 buf2
+		ARG 0 buf2
+		ARG 1 entry
 	CLASS class_7599 Entry
 		COMMENT An entry of the signatures map, consisting of the argument's name and signature data.
 		METHOD <init> (Lnet/minecraft/class_2540;)V

--- a/mappings/net/minecraft/network/message/ArgumentSignatureDataMap.mapping
+++ b/mappings/net/minecraft/network/message/ArgumentSignatureDataMap.mapping
@@ -1,7 +1,8 @@
 CLASS net/minecraft/class_7450 net/minecraft/network/message/ArgumentSignatureDataMap
-	COMMENT A record holding the salt and signatures for all signable arguments of an executed command.
+	COMMENT A record holding the signatures for all signable arguments of an executed command.
 	FIELD field_39185 MAX_ARGUMENT_NAME_LENGTH I
 	FIELD field_39418 MAX_ARGUMENTS I
+	FIELD field_39807 EMPTY Lnet/minecraft/class_7450;
 	METHOD <init> (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD method_43746 collectArguments (Lcom/mojang/brigadier/context/CommandContextBuilder;)Ljava/util/List;
@@ -16,3 +17,24 @@ CLASS net/minecraft/class_7450 net/minecraft/network/message/ArgumentSignatureDa
 		ARG 1 argumentName
 	METHOD method_43749 write (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
+	METHOD method_44797 sign (Lcom/mojang/brigadier/context/CommandContextBuilder;Lnet/minecraft/class_7450$class_7600;)Lnet/minecraft/class_7450;
+		COMMENT {@return the signature map with arguments from {@code builder} signed with
+		COMMENT {@code signer}}
+		ARG 0 builder
+		ARG 1 signer
+	METHOD method_44798 (Lnet/minecraft/class_7450$class_7600;Lcom/mojang/datafixers/util/Pair;)Lnet/minecraft/class_7450$class_7599;
+		ARG 1 entry
+	METHOD method_44799 (Lnet/minecraft/class_2540;Lnet/minecraft/class_7450$class_7599;)V
+		ARG 0 entry
+		ARG 1 buf2
+	CLASS class_7599 Entry
+		COMMENT An entry of the signatures map, consisting of the argument's name and signature data.
+		METHOD <init> (Lnet/minecraft/class_2540;)V
+			ARG 1 buf
+		METHOD method_44800 write (Lnet/minecraft/class_2540;)V
+			ARG 1 buf
+	CLASS class_7600 ArgumentSigner
+		COMMENT A functional interface that signs an argument of a command.
+		METHOD sign (Ljava/lang/String;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7469;
+			ARG 1 argumentName
+			ARG 2 value

--- a/mappings/net/minecraft/network/message/ChatMessageSigner.mapping
+++ b/mappings/net/minecraft/network/message/ChatMessageSigner.mapping
@@ -1,5 +1,0 @@
-CLASS net/minecraft/class_7470 net/minecraft/network/message/ChatMessageSigner
-	COMMENT A signer for chat messages that produces {@link MessageSignature}.
-	METHOD method_43866 create (Ljava/util/UUID;)Lnet/minecraft/class_7470;
-		COMMENT {@return a new signer instance}
-		ARG 0 sender

--- a/mappings/net/minecraft/network/message/MessageBody.mapping
+++ b/mappings/net/minecraft/network/message/MessageBody.mapping
@@ -24,6 +24,10 @@ CLASS net/minecraft/class_7608 net/minecraft/network/message/MessageBody
 		ARG 0 buf2
 		ARG 1 lastSeenMessages
 	METHOD method_44871 toBytes (Lnet/minecraft/class_2561;)[B
+		COMMENT {@return {@code content} converted to a byte array}
+		COMMENT
+		COMMENT @implNote This returns the UTF-8 encoded string representing the
+		COMMENT JSON serialized version of {@code content}.
 		ARG 0 content
 	METHOD method_44872 (Lnet/minecraft/class_7608$class_7609;)I
 		ARG 0 lastSeenMessage

--- a/mappings/net/minecraft/network/message/MessageBody.mapping
+++ b/mappings/net/minecraft/network/message/MessageBody.mapping
@@ -1,0 +1,35 @@
+CLASS net/minecraft/class_7608 net/minecraft/network/message/MessageBody
+	COMMENT A body of a message, including the content, timestamp, salt used for the digest
+	COMMENT (the hashed body), and the list of players' "last seen message". Unlike {@link
+	COMMENT MessageHeader}, clients do not receive this if the message is censored; they receive
+	COMMENT the digest only.
+	FIELD comp_930 timestamp Ljava/time/Instant;
+	FIELD comp_932 lastSeenMessages Ljava/util/List;
+	FIELD field_39817 LAST_SEEN_SEPARATOR B
+	METHOD <init> (Lnet/minecraft/class_2540;)V
+		ARG 1 buf
+	METHOD comp_930 timestamp ()Ljava/time/Instant;
+	METHOD comp_932 lastSeenMessages ()Ljava/util/List;
+	METHOD method_44867 digest ()Lcom/google/common/hash/HashCode;
+		COMMENT {@return the digest of this body}
+		COMMENT
+		COMMENT @implNote This is a SHA-256 hash of the salt, the timestamp represented as the seconds
+		COMMENT since the Unix epoch, {@linkplain #toBytes(Text) the content}, and
+		COMMENT {@linkplain #toBytes(List) the list of each player's last seen message}.
+	METHOD method_44868 toBytes (Ljava/util/List;)[B
+		ARG 0 messages
+	METHOD method_44869 write (Lnet/minecraft/class_2540;)V
+		ARG 1 buf
+	METHOD method_44870 (Lnet/minecraft/class_2540;Lnet/minecraft/class_7608$class_7609;)V
+		ARG 0 buf2
+		ARG 1 lastSeenMessages
+	METHOD method_44871 toBytes (Lnet/minecraft/class_2561;)[B
+		ARG 0 content
+	METHOD method_44872 (Lnet/minecraft/class_7608$class_7609;)I
+		ARG 0 lastSeenMessage
+	CLASS class_7609 LastSeenMessage
+		COMMENT A pair of a player's UUID and the signature of the last message they saw.
+		METHOD <init> (Lnet/minecraft/class_2540;)V
+			ARG 1 buf
+		METHOD method_44873 write (Lnet/minecraft/class_2540;)V
+			ARG 1 buf

--- a/mappings/net/minecraft/network/message/MessageBody.mapping
+++ b/mappings/net/minecraft/network/message/MessageBody.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_7608 net/minecraft/network/message/MessageBody
 	COMMENT A body of a message, including the content, timestamp, salt used for the digest
-	COMMENT (the hashed body), and the list of players' "last seen message". Unlike {@link
+	COMMENT (the hashed body), and the list of players' "last seen messages". Unlike {@link
 	COMMENT MessageHeader}, clients do not receive this if the message is censored; they receive
 	COMMENT the digest only.
 	FIELD comp_930 timestamp Ljava/time/Instant;

--- a/mappings/net/minecraft/network/message/MessageChain.mapping
+++ b/mappings/net/minecraft/network/message/MessageChain.mapping
@@ -1,0 +1,66 @@
+CLASS net/minecraft/class_7610 net/minecraft/network/message/MessageChain
+	COMMENT A class for handling the "message chain".
+	COMMENT
+	COMMENT <p>{@link MessageHeader} includes the signature of the last message the client has seen.
+	COMMENT This can be used to verify the legitimacy of a chain of messages, since if the chain
+	COMMENT is valid, the last message's  "previous signature" should be able to verify the preceding
+	COMMENT message.
+	COMMENT
+	COMMENT <p>Clients signing a message with its preceding message's signature is called
+	COMMENT "packing", and the server creating a signed message with its preceeding message's
+	COMMENT signature is called "unpacking". Unpacked messages can then be verified to check the
+	COMMENT chain's legitimacy.
+	FIELD field_39818 precedingSignature Lnet/minecraft/class_7469;
+	METHOD method_44874 getUnpacker ()Lnet/minecraft/class_7610$class_7611;
+	METHOD method_44875 pack (Lnet/minecraft/class_7501;Lnet/minecraft/class_7470;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7610$class_7613;
+		ARG 1 signer
+		ARG 2 newMetadata
+		ARG 3 newContent
+	METHOD method_44876 sign (Lnet/minecraft/class_7501;Lnet/minecraft/class_7470;Lnet/minecraft/class_7469;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7469;
+		ARG 0 signer
+		ARG 1 newMetadata
+		ARG 2 precedingSignature
+		ARG 3 newContent
+	METHOD method_44877 createMessage (Lnet/minecraft/class_7610$class_7613;Lnet/minecraft/class_7469;Lnet/minecraft/class_7470;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7471;
+		ARG 0 signature
+		ARG 1 precedingSignature
+		ARG 2 newMetadata
+		ARG 3 newContent
+	METHOD method_44878 unpack (Lnet/minecraft/class_7610$class_7613;Lnet/minecraft/class_7470;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7471;
+		ARG 1 signature
+		ARG 2 newMetadata
+		ARG 3 newContent
+	METHOD method_44879 (Lnet/minecraft/class_7614;[BLnet/minecraft/class_7498$class_7499;)V
+		ARG 2 updatable
+	METHOD method_44880 getPacker ()Lnet/minecraft/class_7610$class_7612;
+	CLASS class_7611 Unpacker
+		COMMENT Unpacker creates a signed message on the server with the server's preceding message
+		COMMENT signature when they receive a message. Unpacked messages can then be verified to check
+		COMMENT the message chain's legitimacy.
+		COMMENT
+		COMMENT <p>Messages must be unpacked in the order of the message's reception, as it affects
+		COMMENT the resulting the signed message.
+		COMMENT
+		COMMENT @see MessageChain#getUnpacker
+		FIELD field_39819 UNSIGNED Lnet/minecraft/class_7610$class_7611;
+		METHOD method_44881 (Lnet/minecraft/class_7610$class_7613;Lnet/minecraft/class_7470;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7471;
+			ARG 0 signature
+			ARG 1 newMetadata
+			ARG 2 newContent
+		METHOD unpack (Lnet/minecraft/class_7610$class_7613;Lnet/minecraft/class_7470;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7471;
+			ARG 1 signature
+			ARG 2 newMetadata
+			ARG 3 newContent
+		METHOD unpack (Lnet/minecraft/class_7610$class_7613;Lnet/minecraft/class_7470;Lnet/minecraft/class_5837;)Lnet/minecraft/class_5837;
+			ARG 1 signature
+			ARG 2 newMetadata
+			ARG 3 newContent
+	CLASS class_7612 Packer
+		COMMENT Packers sign a message on the client with its preceding message's signature.
+		COMMENT
+		COMMENT @see MessageChain#getPacker
+		METHOD pack (Lnet/minecraft/class_7501;Lnet/minecraft/class_7470;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7610$class_7613;
+			ARG 1 signer
+			ARG 2 newMetadata
+			ARG 3 newContent
+	CLASS class_7613 Signature

--- a/mappings/net/minecraft/network/message/MessageChain.mapping
+++ b/mappings/net/minecraft/network/message/MessageChain.mapping
@@ -7,7 +7,7 @@ CLASS net/minecraft/class_7610 net/minecraft/network/message/MessageChain
 	COMMENT message.
 	COMMENT
 	COMMENT <p>Clients signing a message with its preceding message's signature is called
-	COMMENT "packing", and the server creating a signed message with its preceeding message's
+	COMMENT "packing", and the server creating a signed message with its preceding message's
 	COMMENT signature is called "unpacking". Unpacked messages can then be verified to check the
 	COMMENT chain's legitimacy.
 	FIELD field_39818 precedingSignature Lnet/minecraft/class_7469;

--- a/mappings/net/minecraft/network/message/MessageChain.mapping
+++ b/mappings/net/minecraft/network/message/MessageChain.mapping
@@ -39,7 +39,7 @@ CLASS net/minecraft/class_7610 net/minecraft/network/message/MessageChain
 		COMMENT the message chain's legitimacy.
 		COMMENT
 		COMMENT <p>Messages must be unpacked in the order of the message's reception, as it affects
-		COMMENT the resulting the signed message.
+		COMMENT the resulting signed message.
 		COMMENT
 		COMMENT @see MessageChain#getUnpacker
 		FIELD field_39819 UNSIGNED Lnet/minecraft/class_7610$class_7611;

--- a/mappings/net/minecraft/network/message/MessageChain.mapping
+++ b/mappings/net/minecraft/network/message/MessageChain.mapping
@@ -14,22 +14,22 @@ CLASS net/minecraft/class_7610 net/minecraft/network/message/MessageChain
 	METHOD method_44874 getUnpacker ()Lnet/minecraft/class_7610$class_7611;
 	METHOD method_44875 pack (Lnet/minecraft/class_7501;Lnet/minecraft/class_7470;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7610$class_7613;
 		ARG 1 signer
-		ARG 2 newMetadata
-		ARG 3 newContent
+		ARG 2 metadata
+		ARG 3 content
 	METHOD method_44876 sign (Lnet/minecraft/class_7501;Lnet/minecraft/class_7470;Lnet/minecraft/class_7469;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7469;
 		ARG 0 signer
-		ARG 1 newMetadata
+		ARG 1 metadata
 		ARG 2 precedingSignature
-		ARG 3 newContent
+		ARG 3 content
 	METHOD method_44877 createMessage (Lnet/minecraft/class_7610$class_7613;Lnet/minecraft/class_7469;Lnet/minecraft/class_7470;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7471;
 		ARG 0 signature
 		ARG 1 precedingSignature
-		ARG 2 newMetadata
-		ARG 3 newContent
+		ARG 2 metadata
+		ARG 3 content
 	METHOD method_44878 unpack (Lnet/minecraft/class_7610$class_7613;Lnet/minecraft/class_7470;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7471;
 		ARG 1 signature
-		ARG 2 newMetadata
-		ARG 3 newContent
+		ARG 2 metadata
+		ARG 3 content
 	METHOD method_44879 (Lnet/minecraft/class_7614;[BLnet/minecraft/class_7498$class_7499;)V
 		ARG 2 updatable
 	METHOD method_44880 getPacker ()Lnet/minecraft/class_7610$class_7612;
@@ -45,22 +45,22 @@ CLASS net/minecraft/class_7610 net/minecraft/network/message/MessageChain
 		FIELD field_39819 UNSIGNED Lnet/minecraft/class_7610$class_7611;
 		METHOD method_44881 (Lnet/minecraft/class_7610$class_7613;Lnet/minecraft/class_7470;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7471;
 			ARG 0 signature
-			ARG 1 newMetadata
-			ARG 2 newContent
+			ARG 1 metadata
+			ARG 2 content
 		METHOD unpack (Lnet/minecraft/class_7610$class_7613;Lnet/minecraft/class_7470;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7471;
 			ARG 1 signature
-			ARG 2 newMetadata
-			ARG 3 newContent
+			ARG 2 metadata
+			ARG 3 content
 		METHOD unpack (Lnet/minecraft/class_7610$class_7613;Lnet/minecraft/class_7470;Lnet/minecraft/class_5837;)Lnet/minecraft/class_5837;
 			ARG 1 signature
-			ARG 2 newMetadata
-			ARG 3 newContent
+			ARG 2 metadata
+			ARG 3 content
 	CLASS class_7612 Packer
 		COMMENT Packers sign a message on the client with its preceding message's signature.
 		COMMENT
 		COMMENT @see MessageChain#getPacker
 		METHOD pack (Lnet/minecraft/class_7501;Lnet/minecraft/class_7470;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7610$class_7613;
 			ARG 1 signer
-			ARG 2 newMetadata
-			ARG 3 newContent
+			ARG 2 metadata
+			ARG 3 content
 	CLASS class_7613 Signature

--- a/mappings/net/minecraft/network/message/MessageDecorator.mapping
+++ b/mappings/net/minecraft/network/message/MessageDecorator.mapping
@@ -19,6 +19,9 @@ CLASS net/minecraft/class_7492 net/minecraft/network/message/MessageDecorator
 	COMMENT a delay between the previewing and the submission.
 	FIELD field_39384 NOOP Lnet/minecraft/class_7492;
 		COMMENT An empty message decorator that returns the original message.
+	METHOD attachDecoration (Lnet/minecraft/class_5837;Lnet/minecraft/class_5837;)Lnet/minecraft/class_5837;
+		ARG 0 message
+		ARG 1 decoratedMessage
 	METHOD decorate (Lnet/minecraft/class_3222;Lnet/minecraft/class_2561;)Ljava/util/concurrent/CompletableFuture;
 		COMMENT {@return the decorated {@code message}}
 		ARG 1 sender
@@ -33,8 +36,17 @@ CLASS net/minecraft/class_7492 net/minecraft/network/message/MessageDecorator
 		COMMENT is partially filtered, both the raw and the filtered message will be decorated.
 		ARG 1 sender
 		ARG 2 message
+	METHOD decorateSignedChat (Lnet/minecraft/class_3222;Lnet/minecraft/class_5837;)Ljava/util/concurrent/CompletableFuture;
+		ARG 1 sender
+		ARG 2 message
 	METHOD method_44303 (Lnet/minecraft/class_3222;Lnet/minecraft/class_2561;)Ljava/util/concurrent/CompletableFuture;
 		ARG 0 sender
 		ARG 1 message
 	METHOD method_44305 (Ljava/util/concurrent/CompletableFuture;Ljava/util/concurrent/CompletableFuture;Ljava/lang/Void;)Lnet/minecraft/class_5837;
 		ARG 2 void_
+	METHOD method_44828 (Lnet/minecraft/class_5837;Lnet/minecraft/class_5837;)Lnet/minecraft/class_5837;
+		ARG 1 decoratedMessage
+	METHOD method_44829 (Lnet/minecraft/class_5837;Lnet/minecraft/class_7471;)Lnet/minecraft/class_7471;
+		ARG 1 filteredMessage
+	METHOD method_44830 (Lnet/minecraft/class_5837;Lnet/minecraft/class_7471;)Lnet/minecraft/class_7471;
+		ARG 1 rawMessage

--- a/mappings/net/minecraft/network/message/MessageHeader.mapping
+++ b/mappings/net/minecraft/network/message/MessageHeader.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/class_7614 net/minecraft/network/message/MessageHeader
+	COMMENT The header of a message, which contains the preceding message's signature and the
+	COMMENT sender's UUID. Unlike {@link MessageBody}, clients receive this even if the message
+	COMMENT is censored.
 	FIELD comp_936 precedingSignature Lnet/minecraft/class_7469;
 	METHOD <init> (Lnet/minecraft/class_2540;)V
 		ARG 1 buf

--- a/mappings/net/minecraft/network/message/MessageHeader.mapping
+++ b/mappings/net/minecraft/network/message/MessageHeader.mapping
@@ -1,0 +1,13 @@
+CLASS net/minecraft/class_7614 net/minecraft/network/message/MessageHeader
+	FIELD comp_936 precedingSignature Lnet/minecraft/class_7469;
+	METHOD <init> (Lnet/minecraft/class_2540;)V
+		ARG 1 buf
+	METHOD comp_936 precedingSignature ()Lnet/minecraft/class_7469;
+	METHOD method_44882 update (Lnet/minecraft/class_7498$class_7499;[B)V
+		ARG 1 updater
+		ARG 2 bodyDigest
+	METHOD method_44883 write (Lnet/minecraft/class_2540;)V
+		ARG 1 buf
+	METHOD method_44884 (Lnet/minecraft/class_2540;Lnet/minecraft/class_7469;)V
+		ARG 0 buf2
+		ARG 1 precedingSignature

--- a/mappings/net/minecraft/network/message/MessageMetadata.mapping
+++ b/mappings/net/minecraft/network/message/MessageMetadata.mapping
@@ -1,0 +1,17 @@
+CLASS net/minecraft/class_7470 net/minecraft/network/message/MessageMetadata
+	COMMENT A metadata for messages.
+	FIELD comp_801 sender Ljava/util/UUID;
+	FIELD comp_802 timestamp Ljava/time/Instant;
+	METHOD <init> (Lnet/minecraft/class_2540;)V
+		ARG 1 buf
+	METHOD comp_801 sender ()Ljava/util/UUID;
+	METHOD comp_802 timestamp ()Ljava/time/Instant;
+	METHOD method_43866 of (Ljava/util/UUID;)Lnet/minecraft/class_7470;
+		COMMENT {@return a new metadata with the given sender, current timestamp, and random salt}
+		ARG 0 sender
+	METHOD method_44849 of ()Lnet/minecraft/class_7470;
+		COMMENT {@return a new metadata without sender}
+	METHOD method_44850 write (Lnet/minecraft/class_2540;)V
+		ARG 1 buf
+	METHOD method_44851 lacksSender ()Z
+		COMMENT {@return {@code true} if the metadata does not have a sender's UUID}

--- a/mappings/net/minecraft/network/message/MessageSender.mapping
+++ b/mappings/net/minecraft/network/message/MessageSender.mapping
@@ -1,4 +1,0 @@
-CLASS net/minecraft/class_7436 net/minecraft/network/message/MessageSender
-	COMMENT The sender, or the source, of a message.
-	COMMENT
-	COMMENT <p>An instance can be obtained via {@link net.minecraft.entity.Entity#asMessageSender}.

--- a/mappings/net/minecraft/network/message/MessageSignature.mapping
+++ b/mappings/net/minecraft/network/message/MessageSignature.mapping
@@ -1,3 +1,0 @@
-CLASS net/minecraft/class_7469 net/minecraft/network/message/MessageSignature
-	COMMENT A signature for chat messages and message command arguments, consisting
-	COMMENT of the sender, the timestamp, and the signature data.

--- a/mappings/net/minecraft/network/message/MessageSignatureData.mapping
+++ b/mappings/net/minecraft/network/message/MessageSignatureData.mapping
@@ -20,7 +20,7 @@ CLASS net/minecraft/class_7469 net/minecraft/network/message/MessageSignatureDat
 			COMMENT the verifier that is created with the sender's public key
 		ARG 2 header
 		ARG 3 bodyDigest
-			COMMENT the {@linkplain MessageBody#getDigest digest of the message body}
+			COMMENT the {@linkplain MessageBody#digest digest of the message body}
 	METHOD method_44845 write (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD method_44846 (Lnet/minecraft/class_7614;[BLnet/minecraft/class_7498$class_7499;)V

--- a/mappings/net/minecraft/network/message/MessageSignatureData.mapping
+++ b/mappings/net/minecraft/network/message/MessageSignatureData.mapping
@@ -19,8 +19,8 @@ CLASS net/minecraft/class_7469 net/minecraft/network/message/MessageSignatureDat
 		ARG 1 verifier
 			COMMENT the verifier that is created with the sender's public key
 		ARG 2 header
-		ARG 3 bodyHash
-			COMMENT the {@linkplain MessageBody#getHash hash of the message body}
+		ARG 3 bodyDigest
+			COMMENT the {@linkplain MessageBody#getDigest digest of the message body}
 	METHOD method_44845 write (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD method_44846 (Lnet/minecraft/class_7614;[BLnet/minecraft/class_7498$class_7499;)V

--- a/mappings/net/minecraft/network/message/MessageSignatureData.mapping
+++ b/mappings/net/minecraft/network/message/MessageSignatureData.mapping
@@ -1,0 +1,31 @@
+CLASS net/minecraft/class_7469 net/minecraft/network/message/MessageSignatureData
+	COMMENT A message signature data that can be verified when given the header.
+	FIELD comp_925 data [B
+	FIELD field_39811 EMPTY Lnet/minecraft/class_7469;
+	METHOD <init> (Lnet/minecraft/class_2540;)V
+		ARG 1 buf
+	METHOD comp_925 data ()[B
+	METHOD equals (Ljava/lang/Object;)Z
+		ARG 1 o
+	METHOD method_44842 isEmpty ()Z
+	METHOD method_44843 verify (Lnet/minecraft/class_7500;Lnet/minecraft/class_7614;Lnet/minecraft/class_7608;)Z
+		COMMENT {@return whether the signature data is verified}
+		ARG 1 verifier
+			COMMENT the verifier that is created with the sender's public key
+		ARG 2 header
+		ARG 3 body
+	METHOD method_44844 verify (Lnet/minecraft/class_7500;Lnet/minecraft/class_7614;[B)Z
+		COMMENT {@return whether the signature data is verified}
+		ARG 1 verifier
+			COMMENT the verifier that is created with the sender's public key
+		ARG 2 header
+		ARG 3 bodyHash
+			COMMENT the {@linkplain MessageBody#getHash hash of the message body}
+	METHOD method_44845 write (Lnet/minecraft/class_2540;)V
+		ARG 1 buf
+	METHOD method_44846 (Lnet/minecraft/class_7614;[BLnet/minecraft/class_7498$class_7499;)V
+		ARG 2 updatable
+	METHOD method_44847 toStringOrNull ()Ljava/lang/String;
+		COMMENT {@return the base64-encoded data, or {@code null} if the data is empty}
+	METHOD method_44848 (Lnet/minecraft/class_7614;[BLnet/minecraft/class_7498$class_7499;)V
+		ARG 2 updatable

--- a/mappings/net/minecraft/network/message/MessageSourceProfile.mapping
+++ b/mappings/net/minecraft/network/message/MessageSourceProfile.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_7436 net/minecraft/network/message/MessageSourceProfile
 	COMMENT A pair of the profile ID and public key of the message's source.
 	COMMENT
-	COMMENT <p>An instance can be obtained via {@link net.minecraft.entity.Entity#asMessageSourceProfile}.
+	COMMENT <p>An instance can be obtained via {@link net.minecraft.entity.Entity#getMessageSourceProfile}.
 	FIELD comp_918 playerPublicKey Lnet/minecraft/class_7428;
 	FIELD field_39810 NONE Lnet/minecraft/class_7436;
 	METHOD comp_918 playerPublicKey ()Lnet/minecraft/class_7428;

--- a/mappings/net/minecraft/network/message/MessageSourceProfile.mapping
+++ b/mappings/net/minecraft/network/message/MessageSourceProfile.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_7436 net/minecraft/network/message/MessageSourceProfile
-	COMMENT A pair of profile ID and the public key of the message's source.
+	COMMENT A pair of the profile ID and public key of the message's source.
 	COMMENT
 	COMMENT <p>An instance can be obtained via {@link net.minecraft.entity.Entity#asMessageSourceProfile}.
 	FIELD comp_918 playerPublicKey Lnet/minecraft/class_7428;

--- a/mappings/net/minecraft/network/message/MessageSourceProfile.mapping
+++ b/mappings/net/minecraft/network/message/MessageSourceProfile.mapping
@@ -1,0 +1,11 @@
+CLASS net/minecraft/class_7436 net/minecraft/network/message/MessageSourceProfile
+	COMMENT A pair of profile ID and the public key of the message's source.
+	COMMENT
+	COMMENT <p>An instance can be obtained via {@link net.minecraft.entity.Entity#asMessageSourceProfile}.
+	FIELD comp_918 playerPublicKey Lnet/minecraft/class_7428;
+	FIELD field_39810 NONE Lnet/minecraft/class_7436;
+	METHOD comp_918 playerPublicKey ()Lnet/minecraft/class_7428;
+	METHOD method_44831 lacksProfileId ()Z
+		COMMENT {@return {@code true} if this source profile does not have the profile ID set}
+		COMMENT
+		COMMENT <p>Commands executed from server console or command block use such source profile.

--- a/mappings/net/minecraft/network/message/MessageType.mapping
+++ b/mappings/net/minecraft/network/message/MessageType.mapping
@@ -63,3 +63,47 @@ CLASS net/minecraft/class_2556 net/minecraft/network/message/MessageType
 		ARG 0 registry
 	METHOD method_43845 register (Ljava/lang/String;)Lnet/minecraft/class_5321;
 		ARG 0 id
+	METHOD method_44832 params (Lnet/minecraft/class_5321;Lnet/minecraft/class_1297;)Lnet/minecraft/class_2556$class_7602;
+		ARG 0 typeKey
+		ARG 1 entity
+	METHOD method_44833 params (Lnet/minecraft/class_5321;Lnet/minecraft/class_2168;)Lnet/minecraft/class_2556$class_7602;
+		ARG 0 typeKey
+		ARG 1 source
+	METHOD method_44834 params (Lnet/minecraft/class_5321;Lnet/minecraft/class_5455;Lnet/minecraft/class_2561;)Lnet/minecraft/class_2556$class_7602;
+		ARG 0 typeKey
+		ARG 1 registryManager
+		ARG 2 name
+	METHOD method_44835 params (Lnet/minecraft/class_2561;)Lnet/minecraft/class_2556$class_7602;
+		ARG 1 name
+	CLASS class_7602 Parameters
+		COMMENT A record holding the message type and the decoration parameters.
+		FIELD comp_919 type Lnet/minecraft/class_2556;
+		METHOD <init> (Lnet/minecraft/class_2556;Lnet/minecraft/class_2561;)V
+			ARG 1 type
+			ARG 2 name
+		METHOD comp_919 type ()Lnet/minecraft/class_2556;
+		METHOD method_44836 toSerialized (Lnet/minecraft/class_5455;)Lnet/minecraft/class_2556$class_7603;
+			COMMENT {@return a serialized version of this instance used in packets}
+			ARG 1 registryManager
+		METHOD method_44837 applyChatDecoration (Lnet/minecraft/class_2561;)Lnet/minecraft/class_2561;
+			ARG 1 content
+		METHOD method_44838 applyNarrationDecoration (Lnet/minecraft/class_2561;)Lnet/minecraft/class_2561;
+			ARG 1 content
+		METHOD method_44839 withTargetName (Lnet/minecraft/class_2561;)Lnet/minecraft/class_2556$class_7602;
+			COMMENT {@return a new instance with the given target name}
+			COMMENT
+			COMMENT <p>Target name is used as the team name in {@link
+			COMMENT net.minecraft.server.command.TeamMsgCommand} and as the recipient name in {@link
+			COMMENT net.minecraft.server.command.MessageCommand}.
+			ARG 1 targetName
+	CLASS class_7603 Serialized
+		COMMENT The serialized version of {@link MessageType.Parameterized} that is used in packets.
+		FIELD comp_922 typeId I
+		METHOD <init> (Lnet/minecraft/class_2540;)V
+			ARG 1 buf
+		METHOD comp_922 typeId ()I
+		METHOD method_44840 toParameters (Lnet/minecraft/class_5455;)Lnet/minecraft/class_2556$class_7602;
+			COMMENT {@return a deserialized version of this instance}
+			ARG 1 registryManager
+		METHOD method_44841 write (Lnet/minecraft/class_2540;)V
+			ARG 1 buf

--- a/mappings/net/minecraft/network/message/MessageType.mapping
+++ b/mappings/net/minecraft/network/message/MessageType.mapping
@@ -17,11 +17,9 @@ CLASS net/minecraft/class_2556 net/minecraft/network/message/MessageType
 	COMMENT {@linkplain Decoration#apply applied} to the message to produce the displayed or
 	COMMENT narrated text.
 	FIELD comp_792 Lnet/minecraft/class_7463;
-		COMMENT the display rule for the content displayed in the chat hud, or
-		COMMENT {@link Optional#empty()} if it should not be displayed in the chat hud
+		COMMENT the display rule for the content displayed in the chat hud
 	FIELD comp_794 Lnet/minecraft/class_7463;
-		COMMENT the narration rule for the content, or {@link Optional#empty()}
-		COMMENT if it should not be narrated
+		COMMENT the narration rule for the content
 	FIELD field_11737 Lnet/minecraft/class_5321;
 		COMMENT The registry key for the message type used by {@link
 		COMMENT net.minecraft.network.packet.c2s.play.ChatMessageC2SPacket chat messages}.
@@ -97,7 +95,7 @@ CLASS net/minecraft/class_2556 net/minecraft/network/message/MessageType
 			COMMENT net.minecraft.server.command.MessageCommand}.
 			ARG 1 targetName
 	CLASS class_7603 Serialized
-		COMMENT The serialized version of {@link MessageType.Parameterized} that is used in packets.
+		COMMENT The serialized version of {@link MessageType.Parameters} that is used in packets.
 		FIELD comp_922 typeId I
 		METHOD <init> (Lnet/minecraft/class_2540;)V
 			ARG 1 buf

--- a/mappings/net/minecraft/network/message/MessageVerifier.mapping
+++ b/mappings/net/minecraft/network/message/MessageVerifier.mapping
@@ -1,0 +1,28 @@
+CLASS net/minecraft/class_7615 net/minecraft/network/message/MessageVerifier
+	COMMENT Verifies incoming messages' signature and the message chain.
+	COMMENT
+	COMMENT <p>Methods in this interface must be called in the order of the message's reception,
+	COMMENT as it affects the verification result.
+	FIELD field_39820 NOOP Lnet/minecraft/class_7615;
+	METHOD method_44885 create (Lnet/minecraft/class_7428;)Lnet/minecraft/class_7615;
+		ARG 0 publicKey
+	METHOD method_44886 verify (Lnet/minecraft/class_7471;)Z
+		ARG 1 message
+	METHOD method_44887 storeHeaderVerification (Lnet/minecraft/class_7614;Lnet/minecraft/class_7469;[B)V
+		COMMENT Stores the status of verifying the header.
+		COMMENT
+		COMMENT <p>Clients can receive only the message header instead of the whole message. This
+		COMMENT allows the chain to reference such messages. Since no actual content is received,
+		COMMENT this does not return the verification status.
+		ARG 1 header
+		ARG 2 signature
+		ARG 3 bodyDigest
+	CLASS class_7616 Impl
+		FIELD field_39821 lastMessageVerified Z
+		FIELD field_39822 signatureVerifier Lnet/minecraft/class_7500;
+		FIELD field_39823 precedingSignature Lnet/minecraft/class_7469;
+		METHOD <init> (Lnet/minecraft/class_7500;)V
+			ARG 1 signatureVerifier
+		METHOD method_44888 verifyChain (Lnet/minecraft/class_7614;Lnet/minecraft/class_7469;)Z
+			ARG 1 header
+			ARG 2 signature

--- a/mappings/net/minecraft/network/message/SentMessage.mapping
+++ b/mappings/net/minecraft/network/message/SentMessage.mapping
@@ -1,28 +1,50 @@
 CLASS net/minecraft/class_7604 net/minecraft/network/message/SentMessage
-	METHOD method_44852 getOriginalMessage ()Lnet/minecraft/class_7471;
+	COMMENT A class wrapping {@link SignedMessage} on the server to allow custom behavior for
+	COMMENT sending messages.
+	METHOD method_44852 getWrappedMessage ()Lnet/minecraft/class_7471;
+		COMMENT {@return the wrapped message}
 	METHOD method_44853 toPacket (Lnet/minecraft/class_3222;Lnet/minecraft/class_2556$class_7602;)Lnet/minecraft/class_7438;
+		COMMENT {@return the chat message packet to be sent}
 		ARG 1 player
 		ARG 2 params
 	METHOD method_44854 of (Lnet/minecraft/class_5837;Lnet/minecraft/class_7436;)Lnet/minecraft/class_5837;
+		COMMENT {@return the wrapped {@code message}}
 		ARG 0 message
 		ARG 1 profile
 	METHOD method_44855 (Lnet/minecraft/class_5837;Lnet/minecraft/class_7436;Lnet/minecraft/class_7471;)Lnet/minecraft/class_7604;
 		ARG 2 rawMessage
 	METHOD method_44856 afterPacketsSent (Lnet/minecraft/class_3324;)V
+		COMMENT Called after sending the message to applicable clients.
+		COMMENT
+		COMMENT @apiNote This is used to send the message header to clients that didn't receive
+		COMMENT the message due to text filtering.
+		COMMENT
+		COMMENT @see PlayerManager#sendMessageHeader
 		ARG 1 playerManager
 	METHOD method_44857 of (Lnet/minecraft/class_7471;Lnet/minecraft/class_7436;)Lnet/minecraft/class_7604;
+		COMMENT {@return the wrapped {@code message}}
 		ARG 0 message
 		ARG 1 profile
+			COMMENT the original source of the message
 	CLASS class_7605 Entity
+		COMMENT The wrapper used for messages sent from entities via {@code /execute} command.
+		COMMENT
+		COMMENT <p>The client receives the message without the metadata first; the header is sent
+		COMMENT separately.
 		FIELD field_39812 originalMessage Lnet/minecraft/class_7471;
 		FIELD field_39813 messageWithoutMetadata Lnet/minecraft/class_7471;
 		METHOD <init> (Lnet/minecraft/class_7471;)V
 			ARG 1 originalMessage
 	CLASS class_7606 Profileless
+		COMMENT The wrapper used for messages without associated source profile.
 		FIELD field_39814 message Lnet/minecraft/class_7471;
 		METHOD <init> (Lnet/minecraft/class_7471;)V
 			ARG 1 message
 	CLASS class_7607 Chat
+		COMMENT The wrapper used for normal chat messages.
+		COMMENT
+		COMMENT <p>Text filtering can cause some players to not receive this kind of message.
+		COMMENT Message header is sent separately to those players.
 		FIELD field_39815 message Lnet/minecraft/class_7471;
 		FIELD field_39816 recipients Ljava/util/Set;
 		METHOD <init> (Lnet/minecraft/class_7471;)V

--- a/mappings/net/minecraft/network/message/SentMessage.mapping
+++ b/mappings/net/minecraft/network/message/SentMessage.mapping
@@ -1,0 +1,29 @@
+CLASS net/minecraft/class_7604 net/minecraft/network/message/SentMessage
+	METHOD method_44852 getOriginalMessage ()Lnet/minecraft/class_7471;
+	METHOD method_44853 toPacket (Lnet/minecraft/class_3222;Lnet/minecraft/class_2556$class_7602;)Lnet/minecraft/class_7438;
+		ARG 1 player
+		ARG 2 params
+	METHOD method_44854 of (Lnet/minecraft/class_5837;Lnet/minecraft/class_7436;)Lnet/minecraft/class_5837;
+		ARG 0 message
+		ARG 1 profile
+	METHOD method_44855 (Lnet/minecraft/class_5837;Lnet/minecraft/class_7436;Lnet/minecraft/class_7471;)Lnet/minecraft/class_7604;
+		ARG 2 rawMessage
+	METHOD method_44856 afterPacketsSent (Lnet/minecraft/class_3324;)V
+		ARG 1 playerManager
+	METHOD method_44857 of (Lnet/minecraft/class_7471;Lnet/minecraft/class_7436;)Lnet/minecraft/class_7604;
+		ARG 0 message
+		ARG 1 profile
+	CLASS class_7605 Entity
+		FIELD field_39812 originalMessage Lnet/minecraft/class_7471;
+		FIELD field_39813 messageWithoutMetadata Lnet/minecraft/class_7471;
+		METHOD <init> (Lnet/minecraft/class_7471;)V
+			ARG 1 originalMessage
+	CLASS class_7606 Profileless
+		FIELD field_39814 message Lnet/minecraft/class_7471;
+		METHOD <init> (Lnet/minecraft/class_7471;)V
+			ARG 1 message
+	CLASS class_7607 Chat
+		FIELD field_39815 message Lnet/minecraft/class_7471;
+		FIELD field_39816 recipients Ljava/util/Set;
+		METHOD <init> (Lnet/minecraft/class_7471;)V
+			ARG 1 message

--- a/mappings/net/minecraft/network/message/SignedCommandArguments.mapping
+++ b/mappings/net/minecraft/network/message/SignedCommandArguments.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_7448 net/minecraft/network/message/SignedCommandArguments
-	COMMENT A signer for command arguments.
+	COMMENT An interface wrapping {@link ArgumentSignatureDataMap} with metadata attached.
 	METHOD comp_911 metadata ()Lnet/minecraft/class_7470;
 	METHOD method_44250 isPreviewSigned (Ljava/lang/String;)Z
 		ARG 1 argumentName

--- a/mappings/net/minecraft/network/message/SignedCommandArguments.mapping
+++ b/mappings/net/minecraft/network/message/SignedCommandArguments.mapping
@@ -1,9 +1,12 @@
-CLASS net/minecraft/class_7448 net/minecraft/network/message/CommandArgumentSigner
+CLASS net/minecraft/class_7448 net/minecraft/network/message/SignedCommandArguments
 	COMMENT A signer for command arguments.
+	METHOD comp_911 metadata ()Lnet/minecraft/class_7470;
 	METHOD method_44250 isPreviewSigned (Ljava/lang/String;)Z
 		ARG 1 argumentName
+	METHOD method_44795 none ()Lnet/minecraft/class_7448;
 	METHOD method_44796 getArgumentSignature (Ljava/lang/String;)Lnet/minecraft/class_7469;
 		ARG 1 argumentName
-	CLASS class_7449 Signatures
+	CLASS class_7449 Impl
 		COMMENT A signature for command arguments, consisting of the sender, the timestamp,
 		COMMENT and the signature datas for the arguments.
+		FIELD comp_911 metadata Lnet/minecraft/class_7470;

--- a/mappings/net/minecraft/network/message/SignedMessage.mapping
+++ b/mappings/net/minecraft/network/message/SignedMessage.mapping
@@ -6,6 +6,8 @@ CLASS net/minecraft/class_7471 net/minecraft/network/message/SignedMessage
 	COMMENT <p>Note that the signature itself might not be valid.
 	FIELD field_39786 SERVERBOUND_TIME_TO_LIVE Ljava/time/Duration;
 	FIELD field_39787 CLIENTBOUND_TIME_TO_LIVE Ljava/time/Duration;
+	METHOD <init> (Lnet/minecraft/class_2540;)V
+		ARG 1 buf
 	METHOD method_43867 verify (Lnet/minecraft/class_7428;)Z
 		COMMENT {@return whether the message can be verified using the public key}
 		ARG 1 key
@@ -16,6 +18,7 @@ CLASS net/minecraft/class_7471 net/minecraft/network/message/SignedMessage
 	METHOD method_44310 verify (Lnet/minecraft/class_7436;)Z
 		COMMENT {@return whether the message can be verified using the public key <strong>or if the
 		COMMENT player does not have the key</strong>}
+		ARG 1 profile
 	METHOD method_44607 withoutUnsigned ()Lnet/minecraft/class_7471;
 		COMMENT {@return the signed chat message with {@link #unsignedContent} removed if it exists}
 		COMMENT
@@ -24,3 +27,19 @@ CLASS net/minecraft/class_7471 net/minecraft/network/message/SignedMessage
 		ARG 1 currentTime
 	METHOD method_44748 isExpiredOnClient (Ljava/time/Instant;)Z
 		ARG 1 currentTime
+	METHOD method_44858 verify (Lnet/minecraft/class_7500;)Z
+		ARG 1 verifier
+	METHOD method_44859 write (Lnet/minecraft/class_2540;)V
+		ARG 1 buf
+	METHOD method_44860 withFilteredContent (Lnet/minecraft/class_2561;)Lnet/minecraft/class_5837;
+		ARG 1 filteredContent
+	METHOD method_44861 ofUnsigned (Lnet/minecraft/class_7470;Lnet/minecraft/class_2561;)Lnet/minecraft/class_7471;
+		COMMENT {@return a new signed message without valid signatures}
+		ARG 0 metadata
+		ARG 1 content
+	METHOD method_44862 getSignedContent ()Lnet/minecraft/class_2561;
+	METHOD method_44863 withUnsignedContent (Lnet/minecraft/class_2561;)Lnet/minecraft/class_7471;
+		ARG 1 unsignedContent
+	METHOD method_44864 getTimestamp ()Ljava/time/Instant;
+	METHOD method_44865 getSalt ()J
+	METHOD method_44866 createMetadata ()Lnet/minecraft/class_7470;

--- a/mappings/net/minecraft/network/packet/c2s/play/ChatMessageC2SPacket.mapping
+++ b/mappings/net/minecraft/network/packet/c2s/play/ChatMessageC2SPacket.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/class_2797 net/minecraft/network/packet/c2s/play/ChatMessage
 	COMMENT 256 characters, it will reject the message and disconnect the client.
 	COMMENT
 	COMMENT <p>If the message contains an invalid character (see {@link
-	COMMENT net.minecraft.SharedConstants#isValidChar isValidChar}) or if the server
+	COMMENT net.minecraft.SharedConstants#isValidChar}) or if the server
 	COMMENT receives the messages in improper order. the server will
 	COMMENT reject the message and disconnect the client.
 	COMMENT
@@ -21,16 +21,15 @@ CLASS net/minecraft/class_2797 net/minecraft/network/packet/c2s/play/ChatMessage
 	COMMENT @see net.minecraft.server.network.ServerPlayNetworkHandler#onChatMessage
 	FIELD comp_945 chatMessage Ljava/lang/String;
 	FIELD comp_946 timestamp Ljava/time/Instant;
-	FIELD comp_948 createSignatureInstance Lnet/minecraft/class_7469;
-	FIELD comp_949 previewed Z
 	METHOD <init> (Ljava/lang/String;Ljava/time/Instant;JLnet/minecraft/class_7469;Z)V
 		ARG 1 chatMessage
+		ARG 2 timestamp
+		ARG 3 salt
+		ARG 5 signature
+		ARG 6 signedPreview
 	METHOD <init> (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD comp_945 chatMessage ()Ljava/lang/String;
 	METHOD comp_946 timestamp ()Ljava/time/Instant;
-	METHOD comp_948 createSignatureInstance ()Lnet/minecraft/class_7469;
-	METHOD comp_949 previewed ()Z
-		COMMENT {@return whether the chat message was previewed before sending}
-		COMMENT
-		COMMENT @apiNote Chat decorators can produce signed decorated content only if it was previewed.
+	METHOD method_44892 getMetadata (Lnet/minecraft/class_3222;)Lnet/minecraft/class_7470;
+		ARG 1 sender

--- a/mappings/net/minecraft/network/packet/c2s/play/ChatMessageC2SPacket.mapping
+++ b/mappings/net/minecraft/network/packet/c2s/play/ChatMessageC2SPacket.mapping
@@ -10,9 +10,11 @@ CLASS net/minecraft/class_2797 net/minecraft/network/packet/c2s/play/ChatMessage
 	COMMENT receives the messages in improper order. the server will
 	COMMENT reject the message and disconnect the client.
 	COMMENT
-	COMMENT <p>Messages that took more than {@link SignedMessage#SERVERBOUND_TIME_TO_LIVE}
+	COMMENT <p>Messages that took more than {@link
+	COMMENT net.minecraft.network.message.SignedMessage#SERVERBOUND_TIME_TO_LIVE}
 	COMMENT to reach the server are considered expired and log warnings on the server.
-	COMMENT If the message takes more than {@link SignedMessage#CLIENTBOUND_TIME_TO_LIVE}
+	COMMENT If the message takes more than {@link
+	COMMENT net.minecraft.network.message.SignedMessage#CLIENTBOUND_TIME_TO_LIVE}
 	COMMENT to reach the clients (including the time it took to reach the server), the
 	COMMENT message is not considered secure anymore by the clients, and may be discarded
 	COMMENT depending on the clients' options.

--- a/mappings/net/minecraft/network/packet/c2s/play/CommandExecutionC2SPacket.mapping
+++ b/mappings/net/minecraft/network/packet/c2s/play/CommandExecutionC2SPacket.mapping
@@ -23,7 +23,11 @@ CLASS net/minecraft/class_7472 net/minecraft/network/packet/c2s/play/CommandExec
 	METHOD <init> (Ljava/lang/String;Ljava/time/Instant;JLnet/minecraft/class_7450;Z)V
 		ARG 1 command
 		ARG 2 timestamp
+		ARG 3 salt
+		ARG 5 argumentSignatures
+		ARG 6 signedPreview
 	METHOD <init> (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD comp_809 timestamp ()Ljava/time/Instant;
-	METHOD method_43896 createArgumentsSigner (Lnet/minecraft/class_3222;)Lnet/minecraft/class_7448;
+	METHOD method_43896 createSignedArguments (Lnet/minecraft/class_3222;)Lnet/minecraft/class_7448;
+		ARG 1 player

--- a/mappings/net/minecraft/network/packet/c2s/play/CommandExecutionC2SPacket.mapping
+++ b/mappings/net/minecraft/network/packet/c2s/play/CommandExecutionC2SPacket.mapping
@@ -6,16 +6,18 @@ CLASS net/minecraft/class_7472 net/minecraft/network/packet/c2s/play/CommandExec
 	COMMENT it will reject the message and disconnect the client.
 	COMMENT
 	COMMENT <p>If the command contains an invalid character (see {@link
-	COMMENT net.minecraft.SharedConstants#isValidChar isValidChar}) or if the server receives
+	COMMENT net.minecraft.SharedConstants#isValidChar}) or if the server receives
 	COMMENT the commands in improper order, the server will reject the command and disconnect
 	COMMENT the client.
 	COMMENT
-	COMMENT <p>Commands that took more than {@link SignedMessage#SERVERBOUND_TIME_TO_LIVE}
+	COMMENT <p>Commands that took more than {@link
+	COMMENT net.minecraft.network.message.SignedMessage#SERVERBOUND_TIME_TO_LIVE}
 	COMMENT to reach the server are considered expired and log warnings on the server
 	COMMENT if it contains signed message arguments. If the message takes more than
-	COMMENT {@link SignedMessage#CLIENTBOUND_TIME_TO_LIVE} to reach the clients (including
-	COMMENT the time it took to reach the server), the message is not considered secure
-	COMMENT anymore by the clients, and may be discarded depending on the clients' options.
+	COMMENT {@link net.minecraft.network.message.SignedMessage#CLIENTBOUND_TIME_TO_LIVE} to
+	COMMENT reach the clients (including the time it took to reach the server), the message
+	COMMENT is not considered secure anymore by the clients, and may be discarded depending
+	COMMENT on the clients' options.
 	COMMENT
 	COMMENT @see net.minecraft.client.network.ClientPlayerEntity#sendCommand
 	COMMENT @see net.minecraft.server.network.ServerPlayNetworkHandler#onCommandExecution

--- a/mappings/net/minecraft/network/packet/s2c/play/ChatMessageS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/ChatMessageS2CPacket.mapping
@@ -6,12 +6,10 @@ CLASS net/minecraft/class_7438 net/minecraft/network/packet/s2c/play/ChatMessage
 	COMMENT custom wrapping behaviors, check {@link MessageType#register}.
 	COMMENT
 	COMMENT <p>Chat messages have signatures. It is possible to use a bogus signature - such as
-	COMMENT {@link net.minecraft.network.message.MessageSignature#none} - to send a chat
+	COMMENT {@link net.minecraft.network.message.SignedMessage#ofUnsigned} - to send a chat
 	COMMENT message; however if the signature is invalid (e.g. because the text's content differs
 	COMMENT from the one sent by the client, or because the passed signature is invalid) the client
-	COMMENT will show a warning and can discard it depending on the options. See {@link
-	COMMENT net.minecraft.network.message.MessageSignature#updateSignature} for how the
-	COMMENT message is signed.
+	COMMENT will show a warning and can discard it depending on the options.
 	COMMENT
 	COMMENT <p>If the message takes more than {@link SignedMessage#CLIENTBOUND_TIME_TO_LIVE}
 	COMMENT to reach the clients (including the time it originally took to reach the server),
@@ -20,6 +18,9 @@ CLASS net/minecraft/class_7438 net/minecraft/network/packet/s2c/play/ChatMessage
 	COMMENT
 	COMMENT @see net.minecraft.server.network.ServerPlayerEntity#sendChatMessage
 	COMMENT @see net.minecraft.client.network.ClientPlayNetworkHandler#onChatMessage
+	FIELD comp_943 serializedParameters Lnet/minecraft/class_2556$class_7603;
 	METHOD <init> (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
-
+	METHOD comp_943 serializedParameters ()Lnet/minecraft/class_2556$class_7603;
+	METHOD method_44891 getParameters (Lnet/minecraft/class_5455;)Lnet/minecraft/class_2556$class_7602;
+		ARG 1 dynamicRegistryManager

--- a/mappings/net/minecraft/network/packet/s2c/play/HideMessageS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/HideMessageS2CPacket.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_7617 net/minecraft/network/packet/s2c/play/HideMessageS2CPacket
+	METHOD <init> (Lnet/minecraft/class_2540;)V
+		ARG 1 buf

--- a/mappings/net/minecraft/network/packet/s2c/play/MessageHeaderS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/MessageHeaderS2CPacket.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_7618 net/minecraft/network/packet/s2c/play/MessageHeaderS2CPacket
+	METHOD <init> (Lnet/minecraft/class_2540;)V
+		ARG 1 buf

--- a/mappings/net/minecraft/server/PlayerManager.mapping
+++ b/mappings/net/minecraft/server/PlayerManager.mapping
@@ -249,7 +249,9 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 	METHOD method_44792 sendMessageHeader (Lnet/minecraft/class_7471;Ljava/util/Set;)V
 		COMMENT Sends {@code message}'s headers (only) to all players except {@code except}.
 		COMMENT
-		COMMENT <p>This is used to keep the integrity of the "message chain" when a message is censored.
+		COMMENT <p>This is used to keep the integrity of the "message chain" when a message is censored
+		COMMENT or when the message is originally sent without metadata due to it being originated from
+		COMMENT entities.
 		ARG 1 message
 		ARG 2 except
 	METHOD method_44793 verify (Lnet/minecraft/class_7471;Lnet/minecraft/class_7436;)Z

--- a/mappings/net/minecraft/server/PlayerManager.mapping
+++ b/mappings/net/minecraft/server/PlayerManager.mapping
@@ -145,10 +145,10 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		COMMENT message can be sent to a different player.
 		COMMENT
 		COMMENT @see #broadcast(Text, boolean)
-		COMMENT @see #broadcast(FilteredMessage, ServerCommandSource, RegistryKey)
-		COMMENT @see #broadcast(FilteredMessage, ServerPlayerEntity, RegistryKey)
-		COMMENT @see #broadcast(SignedMessage, MessageSender, RegistryKey)
-		COMMENT @see #broadcast(SignedMessage, Function, MessageSender, RegistryKey)
+		COMMENT @see #broadcast(FilteredMessage, ServerCommandSource, MessageType.Parameters)
+		COMMENT @see #broadcast(FilteredMessage, ServerPlayerEntity, MessageType.Parameters)
+		COMMENT @see #broadcast(SignedMessage, MessageSourceProfile, MessageType.Parameters)
+		COMMENT @see #broadcast(FilteredMessage, Predicate, MessageSourceProfile, MessageType.Parameters)
 		ARG 1 message
 		ARG 2 playerMessageFactory
 			COMMENT a function that takes the player to send the message to
@@ -162,10 +162,10 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		COMMENT message or a join/leave message.
 		COMMENT
 		COMMENT @see #broadcast(Text, Function, boolean)
-		COMMENT @see #broadcast(FilteredMessage, ServerCommandSource, RegistryKey)
-		COMMENT @see #broadcast(FilteredMessage, ServerPlayerEntity, RegistryKey)
-		COMMENT @see #broadcast(SignedMessage, MessageSender, RegistryKey)
-		COMMENT @see #broadcast(SignedMessage, Function, MessageSender, RegistryKey)
+		COMMENT @see #broadcast(FilteredMessage, ServerCommandSource, MessageType.Parameters)
+		COMMENT @see #broadcast(FilteredMessage, ServerPlayerEntity, MessageType.Parameters)
+		COMMENT @see #broadcast(SignedMessage, MessageSourceProfile, MessageType.Parameters)
+		COMMENT @see #broadcast(FilteredMessage, Predicate, MessageSourceProfile, MessageType.Parameters)
 		ARG 1 message
 		ARG 2 overlay
 	METHOD method_43670 (Lnet/minecraft/class_3222;Lnet/minecraft/server/MinecraftServer$class_7460;)V
@@ -174,12 +174,10 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		COMMENT Broadcasts a chat message to all players and the server console.
 		COMMENT
 		COMMENT <p>Chat messages have signatures. It is possible to use a bogus signature - such as
-		COMMENT {@link net.minecraft.network.message.MessageSignature#none} - to send a chat
+		COMMENT {@link net.minecraft.network.message.SignedMessage#ofUnsigned} - to send a chat
 		COMMENT message; however if the signature is invalid (e.g. because the text's content differs
 		COMMENT from the one sent by the client, or because the passed signature is invalid) the client
-		COMMENT will show a warning and can discard it depending on the client's options.  See {@link
-		COMMENT net.minecraft.network.message.MessageSignature#updateSignature} for how the
-		COMMENT message is signed.
+		COMMENT will show a warning and can discard it depending on the client's options.
 		COMMENT
 		COMMENT @apiNote This method is used to broadcast a message sent by a player
 		COMMENT through {@linkplain net.minecraft.client.gui.screen.ChatScreen the chat screen}
@@ -188,32 +186,32 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		COMMENT
 		COMMENT @see #broadcast(Text, boolean)
 		COMMENT @see #broadcast(Text, Function, boolean)
-		COMMENT @see #broadcast(FilteredMessage, ServerCommandSource, RegistryKey)
-		COMMENT @see #broadcast(SignedMessage, MessageSender, RegistryKey)
-		COMMENT @see #broadcast(SignedMessage, Function, MessageSender, RegistryKey)
+		COMMENT @see #broadcast(FilteredMessage, ServerCommandSource, MessageType.Parameters)
+		COMMENT @see #broadcast(SignedMessage, MessageSourceProfile, MessageType.Parameters)
+		COMMENT @see #broadcast(FilteredMessage, Predicate, MessageSourceProfile, MessageType.Parameters)
 		ARG 1 message
 		ARG 2 sender
+		ARG 3 params
 	METHOD method_43674 broadcast (Lnet/minecraft/class_7471;Lnet/minecraft/class_7436;Lnet/minecraft/class_2556$class_7602;)V
 		COMMENT Broadcasts a chat message to all players and the server console.
 		COMMENT
 		COMMENT <p>Chat messages have signatures. It is possible to use a bogus signature - such as
-		COMMENT {@link net.minecraft.network.message.MessageSignature#none} - to send a chat
+		COMMENT {@link net.minecraft.network.message.SignedMessage#ofUnsigned} - to send a chat
 		COMMENT message; however if the signature is invalid (e.g. because the text's content differs
 		COMMENT from the one sent by the client, or because the passed signature is invalid) the client
-		COMMENT will show a warning and can discard it depending on the client's options. See {@link
-		COMMENT net.minecraft.network.message.MessageSignature#updateSignature} for how the
-		COMMENT message is signed.
+		COMMENT will show a warning and can discard it depending on the client's options.
 		COMMENT
 		COMMENT @apiNote This method is used to broadcast messages from commands like {@link
 		COMMENT net.minecraft.server.command.MeCommand} or {@link net.minecraft.server.command.SayCommand}.
 		COMMENT
 		COMMENT @see #broadcast(Text, boolean)
 		COMMENT @see #broadcast(Text, Function, boolean)
-		COMMENT @see #broadcast(FilteredMessage, ServerCommandSource, RegistryKey)
-		COMMENT @see #broadcast(FilteredMessage, ServerPlayerEntity, RegistryKey)
-		COMMENT @see #broadcast(SignedMessage, Function, MessageSender, RegistryKey)
+		COMMENT @see #broadcast(FilteredMessage, ServerCommandSource, MessageType.Parameters)
+		COMMENT @see #broadcast(FilteredMessage, ServerPlayerEntity, MessageType.Parameters)
+		COMMENT @see #broadcast(FilteredMessage, Predicate, MessageSourceProfile, MessageType.Parameters)
 		ARG 1 message
-		ARG 2 sender
+		ARG 2 profile
+		ARG 3 params
 	METHOD method_44166 broadcast (Lnet/minecraft/class_5837;Lnet/minecraft/class_2168;Lnet/minecraft/class_2556$class_7602;)V
 		COMMENT Broadcasts a chat message to all players and the server console.
 		COMMENT
@@ -223,8 +221,43 @@ CLASS net/minecraft/class_3324 net/minecraft/server/PlayerManager
 		COMMENT
 		COMMENT @see #broadcast(Text, boolean)
 		COMMENT @see #broadcast(Text, Function, boolean)
-		COMMENT @see #broadcast(FilteredMessage, ServerPlayerEntity, RegistryKey)
-		COMMENT @see #broadcast(SignedMessage, MessageSender, RegistryKey)
-		COMMENT @see #broadcast(SignedMessage, Function, MessageSender, RegistryKey)
+		COMMENT @see #broadcast(FilteredMessage, ServerPlayerEntity, MessageType.Parameters)
+		COMMENT @see #broadcast(SignedMessage, MessageSourceProfile, MessageType.Parameters)
+		COMMENT @see #broadcast(FilteredMessage, Predicate, MessageSourceProfile, MessageType.Parameters)
 		ARG 1 message
 		ARG 2 source
+		ARG 3 params
+	METHOD method_44791 broadcast (Lnet/minecraft/class_5837;Ljava/util/function/Predicate;Lnet/minecraft/class_7436;Lnet/minecraft/class_2556$class_7602;)V
+		COMMENT Broadcasts a chat message to all players and the server console.
+		COMMENT
+		COMMENT <p>Chat messages have signatures. It is possible to use a bogus signature - such as
+		COMMENT {@link net.minecraft.network.message.SignedMessage#ofUnsigned} - to send a chat
+		COMMENT message; however if the signature is invalid (e.g. because the text's content differs
+		COMMENT from the one sent by the client, or because the passed signature is invalid) the client
+		COMMENT will show a warning and can discard it depending on the client's options.
+		COMMENT
+		COMMENT @see #broadcast(Text, boolean)
+		COMMENT @see #broadcast(Text, Function, boolean)
+		COMMENT @see #broadcast(FilteredMessage, ServerCommandSource, MessageType.Parameters)
+		COMMENT @see #broadcast(FilteredMessage, ServerPlayerEntity, MessageType.Parameters)
+		COMMENT @see #broadcast(SignedMessage, MessageSourceProfile, MessageType.Parameters)
+		ARG 1 message
+		ARG 2 shouldSendFiltered
+			COMMENT predicate that determines whether to send the filtered message for the given player
+		ARG 3 profile
+		ARG 4 params
+	METHOD method_44792 sendMessageHeader (Lnet/minecraft/class_7471;Ljava/util/Set;)V
+		COMMENT Sends {@code message}'s headers (only) to all players except {@code except}.
+		COMMENT
+		COMMENT <p>This is used to keep the integrity of the "message chain" when a message is censored.
+		ARG 1 message
+		ARG 2 except
+	METHOD method_44793 verify (Lnet/minecraft/class_7471;Lnet/minecraft/class_7436;)Z
+		COMMENT {@return whether {@code message} is not expired and is verified}
+		COMMENT
+		COMMENT @implNote This only affects the server log. Unverified messages are still broadcast
+		COMMENT to other clients.
+		ARG 1 message
+		ARG 2 profile
+	METHOD method_44794 (Lnet/minecraft/class_3222;)Z
+		ARG 0 player

--- a/mappings/net/minecraft/server/command/MessageCommand.mapping
+++ b/mappings/net/minecraft/server/command/MessageCommand.mapping
@@ -7,3 +7,5 @@ CLASS net/minecraft/class_3082 net/minecraft/server/command/MessageCommand
 		ARG 2 signedMessage
 	METHOD method_13463 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context
+	METHOD method_44144 (Lnet/minecraft/class_7436;Ljava/util/Collection;Lnet/minecraft/class_2168;Lnet/minecraft/class_2556$class_7602;Lnet/minecraft/class_5837;)V
+		ARG 4 decoratedMessage

--- a/mappings/net/minecraft/server/command/ServerCommandSource.mapping
+++ b/mappings/net/minecraft/server/command/ServerCommandSource.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_2168 net/minecraft/server/command/ServerCommandSource
 	COMMENT
 	COMMENT @see MinecraftServer#getCommandSource()
 	COMMENT @see Entity#getCommandSource()
-	FIELD field_39183 signer Lnet/minecraft/class_7448;
+	FIELD field_39183 signedArguments Lnet/minecraft/class_7448;
 	FIELD field_9815 level I
 	FIELD field_9816 entityAnchor Lnet/minecraft/class_2183$class_2184;
 	FIELD field_9817 position Lnet/minecraft/class_243;
@@ -41,21 +41,23 @@ CLASS net/minecraft/class_2168 net/minecraft/server/command/ServerCommandSource
 		ARG 10 silent
 		ARG 11 consumer
 		ARG 12 entityAnchor
-		ARG 13 signer
+		ARG 13 signedArguments
 	METHOD method_36321 withOutput (Lnet/minecraft/class_2165;)Lnet/minecraft/class_2168;
 		ARG 1 output
 	METHOD method_41212 (Lnet/minecraft/class_2172$class_7078;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;Lnet/minecraft/class_2378;)Ljava/util/concurrent/CompletableFuture;
 		ARG 3 registry
-	METHOD method_43735 withSigner (Lnet/minecraft/class_7448;)Lnet/minecraft/class_2168;
-		ARG 1 signer
-	METHOD method_43736 getChatMessageSender ()Lnet/minecraft/class_7436;
+	METHOD method_43735 withSignedArguments (Lnet/minecraft/class_7448;)Lnet/minecraft/class_2168;
+		ARG 1 signedArguments
+	METHOD method_43736 getMessageSourceProfile ()Lnet/minecraft/class_7436;
 	METHOD method_43737 isExecutedByPlayer ()Z
-	METHOD method_43738 getSigner ()Lnet/minecraft/class_7448;
+	METHOD method_43738 getSignedArguments ()Lnet/minecraft/class_7448;
 	METHOD method_44023 getPlayer ()Lnet/minecraft/class_3222;
 		COMMENT {@return the player from this command source, or {@code null} if the source is not a player}
 	METHOD method_44749 sendChatMessage (Lnet/minecraft/class_7604;Lnet/minecraft/class_2556$class_7602;)V
 		COMMENT Sends {@code message} as the feedback to the command's executor, or to the server's log
 		COMMENT if the command is not executed by a player.
+		ARG 1 message
+		ARG 2 params
 	METHOD method_9206 withLevel (I)Lnet/minecraft/class_2168;
 		ARG 1 level
 	METHOD method_9207 getPlayerOrThrow ()Lnet/minecraft/class_3222;

--- a/mappings/net/minecraft/server/command/TeamMsgCommand.mapping
+++ b/mappings/net/minecraft/server/command/TeamMsgCommand.mapping
@@ -8,3 +8,7 @@ CLASS net/minecraft/class_3945 net/minecraft/server/command/TeamMsgCommand
 		ARG 0 dispatcher
 	METHOD method_17601 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context
+	METHOD method_44147 (Lnet/minecraft/class_1297;Lnet/minecraft/class_268;Lnet/minecraft/class_3222;)Z
+		ARG 2 player
+	METHOD method_44148 (Lnet/minecraft/class_7436;Ljava/util/List;Lnet/minecraft/class_1297;Lnet/minecraft/class_2561;Lnet/minecraft/class_2168;Lnet/minecraft/class_2556$class_7602;Lnet/minecraft/class_5837;)V
+		ARG 6 decoratedMessage

--- a/mappings/net/minecraft/server/filter/FilteredMessage.mapping
+++ b/mappings/net/minecraft/server/filter/FilteredMessage.mapping
@@ -22,7 +22,15 @@ CLASS net/minecraft/class_5837 net/minecraft/server/filter/FilteredMessage
 		ARG 1 source
 		ARG 2 receiver
 	METHOD method_44151 map (Ljava/util/function/Function;)Lnet/minecraft/class_5837;
+		ARG 1 mapper
 	METHOD method_44152 isCensored ()Z
 		COMMENT {@return if all of the messages are filtered, e.g. by using {@link #censored}}
 	METHOD method_44153 filteredOrElse (Ljava/lang/Object;)Ljava/lang/Object;
 		ARG 1 filterable
+	METHOD method_44787 map (Ljava/util/function/Function;Ljava/util/function/Function;)Lnet/minecraft/class_5837;
+		ARG 1 rawMapper
+		ARG 2 filteredMapper
+	METHOD method_44788 get (Z)Ljava/lang/Object;
+		COMMENT {@return {@link #filtered} if {@code filtered} is {@code true}, otherwise
+		COMMENT {@link #raw}}
+		ARG 1 filtered

--- a/mappings/net/minecraft/server/network/ServerPlayNetworkHandler.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayNetworkHandler.mapping
@@ -36,7 +36,9 @@ CLASS net/minecraft/class_3244 net/minecraft/server/network/ServerPlayNetworkHan
 	FIELD field_37282 sequence I
 	FIELD field_39261 previewTaskRunner Lnet/minecraft/class_7493;
 	FIELD field_39394 lastMessageTimestamp Ljava/util/concurrent/atomic/AtomicReference;
+	FIELD field_39805 messageUnpacker Lnet/minecraft/class_7610$class_7611;
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/class_2535;Lnet/minecraft/class_3222;)V
+		ARG 1 server
 		ARG 2 connection
 		ARG 3 player
 	METHOD method_14360 requestTeleport (DDDFFLjava/util/Set;)V
@@ -183,6 +185,9 @@ CLASS net/minecraft/class_3244 net/minecraft/server/network/ServerPlayNetworkHan
 		COMMENT accepted in this case.
 		ARG 1 message
 		ARG 2 timestamp
+	METHOD method_44789 (Lnet/minecraft/class_7610$class_7613;Lnet/minecraft/class_7470;Lnet/minecraft/class_5837;)Lnet/minecraft/class_5837;
+		ARG 3 decoratedMessage
+	METHOD method_44790 getMessageUnpacker ()Lnet/minecraft/class_7610$class_7611;
 	CLASS 1
 		METHOD method_33897 processInteract (Lnet/minecraft/class_1268;Lnet/minecraft/class_3244$class_5860;)V
 			ARG 1 hand

--- a/mappings/net/minecraft/server/network/ServerPlayNetworkHandler.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayNetworkHandler.mapping
@@ -180,9 +180,7 @@ CLASS net/minecraft/class_3244 net/minecraft/server/network/ServerPlayNetworkHan
 		COMMENT {@return whether {@code message}, sent at {@code timestamp}, should be accepted}
 		COMMENT
 		COMMENT @implNote This returns {@code false} if the message arrives in {@linkplain
-		COMMENT #isInProperOrder improper order} or if chat is disabled. This also logs a warning
-		COMMENT when the message is {@linkplain #isExpired expired}, but the message is still
-		COMMENT accepted in this case.
+		COMMENT #isInProperOrder improper order} or if chat is disabled.
 		ARG 1 message
 		ARG 2 timestamp
 	METHOD method_44789 (Lnet/minecraft/class_7610$class_7613;Lnet/minecraft/class_7470;Lnet/minecraft/class_5837;)Lnet/minecraft/class_5837;

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -221,15 +221,15 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 		COMMENT Sends a chat message to the player.
 		COMMENT
 		COMMENT <p>Chat messages have signatures. It is possible to use a bogus signature - such as
-		COMMENT {@link net.minecraft.network.message.MessageSignature#none} - to send a chat
+		COMMENT {@link net.minecraft.network.message.SignedMessage#ofUnsigned} - to send a chat
 		COMMENT message; however if the signature is invalid (e.g. because the text's content differs
 		COMMENT from the one sent by the client, or because the passed signature is invalid) the client
-		COMMENT will show a warning and can discard it depending on the client's options. See {@link
-		COMMENT net.minecraft.network.message.MessageSignature#updateSignature} for how the
-		COMMENT message is signed.
+		COMMENT will show a warning and can discard it depending on the client's options.
 		COMMENT
 		COMMENT @see #sendMessage(Text)
 		COMMENT @see #sendMessage(Text, boolean)
+		ARG 1 message
+		ARG 2 params
 	METHOD method_43506 sendMessageDeliverError (Lnet/minecraft/class_2561;)V
 		ARG 1 message
 	METHOD method_43507 (Lnet/minecraft/class_2561;Lio/netty/util/concurrent/Future;)V
@@ -239,6 +239,13 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	METHOD method_44706 acceptsChatMessage ()Z
 	METHOD method_44707 acceptsMessage (Z)Z
 		ARG 1 overlay
+	METHOD method_44786 sendMessageHeader (Lnet/minecraft/class_7614;Lnet/minecraft/class_7469;[B)V
+		COMMENT Sends a message's header and other data required for verification to this player.
+		COMMENT
+		COMMENT <p>This is used to keep the integrity of the "message chain" when a message is censored.
+		ARG 1 header
+		ARG 2 headerSignature
+		ARG 3 bodyDigest
 	METHOD method_7336 changeGameMode (Lnet/minecraft/class_1934;)Z
 		ARG 1 gameMode
 	CLASS 1

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -242,7 +242,9 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	METHOD method_44786 sendMessageHeader (Lnet/minecraft/class_7614;Lnet/minecraft/class_7469;[B)V
 		COMMENT Sends a message's header and other data required for verification to this player.
 		COMMENT
-		COMMENT <p>This is used to keep the integrity of the "message chain" when a message is censored.
+		COMMENT <p>This is used to keep the integrity of the "message chain" when a message is censored
+		COMMENT or when the message is originally sent without metadata due to it being originated from
+		COMMENT entities.
 		ARG 1 header
 		ARG 2 headerSignature
 		ARG 3 bodyDigest

--- a/mappings/net/minecraft/text/Decoration.mapping
+++ b/mappings/net/minecraft/text/Decoration.mapping
@@ -15,12 +15,14 @@ CLASS net/minecraft/class_7463 net/minecraft/text/Decoration
 		COMMENT {@return the text obtained by applying the passed values to the decoration}
 		ARG 1 content
 			COMMENT the value of the content parameter
+		ARG 2 params
 	METHOD method_43834 collectArguments (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556$class_7602;)[Lnet/minecraft/class_2561;
 		COMMENT {@return the arguments passed to {@link Text#translatable(String, Object[])}}
 		COMMENT
 		COMMENT <p>This is collected by supplying {@code content} and {@code sender} to the
 		COMMENT parameters' {@link Decoration.Parameter#apply} method.
 		ARG 1 content
+		ARG 2 params
 	METHOD method_43835 ofTeamMessage (Ljava/lang/String;)Lnet/minecraft/class_7463;
 		COMMENT {@return the decoration used in chat messages}
 		COMMENT
@@ -52,13 +54,18 @@ CLASS net/minecraft/class_7463 net/minecraft/text/Decoration
 		METHOD method_43837 apply (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556$class_7602;)Lnet/minecraft/class_2561;
 			COMMENT {@return the text obtained by applying the passed values to the parameter}
 			ARG 1 content
+			ARG 2 params
 		METHOD method_43838 (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556$class_7602;)Lnet/minecraft/class_2561;
 			ARG 0 content
+			ARG 1 params
 		METHOD method_43839 (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556$class_7602;)Lnet/minecraft/class_2561;
 			ARG 0 content
+			ARG 1 params
 		METHOD method_43840 (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556$class_7602;)Lnet/minecraft/class_2561;
 			ARG 0 content
+			ARG 1 params
 		CLASS class_7465 Selector
-			COMMENT A functional interface that selects the text from the passed values.
+			COMMENT A functional interface that selects the text from the passed parameters.
 			METHOD select (Lnet/minecraft/class_2561;Lnet/minecraft/class_2556$class_7602;)Lnet/minecraft/class_2561;
 				ARG 1 content
+				ARG 2 params

--- a/mappings/net/minecraft/util/dynamic/DynamicSerializableUuid.mapping
+++ b/mappings/net/minecraft/util/dynamic/DynamicSerializableUuid.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_4844 net/minecraft/util/dynamic/DynamicSerializableUuid
 	FIELD field_25122 CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_38907 OFFLINE_PLAYER_UUID_PREFIX Ljava/lang/String;
+	FIELD field_39211 BYTE_ARRAY_SIZE I
 	METHOD method_26274 toIntArray (JJ)[I
 		ARG 0 uuidMost
 		ARG 2 uuidLeast
@@ -18,3 +19,5 @@ CLASS net/minecraft/class_4844 net/minecraft/util/dynamic/DynamicSerializableUui
 		ARG 0 profile
 	METHOD method_43344 getOfflinePlayerUuid (Ljava/lang/String;)Ljava/util/UUID;
 		ARG 0 nickname
+	METHOD method_44827 toByteArray (Ljava/util/UUID;)[B
+		ARG 0 uuid


### PR DESCRIPTION
This is probably the biggest refactor to these area since 22w17a. Many classes and methods were renamed due to impl change. Javadoc might have some errors, please comment if you spot one.