### PR TITLE
Rename MathHelper.(clamped)lerpFromProgress -> (clamped)map, add docs

### DIFF
--- a/mappings/net/minecraft/util/math/MathHelper.mapping
+++ b/mappings/net/minecraft/util/math/MathHelper.mapping
@@ -312,22 +312,44 @@ CLASS net/minecraft/class_3532 net/minecraft/util/math/MathHelper
 			COMMENT the minimum value, inclusive
 		ARG 2 max
 			COMMENT the maximum value, inclusive
-	METHOD method_32854 clampedLerpFromProgress (DDDDD)D
-		ARG 0 lerpValue
-		ARG 2 lerpStart
-		ARG 4 lerpEnd
-		ARG 6 start
-		ARG 8 end
+	METHOD method_32854 clampedMap (DDDDD)D
+		COMMENT Linearly maps a value from one number range to another
+		COMMENT and clamps the result.
+		COMMENT
+		COMMENT @return the mapped value, clamped between {@code newStart} and {@code newEnd}
+		COMMENT @see #map(double, double, double, double, double) the unclamped variant
+		ARG 0 value
+			COMMENT the input value
+		ARG 2 oldStart
+			COMMENT the starting value of the original range
+		ARG 4 oldEnd
+			COMMENT the end value of the original range
+		ARG 6 newStart
+			COMMENT the starting value of the new range
+		ARG 8 newEnd
+			COMMENT the end value of the new range
 	METHOD method_32855 nextGaussian (Lnet/minecraft/class_5819;FF)F
 		ARG 0 random
 		ARG 1 mean
 		ARG 2 deviation
-	METHOD method_33722 lerpFromProgress (DDDDD)D
-		ARG 0 lerpValue
-		ARG 2 lerpStart
-		ARG 4 lerpEnd
-		ARG 6 start
-		ARG 8 end
+	METHOD method_33722 map (DDDDD)D
+		COMMENT Linearly maps a value from one number range to another, unclamped.
+		COMMENT
+		COMMENT <p>For the return value {@code result}, {@code getLerpProgress(value, oldStart, oldEnd)}
+		COMMENT is approximately equal to {@code getLerpProgress(result, newStart, newEnd)}
+		COMMENT (accounting for floating point errors).
+		COMMENT
+		COMMENT @return the mapped value
+		ARG 0 value
+			COMMENT the input value
+		ARG 2 oldStart
+			COMMENT the starting value of the original range
+		ARG 4 oldEnd
+			COMMENT the end value of the original range
+		ARG 6 newStart
+			COMMENT the starting value of the new range
+		ARG 8 newEnd
+			COMMENT the end value of the new range
 	METHOD method_33723 square (D)D
 		ARG 0 n
 	METHOD method_33825 magnitude (DDD)D
@@ -381,18 +403,40 @@ CLASS net/minecraft/class_3532 net/minecraft/util/math/MathHelper
 		ARG 0 start
 		ARG 1 end
 		ARG 2 delta
-	METHOD method_37958 clampedLerpFromProgress (FFFFF)F
-		ARG 0 lerpValue
-		ARG 1 lerpStart
-		ARG 2 lerpEnd
-		ARG 3 start
-		ARG 4 end
-	METHOD method_37959 lerpFromProgress (FFFFF)F
-		ARG 0 lerpValue
-		ARG 1 lerpStart
-		ARG 2 lerpEnd
-		ARG 3 start
-		ARG 4 end
+	METHOD method_37958 clampedMap (FFFFF)F
+		COMMENT Linearly maps a value from one number range to another
+		COMMENT and clamps the result.
+		COMMENT
+		COMMENT @return the mapped value, clamped between {@code newStart} and {@code newEnd}
+		COMMENT @see #map(float, float, float, float, float) the unclamped variant
+		ARG 0 value
+			COMMENT the input value
+		ARG 1 oldStart
+			COMMENT the starting value of the original range
+		ARG 2 oldEnd
+			COMMENT the end value of the original range
+		ARG 3 newStart
+			COMMENT the starting value of the new range
+		ARG 4 newEnd
+			COMMENT the end value of the new range
+	METHOD method_37959 map (FFFFF)F
+		COMMENT Linearly maps a value from one number range to another, unclamped.
+		COMMENT
+		COMMENT <p>For the return value {@code result}, {@code getLerpProgress(value, oldStart, oldEnd)}
+		COMMENT is approximately equal to {@code getLerpProgress(result, newStart, newEnd)}
+		COMMENT (accounting for floating point errors).
+		COMMENT
+		COMMENT @return the mapped value
+		ARG 0 value
+			COMMENT the input value
+		ARG 1 oldStart
+			COMMENT the starting value of the original range
+		ARG 2 oldEnd
+			COMMENT the end value of the original range
+		ARG 3 newStart
+			COMMENT the starting value of the new range
+		ARG 4 newEnd
+			COMMENT the end value of the new range
 	METHOD method_37960 getLerpProgress (FFF)F
 		ARG 0 value
 		ARG 1 start


### PR DESCRIPTION
- `MathHelper.lerpFromProgress` -> `map`
- `MathHelper.clampedLerpFromProgress` -> `clampedMap`
- Documented both methods and their overloads

`map` is the name that seems to be generally used for this function in game programming, see for example [Processing](https://processing.org/reference/map_.html) and [Unreal Engine](https://docs.unrealengine.com/5.0/en-US/BlueprintAPI/Math/Float/MapRangeUnclamped/).