### PR TITLE
Fix method name for `CsvWriter#print`

### DIFF
--- a/mappings/net/minecraft/util/CsvWriter.mapping
+++ b/mappings/net/minecraft/util/CsvWriter.mapping
@@ -7,7 +7,7 @@ CLASS net/minecraft/class_4456 net/minecraft/util/CsvWriter
 		ARG 1 writer
 		ARG 2 columns
 	METHOD method_21627 makeHeader ()Lnet/minecraft/class_4456$class_4457;
-	METHOD method_21628 print (Ljava/lang/Object;)Ljava/lang/String;
+	METHOD method_21628 escape (Ljava/lang/Object;)Ljava/lang/String;
 		ARG 0 o
 	METHOD method_21629 printRow (Ljava/util/stream/Stream;)V
 		ARG 1 columns


### PR DESCRIPTION
Resolves #3295

This method only escapes the value, and does not print anything by itself.