### PR TITLE
Rename worldgen methods to `bootstrap` for consistency

### DIFF
--- a/mappings/net/minecraft/world/gen/feature/PlacedFeatures.mapping
+++ b/mappings/net/minecraft/world/gen/feature/PlacedFeatures.mapping
@@ -8,7 +8,7 @@ CLASS net/minecraft/class_6817 net/minecraft/world/gen/feature/PlacedFeatures
 	FIELD field_36084 EIGHT_ABOVE_AND_BELOW_RANGE Lnet/minecraft/class_6797;
 	FIELD field_36085 FOUR_ABOVE_AND_BELOW_RANGE Lnet/minecraft/class_6797;
 	FIELD field_36086 BOTTOM_TO_120_RANGE Lnet/minecraft/class_6797;
-	METHOD method_39735 getDefaultPlacedFeature (Lnet/minecraft/class_7891;)V
+	METHOD method_39735 bootstrap (Lnet/minecraft/class_7891;)V
 		ARG 0 featureRegisterable
 	METHOD method_39736 createCountExtraModifier (IFI)Lnet/minecraft/class_6797;
 		ARG 0 count

--- a/mappings/net/minecraft/world/gen/noise/BuiltinNoiseParameters.mapping
+++ b/mappings/net/minecraft/world/gen/noise/BuiltinNoiseParameters.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_6736 net/minecraft/world/gen/noise/BuiltinNoiseParameters
 	FIELD field_40960 OFFSET Lnet/minecraft/class_5216$class_5487;
-	METHOD method_39216 init (Lnet/minecraft/class_7891;)V
+	METHOD method_39216 bootstrap (Lnet/minecraft/class_7891;)V
 		ARG 0 noiseParametersRegisterable
 	METHOD method_39217 register (Lnet/minecraft/class_7891;Lnet/minecraft/class_5321;ID[D)V
 		ARG 0 noiseParametersRegisterable


### PR DESCRIPTION
Renames two methods to `bootstrap` for consistency with the others.
Specifically these:
- `net.minecraft.world.gen.feature.PlacedFeatures::getDefaultPlacedFeature`
- `net.minecraft.world.gen.noise.BuiltinNoiseParameters::init`

These were found from `net.minecraft.util.registry.BuiltinRegistries`.
