### PR TITLE
Misleading ChatHud#render

### DIFF
--- a/mappings/net/minecraft/client/gui/hud/ChatHud.mapping
+++ b/mappings/net/minecraft/client/gui/hud/ChatHud.mapping
@@ -20,7 +20,7 @@ CLASS net/minecraft/class_338 net/minecraft/client/gui/hud/ChatHud
 		ARG 1 message
 	METHOD method_1805 render (Lnet/minecraft/class_4587;I)V
 		ARG 1 matrices
-		ARG 2 tickDelta
+		ARG 2 tickValue
 	METHOD method_1806 getWidth (D)I
 		ARG 0 widthOption
 	METHOD method_1808 clear (Z)V


### PR DESCRIPTION
TickDelta is incorrectly labeled, it is the *total amount of ticks in the render cycle that have passed.*

Grain of salt on that explanation, it's hard to explain the values because it's sporadic and does not have a clear pattern from a brief glance.