### PR TITLE
Document screen narration

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/Screen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/Screen.mapping
@@ -151,9 +151,12 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 	METHOD method_37063 addDrawableChild (Lnet/minecraft/class_364;)Lnet/minecraft/class_364;
 		ARG 1 drawableElement
 	METHOD method_37064 narrateScreenIfNarrationEnabled (Z)V
-		ARG 1 useTranslationsCache
+		COMMENT If narration is enabled, narrates the elements of this screen.
+		ARG 1 onlyChangedNarrations
+			COMMENT if {@code true}, the text will not include unchanged narrations that have
+			COMMENT already been narrated previously
 	METHOD method_37065 narrateScreen (Z)V
-		ARG 1 useTranslationsCache
+		ARG 1 onlyChangedNarrations
 	METHOD method_37066 remove (Lnet/minecraft/class_364;)V
 		ARG 1 child
 	METHOD method_37067 clearChildren ()V

--- a/mappings/net/minecraft/client/gui/screen/narration/Narration.mapping
+++ b/mappings/net/minecraft/client/gui/screen/narration/Narration.mapping
@@ -1,5 +1,11 @@
 CLASS net/minecraft/class_6384 net/minecraft/client/gui/screen/narration/Narration
+	COMMENT A narration is a message consisting of a list of string "sentences".
+	COMMENT The sentences can be iterated using {@link #forEachSentence forEachSentence}.
+	COMMENT
+	COMMENT <p>Narrations are attached to {@linkplain NarrationPart narration parts}
+	COMMENT using {@link NarrationMessageBuilder#put(NarrationPart, Narration)}.
 	FIELD field_33793 EMPTY Lnet/minecraft/class_6384;
+		COMMENT An empty narration that contains no sentences.
 	FIELD field_33794 value Ljava/lang/Object;
 	FIELD field_33795 transformer Ljava/util/function/BiConsumer;
 	METHOD <init> (Ljava/lang/Object;Ljava/util/function/BiConsumer;)V
@@ -8,14 +14,25 @@ CLASS net/minecraft/class_6384 net/minecraft/client/gui/screen/narration/Narrati
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o
 	METHOD method_37036 string (Ljava/lang/String;)Lnet/minecraft/class_6384;
+		COMMENT Creates a narration from a single string sentence.
+		COMMENT
+		COMMENT @return the created narration
 		ARG 0 string
+			COMMENT the narrated sentence
 	METHOD method_37037 texts (Ljava/util/List;)Lnet/minecraft/class_6384;
+		COMMENT Creates a narration from a list of {@link Text} sentences.
+		COMMENT
+		COMMENT @implSpec The sentences are converted to strings using {@link Text#getString}.
+		COMMENT @return the created narration
 		ARG 0 texts
+			COMMENT the narrated sentences
 	METHOD method_37038 (Ljava/util/List;Ljava/util/function/Consumer;Ljava/util/List;)V
 		ARG 1 consumer
 		ARG 2 texts
 	METHOD method_37039 forEachSentence (Ljava/util/function/Consumer;)V
+		COMMENT Iterates all sentences in this narration with a {@link Consumer}.
 		ARG 1 consumer
+			COMMENT the consumer to accept all sentences in this narration
 	METHOD method_37040 (Ljava/util/function/Consumer;Lnet/minecraft/class_3902;)V
 		ARG 0 consumer
 		ARG 1 text
@@ -23,4 +40,9 @@ CLASS net/minecraft/class_6384 net/minecraft/client/gui/screen/narration/Narrati
 		ARG 0 consumer
 		ARG 1 text
 	METHOD method_37042 text (Lnet/minecraft/class_2561;)Lnet/minecraft/class_6384;
+		COMMENT Creates a narration from a single {@link Text} sentence.
+		COMMENT
+		COMMENT @implSpec The sentence is converted to a string using {@link Text#getString}.
+		COMMENT @return the created narration
 		ARG 0 text
+			COMMENT the narrated sentence

--- a/mappings/net/minecraft/client/gui/screen/narration/NarrationMessageBuilder.mapping
+++ b/mappings/net/minecraft/client/gui/screen/narration/NarrationMessageBuilder.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_6382 net/minecraft/client/gui/screen/narration/Narrati
 	COMMENT Each submessage can have its own set of narrations for the different
 	COMMENT narration parts.
 	COMMENT
-	COMMENT <p id="ordering">The narrations added to a meesage will be ordered by their part
+	COMMENT <p id="ordering">The narrations added to a message will be ordered by their part
 	COMMENT first, in {@link NarrationPart}'s natural ordering. If there are multiple
 	COMMENT narrations for a part added through submessages, they will be ordered earliest
 	COMMENT submessage first.

--- a/mappings/net/minecraft/client/gui/screen/narration/NarrationMessageBuilder.mapping
+++ b/mappings/net/minecraft/client/gui/screen/narration/NarrationMessageBuilder.mapping
@@ -1,14 +1,71 @@
 CLASS net/minecraft/class_6382 net/minecraft/client/gui/screen/narration/NarrationMessageBuilder
+	COMMENT A builder for narration messages.
+	COMMENT
+	COMMENT <p>Narration messages consist of multiple sections known as
+	COMMENT {@linkplain NarrationPart parts}. Each narration message can
+	COMMENT contain only one narration per part.
+	COMMENT
+	COMMENT <p>You can create a <em>submessage</em> by calling {@link #nextMessage()}.
+	COMMENT Each submessage can have its own set of narrations for the different
+	COMMENT narration parts.
+	COMMENT
+	COMMENT <p id="ordering">The narrations added to a meesage will be ordered by their part
+	COMMENT first, in {@link NarrationPart}'s natural ordering. If there are multiple
+	COMMENT narrations for a part added through submessages, they will be ordered earliest
+	COMMENT submessage first.
 	METHOD method_37031 nextMessage ()Lnet/minecraft/class_6382;
+		COMMENT Creates a narration message builder for a submessage.
+		COMMENT
+		COMMENT <p>Submessages can have their own set of narrations for the narration parts,
+		COMMENT which are merged with the "parent" message's narrations
+		COMMENT <a href="#ordering">as described above</a>.
+		COMMENT
+		COMMENT @apiNote All returned builder instances are equivalent and refer to the same
+		COMMENT submessage. If you want to add yet another set of narrations, call this method
+		COMMENT again on the first submessage builder to obtain a "nested" submessage builder.
+		COMMENT
+		COMMENT @return the created builder
 	METHOD method_37032 put (Lnet/minecraft/class_6381;Lnet/minecraft/class_6384;)V
+		COMMENT Adds a narration to this message builder.
+		COMMENT
+		COMMENT <p>If a narration already exists for the specified narration part,
+		COMMENT it is replaced by the new narration.
+		COMMENT
+		COMMENT @see #put(NarrationPart, Text)
+		COMMENT @see #put(NarrationPart, String)
+		COMMENT @see #put(NarrationPart, Text...)
 		ARG 1 part
 		ARG 2 narration
 	METHOD method_37033 put (Lnet/minecraft/class_6381;Ljava/lang/String;)V
+		COMMENT Adds a string narration to this message builder.
+		COMMENT
+		COMMENT <p>If a narration already exists for the specified narration part,
+		COMMENT it is replaced by the new narration.
 		ARG 1 part
 		ARG 2 string
+			COMMENT the message for the narration
 	METHOD method_37034 put (Lnet/minecraft/class_6381;Lnet/minecraft/class_2561;)V
+		COMMENT Adds a {@link Text} narration to this message builder.
+		COMMENT
+		COMMENT <p>If a narration already exists for the specified narration part,
+		COMMENT it is replaced by the new narration.
+		COMMENT
+		COMMENT @implSpec The default implementation behaves like
+		COMMENT {@code put(part, text.getString())}.
 		ARG 1 part
 		ARG 2 text
+			COMMENT the message for the narration
 	METHOD method_37035 put (Lnet/minecraft/class_6381;[Lnet/minecraft/class_2561;)V
+		COMMENT Adds an array of {@link Text} narrations to this message builder.
+		COMMENT
+		COMMENT <p>Each {@link Text} in the input array will be its own sentence
+		COMMENT as described in {@link Narration#texts}.
+		COMMENT
+		COMMENT <p>If a narration already exists for the specified narration part,
+		COMMENT it is replaced by the new narration.
+		COMMENT
+		COMMENT @implSpec The default implementation creates a {@link Narration} for the
+		COMMENT texts using {@link Narration#texts}.
 		ARG 1 part
 		ARG 2 texts
+			COMMENT the messages for the narration

--- a/mappings/net/minecraft/client/gui/screen/narration/NarrationPart.mapping
+++ b/mappings/net/minecraft/client/gui/screen/narration/NarrationPart.mapping
@@ -1,1 +1,12 @@
 CLASS net/minecraft/class_6381 net/minecraft/client/gui/screen/narration/NarrationPart
+	COMMENT A component of a {@linkplain NarrationMessageBuilder narration message}.
+	COMMENT This enum is mostly used for grouping and ordering narrations in a narration
+	COMMENT message.
+	FIELD field_33788 Lnet/minecraft/class_6381;
+		COMMENT The main narration for a narrated element.
+	FIELD field_33789 Lnet/minecraft/class_6381;
+		COMMENT The position of a narrated element in a container such as a list.
+	FIELD field_33790 Lnet/minecraft/class_6381;
+		COMMENT A hint for a narrated element, e.g. a button tooltip.
+	FIELD field_33791 Lnet/minecraft/class_6381;
+		COMMENT Usage instructions for a narrated element.

--- a/mappings/net/minecraft/client/gui/screen/narration/ScreenNarrator.mapping
+++ b/mappings/net/minecraft/client/gui/screen/narration/ScreenNarrator.mapping
@@ -1,12 +1,25 @@
 CLASS net/minecraft/class_6385 net/minecraft/client/gui/screen/narration/ScreenNarrator
+	COMMENT Manages narration messages and combines them into a narrated string.
 	FIELD field_33796 currentMessageIndex I
 	FIELD field_33797 narrations Ljava/util/Map;
 	METHOD method_37043 (Lnet/minecraft/class_6385$class_6386;)Ljava/lang/Integer;
 		ARG 0 partIndex
 	METHOD method_37044 buildNarrations (Ljava/util/function/Consumer;)V
+		COMMENT Creates the narration messages for the next narration using a
+		COMMENT {@link NarrationMessageBuilder}.
 		ARG 1 builderConsumer
+			COMMENT a consumer that adds the narrations to a {@link NarrationMessageBuilder}
 	METHOD method_37045 buildNarratorText (Z)Ljava/lang/String;
-		ARG 1 forceTransform
+		COMMENT Builds a text representation of the narrations produced by the last call to
+		COMMENT {@link #buildNarrations buildNarrations}.
+		COMMENT
+		COMMENT @implNote Contains all sentences in the narrations of the current narration
+		COMMENT message separated by {@code ". "}, ordered as described in
+		COMMENT {@link NarrationMessageBuilder}.
+		COMMENT @return the created narrator text
+		ARG 1 includeUnchangedSentences
+			COMMENT if {@code true}, the text will include unchanged sentences that have
+			COMMENT already been included in the output of this method previously
 	METHOD method_37046 (ZLjava/util/function/Consumer;Lnet/minecraft/class_6385$class_6386;Lnet/minecraft/class_6385$class_6387;)V
 		ARG 3 partIndex
 		ARG 4 message
@@ -18,20 +31,20 @@ CLASS net/minecraft/class_6385 net/minecraft/client/gui/screen/narration/ScreenN
 			ARG 1 sentence
 	CLASS class_6386 PartIndex
 		FIELD field_33801 part Lnet/minecraft/class_6381;
-		FIELD field_33802 messageIndex I
+		FIELD field_33802 depth I
 		METHOD <init> (Lnet/minecraft/class_6381;I)V
 			ARG 1 part
-			ARG 2 messageIndex
+			ARG 2 depth
 	CLASS class_6387 Message
 		FIELD field_33803 narration Lnet/minecraft/class_6384;
 		FIELD field_33804 index I
-		FIELD field_33805 transformed Z
+		FIELD field_33805 used Z
 		METHOD method_37049 setNarration (ILnet/minecraft/class_6384;)Lnet/minecraft/class_6385$class_6387;
 			ARG 1 index
 			ARG 2 narration
 	CLASS class_6388 MessageBuilder
-		FIELD field_33807 messageIndex I
+		FIELD field_33807 depth I
 		METHOD <init> (Lnet/minecraft/class_6385;I)V
-			ARG 2 startIndex
+			ARG 2 depth
 		METHOD method_37050 (Lnet/minecraft/class_6385$class_6386;)Lnet/minecraft/class_6385$class_6387;
 			ARG 0 partIndex

--- a/mappings/net/minecraft/client/gui/screen/narration/ScreenNarrator.mapping
+++ b/mappings/net/minecraft/client/gui/screen/narration/ScreenNarrator.mapping
@@ -17,8 +17,8 @@ CLASS net/minecraft/class_6385 net/minecraft/client/gui/screen/narration/ScreenN
 		COMMENT message separated by {@code ". "}, ordered as described in
 		COMMENT {@link NarrationMessageBuilder}.
 		COMMENT @return the created narrator text
-		ARG 1 includeUnchangedSentences
-			COMMENT if {@code true}, the text will include unchanged sentences that have
+		ARG 1 includeUnchanged
+			COMMENT if {@code true}, the text will include unchanged messages that have
 			COMMENT already been included in the output of this method previously
 	METHOD method_37046 (ZLjava/util/function/Consumer;Lnet/minecraft/class_6385$class_6386;Lnet/minecraft/class_6385$class_6387;)V
 		ARG 3 partIndex

--- a/src/packageDocs/java/net/minecraft/client/gui/screen/narration/package-info.java
+++ b/src/packageDocs/java/net/minecraft/client/gui/screen/narration/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * This file is free for everyone to use under the Creative Commons Zero license.
+ */
+
+/**
+ * Contains the screen narrator for building
+ * narration messages.
+ */
+package net.minecraft.client.gui.screen.narration;


### PR DESCRIPTION
Documents the `net.minecraft.client.screen.gui.narration` package.

Also fixes a few param/field names in Screen narration methods and ScreenNarrator which didn't make sense:
- `Screen.narrateScreen(IfNarrationEnabled)` parameter `useTranslationsCache` -> `onlyChangedNarrations`. The parameter has nothing to do with translations (though it is related to caching in a way)
- `ScreenNarrator.buildNarratorText` parameter `forceTransform` -> `includeUnchanged`. The parameter has nothing to do with transformations. Instead, it describes whether the narrator should force already used messages to be repeated in the new narrator text.
- `ScreenNarrator.Message.transformed` -> `used`: same reason as above.
- `ScreenNarrator.PartIndex.messageIndex`, `ScreenNarrator.MessageBuilder.messageIndex` -> `depth`: reduces confusion between the two different indices:
  1. the "depth" of narration submessages
  2. the "current message index" used to track what messages belong to the current narration round