### PR TITLE
Rename the BlockLootTableGenerator.addDoorDrop method to doorDrops

### DIFF
--- a/mappings/net/minecraft/data/server/BlockLootTableGenerator.mapping
+++ b/mappings/net/minecraft/data/server/BlockLootTableGenerator.mapping
@@ -212,7 +212,7 @@ CLASS net/minecraft/class_2430 net/minecraft/data/server/BlockLootTableGenerator
 		ARG 0 block
 	METHOD method_23231 (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
 		ARG 0 block
-	METHOD method_24817 addDoorDrop (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
+	METHOD method_24817 doorDrops (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
 		ARG 0 block
 	METHOD method_26000 addVinePlantDrop (Lnet/minecraft/class_2248;Lnet/minecraft/class_2248;)V
 		ARG 1 block


### PR DESCRIPTION
Fixes #3275