### PR TITLE
Update Gson javadoc link

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -679,7 +679,7 @@ javadoc {
 		addBooleanOption "-ignore-source-errors", true
 		links(
 				'https://guava.dev/releases/31.1-jre/api/docs/',
-				'https://www.javadoc.io/doc/com.google.code.gson/gson/2.9.1/',
+				'https://www.javadoc.io/doc/com.google.code.gson/gson/2.10/',
 				'https://logging.apache.org/log4j/2.x/log4j-api/apidocs/',
 				'https://www.slf4j.org/apidocs/',
 				"https://javadoc.io/doc/org.jetbrains/annotations/${project.jetbrains_annotations_version}/",


### PR DESCRIPTION
Mojang updated Gson to 2.10. This updates javadoc link to link to the new version.