### PR TITLE
update names in entity spawn packet

### DIFF
--- a/mappings/net/minecraft/network/packet/s2c/play/EntitySpawnS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/EntitySpawnS2CPacket.mapping
@@ -8,7 +8,7 @@ CLASS net/minecraft/class_2604 net/minecraft/network/packet/s2c/play/EntitySpawn
 	FIELD field_11952 uuid Ljava/util/UUID;
 	FIELD field_11953 id I
 	FIELD field_11954 entityData I
-	FIELD field_11955 entityTypeId Lnet/minecraft/class_1299;
+	FIELD field_11955 entityType Lnet/minecraft/class_1299;
 	FIELD field_11956 z D
 	FIELD field_11957 yaw B
 	FIELD field_33293 VELOCITY_SCALE D
@@ -24,7 +24,7 @@ CLASS net/minecraft/class_2604 net/minecraft/network/packet/s2c/play/EntitySpawn
 		ARG 7 z
 		ARG 9 pitch
 		ARG 10 yaw
-		ARG 11 entityTypeId
+		ARG 11 entityType
 		ARG 12 entityData
 		ARG 13 velocity
 		ARG 14 headYaw
@@ -35,7 +35,7 @@ CLASS net/minecraft/class_2604 net/minecraft/network/packet/s2c/play/EntitySpawn
 		ARG 2 entityData
 	METHOD <init> (Lnet/minecraft/class_1297;ILnet/minecraft/class_2338;)V
 		ARG 1 entity
-		ARG 2 entityTypeId
+		ARG 2 entityData
 		ARG 3 pos
 	METHOD <init> (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
@@ -43,7 +43,7 @@ CLASS net/minecraft/class_2604 net/minecraft/network/packet/s2c/play/EntitySpawn
 	METHOD method_11166 getEntityData ()I
 	METHOD method_11167 getId ()I
 	METHOD method_11168 getYaw ()F
-	METHOD method_11169 getEntityTypeId ()Lnet/minecraft/class_1299;
+	METHOD method_11169 getEntityType ()Lnet/minecraft/class_1299;
 	METHOD method_11170 getVelocityX ()D
 	METHOD method_11171 getPitch ()F
 	METHOD method_11172 getVelocityY ()D


### PR DESCRIPTION
I feel like `entityTypeId` isn't a good name for an `EntityType` field. The `Id` suffix would imply its the numerical network ID for that entity type, when the field is just the EntityType object itself.

Also fixes a parameter in the spawn packet constructor that was incorrectly named.