### PR TITLE
Fix typo and outdated javadoc

### DIFF
--- a/mappings/net/minecraft/network/encryption/PlayerPublicKey.mapping
+++ b/mappings/net/minecraft/network/encryption/PlayerPublicKey.mapping
@@ -17,9 +17,7 @@ CLASS net/minecraft/class_7428 net/minecraft/network/encryption/PlayerPublicKey
 		COMMENT <p>The checks whether the public key is present, signed with the Mojang's private key,
 		COMMENT and not expired (taking into account the provided grace period).
 		COMMENT
-		COMMENT @throws InsecurePublicKeyException.MissingException when the key is missing or empty
-		COMMENT @throws InsecurePublicKeyException.InvalidException when the key does not belong to the profile, is unsigned, or expired
-		COMMENT @throws NetworkEncryptionException when the key is malformed
+		COMMENT @throws PublicKeyException when the key is expired or malformed
 		ARG 0 servicesSignatureVerifier
 		ARG 1 playerUuid
 		ARG 2 publicKeyData

--- a/mappings/net/minecraft/screen/ScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/ScreenHandler.mapping
@@ -8,7 +8,7 @@ CLASS net/minecraft/class_1703 net/minecraft/screen/ScreenHandler
 	COMMENT reference to a client-sided screen handler that is exposed through the
 	COMMENT {@link net.minecraft.client.gui.screen.ingame.ScreenHandlerProvider} interface.
 	COMMENT
-	COMMENT <h2 id="models">Models</h3>
+	COMMENT <h2 id="models">Models</h2>
 	COMMENT <p>Screen handlers hold slots, properties, property delegates, and screen handler
 	COMMENT contexts. This allows easy synchronization of states between the client and the
 	COMMENT server, and prevents running code on the wrong side.

--- a/mappings/net/minecraft/screen/ScreenHandlerType.mapping
+++ b/mappings/net/minecraft/screen/ScreenHandlerType.mapping
@@ -1,7 +1,8 @@
 CLASS net/minecraft/class_3917 net/minecraft/screen/ScreenHandlerType
 	COMMENT Screen handler type is used to create screen handlers on the client.
 	COMMENT It is a holder object holding a factory (usually a reference to the constructor).
-	COMMENT They are registered in the registry under {@link Registry#SCREEN_HANDLER}.
+	COMMENT They are registered in the registry under {@link
+	COMMENT net.minecraft.util.registry.Registry#SCREEN_HANDLER}.
 	COMMENT
 	COMMENT <p>Technically speaking, screen handlers do not have to register screen handler
 	COMMENT types. However, such screen handlers are practically useless as they cannot be

--- a/mappings/net/minecraft/world/poi/PointOfInterestStorage.mapping
+++ b/mappings/net/minecraft/world/poi/PointOfInterestStorage.mapping
@@ -85,9 +85,9 @@ CLASS net/minecraft/class_4153 net/minecraft/world/poi/PointOfInterestStorage
 	METHOD method_20348 scanAndPopulate (Lnet/minecraft/class_2826;Lnet/minecraft/class_4076;Ljava/util/function/BiConsumer;)V
 		ARG 1 chunkSection
 		ARG 2 sectionPos
-		ARG 3 populater
+		ARG 3 populator
 	METHOD method_20349 (Lnet/minecraft/class_2826;Lnet/minecraft/class_4076;Ljava/util/function/BiConsumer;)V
-		ARG 3 populater
+		ARG 3 populator
 	METHOD method_20592 (Lnet/minecraft/class_4157;)Ljava/lang/Boolean;
 		ARG 0 poiSet
 	METHOD method_21647 getPositions (Ljava/util/function/Predicate;Ljava/util/function/Predicate;Lnet/minecraft/class_2338;ILnet/minecraft/class_4153$class_4155;)Ljava/util/stream/Stream;


### PR DESCRIPTION
Fixes typo, javadoc error, and outdated `@throws` comment.