### PR TITLE
Resolve more javadoc links

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -878,19 +878,25 @@ javadoc {
 		addBooleanOption "-allow-script-in-comments", true
 		addBooleanOption "-ignore-source-errors", true
 		links(
-				'https://guava.dev/releases/21.0/api/docs/',
-				'https://www.javadoc.io/doc/com.google.code.gson/gson/2.8.0/',
+				'https://guava.dev/releases/31.0-jre/api/docs/',
+				'https://www.javadoc.io/doc/com.google.code.gson/gson/2.8.9/',
 				'https://logging.apache.org/log4j/2.x/log4j-api/apidocs/',
+				'https://www.slf4j.org/apidocs/',
 				"https://javadoc.io/doc/org.jetbrains/annotations/${project.jetbrains_annotations_version}/",
-				'https://www.javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.2/',
 				'https://javadoc.lwjgl.org/',
 				'https://fastutil.di.unimi.it/docs/',
 				'https://netty.io/4.1/api/',
-				'https://commons.apache.org/proper/commons-logging/javadocs/api-1.1.3/',
-				'https://commons.apache.org/proper/commons-lang/javadocs/api-3.5',
-				'https://commons.apache.org/proper/commons-io/javadocs/api-2.5',
-				'https://commons.apache.org/proper/commons-codec/archives/1.10/apidocs',
-				'https://commons.apache.org/proper/commons-compress/javadocs/api-1.8.1/',
+				'https://www.oshi.ooo/oshi-core-java11/apidocs/',
+				'https://java-native-access.github.io/jna/5.10.0/javadoc/',
+				'https://unicode-org.github.io/icu-docs/apidoc/released/icu4j/',
+				'https://jopt-simple.github.io/jopt-simple/apidocs/',
+				'https://solutions.weblite.ca/java-objective-c-bridge/docs/',
+				'https://commons.apache.org/proper/commons-logging/apidocs/',
+				'https://commons.apache.org/proper/commons-lang/javadocs/api-release/',
+				'https://commons.apache.org/proper/commons-io/apidocs/',
+				'https://commons.apache.org/proper/commons-codec/archives/1.15/apidocs/',
+				'https://commons.apache.org/proper/commons-compress/apidocs/',
+				'https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/apidocs/',
 				"https://maven.fabricmc.net/docs/fabric-loader-${project.fabric_loader_version}/",
 				"https://docs.oracle.com/en/java/javase/17/docs/api/"
 		)


### PR DESCRIPTION
Resolves #2977 

This resolves the following links:

- SLF4J (Used everywhere)
- Oshi (`SystemDetails`)
- JNA (`WinNativeModuleUtil`)
- ICU4J (no links)
- JOptSimple (`client.main.Main`)
- ObjCBridge (`MacWindowUtil`)
- Apache HTTPComponents (Realms)

This also updates versions of various links, and removes jsr305 as it is not linked anymore.