### PR TITLE
Rename `EmptyEntry#Serializer` to `builder`

### DIFF
--- a/mappings/net/minecraft/loot/entry/EmptyEntry.mapping
+++ b/mappings/net/minecraft/loot/entry/EmptyEntry.mapping
@@ -1,3 +1,3 @@
 CLASS net/minecraft/class_73 net/minecraft/loot/entry/EmptyEntry
-	METHOD method_401 Serializer ()Lnet/minecraft/class_85$class_86;
+	METHOD method_401 builder ()Lnet/minecraft/class_85$class_86;
 	CLASS class_74 Serializer


### PR DESCRIPTION
Resolves #3229