### PR TITLE
Refactor rendering stuff

### DIFF
--- a/mappings/com/mojang/blaze3d/systems/RenderSystem.mapping
+++ b/mappings/com/mojang/blaze3d/systems/RenderSystem.mapping
@@ -151,10 +151,10 @@ CLASS com/mojang/blaze3d/systems/RenderSystem
 		ARG 1 debugSync
 	METHOD lambda$static$0 (Lit/unimi/dsi/fastutil/ints/IntConsumer;I)V
 		ARG 0 indexConsumer
-		ARG 1 vertexCount
+		ARG 1 firstVertexIndex
 	METHOD lambda$static$1 (Lit/unimi/dsi/fastutil/ints/IntConsumer;I)V
 		ARG 0 indexConsumer
-		ARG 1 vertexCount
+		ARG 1 firstVertexIndex
 	METHOD limitDisplayFPS (I)V
 		ARG 0 fps
 	METHOD lineWidth (F)V
@@ -252,31 +252,50 @@ CLASS com/mojang/blaze3d/systems/RenderSystem
 		ARG 1 y
 		ARG 2 width
 		ARG 3 height
-	CLASS class_5590 IndexBuffer
-		FIELD field_27332 sizeMultiplier I
-		FIELD field_27333 increment I
-		FIELD field_27334 indexMapper Lcom/mojang/blaze3d/systems/RenderSystem$class_5590$class_5591;
+	CLASS class_5590 ShapeIndexBuffer
+		COMMENT An index buffer that holds a pre-made indices for a specific shape. If
+		COMMENT this buffer is not large enough for the required number of indices when
+		COMMENT this buffer is bound, it automatically grows and fills indices using a
+		COMMENT given {@code triangulator}.
+		FIELD field_27332 vertexCountInShape I
+		FIELD field_27333 vertexCountInTriangulated I
+		FIELD field_27334 triangulator Lcom/mojang/blaze3d/systems/RenderSystem$class_5590$class_5591;
 		FIELD field_27335 id I
 		FIELD field_27336 indexType Lnet/minecraft/class_293$class_5595;
 		FIELD field_27337 size I
 		METHOD <init> (IILcom/mojang/blaze3d/systems/RenderSystem$class_5590$class_5591;)V
-			ARG 1 sizeMultiplier
-			ARG 2 increment
-			ARG 3 indexMapper
+			ARG 1 vertexCountInShape
+				COMMENT the number of vertices in a shape
+			ARG 2 vertexCountInTriangulated
+				COMMENT the number of vertices in the triangles decomposed from the shape
+			ARG 3 triangulator
+				COMMENT a function that decomposes a shape into triangles
 		METHOD method_31920 grow (I)V
-			ARG 1 newSize
+			ARG 1 requiredSize
 		METHOD method_31922 getIndexConsumer (Ljava/nio/ByteBuffer;)Lit/unimi/dsi/fastutil/ints/IntConsumer;
-			ARG 1 indicesBuffer
+			ARG 1 indexBuffer
 		METHOD method_31923 (Ljava/nio/ByteBuffer;I)V
 			ARG 1 index
 		METHOD method_31924 getIndexType ()Lnet/minecraft/class_293$class_5595;
 		METHOD method_31925 (Ljava/nio/ByteBuffer;I)V
 			ARG 1 index
-		METHOD method_43409 isSizeLessThanOrEqual (I)Z
-			ARG 1 size
+		METHOD method_43409 isLargeEnough (I)Z
+			ARG 1 requiredSize
 		METHOD method_43410 bindAndGrow (I)V
-			ARG 1 newSize
-		CLASS class_5591 IndexMapper
+			COMMENT Binds this buffer as a current index buffer. If necessary, it grows this
+			COMMENT buffer in size and uploads indices to the corresponding buffer in GPU.
+			ARG 1 requiredSize
+		CLASS class_5591 Triangulator
+			COMMENT A functional interface that decomposes a shape into triangles.
+			COMMENT
+			COMMENT <p>The input shape is represented by the index of the first vertex in
+			COMMENT the shape. An output triangle is represented by the indices of the
+			COMMENT vertices in the triangle.
+			COMMENT
+			COMMENT @see <a href="https://en.wikipedia.org/wiki/Polygon_triangulation">Polygon triangulation - Wikipedia</a>
 			METHOD accept (Lit/unimi/dsi/fastutil/ints/IntConsumer;I)V
+				COMMENT Decomposes a shape into triangles.
 				ARG 1 indexConsumer
-				ARG 2 vertexCount
+					COMMENT the consumer that accepts triangles
+				ARG 2 firstVertexIndex
+					COMMENT the index of the first vertex in the input shape

--- a/mappings/net/minecraft/client/gl/VertexBuffer.mapping
+++ b/mappings/net/minecraft/client/gl/VertexBuffer.mapping
@@ -8,14 +8,14 @@ CLASS net/minecraft/class_291 net/minecraft/client/gl/VertexBuffer
 	COMMENT
 	COMMENT @implNote This is mostly a wrapper around vertex buffer object (VBO),
 	COMMENT element buffer object (EBO), and vertex array object (VAO).
-	FIELD field_1593 vertexCount I
+	FIELD field_1593 indexCount I
 	FIELD field_1594 vertexBufferId I
 	FIELD field_27366 indexBufferId I
 	FIELD field_27367 indexType Lnet/minecraft/class_293$class_5595;
 	FIELD field_27368 drawMode Lnet/minecraft/class_293$class_5596;
 	FIELD field_29338 vertexArrayId I
 	FIELD field_29339 vertexFormat Lnet/minecraft/class_293;
-	FIELD field_38983 indexBuffer Lcom/mojang/blaze3d/systems/RenderSystem$class_5590;
+	FIELD field_38983 sharedSequentialIndexBuffer Lcom/mojang/blaze3d/systems/RenderSystem$class_5590;
 	METHOD method_1352 upload (Lnet/minecraft/class_287$class_7433;)V
 		COMMENT Uploads the contents of {@code buffer} to GPU, discarding previously
 		COMMENT uploaded data.
@@ -41,7 +41,7 @@ CLASS net/minecraft/class_291 net/minecraft/client/gl/VertexBuffer
 		ARG 2 projectionMatrix
 		ARG 3 shader
 	METHOD method_34435 getVertexFormat ()Lnet/minecraft/class_293;
-	METHOD method_35665 drawElements ()V
+	METHOD method_35665 draw ()V
 		COMMENT Draws the contents in this vertex buffer.
 		COMMENT
 		COMMENT <p>The caller of this method must {@linkplain #bind bind} this vertex
@@ -49,11 +49,11 @@ CLASS net/minecraft/class_291 net/minecraft/client/gl/VertexBuffer
 		COMMENT
 		COMMENT <p>Unlike {@link #draw(Matrix4f, Matrix4f, Shader)}, the caller of this
 		COMMENT method must manually bind a shader before calling this method.
-	METHOD method_43442 configureVertexFormat (Lnet/minecraft/class_287$class_4574;Ljava/nio/ByteBuffer;)Lnet/minecraft/class_293;
+	METHOD method_43442 uploadVertexBuffer (Lnet/minecraft/class_287$class_4574;Ljava/nio/ByteBuffer;)Lnet/minecraft/class_293;
 		ARG 1 parameters
-		ARG 2 data
-	METHOD method_43443 configureIndexBuffer (Lnet/minecraft/class_287$class_4574;Ljava/nio/ByteBuffer;)Lcom/mojang/blaze3d/systems/RenderSystem$class_5590;
+		ARG 2 vertexBuffer
+	METHOD method_43443 uploadIndexBuffer (Lnet/minecraft/class_287$class_4574;Ljava/nio/ByteBuffer;)Lcom/mojang/blaze3d/systems/RenderSystem$class_5590;
 		ARG 1 parameters
-		ARG 2 data
+		ARG 2 indexBuffer
 	METHOD method_43444 isClosed ()Z
 	METHOD method_43445 getIndexType ()Lnet/minecraft/class_293$class_5595;

--- a/mappings/net/minecraft/client/render/BufferBuilder.mapping
+++ b/mappings/net/minecraft/client/render/BufferBuilder.mapping
@@ -22,19 +22,24 @@ CLASS net/minecraft/class_287 net/minecraft/client/render/BufferBuilder
 	FIELD field_1565 format Lnet/minecraft/class_293;
 	FIELD field_1567 drawMode Lnet/minecraft/class_293$class_5596;
 	FIELD field_20884 elementOffset I
-	FIELD field_21594 textured Z
+	FIELD field_21594 canSkipElementChecks Z
+		COMMENT Whether this builder is aware of the vertex format and can skip checks
+		COMMENT for the current target element while building a vertex in {@link
+		COMMENT #vertex(float, float, float, float, float, float, float, float, float, int, int, float, float, float)}.
 	FIELD field_21595 hasOverlay Z
 	FIELD field_27348 sortingPrimitiveCenters [Lorg/joml/Vector3f;
 	FIELD field_27349 sortingCameraX F
 	FIELD field_27350 sortingCameraY F
 	FIELD field_27351 sortingCameraZ F
 	FIELD field_27352 hasNoVertexBuffer Z
-	FIELD field_32050 MAX_BUFFER_SIZE I
+	FIELD field_32050 ROUND_SIZE_CHANGE I
+		COMMENT An integer a size change of a buffer must be a
+		COMMENT multiple of
 	FIELD field_39061 builtBufferCount I
 	FIELD field_39062 batchOffset I
 	METHOD <init> (I)V
 		ARG 1 initialCapacity
-	METHOD method_1324 restoreState (Lnet/minecraft/class_287$class_5594;)V
+	METHOD method_1324 beginSortedIndexBuffer (Lnet/minecraft/class_287$class_5594;)V
 		ARG 1 state
 	METHOD method_1326 end ()Lnet/minecraft/class_287$class_7433;
 		COMMENT Builds a buffer from the current batch and resets the building state.
@@ -48,7 +53,7 @@ CLASS net/minecraft/class_287 net/minecraft/client/render/BufferBuilder
 	METHOD method_1328 begin (Lnet/minecraft/class_293$class_5596;Lnet/minecraft/class_293;)V
 		ARG 1 drawMode
 		ARG 2 format
-	METHOD method_1334 popState ()Lnet/minecraft/class_287$class_5594;
+	METHOD method_1334 getSortingData ()Lnet/minecraft/class_287$class_5594;
 	METHOD method_1335 grow (I)V
 		ARG 1 size
 	METHOD method_1343 clear ()V
@@ -66,7 +71,7 @@ CLASS net/minecraft/class_287 net/minecraft/client/render/BufferBuilder
 		ARG 1 cameraX
 		ARG 2 cameraY
 		ARG 3 cameraZ
-	METHOD method_31949 createIndexWriter (ILnet/minecraft/class_293$class_5595;)Lit/unimi/dsi/fastutil/ints/IntConsumer;
+	METHOD method_31949 getIndexConsumer (ILnet/minecraft/class_293$class_5595;)Lit/unimi/dsi/fastutil/ints/IntConsumer;
 		ARG 1 offset
 		ARG 2 indexType
 	METHOD method_31950 writeSortedIndices (Lnet/minecraft/class_293$class_5595;)V
@@ -95,25 +100,27 @@ CLASS net/minecraft/class_287 net/minecraft/client/render/BufferBuilder
 	METHOD method_43578 build ()Lnet/minecraft/class_287$class_7433;
 	METHOD method_43579 resetBuilding ()V
 	METHOD method_43580 releaseBuiltBuffer ()V
-	CLASS class_4574 DrawArrayParameters
-		METHOD method_31957 getIndexBufferStart ()I
-		METHOD method_31958 getIndexBufferEnd ()I
-		METHOD method_31961 getIndexBufferLength ()I
-		METHOD method_43429 getVertexBufferPosition ()I
-		METHOD method_43430 getVertexBufferLimit ()I
-		METHOD method_43431 getIndexBufferPosition ()I
-		METHOD method_43432 getIndexBufferLimit ()I
-	CLASS class_5594 State
+	CLASS class_4574 DrawParameters
+		METHOD method_31957 getVertexBufferSize ()I
+		METHOD method_31958 getBufferSize ()I
+			COMMENT {@return the total size of the index buffer and the vertex buffer
+			COMMENT combined}
+		METHOD method_31961 getIndexBufferSize ()I
+		METHOD method_43429 getVertexBufferStart ()I
+		METHOD method_43430 getVertexBufferEnd ()I
+		METHOD method_43431 getIndexBufferStart ()I
+		METHOD method_43432 getIndexBufferEnd ()I
+	CLASS class_5594 TransparentSortingData
 		FIELD field_27358 drawMode Lnet/minecraft/class_293$class_5596;
 		FIELD field_27359 vertexCount I
-		FIELD field_27360 sortingPrimitiveCenters [Lorg/joml/Vector3f;
-		FIELD field_27361 sortingCameraX F
-		FIELD field_27362 sortingCameraY F
-		FIELD field_27363 sortingCameraZ F
+		FIELD field_27360 primitiveCenters [Lorg/joml/Vector3f;
+		FIELD field_27361 cameraX F
+		FIELD field_27362 cameraY F
+		FIELD field_27363 cameraZ F
 		METHOD <init> (Lnet/minecraft/class_293$class_5596;I[Lorg/joml/Vector3f;FFF)V
 			ARG 1 drawMode
 			ARG 2 vertexCount
-			ARG 3 currentParameters
+			ARG 3 primitiveCenters
 			ARG 4 cameraX
 			ARG 5 cameraY
 			ARG 6 cameraZ

--- a/mappings/net/minecraft/client/render/BufferRenderer.mapping
+++ b/mappings/net/minecraft/client/render/BufferRenderer.mapping
@@ -2,18 +2,18 @@ CLASS net/minecraft/class_286 net/minecraft/client/render/BufferRenderer
 	COMMENT Containing methods for immediately drawing a buffer built with {@link
 	COMMENT BufferBuilder}.
 	FIELD field_38982 currentVertexBuffer Lnet/minecraft/class_291;
-	METHOD method_34420 unbindAll ()V
+	METHOD method_34420 reset ()V
 	METHOD method_43433 drawWithShader (Lnet/minecraft/class_287$class_7433;)V
 		COMMENT Draws {@code buffer} using the shader specified with {@link
 		COMMENT com.mojang.blaze3d.systems.RenderSystem#setShader
 		COMMENT RenderSystem#setShader}
 		ARG 0 buffer
-	METHOD method_43434 bindAndSet (Lnet/minecraft/class_291;)V
+	METHOD method_43434 bind (Lnet/minecraft/class_291;)V
 		ARG 0 vertexBuffer
-	METHOD method_43435 bindAndSet (Lnet/minecraft/class_293;)Lnet/minecraft/class_291;
+	METHOD method_43435 bind (Lnet/minecraft/class_293;)Lnet/minecraft/class_291;
 		ARG 0 vertexFormat
 	METHOD method_43436 resetCurrentVertexBuffer ()V
-	METHOD method_43437 drawWithoutShader (Lnet/minecraft/class_287$class_7433;)V
+	METHOD method_43437 draw (Lnet/minecraft/class_287$class_7433;)V
 		COMMENT Draws {@code buffer}.
 		COMMENT
 		COMMENT <p>Unlike {@link #drawWithShader}, the shader cannot be specified with
@@ -23,5 +23,5 @@ CLASS net/minecraft/class_286 net/minecraft/client/render/BufferRenderer
 		ARG 0 buffer
 	METHOD method_43438 drawWithShaderInternal (Lnet/minecraft/class_287$class_7433;)V
 		ARG 0 buffer
-	METHOD method_43439 getVertexBuffer (Lnet/minecraft/class_287$class_7433;)Lnet/minecraft/class_291;
+	METHOD method_43439 upload (Lnet/minecraft/class_287$class_7433;)Lnet/minecraft/class_291;
 		ARG 0 buffer

--- a/mappings/net/minecraft/client/render/BufferVertexConsumer.mapping
+++ b/mappings/net/minecraft/client/render/BufferVertexConsumer.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_4584 net/minecraft/client/render/BufferVertexConsumer
 	METHOD method_22898 putShort (IS)V
 		ARG 1 index
 		ARG 2 value
-	METHOD method_22899 texture (SSI)Lnet/minecraft/class_4588;
+	METHOD method_22899 uv (SSI)Lnet/minecraft/class_4588;
 		ARG 1 u
 		ARG 2 v
 		ARG 3 index

--- a/mappings/net/minecraft/client/render/OutlineVertexConsumerProvider.mapping
+++ b/mappings/net/minecraft/client/render/OutlineVertexConsumerProvider.mapping
@@ -18,8 +18,8 @@ CLASS net/minecraft/class_4618 net/minecraft/client/render/OutlineVertexConsumer
 		FIELD field_21064 x D
 		FIELD field_21065 y D
 		FIELD field_21066 z D
-		FIELD field_21067 u F
-		FIELD field_21068 v F
+		FIELD field_21067 textureU F
+		FIELD field_21068 textureV F
 		METHOD <init> (Lnet/minecraft/class_4588;IIII)V
 			ARG 1 delegate
 			ARG 2 red

--- a/mappings/net/minecraft/client/render/OverlayVertexConsumer.mapping
+++ b/mappings/net/minecraft/client/render/OverlayVertexConsumer.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_4583 net/minecraft/client/render/OverlayVertexConsumer
-	FIELD field_20866 vertexConsumer Lnet/minecraft/class_4588;
+	FIELD field_20866 delegate Lnet/minecraft/class_4588;
 	FIELD field_20870 x F
 	FIELD field_20871 y F
 	FIELD field_20872 z F
@@ -9,10 +9,10 @@ CLASS net/minecraft/class_4583 net/minecraft/client/render/OverlayVertexConsumer
 	FIELD field_20880 normalX F
 	FIELD field_20881 normalY F
 	FIELD field_20882 normalZ F
-	FIELD field_21053 textureMatrix Lorg/joml/Matrix4f;
-	FIELD field_21054 normalMatrix Lorg/joml/Matrix3f;
+	FIELD field_21053 inverseTextureMatrix Lorg/joml/Matrix4f;
+	FIELD field_21054 inverseNormalMatrix Lorg/joml/Matrix3f;
 	METHOD <init> (Lnet/minecraft/class_4588;Lorg/joml/Matrix4f;Lorg/joml/Matrix3f;)V
-		ARG 1 vertexConsumer
+		ARG 1 delegate
 		ARG 2 textureMatrix
 		ARG 3 normalMatrix
 	METHOD method_22891 init ()V

--- a/mappings/net/minecraft/client/render/SpriteTexturedVertexConsumer.mapping
+++ b/mappings/net/minecraft/client/render/SpriteTexturedVertexConsumer.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_4723 net/minecraft/client/render/SpriteTexturedVertexConsumer
-	FIELD field_21730 parent Lnet/minecraft/class_4588;
+	FIELD field_21730 delegate Lnet/minecraft/class_4588;
 	FIELD field_21731 sprite Lnet/minecraft/class_1058;
 	METHOD <init> (Lnet/minecraft/class_4588;Lnet/minecraft/class_1058;)V
-		ARG 1 parent
+		ARG 1 delegate
 		ARG 2 sprite

--- a/mappings/net/minecraft/client/render/VertexConsumers.mapping
+++ b/mappings/net/minecraft/client/render/VertexConsumers.mapping
@@ -24,20 +24,20 @@ CLASS net/minecraft/class_4720 net/minecraft/client/render/VertexConsumers
 		METHOD <init> ([Lnet/minecraft/class_4588;)V
 			ARG 1 delegates
 		METHOD method_35671 (DDDLnet/minecraft/class_4588;)V
-			ARG 6 i
+			ARG 6 vertexConsumer
 		METHOD method_35672 (FFFFFFFFFIIFFFLnet/minecraft/class_4588;)V
-			ARG 14 i
+			ARG 14 vertexConsumer
 		METHOD method_35673 (FFFLnet/minecraft/class_4588;)V
-			ARG 3 i
+			ARG 3 vertexConsumer
 		METHOD method_35674 (FFLnet/minecraft/class_4588;)V
-			ARG 2 i
+			ARG 2 vertexConsumer
 		METHOD method_35675 (IIIILnet/minecraft/class_4588;)V
-			ARG 4 i
+			ARG 4 vertexConsumer
 		METHOD method_35676 (IILnet/minecraft/class_4588;)V
-			ARG 2 i
+			ARG 2 vertexConsumer
 		METHOD method_35677 delegate (Ljava/util/function/Consumer;)V
 			ARG 1 action
 		METHOD method_35678 (IIIILnet/minecraft/class_4588;)V
-			ARG 4 i
+			ARG 4 vertexConsumer
 		METHOD method_35679 (IILnet/minecraft/class_4588;)V
-			ARG 2 i
+			ARG 2 vertexConsumer

--- a/mappings/net/minecraft/client/render/chunk/ChunkBuilder.mapping
+++ b/mappings/net/minecraft/client/render/chunk/ChunkBuilder.mapping
@@ -53,7 +53,7 @@ CLASS net/minecraft/class_846 net/minecraft/client/render/chunk/ChunkBuilder
 	CLASS class_849 ChunkData
 		FIELD field_4450 nonEmptyLayers Ljava/util/Set;
 		FIELD field_4451 EMPTY Lnet/minecraft/class_846$class_849;
-		FIELD field_4453 bufferState Lnet/minecraft/class_287$class_5594;
+		FIELD field_4453 transparentSortingData Lnet/minecraft/class_287$class_5594;
 		FIELD field_4455 occlusionGraph Lnet/minecraft/class_854;
 		FIELD field_4456 blockEntities Ljava/util/List;
 		METHOD method_3641 isEmpty (Lnet/minecraft/class_1921;)Z


### PR DESCRIPTION
Redo of #3151 and #3152. Fixes the following issues.

Incorrect names:

* `BufferBuilder.textured` → `canSkipElementChecks`: This has nothing to do with texture. See my javadoc.
* `BufferBuilder.MAX_BUFFER_SIZE` → `ROUND_SIZE_CHANGE`: This is an integer a size change of a buffer must be a multiple of, nothing related to the size limit.
* `BufferBuilder.DrawArrayParameters` → `DrawParameters`: This was correct at one point, but the game doesn't use `glDrawArrays` in recent versions.
* `BufferVertexConsumer.texture` → `uv`: This is also used to specify an overlay element or a light element.
* `OverlayVertexConsumer.textureMatrix` → `inverseTextureMatrix`: It's inverted in the constructor.
* `OverlayVertexConsumer.normalMatrix` → `inverseNormalMatrix`: It's inverted in the constructor.

Misleading/inaccurate names:

* `BufferBuilder.restoreState` → `beginSortedIndexBuffer`: See https://github.com/FabricMC/yarn/pull/3152#discussion_r873213511.
* `BufferBuilder.popState` → `getSortingData`: "pop" should be used for a method that removes an element. This does not mutate any state.
* `BufferBuilder.State` → `TransparentSortingData`: This is only used for sorting translucent objects. `State` is too obscure.
* `RenderSystem.IndexBuffer` → `ShapeIndexBuffer`: See https://github.com/FabricMC/yarn/pull/3151#discussion_r873214122.
* `RenderSystem.IndexBuffer.IndexMapper` → `Triangulator`: See https://github.com/FabricMC/yarn/pull/3151#discussion_r873214291.
* `VertexBuffer.indexBuffer` → `sharedSequentialIndexBuffer`: This is an index buffer used only when primitives have not been sorted. `sequentialIndex` is an exposed name from the `DrawArrayParameters` record.
* `VertexBuffer.drawElements` → `draw`: Calling `glDrawElements` is an implementation detail that `VertexBuffer` should hide as the purpose of `VertexBuffer` is being a bridge between GL and the game.
* `VertexBuffer.configureVertexFormat` → `uploadVertexBuffer`: The `glBufferData` call uploads a vertex buffer to GPU.
* `VertexBuffer.configureIndexBuffer` → `uploadIndexBuffer`: The `glBufferData` call uploads an index buffer to GPU.
* `BufferRenderer.drawWithoutShader` → `draw`: Things cannot be drawn without a shader. This method only requires the caller to set a shader beforehand.
* `BufferRenderer.getVertexBuffer` → `upload`: This uploads a vertex buffer and an index buffer.

Inconsistent names:

* `BufferBuilder.createIndexWriter` → `getIndexConsumer`: Inconsistent with `RenderSystem.IndexBuffer.getIndexConsumer`
* `OverlayVertexConsumer.vertexConsumer` → `delegate`: Inconsistent with `OutlineVertexConsumer.delegate`
* `SpriteTexturedVertexConsumer.parent` → `delegate`: Inconsistent with `OutlineVertexConsumer.delegate`
