### PR TITLE
Added RedstoneSignalStrength

### DIFF
--- a/mappings/net/minecraft/block/redstone/RedstoneSignalStrength.mapping
+++ b/mappings/net/minecraft/block/redstone/RedstoneSignalStrength.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_6148 net/minecraft/block/redstone/RedstoneSignalStrength
+	FIELD field_31827 MIN I
+	FIELD field_31828 MAX I
+	FIELD field_31829 NONE I

--- a/mappings/net/minecraft/class_6148.mapping
+++ b/mappings/net/minecraft/class_6148.mapping
@@ -1,7 +1,0 @@
-CLASS net/minecraft/class_6148
-	COMMENT A class holding unknown constants.
-	COMMENT
-	COMMENT @apiNote From the package structure, this class appears to be world-related,
-	COMMENT but it seems to be the exclusive class in a package. Its neighboring packages
-	COMMENT are about portal teleporting and persistent state, yet these constants don't
-	COMMENT seem to relate to those.


### PR DESCRIPTION
This finally maps the mysterious class_6148 to what it really is.

Proof that this class contains the redstone power strength:

One of the constants is 15, which is the max value for redstone power.

The other one contains 0, which is the minimum value.

The last one is also zero, which is kind of weird, but I suppose it’s the default value for no power or something similar.


