### PR TITLE
Update BirdNavigation.mapping, QOL patch

### DIFF
--- a/mappings/net/minecraft/entity/ai/pathing/BirdNavigation.mapping
+++ b/mappings/net/minecraft/entity/ai/pathing/BirdNavigation.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_1407 net/minecraft/entity/ai/pathing/BirdNavigation
 	METHOD method_35128 canEnterOpenDoors ()Z
+	METHOD method_35129 canEnterOpenDoors2 ()Z
 	METHOD method_6331 setCanEnterOpenDoors (Z)V
 		ARG 1 canEnterOpenDoors
 	METHOD method_6332 setCanPathThroughDoors (Z)V


### PR DESCRIPTION
Added a mapping for a duplicate method for BirdNavigation::canEnterOpenDoors (QOL patch)

Reference: 
![image](https://user-images.githubusercontent.com/80366076/195757192-08c2e121-7be1-4fe0-92e9-e5b0c8b20811.png)

```java

    public boolean canEnterOpenDoors() {
        return this.nodeMaker.canEnterOpenDoors();
    }
    ...
    public boolean method_35129() {
        return this.nodeMaker.canEnterOpenDoors();
    }
```