### PR TITLE
Switch 'GroupEntry' and 'SequenceEntry'

### DIFF
--- a/mappings/net/minecraft/loot/entry/GroupEntry.mapping
+++ b/mappings/net/minecraft/loot/entry/GroupEntry.mapping
@@ -1,10 +1,12 @@
-CLASS net/minecraft/class_72 net/minecraft/loot/entry/GroupEntry
-	METHOD method_35515 create ([Lnet/minecraft/class_79$class_80;)Lnet/minecraft/class_72$class_6153;
+CLASS net/minecraft/class_93 net/minecraft/loot/entry/GroupEntry
+	METHOD method_29315 (Lnet/minecraft/class_64;Lnet/minecraft/class_64;Lnet/minecraft/class_47;Ljava/util/function/Consumer;)Z
+		ARG 2 context
+	METHOD method_35511 create ([Lnet/minecraft/class_79$class_80;)Lnet/minecraft/class_93$class_6152;
 		ARG 0 entries
-	METHOD method_400 ([Lnet/minecraft/class_64;Lnet/minecraft/class_47;Ljava/util/function/Consumer;)Z
+	METHOD method_452 ([Lnet/minecraft/class_64;Lnet/minecraft/class_47;Ljava/util/function/Consumer;)Z
 		ARG 1 context
 		ARG 2 lootChoiceExpander
-	CLASS class_6153 Builder
-		FIELD field_31849 entries Ljava/util/List;
+	CLASS class_6152 Builder
+		FIELD field_31846 entries Ljava/util/List;
 		METHOD <init> ([Lnet/minecraft/class_79$class_80;)V
 			ARG 1 entries

--- a/mappings/net/minecraft/loot/entry/SequenceEntry.mapping
+++ b/mappings/net/minecraft/loot/entry/SequenceEntry.mapping
@@ -1,12 +1,10 @@
-CLASS net/minecraft/class_93 net/minecraft/loot/entry/SequenceEntry
-	METHOD method_29315 (Lnet/minecraft/class_64;Lnet/minecraft/class_64;Lnet/minecraft/class_47;Ljava/util/function/Consumer;)Z
-		ARG 2 context
-	METHOD method_35511 create ([Lnet/minecraft/class_79$class_80;)Lnet/minecraft/class_93$class_6152;
+CLASS net/minecraft/class_72 net/minecraft/loot/entry/SequenceEntry
+	METHOD method_35515 create ([Lnet/minecraft/class_79$class_80;)Lnet/minecraft/class_72$class_6153;
 		ARG 0 entries
-	METHOD method_452 ([Lnet/minecraft/class_64;Lnet/minecraft/class_47;Ljava/util/function/Consumer;)Z
+	METHOD method_400 ([Lnet/minecraft/class_64;Lnet/minecraft/class_47;Ljava/util/function/Consumer;)Z
 		ARG 1 context
 		ARG 2 lootChoiceExpander
-	CLASS class_6152 Builder
-		FIELD field_31846 entries Ljava/util/List;
+	CLASS class_6153 Builder
+		FIELD field_31849 entries Ljava/util/List;
 		METHOD <init> ([Lnet/minecraft/class_79$class_80;)V
 			ARG 1 entries


### PR DESCRIPTION
The names for `GroupEntry` and `SequenceEntry` were swapped. This PR fixes it.