### PR TITLE
22w42a command

### DIFF
--- a/mappings/net/minecraft/command/CommandRegistryAccess.mapping
+++ b/mappings/net/minecraft/command/CommandRegistryAccess.mapping
@@ -7,8 +7,10 @@ CLASS net/minecraft/class_7157 net/minecraft/command/CommandRegistryAccess
 	COMMENT provides an instance with proper configurations.
 	FIELD field_37820 dynamicRegistryManager Lnet/minecraft/class_5455;
 	FIELD field_37821 entryListCreationPolicy Lnet/minecraft/class_7157$class_7158;
+	FIELD field_40368 enabledFeatures Lnet/minecraft/class_7699;
 	METHOD <init> (Lnet/minecraft/class_5455;Lnet/minecraft/class_7699;)V
 		ARG 1 dynamicRegistryManager
+		ARG 2 enabledFeatures
 	METHOD method_41698 setEntryListCreationPolicy (Lnet/minecraft/class_7157$class_7158;)V
 		COMMENT Sets the policy on how to handle unrecognized tags.
 		COMMENT

--- a/mappings/net/minecraft/command/CommandRegistryWrapper.mapping
+++ b/mappings/net/minecraft/command/CommandRegistryWrapper.mapping
@@ -35,3 +35,12 @@ CLASS net/minecraft/class_7225 net/minecraft/command/CommandRegistryWrapper
 		FIELD field_37996 registry Lnet/minecraft/class_2378;
 		METHOD <init> (Lnet/minecraft/class_2378;)V
 			ARG 1 registry
+		METHOD method_45919 withFeatureFilter (Lnet/minecraft/class_7699;)Lnet/minecraft/class_7225;
+			ARG 1 enabledFeatures
+		METHOD method_45921 withFilter (Ljava/util/function/Predicate;)Lnet/minecraft/class_7225;
+			ARG 1 filter
+		CLASS 1
+			METHOD method_45922 (Ljava/util/function/Predicate;Lnet/minecraft/class_6880$class_6883;)Z
+				ARG 1 entry
+			METHOD method_45923 (Ljava/util/function/Predicate;Ljava/util/Map$Entry;)Z
+				ARG 1 entry

--- a/mappings/net/minecraft/command/CommandSource.mapping
+++ b/mappings/net/minecraft/command/CommandSource.mapping
@@ -29,6 +29,7 @@ CLASS net/minecraft/class_2172 net/minecraft/command/CommandSource
 		ARG 2 suggestedIdType
 		ARG 3 builder
 	METHOD method_44750 getChatSuggestions ()Ljava/util/Collection;
+	METHOD method_45549 getEnabledFeatures ()Lnet/minecraft/class_7699;
 	METHOD method_9250 forEachMatching (Ljava/lang/Iterable;Ljava/lang/String;Ljava/lang/String;Ljava/util/function/Function;Ljava/util/function/Consumer;)V
 		ARG 0 candidates
 		ARG 1 remaining

--- a/mappings/net/minecraft/command/EntitySelector.mapping
+++ b/mappings/net/minecraft/command/EntitySelector.mapping
@@ -29,6 +29,10 @@ CLASS net/minecraft/class_2300 net/minecraft/command/EntitySelector
 		ARG 12 type
 		ARG 13 usesAt
 	METHOD method_35815 usesAt ()Z
+	METHOD method_45914 (Lnet/minecraft/class_2168;Lnet/minecraft/class_1297;)Z
+		ARG 1 entity
+	METHOD method_45915 getUnfilteredEntities (Lnet/minecraft/class_2168;)Ljava/util/List;
+		ARG 1 source
 	METHOD method_9809 getEntity (Lnet/minecraft/class_2168;)Lnet/minecraft/class_1297;
 		ARG 1 source
 	METHOD method_9810 (Lnet/minecraft/class_238;Lnet/minecraft/class_1297;)Z

--- a/mappings/net/minecraft/command/EntitySelectorOptions.mapping
+++ b/mappings/net/minecraft/command/EntitySelectorOptions.mapping
@@ -79,6 +79,8 @@ CLASS net/minecraft/class_2306 net/minecraft/command/EntitySelectorOptions
 		ARG 0 reader
 	METHOD method_9949 (Lnet/minecraft/class_2303;)Z
 		ARG 0 reader
+	METHOD method_9950 (Lnet/minecraft/class_6862;ZLnet/minecraft/class_1297;)Z
+		ARG 2 entity
 	METHOD method_9951 (Lnet/minecraft/class_2303;)V
 		ARG 0 reader
 	METHOD method_9952 (Lnet/minecraft/class_2303;)Z

--- a/mappings/net/minecraft/command/argument/BlockArgumentParser.mapping
+++ b/mappings/net/minecraft/command/argument/BlockArgumentParser.mapping
@@ -36,6 +36,7 @@ CLASS net/minecraft/class_2259 net/minecraft/command/argument/BlockArgumentParse
 		ARG 1 reader
 		ARG 2 allowSnbt
 	METHOD method_41957 block (Lnet/minecraft/class_7225;Ljava/lang/String;Z)Lnet/minecraft/class_2259$class_7211;
+		ARG 0 registryWrapper
 		ARG 1 string
 		ARG 2 allowSnbt
 	METHOD method_41958 (Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
@@ -47,6 +48,7 @@ CLASS net/minecraft/class_2259 net/minecraft/command/argument/BlockArgumentParse
 		ARG 1 reader
 		ARG 2 allowSnbt
 	METHOD method_41962 blockOrTag (Lnet/minecraft/class_7225;Ljava/lang/String;Z)Lcom/mojang/datafixers/util/Either;
+		ARG 0 registryWrapper
 		ARG 1 string
 		ARG 2 allowSnbt
 	METHOD method_41963 suggestBlockId (Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;

--- a/mappings/net/minecraft/command/argument/ParticleEffectArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/ParticleEffectArgumentType.mapping
@@ -1,12 +1,20 @@
 CLASS net/minecraft/class_2223 net/minecraft/command/argument/ParticleEffectArgumentType
+	FIELD field_40383 registryWrapper Lnet/minecraft/class_7225;
 	FIELD field_9935 EXAMPLES Ljava/util/Collection;
 	FIELD field_9936 UNKNOWN_PARTICLE_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
+	METHOD <init> (Lnet/minecraft/class_7157;)V
+		ARG 1 registryAccess
 	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 context
 		ARG 2 builder
+	METHOD method_45583 getType (Lcom/mojang/brigadier/StringReader;Lnet/minecraft/class_7225;)Lnet/minecraft/class_2396;
+		ARG 0 reader
+		ARG 1 registryWrapper
 	METHOD method_9417 particleEffect (Lnet/minecraft/class_7157;)Lnet/minecraft/class_2223;
+		ARG 0 registryAccess
 	METHOD method_9418 readParameters (Lcom/mojang/brigadier/StringReader;Lnet/minecraft/class_7225;)Lnet/minecraft/class_2394;
 		ARG 0 reader
+		ARG 1 registryWrapper
 	METHOD method_9419 (Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
 		ARG 0 id
 	METHOD method_9420 readParameters (Lcom/mojang/brigadier/StringReader;Lnet/minecraft/class_2396;)Lnet/minecraft/class_2394;

--- a/mappings/net/minecraft/command/argument/RegistryEntryArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/RegistryEntryArgumentType.mapping
@@ -1,0 +1,57 @@
+CLASS net/minecraft/class_7733 net/minecraft/command/argument/RegistryEntryArgumentType
+	FIELD field_40401 NOT_FOUND_EXCEPTION Lcom/mojang/brigadier/exceptions/Dynamic2CommandExceptionType;
+	FIELD field_40402 INVALID_TYPE_EXCEPTION Lcom/mojang/brigadier/exceptions/Dynamic3CommandExceptionType;
+	FIELD field_40403 EXAMPLES Ljava/util/Collection;
+	FIELD field_40404 NOT_SUMMONABLE_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
+	FIELD field_40405 registryRef Lnet/minecraft/class_5321;
+	FIELD field_40406 registryWrapper Lnet/minecraft/class_7225;
+	METHOD <init> (Lnet/minecraft/class_7157;Lnet/minecraft/class_5321;)V
+		ARG 1 registryAccess
+		ARG 2 registryRef
+	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
+		ARG 1 context
+		ARG 2 builder
+	METHOD method_45601 getEntityAttribute (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lnet/minecraft/class_6880$class_6883;
+		ARG 0 context
+		ARG 1 name
+	METHOD method_45602 getRegistryEntry (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;Lnet/minecraft/class_5321;)Lnet/minecraft/class_6880$class_6883;
+		ARG 0 context
+		ARG 1 name
+		ARG 2 registryRef
+	METHOD method_45603 registryEntry (Lnet/minecraft/class_7157;Lnet/minecraft/class_5321;)Lnet/minecraft/class_7733;
+		ARG 0 registryAccess
+		ARG 1 registryRef
+	METHOD method_45604 (Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
+		ARG 0 id
+	METHOD method_45605 (Ljava/lang/Object;Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
+		ARG 0 element
+		ARG 1 type
+	METHOD method_45606 (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
+		ARG 0 element
+		ARG 1 type
+		ARG 2 expectedType
+	METHOD method_45607 getConfiguredFeature (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lnet/minecraft/class_6880$class_6883;
+		ARG 0 context
+		ARG 1 name
+	METHOD method_45608 getStructure (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lnet/minecraft/class_6880$class_6883;
+		ARG 0 context
+		ARG 1 name
+	METHOD method_45609 getEntityType (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lnet/minecraft/class_6880$class_6883;
+		ARG 0 context
+		ARG 1 name
+	METHOD method_45610 getSummonableEntityType (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lnet/minecraft/class_6880$class_6883;
+		ARG 0 context
+		ARG 1 name
+	METHOD method_45611 getStatusEffect (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lnet/minecraft/class_6880$class_6883;
+		ARG 0 context
+		ARG 1 name
+	METHOD method_45612 getEnchantment (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lnet/minecraft/class_6880$class_6883;
+		ARG 0 context
+		ARG 1 name
+	METHOD parse (Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;
+		ARG 1 reader
+	CLASS class_7734 Serializer
+		CLASS class_7735 Properties
+			FIELD field_40408 registryRef Lnet/minecraft/class_5321;
+			METHOD <init> (Lnet/minecraft/class_7733$class_7734;Lnet/minecraft/class_5321;)V
+				ARG 2 registryRef

--- a/mappings/net/minecraft/command/argument/RegistryEntryPredicateArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/RegistryEntryPredicateArgumentType.mapping
@@ -1,0 +1,48 @@
+CLASS net/minecraft/class_7737 net/minecraft/command/argument/RegistryEntryPredicateArgumentType
+	FIELD field_40417 EXAMPLES Ljava/util/Collection;
+	FIELD field_40418 NOT_FOUND_EXCEPTION Lcom/mojang/brigadier/exceptions/Dynamic2CommandExceptionType;
+	FIELD field_40419 WRONG_TYPE_EXCEPTION Lcom/mojang/brigadier/exceptions/Dynamic3CommandExceptionType;
+	FIELD field_40420 registryWrapper Lnet/minecraft/class_7225;
+	FIELD field_40421 registryRef Lnet/minecraft/class_5321;
+	METHOD <init> (Lnet/minecraft/class_7157;Lnet/minecraft/class_5321;)V
+		ARG 1 registryAccess
+		ARG 2 registryRef
+	METHOD listSuggestions (Lcom/mojang/brigadier/context/CommandContext;Lcom/mojang/brigadier/suggestion/SuggestionsBuilder;)Ljava/util/concurrent/CompletableFuture;
+		ARG 1 context
+		ARG 2 builder
+	METHOD method_45632 (Lnet/minecraft/class_5321;Lnet/minecraft/class_6880$class_6883;)Lcom/mojang/brigadier/exceptions/CommandSyntaxException;
+		ARG 1 entry
+	METHOD method_45633 (Lnet/minecraft/class_5321;Lnet/minecraft/class_6885$class_6888;)Lcom/mojang/brigadier/exceptions/CommandSyntaxException;
+		ARG 1 entryList
+	METHOD method_45636 getRegistryEntryPredicate (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;Lnet/minecraft/class_5321;)Lnet/minecraft/class_7737$class_7741;
+		ARG 0 context
+		ARG 1 name
+		ARG 2 registryRef
+	METHOD method_45637 registryEntryPredicate (Lnet/minecraft/class_7157;Lnet/minecraft/class_5321;)Lnet/minecraft/class_7737;
+		ARG 0 registryRef
+		ARG 1 registryAccess
+	METHOD method_45639 (Ljava/lang/Object;Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
+		ARG 0 tag
+		ARG 1 type
+	METHOD method_45640 (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
+		ARG 0 tag
+		ARG 1 type
+		ARG 2 expectedType
+	METHOD parse (Lcom/mojang/brigadier/StringReader;)Ljava/lang/Object;
+		ARG 1 reader
+	CLASS class_7738 Serializer
+		CLASS class_7739 Properties
+			FIELD field_40423 registryRef Lnet/minecraft/class_5321;
+			METHOD <init> (Lnet/minecraft/class_7737$class_7738;Lnet/minecraft/class_5321;)V
+				ARG 2 registryRef
+	CLASS class_7740 EntryBased
+		METHOD test (Ljava/lang/Object;)Z
+			ARG 1 entry
+	CLASS class_7741 EntryPredicate
+		METHOD method_45647 getEntry ()Lcom/mojang/datafixers/util/Either;
+		METHOD method_45648 tryCast (Lnet/minecraft/class_5321;)Ljava/util/Optional;
+			ARG 1 registryRef
+		METHOD method_45650 asString ()Ljava/lang/String;
+	CLASS class_7742 TagBased
+		METHOD test (Ljava/lang/Object;)Z
+			ARG 1 entry

--- a/mappings/net/minecraft/server/command/AttributeCommand.mapping
+++ b/mappings/net/minecraft/server/command/AttributeCommand.mapping
@@ -7,8 +7,10 @@ CLASS net/minecraft/class_5252 net/minecraft/server/command/AttributeCommand
 		ARG 0 entity
 	METHOD method_27734 getAttributeInstance (Lnet/minecraft/class_1297;Lnet/minecraft/class_6880;)Lnet/minecraft/class_1324;
 		ARG 0 entity
+		ARG 1 attribute
 	METHOD method_27735 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
+		ARG 1 registryAccess
 	METHOD method_27736 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context
 	METHOD method_27738 (Lnet/minecraft/class_2168;)Z
@@ -16,19 +18,23 @@ CLASS net/minecraft/class_5252 net/minecraft/server/command/AttributeCommand
 	METHOD method_27739 executeValueGet (Lnet/minecraft/class_2168;Lnet/minecraft/class_1297;Lnet/minecraft/class_6880;D)I
 		ARG 0 source
 		ARG 1 target
+		ARG 2 attribute
 		ARG 3 multiplier
 	METHOD method_27740 executeModifierRemove (Lnet/minecraft/class_2168;Lnet/minecraft/class_1297;Lnet/minecraft/class_6880;Ljava/util/UUID;)I
 		ARG 0 source
 		ARG 1 target
+		ARG 2 attribute
 		ARG 3 uuid
 	METHOD method_27741 executeModifierValueGet (Lnet/minecraft/class_2168;Lnet/minecraft/class_1297;Lnet/minecraft/class_6880;Ljava/util/UUID;D)I
 		ARG 0 source
 		ARG 1 target
+		ARG 2 attribute
 		ARG 3 uuid
 		ARG 4 multiplier
 	METHOD method_27742 executeModifierAdd (Lnet/minecraft/class_2168;Lnet/minecraft/class_1297;Lnet/minecraft/class_6880;Ljava/util/UUID;Ljava/lang/String;DLnet/minecraft/class_1322$class_1323;)I
 		ARG 0 source
 		ARG 1 target
+		ARG 2 attribute
 		ARG 3 uuid
 		ARG 4 name
 		ARG 5 value
@@ -44,11 +50,13 @@ CLASS net/minecraft/class_5252 net/minecraft/server/command/AttributeCommand
 		ARG 2 uuid
 	METHOD method_27746 getLivingEntityWithAttribute (Lnet/minecraft/class_1297;Lnet/minecraft/class_6880;)Lnet/minecraft/class_1309;
 		ARG 0 entity
+		ARG 1 attribute
 	METHOD method_27747 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context
 	METHOD method_27748 executeBaseValueGet (Lnet/minecraft/class_2168;Lnet/minecraft/class_1297;Lnet/minecraft/class_6880;D)I
 		ARG 0 source
 		ARG 1 target
+		ARG 2 attribute
 		ARG 3 multiplier
 	METHOD method_27749 (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
 		ARG 0 entityName
@@ -59,6 +67,7 @@ CLASS net/minecraft/class_5252 net/minecraft/server/command/AttributeCommand
 	METHOD method_27751 executeBaseValueSet (Lnet/minecraft/class_2168;Lnet/minecraft/class_1297;Lnet/minecraft/class_6880;D)I
 		ARG 0 source
 		ARG 1 target
+		ARG 2 attribute
 		ARG 3 value
 	METHOD method_27752 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context
@@ -76,3 +85,5 @@ CLASS net/minecraft/class_5252 net/minecraft/server/command/AttributeCommand
 		ARG 0 context
 	METHOD method_27759 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context
+	METHOD method_45144 getName (Lnet/minecraft/class_6880;)Lnet/minecraft/class_2561;
+		ARG 0 attribute

--- a/mappings/net/minecraft/server/command/EffectCommand.mapping
+++ b/mappings/net/minecraft/server/command/EffectCommand.mapping
@@ -9,6 +9,7 @@ CLASS net/minecraft/class_3043 net/minecraft/server/command/EffectCommand
 	METHOD method_13227 executeGive (Lnet/minecraft/class_2168;Ljava/util/Collection;Lnet/minecraft/class_6880;Ljava/lang/Integer;IZ)I
 		ARG 0 source
 		ARG 1 targets
+		ARG 2 statusEffect
 		ARG 3 seconds
 		ARG 4 amplifier
 		ARG 5 showParticles
@@ -16,12 +17,14 @@ CLASS net/minecraft/class_3043 net/minecraft/server/command/EffectCommand
 		ARG 0 context
 	METHOD method_13229 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
+		ARG 1 registryAccess
 	METHOD method_13230 executeClear (Lnet/minecraft/class_2168;Ljava/util/Collection;)I
 		ARG 0 source
 		ARG 1 targets
 	METHOD method_13231 executeClear (Lnet/minecraft/class_2168;Ljava/util/Collection;Lnet/minecraft/class_6880;)I
 		ARG 0 source
 		ARG 1 targets
+		ARG 2 statusEffect
 	METHOD method_13232 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context
 	METHOD method_13233 (Lcom/mojang/brigadier/context/CommandContext;)I

--- a/mappings/net/minecraft/server/command/EnchantCommand.mapping
+++ b/mappings/net/minecraft/server/command/EnchantCommand.mapping
@@ -9,11 +9,13 @@ CLASS net/minecraft/class_3048 net/minecraft/server/command/EnchantCommand
 	METHOD method_13241 execute (Lnet/minecraft/class_2168;Ljava/util/Collection;Lnet/minecraft/class_6880;I)I
 		ARG 0 source
 		ARG 1 targets
+		ARG 2 enchantment
 		ARG 3 level
 	METHOD method_13242 (Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
 		ARG 0 entityName
 	METHOD method_13243 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
+		ARG 1 registryAccess
 	METHOD method_13244 (Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
 		ARG 0 itemName
 	METHOD method_13245 (Lcom/mojang/brigadier/context/CommandContext;)I

--- a/mappings/net/minecraft/server/command/LocateCommand.mapping
+++ b/mappings/net/minecraft/server/command/LocateCommand.mapping
@@ -15,14 +15,18 @@ CLASS net/minecraft/class_3079 net/minecraft/server/command/LocateCommand
 		ARG 3 y2
 	METHOD method_13443 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
+		ARG 1 registryAccess
+	METHOD method_13447 (Lnet/minecraft/class_2338;Ljava/lang/String;Lnet/minecraft/class_2583;)Lnet/minecraft/class_2583;
+		ARG 2 style
 	METHOD method_13448 (Lnet/minecraft/class_2168;)Z
 		ARG 0 source
 	METHOD method_24499 sendCoordinates (Lnet/minecraft/class_2168;Lnet/minecraft/class_7066$class_7068;Lnet/minecraft/class_2338;Lcom/mojang/datafixers/util/Pair;Ljava/lang/String;Z)I
 		ARG 0 source
 		ARG 1 structure
 		ARG 2 currentPos
-		ARG 3 structurePosAndEntry
+		ARG 3 result
 		ARG 4 successMessage
+		ARG 5 includeY
 	METHOD method_39985 (Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
 		ARG 0 id
 	METHOD method_40998 (Lcom/mojang/datafixers/util/Pair;Lnet/minecraft/class_6862;)Ljava/lang/String;
@@ -31,6 +35,8 @@ CLASS net/minecraft/class_3079 net/minecraft/server/command/LocateCommand
 		ARG 0 id
 	METHOD method_41004 (Lnet/minecraft/class_5321;)Ljava/lang/String;
 		ARG 0 key
+	METHOD method_43904 (Lcom/mojang/brigadier/context/CommandContext;)I
+		ARG 0 context
 	METHOD method_43905 executeLocateStructure (Lnet/minecraft/class_2168;Lnet/minecraft/class_7066$class_7068;)I
 		ARG 0 source
 		ARG 1 predicate
@@ -41,11 +47,39 @@ CLASS net/minecraft/class_3079 net/minecraft/server/command/LocateCommand
 		ARG 0 entry
 	METHOD method_43909 (Lnet/minecraft/class_2378;Lnet/minecraft/class_5321;)Ljava/util/Optional;
 		ARG 1 key
+	METHOD method_43911 (Lcom/mojang/brigadier/context/CommandContext;)I
+		ARG 0 context
 	METHOD method_43912 executeLocateBiome (Lnet/minecraft/class_2168;Lnet/minecraft/class_7737$class_7741;)I
 		ARG 0 source
+		ARG 1 predicate
 	METHOD method_43913 (Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
 		ARG 0 id
+	METHOD method_43914 (Lcom/mojang/brigadier/context/CommandContext;)I
+		ARG 0 context
 	METHOD method_43915 executeLocatePoi (Lnet/minecraft/class_2168;Lnet/minecraft/class_7737$class_7741;)I
 		ARG 0 source
+		ARG 1 predicate
 	METHOD method_43917 (Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
 		ARG 0 id
+	METHOD method_45147 getKeyString (Lcom/mojang/datafixers/util/Pair;)Ljava/lang/String;
+		ARG 0 result
+	METHOD method_45148 sendCoordinates (Lnet/minecraft/class_2168;Lnet/minecraft/class_7737$class_7741;Lnet/minecraft/class_2338;Lcom/mojang/datafixers/util/Pair;Ljava/lang/String;Z)I
+		ARG 0 source
+		ARG 1 predicate
+		ARG 2 currentPos
+		ARG 3 result
+		ARG 4 successMessage
+		ARG 5 includeY
+	METHOD method_45149 sendCoordinates (Lnet/minecraft/class_2168;Lnet/minecraft/class_2338;Lcom/mojang/datafixers/util/Pair;Ljava/lang/String;ZLjava/lang/String;)I
+		ARG 0 source
+		ARG 1 currentPos
+		ARG 2 result
+		ARG 3 successMessage
+		ARG 4 includeY
+		ARG 5 entryString
+	METHOD method_45150 (Lnet/minecraft/class_7737$class_7741;Lcom/mojang/datafixers/util/Pair;Lnet/minecraft/class_6885$class_6888;)Ljava/lang/String;
+		ARG 2 tag
+	METHOD method_45151 (Lnet/minecraft/class_7737$class_7741;Lnet/minecraft/class_6880$class_6883;)Ljava/lang/String;
+		ARG 1 entry
+	METHOD method_45152 (Lnet/minecraft/class_5321;)Ljava/lang/String;
+		ARG 0 key

--- a/mappings/net/minecraft/server/command/ParticleCommand.mapping
+++ b/mappings/net/minecraft/server/command/ParticleCommand.mapping
@@ -8,6 +8,7 @@ CLASS net/minecraft/class_3089 net/minecraft/server/command/ParticleCommand
 		ARG 0 context
 	METHOD method_13486 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
+		ARG 1 registryAccess
 	METHOD method_13487 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context
 	METHOD method_13488 (Lcom/mojang/brigadier/context/CommandContext;)I

--- a/mappings/net/minecraft/server/command/PlaceCommand.mapping
+++ b/mappings/net/minecraft/server/command/PlaceCommand.mapping
@@ -13,6 +13,7 @@ CLASS net/minecraft/class_6852 net/minecraft/server/command/PlaceCommand
 		ARG 0 source
 	METHOD method_39989 executePlaceFeature (Lnet/minecraft/class_2168;Lnet/minecraft/class_6880$class_6883;Lnet/minecraft/class_2338;)I
 		ARG 0 source
+		ARG 1 feature
 		ARG 2 pos
 	METHOD method_39990 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context
@@ -32,10 +33,13 @@ CLASS net/minecraft/class_6852 net/minecraft/server/command/PlaceCommand
 		ARG 2 id
 		ARG 3 maxDepth
 		ARG 4 pos
+	METHOD method_43651 (Lnet/minecraft/class_6880;)Z
+		ARG 0 biome
 	METHOD method_43653 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context
 	METHOD method_43654 executePlaceStructure (Lnet/minecraft/class_2168;Lnet/minecraft/class_6880$class_6883;Lnet/minecraft/class_2338;)I
 		ARG 0 source
+		ARG 1 structure
 		ARG 2 pos
 	METHOD method_43655 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context

--- a/mappings/net/minecraft/server/command/SummonCommand.mapping
+++ b/mappings/net/minecraft/server/command/SummonCommand.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/class_3138 net/minecraft/server/command/SummonCommand
 		ARG 0 context
 	METHOD method_13690 register (Lcom/mojang/brigadier/CommandDispatcher;Lnet/minecraft/class_7157;)V
 		ARG 0 dispatcher
+		ARG 1 registryAccess
 	METHOD method_13691 (Lcom/mojang/brigadier/context/CommandContext;)I
 		ARG 0 context
 	METHOD method_13692 (Lcom/mojang/brigadier/context/CommandContext;)I
@@ -14,6 +15,7 @@ CLASS net/minecraft/class_3138 net/minecraft/server/command/SummonCommand
 		ARG 0 source
 	METHOD method_13694 execute (Lnet/minecraft/class_2168;Lnet/minecraft/class_6880$class_6883;Lnet/minecraft/class_243;Lnet/minecraft/class_2487;Z)I
 		ARG 0 source
+		ARG 1 entityType
 		ARG 2 pos
 		ARG 3 nbt
 		ARG 4 initialize


### PR DESCRIPTION
Maps two new argument types, along with some methods and fields.
Previously there were registry key and key predicate arguments; now they added entry and entry predicates, replacing individual argument types.