### PR TITLE
Add Documentation for core Particle classes

### DIFF
--- a/mappings/net/minecraft/client/particle/BillboardParticle.mapping
+++ b/mappings/net/minecraft/client/particle/BillboardParticle.mapping
@@ -13,7 +13,5 @@ CLASS net/minecraft/class_3940 net/minecraft/client/particle/BillboardParticle
 	METHOD method_18136 getMaxV ()F
 		COMMENT @return the upper V coordinate of the UV coordinates used to draw this particle
 	METHOD method_3087 (F)Lnet/minecraft/class_703;
-		COMMENT Multiplies the current particle scale by the given amount.
-		COMMENT
-		COMMENT @param the amount to multiply this particle's scale by
-		COMMENT @return this {@link Particle}
+		COMMENT Scales the size of this particle by the given {@code scale} amount.
+			COMMENT the amount to multiply this particle's scale by

--- a/mappings/net/minecraft/client/particle/BillboardParticle.mapping
+++ b/mappings/net/minecraft/client/particle/BillboardParticle.mapping
@@ -1,8 +1,19 @@
 CLASS net/minecraft/class_3940 net/minecraft/client/particle/BillboardParticle
+	COMMENT A {@link Particle} which renders a camera-facing sprite with a target texture scale.
 	FIELD field_17867 scale F
 	METHOD method_18132 getSize (F)F
+		COMMENT @return the draw scale of this particle, which is used while rendering in {@link BillboardParticle#buildGeometry}
 		ARG 1 tickDelta
 	METHOD method_18133 getMinU ()F
+		COMMENT @return the lower U coordinate of the UV coordinates used to draw this particle
 	METHOD method_18134 getMaxU ()F
+		COMMENT @return the upper U coordinate of the UV coordinates used to draw this particle
 	METHOD method_18135 getMinV ()F
+		COMMENT @return the lower V coordinate of the UV coordinates used to draw this particle
 	METHOD method_18136 getMaxV ()F
+		COMMENT @return the upper V coordinate of the UV coordinates used to draw this particle
+	METHOD method_3087 (F)Lnet/minecraft/class_703;
+		COMMENT Multiplies the current particle scale by the given amount.
+		COMMENT
+		COMMENT @param the amount to multiply this particle's scale by
+		COMMENT @return this {@link Particle}

--- a/mappings/net/minecraft/client/particle/BillboardParticle.mapping
+++ b/mappings/net/minecraft/client/particle/BillboardParticle.mapping
@@ -14,4 +14,5 @@ CLASS net/minecraft/class_3940 net/minecraft/client/particle/BillboardParticle
 		COMMENT @return the upper V coordinate of the UV coordinates used to draw this particle
 	METHOD method_3087 (F)Lnet/minecraft/class_703;
 		COMMENT Scales the size of this particle by the given {@code scale} amount.
-			COMMENT the amount to multiply this particle's scale by
+		COMMENT
+		COMMENT @return this {@link Particle}

--- a/mappings/net/minecraft/client/particle/NoRenderParticle.mapping
+++ b/mappings/net/minecraft/client/particle/NoRenderParticle.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_3998 net/minecraft/client/particle/NoRenderParticle
+	COMMENT A {@link Particle} with no rendered texture. Useful for emitter particles (such as {@link net.minecraft.client.particle.EmitterParticle})
+	COMMENT that spawn other particles while ticking, but do not render anything themselves.

--- a/mappings/net/minecraft/client/particle/Particle.mapping
+++ b/mappings/net/minecraft/client/particle/Particle.mapping
@@ -58,13 +58,12 @@ CLASS net/minecraft/class_703 net/minecraft/client/particle/Particle
 		COMMENT @return the {@link ParticleTextureSheet} any {@link Particle} of this type will render through
 	METHOD method_3063 setPos (DDD)V
 		COMMENT Updates the position and bounding box of this {@link Particle} to the target {@code x}, {@code y}, {@code z} position.
-		COMMENT
-		COMMENT @param x the x position to move this particle to
-		COMMENT @param y the y position to move this particle to
-		COMMENT @param z the z position to move this particle to
 		ARG 1 x
+			COMMENT the x position to move this particle to
 		ARG 3 y
+			COMMENT the y position to move this particle to
 		ARG 5 z
+			COMMENT the z position to move this particle to
 	METHOD method_3064 getBoundingBox ()Lnet/minecraft/class_238;
 		COMMENT Returns the bounding {@link Box} of this particle, which is used for collision and movement logic.
 		COMMENT
@@ -82,35 +81,31 @@ CLASS net/minecraft/class_703 net/minecraft/client/particle/Particle
 		ARG 1 tint
 	METHOD method_3069 move (DDD)V
 		COMMENT Moves this {@link Particle} by the specified delta amounts, re-positioning bounding boxes and adjusting movement for collision with the world.
-		COMMENT
-		COMMENT @param dx the delta x to move this particle by
-		COMMENT @param dy the delta y to move this particle by
-		COMMENT @param dz the delta z to move this particle by
 		ARG 1 dx
+			COMMENT the delta x to move this particle by
 		ARG 3 dy
+			COMMENT the delta y to move this particle by
 		ARG 5 dz
+			COMMENT the delta z to move this particle by
 	METHOD method_3070 tick ()V
 		COMMENT This method is called each game tick (20 times per second), and should be used to do core {@link Particle} logic, such as movement and collision.
 	METHOD method_3072 repositionFromBoundingBox ()V
 	METHOD method_3074 buildGeometry (Lnet/minecraft/class_4588;Lnet/minecraft/class_4184;F)V
 		COMMENT Renders this {@link Particle} to the given {@link VertexConsumer} buffer.
-		COMMENT
-		COMMENT @param vertexConsumer the buffer to render to
-		COMMENT @param camera the current active game {@link Camera}
-		COMMENT @param tickDelta frame tick delta amount
 		ARG 1 vertexConsumer
+			COMMENT the buffer to render to
 		ARG 2 camera
+			COMMENT the current active game {@link Camera}
 		ARG 3 tickDelta
+			COMMENT frame tick delta amount
 	METHOD method_3075 move (F)Lnet/minecraft/class_703;
 		COMMENT Multiplies this {@link Particle}'s current velocity by the target {@code speed} amount.
-		COMMENT
-		COMMENT @param speed the velocity multiplier to apply to this {@link Particle}
 		ARG 1 speed
+			COMMENT the velocity multiplier to apply to this {@link Particle}
 	METHOD method_3077 setMaxAge (I)V
 		COMMENT Sets the maximum age, in ticks, that this particle can exist for.
-		COMMENT
-		COMMENT @param maxAge maximum age in ticks
 		ARG 1 maxAge
+			COMMENT the new maximum age of this {@link Particle}, in ticks
 	METHOD method_3080 setBoundingBoxSpacing (FF)V
 		ARG 1 spacingXZ
 		ARG 2 spacingY
@@ -127,19 +122,17 @@ CLASS net/minecraft/class_703 net/minecraft/client/particle/Particle
 		COMMENT
 		COMMENT <p>
 		COMMENT Also note that the default particle shader (core/particle.fsh) will discard all transparent pixels below 0.1 alpha.
-		COMMENT
-		COMMENT @param alpha the new alpha value of this particle
 		ARG 1 alpha
+			COMMENT the new alpha value of this particle
 	METHOD method_3084 setColor (FFF)V
 		COMMENT Updates the rendering color of this particle.
 		COMMENT Each value should be between 0.0 (no channel color) and 1.0 (full channel color).
-		COMMENT
-		COMMENT @param red the target red color to use while rendering
-		COMMENT @param green the target green color to use while rendering
-		COMMENT @param blue the target blue color to use while rendering
 		ARG 1 red
+			COMMENT the target red color to use while rendering
 		ARG 2 green
+			COMMENT the target green color to use while rendering
 		ARG 3 blue
+			COMMENT the target blue color to use while rendering
 	METHOD method_3085 markDead ()V
 		COMMENT Marks this {@link Particle} as ready to be removed from the containing {@link ClientWorld}.
 	METHOD method_3086 isAlive ()Z
@@ -147,8 +140,9 @@ CLASS net/minecraft/class_703 net/minecraft/client/particle/Particle
 	METHOD method_3087 scale (F)Lnet/minecraft/class_703;
 		COMMENT Scales the size of this particle by the given {@code scale} amount.
 		COMMENT
-		COMMENT @param scale the amount to scale this particle's size by
+		COMMENT @return this {@link Particle}
 		ARG 1 scale
+			COMMENT the amount to scale this particle's size by
 	METHOD method_34019 getGroup ()Ljava/util/Optional;
 		COMMENT {@return the optional group that this particle belongs to}
 		COMMENT
@@ -157,10 +151,9 @@ CLASS net/minecraft/class_703 net/minecraft/client/particle/Particle
 		COMMENT it is not restricted.
 	METHOD method_34753 setVelocity (DDD)V
 		COMMENT Updates this {@link Particle}'s velocity to the target X, Y, and Z values.
-		COMMENT
-		COMMENT @param velocityX the new x-velocity of this {@link Particle}
-		COMMENT @param velocityY the new y-velocity of this {@link Particle}
-		COMMENT @param velocityZ the new y-velocity of this {@link Particle}
 		ARG 1 velocityX
+			COMMENT the new x-velocity of this {@link Particle}
 		ARG 3 velocityY
+			COMMENT the new y-velocity of this {@link Particle}
 		ARG 5 velocityZ
+			COMMENT the new z-velocity of this {@link Particle}

--- a/mappings/net/minecraft/client/particle/Particle.mapping
+++ b/mappings/net/minecraft/client/particle/Particle.mapping
@@ -1,4 +1,12 @@
 CLASS net/minecraft/class_703 net/minecraft/client/particle/Particle
+	COMMENT {@link Particle} is a client-side visual effect with position, velocity, collision, and additional render properties.
+	COMMENT
+	COMMENT <p>
+	COMMENT Each {@code Particle} is typically rendered as a camera-facing texture quad.
+	COMMENT {@link net.minecraft.client.particle.SpriteBillboardParticle} provides this behavior, and most vanilla particles inherit from it.
+	COMMENT
+	COMMENT <p>
+	COMMENT If you would like a {@link Particle} with no direct rendering effects, inherit from {@link net.minecraft.client.particle.NoRenderParticle}.
 	FIELD field_28786 velocityMultiplier F
 	FIELD field_36193 MAX_SQUARED_COLLISION_CHECK_DISTANCE D
 	FIELD field_3838 prevPosY D
@@ -42,42 +50,104 @@ CLASS net/minecraft/class_703 net/minecraft/client/particle/Particle
 		ARG 10 velocityY
 		ARG 12 velocityZ
 	METHOD method_18122 getType ()Lnet/minecraft/class_3999;
+		COMMENT Returns the rendering category this {@link Particle} is rendered under.
+		COMMENT
+		COMMENT <p>
+		COMMENT For more information on the properties and types available to each {@code Particle}, visit {@link ParticleTextureSheet}.
+		COMMENT
+		COMMENT @return the {@link ParticleTextureSheet} any {@link Particle} of this type will render through
 	METHOD method_3063 setPos (DDD)V
+		COMMENT Updates the position and bounding box of this {@link Particle} to the target {@code x}, {@code y}, {@code z} position.
+		COMMENT
+		COMMENT @param x the x position to move this particle to
+		COMMENT @param y the y position to move this particle to
+		COMMENT @param z the z position to move this particle to
 		ARG 1 x
 		ARG 3 y
 		ARG 5 z
 	METHOD method_3064 getBoundingBox ()Lnet/minecraft/class_238;
+		COMMENT Returns the bounding {@link Box} of this particle, which is used for collision and movement logic.
+		COMMENT
+		COMMENT <p>
+		COMMENT By default, this bounding box is automatically repositioned when a particle moves in {@link Particle#tick()}.
+		COMMENT To adjust the size of the returned box, visit {@link Particle#setBoundingBoxSpacing(float, float)}.
+		COMMENT To directly update the current bounding box, visit {@link Particle#setBoundingBox(Box)};
+		COMMENT
+		COMMENT @return the bounding {@link Box} of this particle, used for collision and movement
 	METHOD method_3067 setBoundingBox (Lnet/minecraft/class_238;)V
 		ARG 1 boundingBox
 	METHOD method_3068 getBrightness (F)I
+		COMMENT @return the packed light level this particle should render at
+		COMMENT @see net.minecraft.client.render.LightmapTextureManager
 		ARG 1 tint
 	METHOD method_3069 move (DDD)V
+		COMMENT Moves this {@link Particle} by the specified delta amounts, re-positioning bounding boxes and adjusting movement for collision with the world.
+		COMMENT
+		COMMENT @param dx the delta x to move this particle by
+		COMMENT @param dy the delta y to move this particle by
+		COMMENT @param dz the delta z to move this particle by
 		ARG 1 dx
 		ARG 3 dy
 		ARG 5 dz
 	METHOD method_3070 tick ()V
+		COMMENT This method is called each game tick (20 times per second), and should be used to do core {@link Particle} logic, such as movement and collision.
 	METHOD method_3072 repositionFromBoundingBox ()V
 	METHOD method_3074 buildGeometry (Lnet/minecraft/class_4588;Lnet/minecraft/class_4184;F)V
+		COMMENT Renders this {@link Particle} to the given {@link VertexConsumer} buffer.
+		COMMENT
+		COMMENT @param vertexConsumer the buffer to render to
+		COMMENT @param camera the current active game {@link Camera}
+		COMMENT @param tickDelta frame tick delta amount
 		ARG 1 vertexConsumer
 		ARG 2 camera
 		ARG 3 tickDelta
 	METHOD method_3075 move (F)Lnet/minecraft/class_703;
+		COMMENT Multiplies this {@link Particle}'s current velocity by the target {@code speed} amount.
+		COMMENT
+		COMMENT @param speed the velocity multiplier to apply to this {@link Particle}
 		ARG 1 speed
 	METHOD method_3077 setMaxAge (I)V
+		COMMENT Sets the maximum age, in ticks, that this particle can exist for.
+		COMMENT
+		COMMENT @param maxAge maximum age in ticks
 		ARG 1 maxAge
 	METHOD method_3080 setBoundingBoxSpacing (FF)V
 		ARG 1 spacingXZ
 		ARG 2 spacingY
 	METHOD method_3082 getMaxAge ()I
+		COMMENT Returns the maximum age, in ticks, of this particle. If this particle's age exceeds this value, it will be removed from the world.
+		COMMENT
+		COMMENT @return this particle's maximum age, in ticks
 	METHOD method_3083 setAlpha (F)V
+		COMMENT Updates the alpha value of this {@link Particle} to use while rendering.
+		COMMENT
+		COMMENT <p>
+		COMMENT Note that a {@link Particle} cannot render with transparency unless {@link Particle#getType()} is
+		COMMENT {@link ParticleTextureSheet#PARTICLE_SHEET_TRANSLUCENT}, or another sheet that supports transparency.
+		COMMENT
+		COMMENT <p>
+		COMMENT Also note that the default particle shader (core/particle.fsh) will discard all transparent pixels below 0.1 alpha.
+		COMMENT
+		COMMENT @param alpha the new alpha value of this particle
 		ARG 1 alpha
 	METHOD method_3084 setColor (FFF)V
+		COMMENT Updates the rendering color of this particle.
+		COMMENT Each value should be between 0.0 (no channel color) and 1.0 (full channel color).
+		COMMENT
+		COMMENT @param red the target red color to use while rendering
+		COMMENT @param green the target green color to use while rendering
+		COMMENT @param blue the target blue color to use while rendering
 		ARG 1 red
 		ARG 2 green
 		ARG 3 blue
 	METHOD method_3085 markDead ()V
+		COMMENT Marks this {@link Particle} as ready to be removed from the containing {@link ClientWorld}.
 	METHOD method_3086 isAlive ()Z
+		COMMENT @return {@code false} if this particle is finished & should be removed from the parent {@link ParticleManager}, otherwise {@code true} if the particle is still alive
 	METHOD method_3087 scale (F)Lnet/minecraft/class_703;
+		COMMENT Scales the size of this particle by the given {@code scale} amount.
+		COMMENT
+		COMMENT @param scale the amount to scale this particle's size by
 		ARG 1 scale
 	METHOD method_34019 getGroup ()Ljava/util/Optional;
 		COMMENT {@return the optional group that this particle belongs to}
@@ -86,6 +156,11 @@ CLASS net/minecraft/class_703 net/minecraft/client/particle/Particle
 		COMMENT can be rendered in a client world. If the particle does not have a group,
 		COMMENT it is not restricted.
 	METHOD method_34753 setVelocity (DDD)V
+		COMMENT Updates this {@link Particle}'s velocity to the target X, Y, and Z values.
+		COMMENT
+		COMMENT @param velocityX the new x-velocity of this {@link Particle}
+		COMMENT @param velocityY the new y-velocity of this {@link Particle}
+		COMMENT @param velocityZ the new y-velocity of this {@link Particle}
 		ARG 1 velocityX
 		ARG 3 velocityY
 		ARG 5 velocityZ

--- a/mappings/net/minecraft/client/particle/ParticleTextureSheet.mapping
+++ b/mappings/net/minecraft/client/particle/ParticleTextureSheet.mapping
@@ -14,9 +14,9 @@ CLASS net/minecraft/class_3999 net/minecraft/client/particle/ParticleTextureShee
 	METHOD method_18130 begin (Lnet/minecraft/class_287;Lnet/minecraft/class_1060;)V
 		COMMENT Called to set up OpenGL render state for drawing particles of a given type.
 		ARG 1 builder
-			COMMENT builder the buffer particles will draw to in {@link net.minecraft.client.particle.Particle#buildGeometry(VertexConsumer, Camera, float)}
+			COMMENT the buffer particles will draw to in {@link net.minecraft.client.particle.Particle#buildGeometry(VertexConsumer, Camera, float)}
 		ARG 2 textureManager
-			COMMENT textureManager texture loading context
+			COMMENT texture loading context
 	METHOD method_18131 draw (Lnet/minecraft/class_289;)V
 		COMMENT Called after all particles of a {@link ParticleTextureSheet} have finished drawing.
 		ARG 1 tessellator

--- a/mappings/net/minecraft/client/particle/ParticleTextureSheet.mapping
+++ b/mappings/net/minecraft/client/particle/ParticleTextureSheet.mapping
@@ -13,13 +13,11 @@ CLASS net/minecraft/class_3999 net/minecraft/client/particle/ParticleTextureShee
 	FIELD field_17832 NO_RENDER Lnet/minecraft/class_3999;
 	METHOD method_18130 begin (Lnet/minecraft/class_287;Lnet/minecraft/class_1060;)V
 		COMMENT Called to set up OpenGL render state for drawing particles of a given type.
-		COMMENT
-		COMMENT @param builder the buffer particles will draw to in {@link net.minecraft.client.particle.Particle#buildGeometry(VertexConsumer, Camera, float)}
-		COMMENT @param textureManager texture loading context
 		ARG 1 builder
+			COMMENT builder the buffer particles will draw to in {@link net.minecraft.client.particle.Particle#buildGeometry(VertexConsumer, Camera, float)}
 		ARG 2 textureManager
+			COMMENT textureManager texture loading context
 	METHOD method_18131 draw (Lnet/minecraft/class_289;)V
 		COMMENT Called after all particles of a {@link ParticleTextureSheet} have finished drawing.
-		COMMENT
-		COMMENT @param tessellator the {@code Tessellator} all particles in this sheet drew to
 		ARG 1 tessellator
+			COMMENT the {@code Tessellator} all particles in this sheet drew to

--- a/mappings/net/minecraft/client/particle/ParticleTextureSheet.mapping
+++ b/mappings/net/minecraft/client/particle/ParticleTextureSheet.mapping
@@ -1,4 +1,10 @@
 CLASS net/minecraft/class_3999 net/minecraft/client/particle/ParticleTextureSheet
+	COMMENT Defines rendering setup & draw logic for particles based on their requirements for depth checking, textures, and transparency.
+	COMMENT
+	COMMENT <p>
+	COMMENT Each {@link net.minecraft.client.particle.Particle} returns a {@link ParticleTextureSheet} in {@link net.minecraft.client.particle.Particle#getType()}.
+	COMMENT When particles are rendered, each sheet will be drawn once.
+	COMMENT {@link ParticleTextureSheet#begin(BufferBuilder, TextureManager)} is first called to set up render state, and after each particle has emitted geometry, {@link ParticleTextureSheet#draw(Tessellator)} is called to draw to a target buffer.
 	FIELD field_17827 TERRAIN_SHEET Lnet/minecraft/class_3999;
 	FIELD field_17828 PARTICLE_SHEET_OPAQUE Lnet/minecraft/class_3999;
 	FIELD field_17829 PARTICLE_SHEET_TRANSLUCENT Lnet/minecraft/class_3999;
@@ -6,7 +12,14 @@ CLASS net/minecraft/class_3999 net/minecraft/client/particle/ParticleTextureShee
 	FIELD field_17831 CUSTOM Lnet/minecraft/class_3999;
 	FIELD field_17832 NO_RENDER Lnet/minecraft/class_3999;
 	METHOD method_18130 begin (Lnet/minecraft/class_287;Lnet/minecraft/class_1060;)V
+		COMMENT Called to set up OpenGL render state for drawing particles of a given type.
+		COMMENT
+		COMMENT @param builder the buffer particles will draw to in {@link net.minecraft.client.particle.Particle#buildGeometry(VertexConsumer, Camera, float)}
+		COMMENT @param textureManager texture loading context
 		ARG 1 builder
 		ARG 2 textureManager
 	METHOD method_18131 draw (Lnet/minecraft/class_289;)V
+		COMMENT Called after all particles of a {@link ParticleTextureSheet} have finished drawing.
+		COMMENT
+		COMMENT @param tessellator the {@code Tessellator} all particles in this sheet drew to
 		ARG 1 tessellator

--- a/mappings/net/minecraft/client/particle/SpriteBillboardParticle.mapping
+++ b/mappings/net/minecraft/client/particle/SpriteBillboardParticle.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_4003 net/minecraft/client/particle/SpriteBillboardPart
 		COMMENT @return the lower V coordinate of the {@link Sprite} rendered by this particle
 	METHOD method_18136 ()F
 		COMMENT @return the upper U coordinate of the {@link Sprite} rendered by this particle
-	METHOD method_18140 setRandomSprite (Lnet/minecraft/class_4002;)V
+	METHOD method_18140 setSprite (Lnet/minecraft/class_4002;)V
 		COMMENT Sets the current {@link Sprite} of this {@link SpriteBillboardParticle} to a random frame in its atlas sheet.
 		ARG 1 spriteProvider
 			COMMENT sprite access for retrieving random {@link Sprite} frames

--- a/mappings/net/minecraft/client/particle/SpriteBillboardParticle.mapping
+++ b/mappings/net/minecraft/client/particle/SpriteBillboardParticle.mapping
@@ -11,19 +11,16 @@ CLASS net/minecraft/class_4003 net/minecraft/client/particle/SpriteBillboardPart
 		COMMENT @return the upper U coordinate of the {@link Sprite} rendered by this particle
 	METHOD method_18140 setRandomSprite (Lnet/minecraft/class_4002;)V
 		COMMENT Sets the current {@link Sprite} of this {@link SpriteBillboardParticle} to a random frame in its atlas sheet.
-		COMMENT
-		COMMENT @param spriteProvider sprite access for retrieving random {@link Sprite} frames
 		ARG 1 spriteProvider
+			COMMENT sprite access for retrieving random {@link Sprite} frames
 	METHOD method_18141 setSprite (Lnet/minecraft/class_1058;)V
 		COMMENT Sets the current {@link Sprite} of this {@link SpriteBillboardParticle}.
 		COMMENT
 		COMMENT <p>
 		COMMENT To assign a {@link Sprite} based on particle age, visit {@link SpriteBillboardParticle#setSpriteForAge}.
-		COMMENT
-		COMMENT @param sprite the new sprite to assign to this particle
 		ARG 1 sprite
+			COMMENT the new {@link Sprite} to assign to this {@link Particle}
 	METHOD method_18142 setSpriteForAge (Lnet/minecraft/class_4002;)V
 		COMMENT Sets the current {@link Sprite} of this {@link SpriteBillboardParticle} based on the age of the particle, assuming the particle texture is an atlas with multiple frames.
-		COMMENT
-		COMMENT @param spriteProvider sprite access for retrieving the proper {@link Sprite} based on lifetime progress
 		ARG 1 spriteProvider
+			COMMENT sprite access for retrieving the proper {@link Sprite} based on lifetime progress

--- a/mappings/net/minecraft/client/particle/SpriteBillboardParticle.mapping
+++ b/mappings/net/minecraft/client/particle/SpriteBillboardParticle.mapping
@@ -8,7 +8,7 @@ CLASS net/minecraft/class_4003 net/minecraft/client/particle/SpriteBillboardPart
 	METHOD method_18135 ()F
 		COMMENT @return the lower V coordinate of the {@link Sprite} rendered by this particle
 	METHOD method_18136 ()F
-		COMMENT @return the upper U coordinate of the {@link Sprite} rendered by this particle
+		COMMENT @return the upper V coordinate of the {@link Sprite} rendered by this particle
 	METHOD method_18140 setRandomSprite (Lnet/minecraft/class_4002;)V
 		COMMENT Sets the current {@link Sprite} of this {@link SpriteBillboardParticle} to a random frame in its atlas sheet.
 		ARG 1 spriteProvider

--- a/mappings/net/minecraft/client/particle/SpriteBillboardParticle.mapping
+++ b/mappings/net/minecraft/client/particle/SpriteBillboardParticle.mapping
@@ -1,8 +1,29 @@
 CLASS net/minecraft/class_4003 net/minecraft/client/particle/SpriteBillboardParticle
+	COMMENT {@link SpriteBillboardParticle} is a {@link BillboardParticle} implementation class that renders a {@link Sprite} as its camera-facing texture.
 	FIELD field_17886 sprite Lnet/minecraft/class_1058;
-	METHOD method_18140 setSprite (Lnet/minecraft/class_4002;)V
+	METHOD method_18133 ()F
+		COMMENT @return the lower U coordinate of the {@link Sprite} rendered by this particle
+	METHOD method_18134 ()F
+		COMMENT @return the upper U coordinate of the {@link Sprite} rendered by this particle
+	METHOD method_18135 ()F
+		COMMENT @return the lower V coordinate of the {@link Sprite} rendered by this particle
+	METHOD method_18136 ()F
+		COMMENT @return the upper U coordinate of the {@link Sprite} rendered by this particle
+	METHOD method_18140 setRandomSprite (Lnet/minecraft/class_4002;)V
+		COMMENT Sets the current {@link Sprite} of this {@link SpriteBillboardParticle} to a random frame in its atlas sheet.
+		COMMENT
+		COMMENT @param spriteProvider sprite access for retrieving random {@link Sprite} frames
 		ARG 1 spriteProvider
 	METHOD method_18141 setSprite (Lnet/minecraft/class_1058;)V
+		COMMENT Sets the current {@link Sprite} of this {@link SpriteBillboardParticle}.
+		COMMENT
+		COMMENT <p>
+		COMMENT To assign a {@link Sprite} based on particle age, visit {@link SpriteBillboardParticle#setSpriteForAge}.
+		COMMENT
+		COMMENT @param sprite the new sprite to assign to this particle
 		ARG 1 sprite
 	METHOD method_18142 setSpriteForAge (Lnet/minecraft/class_4002;)V
+		COMMENT Sets the current {@link Sprite} of this {@link SpriteBillboardParticle} based on the age of the particle, assuming the particle texture is an atlas with multiple frames.
+		COMMENT
+		COMMENT @param spriteProvider sprite access for retrieving the proper {@link Sprite} based on lifetime progress
 		ARG 1 spriteProvider


### PR DESCRIPTION
Hi! I started a write-up of some Javadocs for the core Particle classes. I would appreciate any feedback on the documentation. I also haven't used Enigma in a while, so please let me know if you spot a syntax error or typo!

I also renamed `method_18140` from `setSprite` to `setRandomSprite`. IMO it's confusing as a caller _what_ method you're looking at (because the arguments are `Sprite` vs. `SpriteProvider`), and the implementation of this method makes it clear it is aimed at selecting a random sprite from the particle's texture atlas. I'm happy to remove this and wait if it needs to be in a separate PR or discussed more first.