### PR TITLE
NarratorMode and NarratorManager docs and minor renames

### DIFF
--- a/mappings/net/minecraft/client/option/NarratorMode.mapping
+++ b/mappings/net/minecraft/client/option/NarratorMode.mapping
@@ -1,4 +1,14 @@
 CLASS net/minecraft/class_4065 net/minecraft/client/option/NarratorMode
+	COMMENT Contains the different narrator modes that control
+	COMMENT which messages the narrator narrates.
+	FIELD field_18176 Lnet/minecraft/class_4065;
+		COMMENT The narrator is disabled and narrates nothing.
+	FIELD field_18177 Lnet/minecraft/class_4065;
+		COMMENT The narrator narrates everything narrated by {@link #CHAT} and {@link #SYSTEM}.
+	FIELD field_18178 Lnet/minecraft/class_4065;
+		COMMENT The narrator narrates chat messages.
+	FIELD field_18179 Lnet/minecraft/class_4065;
+		COMMENT The narrator narrates system text, including screens.
 	FIELD field_18180 VALUES [Lnet/minecraft/class_4065;
 	FIELD field_18181 id I
 	FIELD field_24212 name Lnet/minecraft/class_2561;
@@ -6,8 +16,22 @@ CLASS net/minecraft/class_4065 net/minecraft/client/option/NarratorMode
 		ARG 3 id
 		ARG 4 name
 	METHOD method_18509 getId ()I
+		COMMENT {@return the unique int ID of this mode}
+		COMMENT @see #byId(int)
 	METHOD method_18510 byId (I)Lnet/minecraft/class_4065;
+		COMMENT {@return the narrator mode matching the specified ID with wraparound}
+		COMMENT
+		COMMENT @see #getId
 		ARG 0 id
 	METHOD method_18511 getName ()Lnet/minecraft/class_2561;
+		COMMENT {@return the human-readable name of this mode}
 	METHOD method_44715 shouldNarrateChat ()Z
+		COMMENT Checks if this mode narrates chat messages.
+		COMMENT
+		COMMENT @return {@code true} if chat messages are narrated, {@code false} otherwise
+		COMMENT @see #CHAT
 	METHOD method_44716 shouldNarrateSystem ()Z
+		COMMENT Checks if this mode narrates system text.
+		COMMENT
+		COMMENT @return {@code true} if system text is narrated, {@code false} otherwise
+		COMMENT @see #SYSTEM

--- a/mappings/net/minecraft/client/option/NarratorMode.mapping
+++ b/mappings/net/minecraft/client/option/NarratorMode.mapping
@@ -20,7 +20,6 @@ CLASS net/minecraft/class_4065 net/minecraft/client/option/NarratorMode
 		COMMENT @see #byId(int)
 	METHOD method_18510 byId (I)Lnet/minecraft/class_4065;
 		COMMENT {@return the narrator mode matching the specified ID with wraparound}
-		COMMENT
 		COMMENT @see #getId
 		ARG 0 id
 	METHOD method_18511 getName ()Lnet/minecraft/class_2561;

--- a/mappings/net/minecraft/client/option/NarratorMode.mapping
+++ b/mappings/net/minecraft/client/option/NarratorMode.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_4065 net/minecraft/client/option/NarratorMode
 	FIELD field_18176 Lnet/minecraft/class_4065;
 		COMMENT The narrator is disabled and narrates nothing.
 	FIELD field_18177 Lnet/minecraft/class_4065;
-		COMMENT The narrator narrates everything narrated by {@link #CHAT} and {@link #SYSTEM}.
+		COMMENT The narrator narrates everything narrated in the {@link #CHAT} and {@link #SYSTEM} modes.
 	FIELD field_18178 Lnet/minecraft/class_4065;
 		COMMENT The narrator narrates chat messages.
 	FIELD field_18179 Lnet/minecraft/class_4065;

--- a/mappings/net/minecraft/client/util/NarratorManager.mapping
+++ b/mappings/net/minecraft/client/util/NarratorManager.mapping
@@ -1,21 +1,42 @@
 CLASS net/minecraft/class_333 net/minecraft/client/util/NarratorManager
+	COMMENT A bridge between Minecraft and {@link com.mojang.text2speech.Narrator}.
 	FIELD field_18210 LOGGER Lorg/slf4j/Logger;
 	FIELD field_18967 EMPTY Lnet/minecraft/class_2561;
+		COMMENT An empty text for narration.
 	FIELD field_2055 narrator Lcom/mojang/text2speech/Narrator;
 	FIELD field_39755 client Lnet/minecraft/class_310;
 	METHOD <init> (Lnet/minecraft/class_310;)V
 		ARG 1 client
 	METHOD method_1791 isActive ()Z
-	METHOD method_1792 addToast (Lnet/minecraft/class_4065;)V
-		ARG 1 option
+	METHOD method_1792 onModeChange (Lnet/minecraft/class_4065;)V
+		COMMENT Narrates a message informing the user about a changed narration mode
+		COMMENT and displays it in a toast.
+		ARG 1 mode
+			COMMENT the new narrator mode
 	METHOD method_1793 clear ()V
 	METHOD method_19788 narrate (Ljava/lang/String;)V
+		COMMENT Narrates system text.
+		COMMENT
+		COMMENT @see NarratorMode#shouldNarrateSystem
 		ARG 1 text
+			COMMENT the text to narrate
 	METHOD method_20371 destroy ()V
-	METHOD method_20602 getNarratorOption ()Lnet/minecraft/class_4065;
+	METHOD method_20602 getNarratorMode ()Lnet/minecraft/class_4065;
+		COMMENT {@return the current narrator mode of the client}
 	METHOD method_37015 narrate (Lnet/minecraft/class_2561;)V
+		COMMENT Narrates system text.
+		COMMENT
+		COMMENT @see NarratorMode#shouldNarrateSystem
 		ARG 1 text
+			COMMENT the text to narrate
 	METHOD method_37016 debugPrintMessage (Ljava/lang/String;)V
+		COMMENT If the game is {@linkplain net.minecraft.SharedConstants#isDevelopment
+		COMMENT in a development environment}, logs a debug message for a narrated string.
 		ARG 1 message
+			COMMENT the narrated message
 	METHOD method_44708 narrateChatMessage (Ljava/util/function/Supplier;)V
+		COMMENT Narrates a lazily supplied chat message.
+		COMMENT
+		COMMENT @see NarratorMode#shouldNarrateChat
 		ARG 1 messageSupplier
+			COMMENT the message to narrate


### PR DESCRIPTION
A sequel to #3293.

The renames:
- `NarratorManager.addToast` -> `onModeChange` (also narrates a message in addition to the toast)
- `NarratorManager.getNarratorOption()` -> `getNarratorMode()` (to match the type name; private method)