### PR TITLE
ArmorFeatureRenderer renames and fixes

### DIFF
--- a/mappings/net/minecraft/client/render/entity/feature/ArmorFeatureRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/ArmorFeatureRenderer.mapping
@@ -1,19 +1,19 @@
 CLASS net/minecraft/class_970 net/minecraft/client/render/entity/feature/ArmorFeatureRenderer
 	FIELD field_4829 ARMOR_TEXTURE_CACHE Ljava/util/Map;
-	FIELD field_4830 leggingsModel Lnet/minecraft/class_572;
-	FIELD field_4831 bodyModel Lnet/minecraft/class_572;
+	FIELD field_4830 innerModel Lnet/minecraft/class_572;
+	FIELD field_4831 outerModel Lnet/minecraft/class_572;
 	METHOD <init> (Lnet/minecraft/class_3883;Lnet/minecraft/class_572;Lnet/minecraft/class_572;)V
 		ARG 1 context
-		ARG 2 leggingsModel
-		ARG 3 bodyModel
+		ARG 2 innerModel
+		ARG 3 outerModel
 	METHOD method_23192 renderArmorParts (Lnet/minecraft/class_4587;Lnet/minecraft/class_4597;ILnet/minecraft/class_1738;ZLnet/minecraft/class_572;ZFFFLjava/lang/String;)V
 		ARG 1 matrices
 		ARG 2 vertexConsumers
 		ARG 3 light
 		ARG 4 item
-		ARG 5 usesSecondLayer
+		ARG 5 glint
 		ARG 6 model
-		ARG 7 legs
+		ARG 7 secondTextureLayer
 		ARG 8 red
 		ARG 9 green
 		ARG 10 blue
@@ -28,11 +28,11 @@ CLASS net/minecraft/class_970 net/minecraft/client/render/entity/feature/ArmorFe
 	METHOD method_4170 setVisible (Lnet/minecraft/class_572;Lnet/minecraft/class_1304;)V
 		ARG 1 bipedModel
 		ARG 2 slot
-	METHOD method_4172 getArmor (Lnet/minecraft/class_1304;)Lnet/minecraft/class_572;
+	METHOD method_4172 getModel (Lnet/minecraft/class_1304;)Lnet/minecraft/class_572;
 		ARG 1 slot
-	METHOD method_4173 usesSecondLayer (Lnet/minecraft/class_1304;)Z
+	METHOD method_4173 usesInnerModel (Lnet/minecraft/class_1304;)Z
 		ARG 1 slot
 	METHOD method_4174 getArmorTexture (Lnet/minecraft/class_1738;ZLjava/lang/String;)Lnet/minecraft/class_2960;
 		ARG 1 item
-		ARG 2 legs
+		ARG 2 secondLayer
 		ARG 3 overlay


### PR DESCRIPTION
- Fixed incorrect parameter names
- Renamed `leggingsModel`, `bodyModel` to `innerModel`, `outerModel`. For example, the player renderer just passes in the inner and outer layer of its model.
- Renamed `usesSecondLayer` -> `usesInnerModel` as that seems more relevant to the code. That is also what determines in the first place that the inner model is used for leggings.