### PR TITLE
Document cauldrons

### DIFF
--- a/mappings/net/minecraft/block/AbstractCauldronBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractCauldronBlock.mapping
@@ -1,10 +1,24 @@
 CLASS net/minecraft/class_2275 net/minecraft/block/AbstractCauldronBlock
+	COMMENT The base class for all cauldrons.
+	COMMENT
+	COMMENT <p>Interaction with cauldrons is controlled by {@linkplain CauldronBehavior
+	COMMENT cauldron behaviors}.
+	COMMENT
+	COMMENT @see CauldronBlock empty cauldrons
+	COMMENT @see LavaCauldronBlock cauldrons filled with lava
+	COMMENT @see LeveledCauldronBlock cauldrons with varying levels of contents
+	COMMENT @see PowderSnowCauldronBlock cauldrons filled with powder snow
 	FIELD field_10746 OUTLINE_SHAPE Lnet/minecraft/class_265;
 	FIELD field_10747 RAYCAST_SHAPE Lnet/minecraft/class_265;
 	FIELD field_27084 behaviorMap Ljava/util/Map;
 	METHOD <init> (Lnet/minecraft/class_4970$class_2251;Ljava/util/Map;)V
+		COMMENT Constructs a cauldron block.
+		COMMENT
+		COMMENT <p>The behavior map must match {@link CauldronBehavior#createMap} by providing
+		COMMENT a nonnull value for <em>all</em> items.
 		ARG 1 settings
 		ARG 2 behaviorMap
+			COMMENT the map containing cauldron behaviors for each item
 	METHOD method_31615 getFluidHeight (Lnet/minecraft/class_2680;)D
 		ARG 1 state
 	METHOD method_31616 isEntityTouchingFluid (Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;Lnet/minecraft/class_1297;)Z
@@ -12,11 +26,23 @@ CLASS net/minecraft/class_2275 net/minecraft/block/AbstractCauldronBlock
 		ARG 2 pos
 		ARG 3 entity
 	METHOD method_32764 fillFromDripstone (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_3611;)V
+		COMMENT Fills a cauldron with one level of the specified fluid if possible.
 		ARG 1 state
+			COMMENT the current cauldron state
 		ARG 2 world
+			COMMENT the world where the cauldron is located
 		ARG 3 pos
+			COMMENT the cauldron's position
 		ARG 4 fluid
+			COMMENT the fluid to fill the cauldron with
 	METHOD method_32765 canBeFilledByDripstone (Lnet/minecraft/class_3611;)Z
+		COMMENT Checks if this cauldron block can be filled with the specified fluid by dripstone.
+		COMMENT
+		COMMENT @return {@code true} if this block can be filled, {@code false} otherwise
 		ARG 1 fluid
+			COMMENT the fluid to check
 	METHOD method_32766 isFull (Lnet/minecraft/class_2680;)Z
+		COMMENT {@return {@code true} if the specified cauldron state is completely full,
+		COMMENT {@code false} otherwise}
 		ARG 1 state
+			COMMENT the cauldron state to check

--- a/mappings/net/minecraft/block/CauldronBlock.mapping
+++ b/mappings/net/minecraft/block/CauldronBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_5546 net/minecraft/block/CauldronBlock
+	COMMENT An empty cauldron block.
 	FIELD field_34027 FILL_WITH_RAIN_CHANCE F
 	FIELD field_34028 FILL_WITH_SNOW_CHANCE F
 	METHOD method_31636 canFillWithPrecipitation (Lnet/minecraft/class_1937;Lnet/minecraft/class_1959$class_1963;)Z

--- a/mappings/net/minecraft/block/LavaCauldronBlock.mapping
+++ b/mappings/net/minecraft/block/LavaCauldronBlock.mapping
@@ -1,2 +1,2 @@
 CLASS net/minecraft/class_5553 net/minecraft/block/LavaCauldronBlock
-	COMMENT A cauldron that is filled with lava.
+	COMMENT A cauldron filled with lava.

--- a/mappings/net/minecraft/block/LavaCauldronBlock.mapping
+++ b/mappings/net/minecraft/block/LavaCauldronBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_5553 net/minecraft/block/LavaCauldronBlock
+	COMMENT A cauldron that is filled with lava.

--- a/mappings/net/minecraft/block/LeveledCauldronBlock.mapping
+++ b/mappings/net/minecraft/block/LeveledCauldronBlock.mapping
@@ -1,12 +1,30 @@
 CLASS net/minecraft/class_5556 net/minecraft/block/LeveledCauldronBlock
+	COMMENT A cauldron with a varying level of contents.
+	COMMENT This includes water and powder snow cauldrons.
+	COMMENT
+	COMMENT <p>The amount of stored substance is controlled with the {@link #LEVEL}
+	COMMENT block state property which can take values between {@value #MIN_LEVEL} and
+	COMMENT {@value #MAX_LEVEL} (inclusive).
 	FIELD field_27206 LEVEL Lnet/minecraft/class_2758;
 	FIELD field_27880 RAIN_PREDICATE Ljava/util/function/Predicate;
+		COMMENT A precipitation predicate that allows {@link Biome.Precipitation#RAIN}.
 	FIELD field_27881 SNOW_PREDICATE Ljava/util/function/Predicate;
+		COMMENT A precipitation predicate that allows {@link Biome.Precipitation#SNOW}.
 	FIELD field_27882 precipitationPredicate Ljava/util/function/Predicate;
+	FIELD field_31107 MIN_LEVEL I
+	FIELD field_31108 MAX_LEVEL I
+	FIELD field_31109 BASE_FLUID_HEIGHT I
+	FIELD field_31110 FLUID_HEIGHT_PER_LEVEL D
 	METHOD <init> (Lnet/minecraft/class_4970$class_2251;Ljava/util/function/Predicate;Ljava/util/Map;)V
+		COMMENT Constructs a leveled cauldron block.
+		COMMENT
+		COMMENT @apiNote The precipitation predicates are compared using identity comparisons in some cases,
+		COMMENT so callers should typically use {@link #RAIN_PREDICATE} and {@link #SNOW_PREDICATE} if applicable.
 		ARG 1 settings
 		ARG 2 precipitationPredicate
+			COMMENT a predicate that checks what type of precipitation can fill this cauldron
 		ARG 3 behaviorMap
+			COMMENT the map containing cauldron behaviors for each item
 	METHOD method_31650 decrementFluidLevel (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)V
 		ARG 0 state
 		ARG 1 world

--- a/mappings/net/minecraft/block/PowderSnowCauldronBlock.mapping
+++ b/mappings/net/minecraft/block/PowderSnowCauldronBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_6377 net/minecraft/block/PowderSnowCauldronBlock
+	COMMENT A cauldron filled with powder snow.

--- a/mappings/net/minecraft/block/cauldron/CauldronBehavior.mapping
+++ b/mappings/net/minecraft/block/cauldron/CauldronBehavior.mapping
@@ -1,30 +1,119 @@
 CLASS net/minecraft/class_5620 net/minecraft/block/cauldron/CauldronBehavior
+	COMMENT Cauldron behaviors control what happens when a player interacts with
+	COMMENT cauldrons using a specific item.
+	COMMENT
+	COMMENT <p>To register new cauldron behaviors, you can add them to the corresponding
+	COMMENT maps based on the cauldron type.
+	COMMENT <div class="fabric"><table>
+	COMMENT <caption>Behavior maps by cauldron type</caption>
+	COMMENT <thead><tr>
+	COMMENT     <th>Type</th>
+	COMMENT     <th>Block</th>
+	COMMENT     <th>Behavior map</th>
+	COMMENT </tr></thead>
+	COMMENT <tbody>
+	COMMENT     <tr>
+	COMMENT         <td>Empty</td>
+	COMMENT         <td>{@link net.minecraft.block.Blocks#CAULDRON minecraft:cauldron}</td>
+	COMMENT         <td>{@link #EMPTY_CAULDRON_BEHAVIOR}</td>
+	COMMENT     </tr>
+	COMMENT     <tr>
+	COMMENT         <td>Water</td>
+	COMMENT         <td>{@link net.minecraft.block.Blocks#WATER_CAULDRON minecraft:water_cauldron}</td>
+	COMMENT         <td>{@link #WATER_CAULDRON_BEHAVIOR}</td>
+	COMMENT     </tr>
+	COMMENT     <tr>
+	COMMENT         <td>Lava</td>
+	COMMENT         <td>{@link net.minecraft.block.Blocks#LAVA_CAULDRON minecraft:lava_cauldron}</td>
+	COMMENT         <td>{@link #LAVA_CAULDRON_BEHAVIOR}</td>
+	COMMENT     </tr>
+	COMMENT     <tr>
+	COMMENT         <td>Powder snow</td>
+	COMMENT         <td>{@link net.minecraft.block.Blocks#POWDER_SNOW_CAULDRON minecraft:powder_snow_cauldron}</td>
+	COMMENT         <td>{@link #POWDER_SNOW_CAULDRON_BEHAVIOR}</td>
+	COMMENT     </tr>
+	COMMENT </tbody>
+	COMMENT </table></div>
 	FIELD field_27775 EMPTY_CAULDRON_BEHAVIOR Ljava/util/Map;
+		COMMENT The cauldron behaviors for empty cauldrons.
+		COMMENT
+		COMMENT @see #createMap
 	FIELD field_27776 WATER_CAULDRON_BEHAVIOR Ljava/util/Map;
+		COMMENT The cauldron behaviors for water cauldrons.
+		COMMENT
+		COMMENT @see #createMap
 	FIELD field_27777 LAVA_CAULDRON_BEHAVIOR Ljava/util/Map;
+		COMMENT The cauldron behaviors for lava cauldrons.
+		COMMENT
+		COMMENT @see #createMap
 	FIELD field_27778 FILL_WITH_WATER Lnet/minecraft/class_5620;
+		COMMENT A behavior that fills cauldrons with water.
+		COMMENT
+		COMMENT @see #fillCauldron
 	FIELD field_27779 FILL_WITH_LAVA Lnet/minecraft/class_5620;
+		COMMENT A behavior that fills cauldrons with lava.
+		COMMENT
+		COMMENT @see #fillCauldron
 	FIELD field_27780 CLEAN_SHULKER_BOX Lnet/minecraft/class_5620;
+		COMMENT A behavior that cleans dyed shulker boxes.
 	FIELD field_27781 CLEAN_BANNER Lnet/minecraft/class_5620;
+		COMMENT A behavior that cleans banners with patterns.
 	FIELD field_27782 CLEAN_DYEABLE_ITEM Lnet/minecraft/class_5620;
+		COMMENT A behavior that cleans {@linkplain net.minecraft.item.DyeableItem dyeable items}.
 	FIELD field_28011 POWDER_SNOW_CAULDRON_BEHAVIOR Ljava/util/Map;
+		COMMENT The cauldron behaviors for powder snow cauldrons.
+		COMMENT
+		COMMENT @see #createMap
 	FIELD field_28012 FILL_WITH_POWDER_SNOW Lnet/minecraft/class_5620;
+		COMMENT A behavior that fills cauldrons with powder snow.
+		COMMENT
+		COMMENT @see #fillCauldron
 	METHOD interact (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_1657;Lnet/minecraft/class_1268;Lnet/minecraft/class_1799;)Lnet/minecraft/class_1269;
+		COMMENT Called when a player interacts with a cauldron.
+		COMMENT
+		COMMENT @return a {@linkplain ActionResult#isAccepted successful} action result if this behavior succeeds,
+		COMMENT {@link ActionResult#PASS} otherwise
 		ARG 1 state
+			COMMENT the current cauldron block state
 		ARG 2 world
+			COMMENT the world where the cauldron is located
 		ARG 3 pos
+			COMMENT the cauldron's position
 		ARG 4 player
+			COMMENT the interacting player
 		ARG 5 hand
+			COMMENT the hand interacting with the cauldron
 		ARG 6 stack
+			COMMENT the stack in the player's hand
 	METHOD method_32206 createMap ()Lit/unimi/dsi/fastutil/objects/Object2ObjectOpenHashMap;
+		COMMENT Creates a mutable map from {@linkplain Item items} to their
+		COMMENT corresponding cauldron behaviors.
+		COMMENT
+		COMMENT <p>The default return value in the map is a cauldron behavior
+		COMMENT that returns {@link ActionResult#PASS} for all items.
+		COMMENT
+		COMMENT @return the created map
 	METHOD method_32207 fillCauldron (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_1657;Lnet/minecraft/class_1268;Lnet/minecraft/class_1799;Lnet/minecraft/class_2680;Lnet/minecraft/class_3414;)Lnet/minecraft/class_1269;
+		COMMENT Fills a cauldron from a bucket stack.
+		COMMENT
+		COMMENT <p>The filled bucket stack will be replaced by an empty bucket in the player's
+		COMMENT inventory.
+		COMMENT
+		COMMENT @return a {@linkplain ActionResult#isAccepted successful} action result
 		ARG 0 world
+			COMMENT the world where the cauldron is located
 		ARG 1 pos
+			COMMENT the cauldron's position
 		ARG 2 player
+			COMMENT the interacting player
 		ARG 3 hand
+			COMMENT the hand interacting with the cauldron
 		ARG 4 stack
+			COMMENT the filled bucket stack in the player's hand
 		ARG 5 state
+			COMMENT the filled cauldron state
 		ARG 6 soundEvent
+			COMMENT the sound produced by filling
 	METHOD method_32208 (Lnet/minecraft/class_2680;)Z
 		ARG 0 state
 	METHOD method_32209 (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_1657;Lnet/minecraft/class_1268;Lnet/minecraft/class_1799;)Lnet/minecraft/class_1269;
@@ -35,18 +124,31 @@ CLASS net/minecraft/class_5620 net/minecraft/block/cauldron/CauldronBehavior
 		ARG 4 hand
 		ARG 5 stack
 	METHOD method_32210 emptyCauldron (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_1657;Lnet/minecraft/class_1268;Lnet/minecraft/class_1799;Lnet/minecraft/class_1799;Ljava/util/function/Predicate;Lnet/minecraft/class_3414;)Lnet/minecraft/class_1269;
+		COMMENT Empties a cauldron if it's full.
+		COMMENT
+		COMMENT @return a {@linkplain ActionResult#isAccepted successful} action result if emptied, {@link ActionResult#PASS} otherwise
 		ARG 0 state
+			COMMENT the cauldron block state
 		ARG 1 world
+			COMMENT the world where the cauldron is located
 		ARG 2 pos
+			COMMENT the cauldron's position
 		ARG 3 player
+			COMMENT the interacting player
 		ARG 4 hand
+			COMMENT the hand interacting with the cauldron
 		ARG 5 stack
+			COMMENT the stack in the player's hand
 		ARG 6 output
-		ARG 7 predicate
+			COMMENT the item stack that replaces the interaction stack when the cauldron is emptied
+		ARG 7 fullPredicate
+			COMMENT a predicate used to check if the cauldron can be emptied into the output stack
 		ARG 8 soundEvent
+			COMMENT the sound produced by emptying
 	METHOD method_32211 (Lit/unimi/dsi/fastutil/objects/Object2ObjectOpenHashMap;)V
 		ARG 0 map
 	METHOD method_32212 registerBehavior ()V
+		COMMENT Registers the vanilla cauldron behaviors.
 	METHOD method_32213 (Lnet/minecraft/class_2680;)Z
 		ARG 0 state
 	METHOD method_32214 (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_1657;Lnet/minecraft/class_1268;Lnet/minecraft/class_1799;)Lnet/minecraft/class_1269;
@@ -136,4 +238,5 @@ CLASS net/minecraft/class_5620 net/minecraft/block/cauldron/CauldronBehavior
 		ARG 4 hand
 		ARG 5 stack
 	METHOD method_34850 registerBucketBehavior (Ljava/util/Map;)V
+		COMMENT Registers the behavior for filled buckets in the specified behavior map.
 		ARG 0 behavior

--- a/src/packageDocs/java/net/minecraft/block/cauldron/package-info.java
+++ b/src/packageDocs/java/net/minecraft/block/cauldron/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * This file is free for everyone to use under the Creative Commons Zero license.
+ */
+
+/**
+ * Provides the {@linkplain net.minecraft.block.cauldron.CauldronBehavior cauldron behavior} system,
+ * which determines what happens when a player interacts with a cauldron.
+ *
+ * @see net.minecraft.block.AbstractCauldronBlock
+ */
+package net.minecraft.block.cauldron;


### PR DESCRIPTION
Also mapped some constants in `LeveledCauldronBlock`:
- The values of `BASE_FLUID_HEIGHT` and `FLUID_HEIGHT_PER_LEVEL` are unique in the class
- The value of `MAX_LEVEL` is unique in the class and is immediately preceded by a constant equal to the minimum level so I mapped it `MIN_LEVEL`