### PR TITLE
Rename `ServerPlayerEntity#sendInitialChunkPackets` to `sendChunkPacket`

### DIFF
--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -56,7 +56,7 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	METHOD method_14203 copyFrom (Lnet/minecraft/class_3222;Z)V
 		ARG 1 oldPlayer
 		ARG 2 alive
-	METHOD method_14205 sendInitialChunkPackets (Lnet/minecraft/class_1923;Lnet/minecraft/class_2596;)V
+	METHOD method_14205 sendChunkPacket (Lnet/minecraft/class_1923;Lnet/minecraft/class_2596;)V
 		ARG 1 chunkPos
 		ARG 2 chunkDataPacket
 	METHOD method_14206 getPlayerListName ()Lnet/minecraft/class_2561;


### PR DESCRIPTION
Resolves #3236

The name was correct in 1.17.1, but 1.18 changes made it inapplicable.