### PR TITLE
new ButtonWidget stuff

### DIFF
--- a/mappings/net/minecraft/client/gui/widget/ButtonWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ButtonWidget.mapping
@@ -20,8 +20,9 @@ CLASS net/minecraft/class_4185 net/minecraft/client/gui/widget/ButtonWidget
 		ARG 1 matrices
 		ARG 2 mouseX
 		ARG 3 mouseY
-	METHOD method_37022 (Lnet/minecraft/class_6382;Lnet/minecraft/class_2561;)V
-		ARG 1 text
+	METHOD method_46430 createBuilder (Lnet/minecraft/class_2561;Lnet/minecraft/class_4185$class_4241;)Lnet/minecraft/class_4185$class_7840;
+		ARG 1 message
+		ARG 2 onPress
 	CLASS class_7840 Builder
 		FIELD field_40756 message Lnet/minecraft/class_2561;
 		FIELD field_40757 onPress Lnet/minecraft/class_4185$class_4241;

--- a/mappings/net/minecraft/client/gui/widget/ButtonWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ButtonWidget.mapping
@@ -64,5 +64,3 @@ CLASS net/minecraft/class_4185 net/minecraft/client/gui/widget/ButtonWidget
 			ARG 3 mouseX
 			ARG 4 mouseY
 	CLASS class_7841 NarrationSupplier
-		METHOD createNarrationMessage (Ljava/util/function/Supplier;)Lnet/minecraft/class_5250;
-			ARG 1 supplier

--- a/mappings/net/minecraft/client/gui/widget/ButtonWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ButtonWidget.mapping
@@ -64,5 +64,5 @@ CLASS net/minecraft/class_4185 net/minecraft/client/gui/widget/ButtonWidget
 			ARG 3 mouseX
 			ARG 4 mouseY
 	CLASS class_7841 NarrationSupplier
-		METHOD createNarrationMessage (Ljava/util/function/Consumer;)Lnet/minecraft/class_5250;
+		METHOD createNarrationMessage (Ljava/util/function/Supplier;)Lnet/minecraft/class_5250;
 			ARG 1 supplier

--- a/mappings/net/minecraft/client/gui/widget/ButtonWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ButtonWidget.mapping
@@ -1,7 +1,12 @@
 CLASS net/minecraft/class_4185 net/minecraft/client/gui/widget/ButtonWidget
 	FIELD field_22767 onPress Lnet/minecraft/class_4185$class_4241;
-	FIELD field_25035 EMPTY Lnet/minecraft/class_4185$class_5316;
+	FIELD field_25035 EMPTY_TOOLTIP Lnet/minecraft/class_4185$class_5316;
 	FIELD field_25036 tooltipSupplier Lnet/minecraft/class_4185$class_5316;
+	FIELD field_39499 DEFAULT_WIDTH_SMALL I
+	FIELD field_39500 DEFAULT_WIDTH I
+	FIELD field_39501 DEFAULT_HEIGHT I
+	FIELD field_40754 DEFAULT_NARRATION Lnet/minecraft/class_4185$class_5316;
+	FIELD field_40755 narrationSupplier Lnet/minecraft/class_4185$class_7841;
 	METHOD <init> (IIIILnet/minecraft/class_2561;Lnet/minecraft/class_4185$class_4241;Lnet/minecraft/class_4185$class_5316;Lnet/minecraft/class_4185$class_7841;)V
 		ARG 1 x
 		ARG 2 y
@@ -17,6 +22,36 @@ CLASS net/minecraft/class_4185 net/minecraft/client/gui/widget/ButtonWidget
 		ARG 3 mouseY
 	METHOD method_37022 (Lnet/minecraft/class_6382;Lnet/minecraft/class_2561;)V
 		ARG 1 text
+	CLASS class_7840 Builder
+		FIELD field_40756 message Lnet/minecraft/class_2561;
+		FIELD field_40757 onPress Lnet/minecraft/class_4185$class_4241;
+		FIELD field_40758 tooltipSupplier Lnet/minecraft/class_4185$class_5316;
+		FIELD field_40759 x I
+		FIELD field_40760 y I
+		FIELD field_40761 width I
+		FIELD field_40762 height I
+		FIELD field_40763 narrationSupplier Lnet/minecraft/class_4185$class_7841;
+		METHOD <init> (Lnet/minecraft/class_2561;Lnet/minecraft/class_4185$class_4241;)V
+			ARG 1 message
+			ARG 2 onPress
+		METHOD method_46431 build ()Lnet/minecraft/class_4185;
+		METHOD method_46432 setWidth (I)Lnet/minecraft/class_4185$class_7840;
+			ARG 1 width
+		METHOD method_46433 setPosition (II)Lnet/minecraft/class_4185$class_7840;
+			ARG 1 x
+			ARG 2 y
+		METHOD method_46434 setPositionAndSize (IIII)Lnet/minecraft/class_4185$class_7840;
+			ARG 1 x
+			ARG 2 y
+			ARG 3 width
+			ARG 4 height
+		METHOD method_46435 setNarrationSupplier (Lnet/minecraft/class_4185$class_7841;)Lnet/minecraft/class_4185$class_7840;
+			ARG 1 narrationSupplier
+		METHOD method_46436 setTooltipSupplier (Lnet/minecraft/class_4185$class_5316;)Lnet/minecraft/class_4185$class_7840;
+			ARG 1 tooltipSupplier
+		METHOD method_46437 setSize (II)Lnet/minecraft/class_4185$class_7840;
+			ARG 1 width
+			ARG 2 height
 	CLASS class_4241 PressAction
 		METHOD onPress (Lnet/minecraft/class_4185;)V
 			ARG 1 button
@@ -28,3 +63,6 @@ CLASS net/minecraft/class_4185 net/minecraft/client/gui/widget/ButtonWidget
 			ARG 2 matrices
 			ARG 3 mouseX
 			ARG 4 mouseY
+	CLASS class_7841 NarrationSupplier
+		METHOD createNarrationMessage (Ljava/util/function/Consumer;)Lnet/minecraft/class_5250;
+			ARG 1 supplier

--- a/mappings/net/minecraft/client/gui/widget/ClickableWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ClickableWidget.mapping
@@ -74,3 +74,7 @@ CLASS net/minecraft/class_339 net/minecraft/client/gui/widget/ClickableWidget
 		ARG 0 message
 	METHOD method_37021 appendDefaultNarrations (Lnet/minecraft/class_6382;)V
 		ARG 1 builder
+	METHOD method_46426 getX ()I
+	METHOD method_46421 setX (I)V
+	METHOD method_46427 getY ()I
+	METHOD method_46419 setY (I)V


### PR DESCRIPTION
Written Builder and NarrationSupplier class
and field_25035(`EMPTY`) has been changed to `EMPTY_TOOLTIP` because now ButtonWidget class have several static variables 