### PR TITLE
Add documentation for EquipmentSlot class

### DIFF
--- a/mappings/net/minecraft/entity/EquipmentSlot.mapping
+++ b/mappings/net/minecraft/entity/EquipmentSlot.mapping
@@ -1,7 +1,17 @@
 CLASS net/minecraft/class_1304 net/minecraft/entity/EquipmentSlot
-	COMMENT Represents the type of item found in an inventory slot.
-	COMMENT Each slot can hold hand items (such as weapons or tools in a main hand), or armor items (such as a helmet in the head armor slot).
-	COMMENT Provides additional information regarding the index each slot type should be at inside to an inventory.
+	COMMENT Provides enum types for several key slots found within an entity {@link net.minecraft.inventory.Inventory}.
+	COMMENT <p>
+	COMMENT Each {@link EquipmentSlot} has a type, which represents what inventory category it is contained within.
+	COMMENT The {@code HAND} category cover the mainhand & offhand slot, while the {@code ARMOR} category covers the 4
+	COMMENT types of armor slots found in {@link net.minecraft.entity.LivingEntity}.
+	COMMENT <p>
+	COMMENT Each {@link EquipmentSlot} contains information on where that slot should be located within a parent {@link net.minecraft.inventory.Inventory}.
+	COMMENT {@link EquipmentSlot#getEntitySlotId()} will provide the base slot index an {@code EquipmentSlot} should occupy (starting from {@code 0}),
+	COMMENT while {@link EquipmentSlot#getOffsetEntitySlotId(int)} will return the same value added to an offset index.
+	COMMENT <p>
+	COMMENT {@link EquipmentSlot} can be used to quickly access the item held by an inventory slot in a {@link net.minecraft.entity.LivingEntity} through
+	COMMENT methods such as {@link net.minecraft.entity.LivingEntity#getEquippedStack(EquipmentSlot)}, which will return the {@link net.minecraft.item.ItemStack}
+	COMMENT held in the {@code LivingEntity}'s inventory slot pointed at by the target {@code EquipmentSlot}.
 	FIELD field_6167 armorStandId I
 	FIELD field_6168 entityId I
 	FIELD field_6170 type Lnet/minecraft/class_1304$class_1305;

--- a/mappings/net/minecraft/entity/EquipmentSlot.mapping
+++ b/mappings/net/minecraft/entity/EquipmentSlot.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/class_1304 net/minecraft/entity/EquipmentSlot
+	COMMENT Represents the type of item found in an inventory slot.
+	COMMENT Each slot can hold hand items (such as weapons or tools in a main hand), or armor items (such as a helmet in the head armor slot).
+	COMMENT Provides additional information regarding the index each slot type should be at inside to an inventory.
 	FIELD field_6167 armorStandId I
 	FIELD field_6168 entityId I
 	FIELD field_6170 type Lnet/minecraft/class_1304$class_1305;
@@ -9,14 +12,49 @@ CLASS net/minecraft/class_1304 net/minecraft/entity/EquipmentSlot
 		ARG 5 armorStandId
 		ARG 6 name
 	METHOD method_20234 fromTypeIndex (Lnet/minecraft/class_1304$class_1305;I)Lnet/minecraft/class_1304;
+		COMMENT Returns the {@link EquipmentSlot} where {@link EquipmentSlot#getEntitySlotId()} is equal to {@code index} and the type of the slot is equal to {@code type}.
+		COMMENT If no {@code EquipmentSlot} could be found matching the input {@code type} and {@code index}, throws {@link IllegalArgumentException}.
+		COMMENT
+		COMMENT @throws IllegalArgumentException if no slot type could be found matching {@code type} and {@code index}
+		COMMENT @return an {@link EquipmentSlot} matching the given {@code type} and inventory {@code index}
 		ARG 0 type
 		ARG 1 index
 	METHOD method_32320 getOffsetEntitySlotId (I)I
+		COMMENT @return the index of the inventory slot this {@link EquipmentSlot} should occupy, plus the passed in {@code offset} amount.
 		ARG 1 offset
 	METHOD method_5923 getName ()Ljava/lang/String;
+		COMMENT Returns the unique name of this {@link EquipmentSlot}.
+		COMMENT The returned value will be a lower-case string (such as "chest" for {@link EquipmentSlot#CHEST}).
+		COMMENT
+		COMMENT @return the lower-case name of this {@link EquipmentSlot}
 	METHOD method_5924 byName (Ljava/lang/String;)Lnet/minecraft/class_1304;
+		COMMENT Returns the {@link EquipmentSlot} where {@link EquipmentSlot#getName()} is equal to {@code name}.
+		COMMENT If no {@code EquipmentSlot} could be found matching the input name, throws {@link IllegalArgumentException}.
+		COMMENT
+		COMMENT @throws IllegalArgumentException if no slot type could be found matching {@code name}
+		COMMENT @return an {@link EquipmentSlot} where {@link EquipmentSlot#getName()} equals {@code name}
 		ARG 0 name
 	METHOD method_5925 getType ()Lnet/minecraft/class_1304$class_1305;
+		COMMENT Returns the target {@link EquipmentSlot.Type} that this {@link EquipmentSlot} targets.
+		COMMENT
+		COMMENT <p>
+		COMMENT An {@link EquipmentSlot} either targets the hand or body type, which can be used to determine whether a request
+		COMMENT to manipulate {@link EquipmentSlot} data on an entity should be applied to an armor inventory or general item inventory.
+		COMMENT
+		COMMENT @return the target {@link EquipmentSlot.Type} (hand or armor) of this {@link EquipmentSlot}
 	METHOD method_5926 getArmorStandSlotId ()I
+		COMMENT @return the index of the inventory slot this {@link EquipmentSlot} occupies in an {@link net.minecraft.entity.decoration.ArmorStandEntity}
 	METHOD method_5927 getEntitySlotId ()I
+		COMMENT Returns the index of the inventory slot this {@link EquipmentSlot} should occupy.
+		COMMENT
+		COMMENT <p>
+		COMMENT In the case of {@link EquipmentSlot#MAINHAND} and {@link EquipmentSlot#OFFHAND}, this method will return 0 & 1, respectively.
+		COMMENT The remaining armor slots re-start at index 0 and end at index 3.
+		COMMENT
+		COMMENT <p>
+		COMMENT To calculate the target index of an inventory slot for an {@link EquipmentSlot} relative to the offset index of an entire
+		COMMENT inventory, visit {@link EquipmentSlot#getOffsetEntitySlotId(int)}.
+		COMMENT
+		COMMENT @return index of the inventory slot this {@link EquipmentSlot} should occupy
 	CLASS class_1305 Type
+		COMMENT The type of body item slot an {@link EquipmentSlot} targets.

--- a/mappings/net/minecraft/entity/EquipmentSlot.mapping
+++ b/mappings/net/minecraft/entity/EquipmentSlot.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_1304 net/minecraft/entity/EquipmentSlot
 	COMMENT Provides enum types for several key slots found within an entity {@link net.minecraft.inventory.Inventory}.
 	COMMENT <p>
 	COMMENT Each {@link EquipmentSlot} has a type, which represents what inventory category it is contained within.
-	COMMENT The {@code HAND} category cover the mainhand & offhand slot, while the {@code ARMOR} category covers the 4
+	COMMENT The {@code HAND} category covers the mainhand & offhand slots, while the {@code ARMOR} category covers the 4
 	COMMENT types of armor slots found in {@link net.minecraft.entity.LivingEntity}.
 	COMMENT <p>
 	COMMENT Each {@link EquipmentSlot} contains information on where that slot should be located within a parent {@link net.minecraft.inventory.Inventory}.


### PR DESCRIPTION
An initial take at javadocs for the `EquipmentSlot` class. I'll be looking at tackling the somewhat related `ArmorItem` and `ArmorMaterial` classes tomorrow.