### PR TITLE
Fix typo, javadoc, etc

### DIFF
--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -402,7 +402,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		ARG 3 pos
 		ARG 4 type
 	METHOD method_9517 prepare (Lnet/minecraft/class_2680;Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;II)V
-		COMMENT Called when the block state changes, before the {#linkplain #getStateForNeighborUpdate
+		COMMENT Called when the block state changes, before the {@linkplain #getStateForNeighborUpdate
 		COMMENT neighbor-triggered state update} on the original block, and after the
 		COMMENT neighbor-triggered state update on the replaced block.
 		COMMENT

--- a/mappings/net/minecraft/block/entity/BlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntity.mapping
@@ -176,7 +176,7 @@ CLASS net/minecraft/class_2586 net/minecraft/block/entity/BlockEntity
 		COMMENT
 		COMMENT <p>The passed NBT should use lowercase {@code x}, {@code y}, and {@code z}
 		COMMENT keys to store the position. This is incompatible with {@link
-		COMMENT net.minecraft.nbt.NbtHelper#romBlockPos} that use uppercase keys.
+		COMMENT net.minecraft.nbt.NbtHelper#fromBlockPos} that use uppercase keys.
 		ARG 0 nbt
 	METHOD method_38240 setStackNbt (Lnet/minecraft/class_1799;)V
 		COMMENT Sets {@code stack}'s {@code net.minecraft.item.BlockItem#BLOCK_ENTITY_TAG_KEY}

--- a/mappings/net/minecraft/block/entity/BlockEntityType.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntityType.mapping
@@ -4,8 +4,8 @@ CLASS net/minecraft/class_2591 net/minecraft/block/entity/BlockEntityType
 	COMMENT represents the type of the placed block entities, like chests or furnaces.
 	COMMENT
 	COMMENT <p>Block entity types are pre-defined and registered in {@link
-	COMMENT Registry#BLOCK_ENTITY_TYPE}. To create a block entity type, the {@linkplain
-	COMMENT BlockEntityType.Builder#create builder} should be used.
+	COMMENT net.minecraft.util.registry.Registry#BLOCK_ENTITY_TYPE}. To create a block
+	COMMENT entity type, the {@linkplain BlockEntityType.Builder#create builder} should be used.
 	COMMENT
 	COMMENT <p>Blocks that have corresponding block entities must implement {@link
 	COMMENT net.minecraft.block.BlockEntityProvider} and list it in the builder of the block

--- a/mappings/net/minecraft/client/render/entity/model/ShieldEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/ShieldEntityModel.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_600 net/minecraft/client/render/entity/model/ShieldEntityModel
-	COMMENT Represents the model of an held shield.
+	COMMENT Represents the model of a held shield.
 	COMMENT
 	COMMENT <div class="fabric">
 	COMMENT <table border=1>

--- a/mappings/net/minecraft/command/CommandRegistryWrapper.mapping
+++ b/mappings/net/minecraft/command/CommandRegistryWrapper.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/class_7225 net/minecraft/command/CommandRegistryWrapper
 	COMMENT to make it easier to handle user-passed arguments. For example, {@link #getEntryList(TagKey)}
 	COMMENT may return an empty {@link RegistryEntryList} instead of {@link Optional#empty()}.
 	COMMENT
-	COMMENT <p>A wrapper without any special behaviors can be created by calling {#link of(Registry)}.
+	COMMENT <p>A wrapper without any special behaviors can be created by calling {@link of(Registry)}.
 	METHOD method_41700 getEntryList (Lnet/minecraft/class_6862;)Ljava/util/Optional;
 		COMMENT {@return the entry list for the provided tag}
 		COMMENT

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	COMMENT <p>Examples of entities include players, mobs, minecarts, projectiles, and
 	COMMENT dropped items.
 	COMMENT
-	COMMENT <p>Entity can be identified by the {@link #id ID} or the {#link #uuid UUID}.
+	COMMENT <p>Entity can be identified by the {@link #id ID} or the {@link #uuid UUID}.
 	COMMENT Entity ID is an integer used in networking, and is not saved on disk. UUID is
 	COMMENT used to identify an entity in NBT and other places where persistence is required.
 	COMMENT
@@ -42,19 +42,19 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	COMMENT \t<td>Subclass constructors</td><td>Non-mob entities (such as projectiles)</td><td>NBT and other data must be set manually.</td>
 	COMMENT </tr>
 	COMMENT <tr>
-	COMMENT \t<td>{#link EntityType#create}</td><td>Any entity</td><td>Initializes mobs and supports custom NBT.</td>
+	COMMENT \t<td>{@link EntityType#create}</td><td>Any entity</td><td>Initializes mobs and supports custom NBT.</td>
 	COMMENT </tr>
 	COMMENT <tr>
-	COMMENT \t<td>{#link EntityType#getEntityFromNbt}</td><td>Entities stored in NBT</td><td>Can throw exceptions.</td>
+	COMMENT \t<td>{@link EntityType#getEntityFromNbt}</td><td>Entities stored in NBT</td><td>Can throw exceptions.</td>
 	COMMENT </tr>
 	COMMENT <tr>
-	COMMENT \t<td>{#link EntityType#loadEntityFromNbt}</td><td>Entities stored in user-provided NBT</td><td>Ignores exceptions.</td>
+	COMMENT \t<td>{@link EntityType#loadEntityFromNbt}</td><td>Entities stored in user-provided NBT</td><td>Ignores exceptions.</td>
 	COMMENT </tr>
 	COMMENT <tr>
-	COMMENT \t<td>{#link EntityType#loadEntityWithPassengers}</td><td>Entities with passengers stored in user-provided NBT</td><td>Ignores exceptions. Initializes rides.</td>
+	COMMENT \t<td>{@link EntityType#loadEntityWithPassengers}</td><td>Entities with passengers stored in user-provided NBT</td><td>Ignores exceptions. Initializes rides.</td>
 	COMMENT </tr>
 	COMMENT <tr>
-	COMMENT \t<td>{#link EntityType#streamFromNbt}</td><td>Entities with passengers stored in NBT</td><td>Ignores exceptions.</td>
+	COMMENT \t<td>{@link EntityType#streamFromNbt}</td><td>Entities with passengers stored in NBT</td><td>Ignores exceptions.</td>
 	COMMENT </tr>
 	COMMENT </table>
 	COMMENT
@@ -64,24 +64,24 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	COMMENT \t<th>Method</th><th>Recommended usage</th><th>Additional note</th>
 	COMMENT </tr>
 	COMMENT <tr>
-	COMMENT \t<td>{#link net.minecraft.world.ServerWorldAccess#spawnEntityAndPassengers}</td><td>Any entity</td><td>Does not check duplicate UUID.</td>
+	COMMENT \t<td>{@link net.minecraft.world.ServerWorldAccess#spawnEntityAndPassengers}</td><td>Any entity</td><td>Does not check duplicate UUID.</td>
 	COMMENT </tr>
 	COMMENT <tr>
-	COMMENT \t<td>{#link ServerWorld#spawnNewEntityAndPassengers}</td><td>Any entity</td><td>Checks duplicate UUID.</td>
+	COMMENT \t<td>{@link ServerWorld#spawnNewEntityAndPassengers}</td><td>Any entity</td><td>Checks duplicate UUID.</td>
 	COMMENT </tr>
 	COMMENT <tr>
-	COMMENT \t<td>{#link net.minecraft.world.ModifiableWorld#spawnEntity}</td><td>Any entity</td><td>Does not spawn passengers.</td>
+	COMMENT \t<td>{@link net.minecraft.world.ModifiableWorld#spawnEntity}</td><td>Any entity</td><td>Does not spawn passengers.</td>
 	COMMENT </tr>
 	COMMENT </table>
 	COMMENT </div>
 	COMMENT
 	COMMENT <p><strong>Warning</strong>: When using constructors to spawn mobs instead of
-	COMMENT {#link EntityType#create}, they must be manually
+	COMMENT {@link EntityType#create}, they must be manually
 	COMMENT {@link net.minecraft.entity.mob.MobEntity#initialize initialized} before spawning.
 	COMMENT
 	COMMENT <h2 id="discarding">Discarding</h2>
-	COMMENT Entities can be discarded (despawned) by calling {#link #discard}. This does not drop loot.
-	COMMENT To kill entities and drop loot, call {#link #kill} or {#link damage} (with large enough damage amount).
+	COMMENT Entities can be discarded (despawned) by calling {@link #discard}. This does not drop loot.
+	COMMENT To kill entities and drop loot, call {@link #kill} or {@link damage} (with large enough damage amount).
 	FIELD field_17046 movementMultiplier Lnet/minecraft/class_243;
 	FIELD field_18064 POSE Lnet/minecraft/class_2940;
 	FIELD field_18065 dimensions Lnet/minecraft/class_4048;
@@ -502,7 +502,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT Resets the entity's portal cooldown to the default.
 		COMMENT
 		COMMENT @see #getDefaultPortalCooldown
-	METHOD method_30230 hasPortalCooldownn ()Z
+	METHOD method_30230 hasPortalCooldown ()Z
 		COMMENT {@return whether the entity's portal cooldown is in effect}
 	METHOD method_30329 getTeleportTarget (Lnet/minecraft/class_3218;)Lnet/minecraft/class_5454;
 		COMMENT {@return a {@link TeleportTarget} for the entity based on its current and
@@ -1006,7 +1006,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT @see #getPassengerList
 		COMMENT @see #getFirstPassenger
 	METHOD method_5643 damage (Lnet/minecraft/class_1282;F)Z
-		COMMENT Applies a damage to this entity. The exact implementation differes between subclasses.
+		COMMENT Applies a damage to this entity. The exact implementation differs between subclasses.
 		COMMENT
 		COMMENT <p>{@link LivingEntity} has health value, and damaging the entity decreases it. This
 		COMMENT also handles shields, extra damage to helmets for falling blocks, setting the attacker,
@@ -1170,7 +1170,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT {@return whether the entity is pushed by fluids}
 		COMMENT
 		COMMENT @apiNote Aquatic mobs should override this to return {@code false}.
-		COMMENT Players are not pushed by fluids if they can fly (e.g. because of gamemode).
+		COMMENT Players are not pushed by fluids if they can fly (e.g. because of game mode).
 	METHOD method_5676 getBurningDuration ()I
 	METHOD method_5678 getHeightOffset ()D
 	METHOD method_5679 isInvulnerableTo (Lnet/minecraft/class_1282;)Z
@@ -1485,7 +1485,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT <p>Scoreboard tags are set using the {@linkplain net.minecraft.server.command.TagCommand
 		COMMENT /tag command}, and is different from entity type tags defined in data packs.
 		COMMENT
-		COMMENT @return whether the scorebord tag was successfully removed
+		COMMENT @return whether the scoreboard tag was successfully removed
 		ARG 1 tag
 	METHOD method_5739 distanceTo (Lnet/minecraft/class_1297;)F
 		COMMENT {@return the distance between this entity and {@code entity}}
@@ -1505,7 +1505,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT should override this to remove the player from the boss bar.
 		ARG 1 player
 	METHOD method_5743 getItemsEquipped ()Ljava/lang/Iterable;
-		COMMENT {@return an iterable of item stacks held in the hands or equpipped as armor}
+		COMMENT {@return an iterable of item stacks held in the hands or equipped as armor}
 		COMMENT
 		COMMENT @see #getHandItems
 		COMMENT @see #getArmorItems
@@ -1700,7 +1700,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT <p>Scoreboard tags are set using the {@linkplain net.minecraft.server.command.TagCommand
 		COMMENT /tag command}, and is different from entity type tags defined in data packs.
 		COMMENT
-		COMMENT @return whether the scorebord tag was successfully added
+		COMMENT @return whether the scoreboard tag was successfully added
 		ARG 1 tag
 	METHOD method_5781 getScoreboardTeam ()Lnet/minecraft/class_270;
 		COMMENT {@return the scoreboard team the entity belongs to, or {@code null} if there is none}
@@ -2113,7 +2113,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT
 		COMMENT @see #isOnFire
 	METHOD method_5863 canHit ()Z
-		COMMENT {@return whether the entity can be hit with a projectile or be targetted by
+		COMMENT {@return whether the entity can be hit with a projectile or be targeted by
 		COMMENT the player crosshair}
 	METHOD method_5864 getType ()Lnet/minecraft/class_1299;
 	METHOD method_5865 updatePassengerPosition (Lnet/minecraft/class_1297;)V
@@ -2133,7 +2133,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		ARG 2 yOffset
 	METHOD method_5871 getTargetingMargin ()F
 		COMMENT {@return the margin around the entity's bounding box where the entity
-		COMMENT targetting is still successful}
+		COMMENT targeting is still successful}
 		COMMENT
 		COMMENT @apiNote {@link net.minecraft.entity.projectile.ExplosiveProjectileEntity}
 		COMMENT overrides this method to return {@code 1.0f}, which expands the ghast fireball's
@@ -2208,7 +2208,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_7325 isSpectator ()Z
 		COMMENT {@return whether the entity is a spectator}
 		COMMENT
-		COMMENT <p>This returns {@code false} unless the entity is a player in spectator gamemode.
+		COMMENT <p>This returns {@code false} unless the entity is a player in spectator game mode.
 	CLASS class_4738 PositionUpdater
 		METHOD accept (Lnet/minecraft/class_1297;DDD)V
 			ARG 1 entity

--- a/mappings/net/minecraft/inventory/StackReference.mapping
+++ b/mappings/net/minecraft/inventory/StackReference.mapping
@@ -22,12 +22,12 @@ CLASS net/minecraft/class_5630 net/minecraft/inventory/StackReference
 		ARG 2 stackFilter
 			COMMENT the condition to guard stack setting
 	METHOD method_32330 of (Lnet/minecraft/class_1309;Lnet/minecraft/class_1304;)Lnet/minecraft/class_5630;
-		COMMENT Creates a stack reference backed by an equipment slot of an living entity with
+		COMMENT Creates a stack reference backed by an equipment slot of a living entity with
 		COMMENT no filter, allowing direct manipulation of the equipment slot.
 		ARG 0 entity
 		ARG 1 slot
 	METHOD method_32331 of (Lnet/minecraft/class_1309;Lnet/minecraft/class_1304;Ljava/util/function/Predicate;)Lnet/minecraft/class_5630;
-		COMMENT Creates a stack reference backed by an equipment slot of an living entity and
+		COMMENT Creates a stack reference backed by an equipment slot of a living entity and
 		COMMENT guarded by a condition for setting stacks into the inventory.
 		ARG 0 entity
 		ARG 1 slot

--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -442,8 +442,8 @@ CLASS net/minecraft/class_1799 net/minecraft/item/ItemStack
 		COMMENT <p>If the stack's damage is equal to or above {@linkplain Item#getMaxDamage the maximum
 		COMMENT damage} (i.e. the item is "broken"), this will call {@code breakCallback}, decrement the
 		COMMENT stack, and increment {@link net.minecraft.stat.Stats#BROKEN} if the stack is held
- 		COMMENT by a player. The callback should call {@link LivingEntity#sendEquipmentBreakStatus}
- 		COMMENT or {@link LivingEntity#sendToolBreakStatus}.
+		COMMENT by a player. The callback should call {@link LivingEntity#sendEquipmentBreakStatus}
+		COMMENT or {@link LivingEntity#sendToolBreakStatus}.
 		ARG 1 amount
 		ARG 2 entity
 			COMMENT the entity that holds the stack to be damaged

--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -432,18 +432,18 @@ CLASS net/minecraft/class_1799 net/minecraft/item/ItemStack
 	METHOD method_7956 damage (ILnet/minecraft/class_1309;Ljava/util/function/Consumer;)V
 		COMMENT Damages this item stack. This method should be used when an entity, including a player,
 		COMMENT damages the stack. This does not damage {@linkplain #isDamageable non-damageable}
-		COMMENT stacks, and the {@linkplain UnbreakingEnchantment unbreaking enchantment} is applied to
-		COMMENT {@code amount} before damaging. Additionally, if {@code entity} is a player in creative
-		COMMENT mode, the stack will not be damaged.
+		COMMENT stacks, and the {@linkplain net.minecraft.enchantment.UnbreakingEnchantment
+		COMMENT unbreaking enchantment} is applied to {@code amount} before damaging. Additionally,
+		COMMENT if {@code entity} is a player in creative mode, the stack will not be damaged.
 		COMMENT
 		COMMENT <p>If {@code entity} is a player, this triggers {@link
-		COMMENT Criteria#ITEM_DURABILITY_CHANGED}.
+		COMMENT net.minecraft.advancement.criterion.Criteria#ITEM_DURABILITY_CHANGED}.
 		COMMENT
 		COMMENT <p>If the stack's damage is equal to or above {@linkplain Item#getMaxDamage the maximum
 		COMMENT damage} (i.e. the item is "broken"), this will call {@code breakCallback}, decrement the
-		COMMENT stack, and increment {@link Stats#BROKEN} if the stack is held by a player. The callback
-		COMMENT should call {@link LivingEntity#sendEquipmentBreakStatus} or {@link
-		COMMENT LivingEntity#sendToolBreakStatus}.
+		COMMENT stack, and increment {@link net.minecraft.stat.Stats#BROKEN} if the stack is held
+ 		COMMENT by a player. The callback should call {@link LivingEntity#sendEquipmentBreakStatus}
+ 		COMMENT or {@link LivingEntity#sendToolBreakStatus}.
 		ARG 1 amount
 		ARG 2 entity
 			COMMENT the entity that holds the stack to be damaged
@@ -495,11 +495,11 @@ CLASS net/minecraft/class_1799 net/minecraft/item/ItemStack
 	METHOD method_7970 damage (ILnet/minecraft/class_5819;Lnet/minecraft/class_3222;)Z
 		COMMENT Damages this item stack. This method should be used when a non-entity, such as a
 		COMMENT dispenser, damages the stack. This does not damage {@linkplain #isDamageable non-damageable}
-		COMMENT stacks, and the {@linkplain UnbreakingEnchantment unbreaking enchantment} is applied to
-		COMMENT {@code amount} before damaging.
+		COMMENT stacks, and the {@linkplain net.minecraft.enchantment.UnbreakingEnchantment
+		COMMENT unbreaking enchantment} is applied to {@code amount} before damaging.
 		COMMENT
 		COMMENT <p>If {@code player} is not {@code null}, this triggers {@link
-		COMMENT Criteria#ITEM_DURABILITY_CHANGED}.
+		COMMENT net.minecraft.advancement.criterion.Criteria#ITEM_DURABILITY_CHANGED}.
 		COMMENT
 		COMMENT <p>This method does not decrement the item count when the item "breaks". Callers should
 		COMMENT check the returned value and decrement themselves.

--- a/mappings/net/minecraft/item/ItemUsage.mapping
+++ b/mappings/net/minecraft/item/ItemUsage.mapping
@@ -12,7 +12,7 @@ CLASS net/minecraft/class_5328 net/minecraft/item/ItemUsage
 		COMMENT {@return the stack to put in the player's hand after exchanging stacks}
 		COMMENT
 		COMMENT <p>Exchanging stacks causes the input stack to be decremented and the output stack to
-		COMMENT be inserted to the player's invetory (or dropped if it cannot be inserted.)
+		COMMENT be inserted to the player's inventory (or dropped if it cannot be inserted.)
 		COMMENT For example, milking a cow exchanges one empty bucket and one milk bucket.
 		COMMENT If the player is in creative mode, the player only receives the new stack when
 		COMMENT they do not have the output stack.
@@ -25,7 +25,7 @@ CLASS net/minecraft/class_5328 net/minecraft/item/ItemUsage
 		COMMENT {@return the stack to put in the player's hand after exchanging stacks}
 		COMMENT
 		COMMENT <p>Exchanging stacks causes the input stack to be decremented and the output stack to
-		COMMENT be inserted to the player's invetory (or dropped if it cannot be inserted.)
+		COMMENT be inserted to the player's inventory (or dropped if it cannot be inserted.)
 		COMMENT For example, milking a cow exchanges one empty bucket and one milk bucket.
 		COMMENT If {@code creativeOverride} is {@code true} and the player is in creative mode,
 		COMMENT the player only receives the new stack when they do not have the output stack.

--- a/mappings/net/minecraft/server/MinecraftServer.mapping
+++ b/mappings/net/minecraft/server/MinecraftServer.mapping
@@ -143,7 +143,7 @@ CLASS net/minecraft/server/MinecraftServer
 	METHOD method_29437 (Lnet/minecraft/class_5455$class_6890;Lcom/google/common/collect/ImmutableList;)Ljava/util/concurrent/CompletionStage;
 		ARG 2 resourcePacks
 	METHOD method_29439 reloadResources (Ljava/util/Collection;)Ljava/util/concurrent/CompletableFuture;
-		COMMENT Reloads this server's datapacks.
+		COMMENT Reloads this server's data packs.
 		COMMENT
 		COMMENT @return a completable future which specifies whether the reload was successful
 		COMMENT A reload has failed when the future is exceptionally completed.

--- a/mappings/net/minecraft/util/collection/LinkedBlockPosHashSet.mapping
+++ b/mappings/net/minecraft/util/collection/LinkedBlockPosHashSet.mapping
@@ -58,7 +58,7 @@ CLASS net/minecraft/class_6136 net/minecraft/util/collection/LinkedBlockPosHashS
 			ARG 2 mask
 				COMMENT mask of bits to set
 		METHOD method_35483 getKey (J)J
-			COMMENT Converts a individual position into a key
+			COMMENT Converts an individual position into a key
 			COMMENT representing the 2x cube region containing that position.
 			ARG 0 posLong
 		METHOD method_35484 getBlockPosLong (JI)J

--- a/mappings/net/minecraft/util/math/random/RandomSeed.mapping
+++ b/mappings/net/minecraft/util/math/random/RandomSeed.mapping
@@ -1,16 +1,12 @@
 CLASS net/minecraft/class_6673 net/minecraft/util/math/random/RandomSeed
 	FIELD field_35133 GOLDEN_RATIO_64 J
-		COMMENT @see jdk.internal.util.random.RandomSupport#GOLDEN_RATIO_64
 	FIELD field_35134 SILVER_RATIO_64 J
-		COMMENT @see jdk.internal.util.random.RandomSupport#SILVER_RATIO_64
 	FIELD field_35135 SEED_UNIQUIFIER Ljava/util/concurrent/atomic/AtomicLong;
 	METHOD method_39001 getSeed ()J
 		COMMENT {@return the seed calculated using {@link SEED_UNIQUIFIER} and the system time}
 	METHOD method_39002 mixStafford13 (J)J
-		COMMENT @see jdk.internal.util.random.RandomSupport#mixStafford13(long)
 		ARG 0 seed
 	METHOD method_39003 createXoroshiroSeed (J)Lnet/minecraft/class_6673$class_6674;
-		COMMENT @see jdk.random.Xoroshiro128PlusPlus#Xoroshiro128PlusPlus(long)
 		ARG 0 seed
 	METHOD method_39004 (J)J
 		ARG 0 seedUniquifier

--- a/mappings/net/minecraft/world/WorldAccess.mapping
+++ b/mappings/net/minecraft/world/WorldAccess.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_1936 net/minecraft/world/WorldAccess
 		ARG 2 pos
 		ARG 3 data
 	METHOD method_32888 emitGameEvent (Lnet/minecraft/class_5712;Lnet/minecraft/class_243;Lnet/minecraft/class_5712$class_7397;)V
-		COMMENT Emits an game event.
+		COMMENT Emits a game event.
 		ARG 1 event
 		ARG 2 emitterPos
 		ARG 3 emitter

--- a/mappings/net/minecraft/world/biome/source/util/MultiNoiseUtil.mapping
+++ b/mappings/net/minecraft/world/biome/source/util/MultiNoiseUtil.mapping
@@ -137,7 +137,7 @@ CLASS net/minecraft/class_6544 net/minecraft/world/biome/source/util/MultiNoiseU
 			COMMENT {@return the closest entry at the given point}.
 			COMMENT
 			COMMENT Note that this method only exists for testing, and is usually a lot slower
-			COMMENT than {@link getValue()}.
+			COMMENT than {@link #getValue()}.
 			ARG 1 point
 	CLASS class_6548 SearchTree
 		FIELD field_34486 MAX_NODES_FOR_SIMPLE_TREE I

--- a/mappings/net/minecraft/world/biome/source/util/MultiNoiseUtil.mapping
+++ b/mappings/net/minecraft/world/biome/source/util/MultiNoiseUtil.mapping
@@ -137,7 +137,7 @@ CLASS net/minecraft/class_6544 net/minecraft/world/biome/source/util/MultiNoiseU
 			COMMENT {@return the closest entry at the given point}.
 			COMMENT
 			COMMENT Note that this method only exists for testing, and is usually a lot slower
-			COMMENT than {@link #getValue()}.
+			COMMENT than {@link #getValue}.
 			ARG 1 point
 	CLASS class_6548 SearchTree
 		FIELD field_34486 MAX_NODES_FOR_SIMPLE_TREE I

--- a/mappings/net/minecraft/world/biome/source/util/VanillaBiomeParameters.mapping
+++ b/mappings/net/minecraft/world/biome/source/util/VanillaBiomeParameters.mapping
@@ -46,7 +46,7 @@ CLASS net/minecraft/class_6554 net/minecraft/world/biome/source/util/VanillaBiom
 	METHOD method_38183 getWindsweptOrRegularBiome (IILnet/minecraft/class_6544$class_6546;)Lnet/minecraft/class_5321;
 		COMMENT {@return a windswept or regular biome, depending on temperature and humidity}.
 		COMMENT
-		COMMENT @see #getRegularBiome()
+		COMMENT @see #getRegularBiome
 		ARG 1 temperature
 		ARG 2 humidity
 		ARG 3 weirdness
@@ -79,7 +79,7 @@ CLASS net/minecraft/class_6554 net/minecraft/world/biome/source/util/VanillaBiom
 	METHOD method_38189 getBadlandsOrRegularBiome (IILnet/minecraft/class_6544$class_6546;)Lnet/minecraft/class_5321;
 		COMMENT {@return badlands if {@code temperature} is {@code 4}, otherwise a regular biome}.
 		COMMENT
-		COMMENT @see #getRegularBiome()
+		COMMENT @see #getRegularBiome
 		ARG 1 temperature
 		ARG 2 humidity
 		ARG 3 weirdness
@@ -109,8 +109,8 @@ CLASS net/minecraft/class_6554 net/minecraft/world/biome/source/util/VanillaBiom
 	METHOD method_38194 getMountainStartBiome (IILnet/minecraft/class_6544$class_6546;)Lnet/minecraft/class_5321;
 		COMMENT {@return a slope biome if {@code temperature} is {@code 0}, otherwise a regular biome}.
 		COMMENT
-		COMMENT @see #getMountainSlopeBiome()
-		COMMENT @see getBadlandsOrRegularBiome()
+		COMMENT @see #getMountainSlopeBiome
+		COMMENT @see getBadlandsOrRegularBiome
 		ARG 1 temperature
 		ARG 2 humidity
 		ARG 3 weirdness
@@ -133,9 +133,9 @@ CLASS net/minecraft/class_6554 net/minecraft/world/biome/source/util/VanillaBiom
 		COMMENT If {@code weirdness} is positive, this will be a regular biome.
 		COMMENT For some specific conditions, this can also be a windswept savanna.
 		COMMENT
-		COMMENT @see #getShoreBiome()
-		COMMENT @see #getRegularBiome()
-		COMMENT @see #getBiomeOrWindsweptSavanna()
+		COMMENT @see #getShoreBiome
+		COMMENT @see #getRegularBiome
+		COMMENT @see #getBiomeOrWindsweptSavanna
 		ARG 1 temperature
 		ARG 2 humidity
 		ARG 3 weirdness
@@ -185,9 +185,9 @@ CLASS net/minecraft/class_6554 net/minecraft/world/biome/source/util/VanillaBiom
 		ARG 2 humidity
 		ARG 3 weirdness
 	METHOD method_38205 getMountainSlopeBiome (IILnet/minecraft/class_6544$class_6546;)Lnet/minecraft/class_5321;
-		COMMENT {@return a mountain slope biome for the given temperature, humidity and weirdness.
+		COMMENT {@return a mountain slope biome for the given temperature, humidity and weirdness}
 		COMMENT
-		COMMENT @see #getNearMountainBiome()
+		COMMENT @see #getNearMountainBiome
 		ARG 1 temperature
 		ARG 2 humidity
 		ARG 3 weirdness


### PR DESCRIPTION
Resolves #3238

One mapping-affecting change: `Entity#hasPortalCooldownn` is now `hasPortalCooldown`.