### PR TITLE
22w46a telemetry

### DIFF
--- a/mappings/net/minecraft/client/MinecraftClient.mapping
+++ b/mappings/net/minecraft/client/MinecraftClient.mapping
@@ -179,6 +179,8 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 	FIELD field_39924 advanceValidatingTextRenderer Lnet/minecraft/class_327;
 	FIELD field_40380 defaultResourcePack Lnet/minecraft/class_3268;
 	FIELD field_40381 serverResourcePackProvider Lnet/minecraft/class_1066;
+	FIELD field_41331 telemetryManager Lnet/minecraft/class_6628;
+	FIELD field_41332 renderTime J
 	METHOD <init> (Lnet/minecraft/class_542;)V
 		ARG 1 args
 	METHOD method_1476 checkIs64Bit ()Z
@@ -376,6 +378,7 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 		ARG 2 session
 		ARG 3 dataPackManager
 		ARG 4 saveLoader
+		ARG 5 newWorld
 	METHOD method_29611 isFabulousGraphicsOrBetter ()Z
 	METHOD method_29970 setScreenAndRender (Lnet/minecraft/class_437;)V
 		ARG 1 screen
@@ -498,6 +501,13 @@ CLASS net/minecraft/class_310 net/minecraft/client/MinecraftClient
 		ARG 1 segments
 	METHOD method_46740 (Ljava/util/List;)V
 		ARG 1 stacks
+	METHOD method_47392 isConnectedToLocalServer ()Z
+	METHOD method_47595 isOptionalTelemetryEnabledByApi ()Z
+	METHOD method_47596 isTelemetryEnabledByApi ()Z
+	METHOD method_47599 getCurrentFps ()I
+	METHOD method_47600 getRenderTime ()J
+	METHOD method_47601 getTelemetryManager ()Lnet/minecraft/class_6628;
+	METHOD method_47602 isOptionalTelemetryEnabled ()Z
 	CLASS class_5859 ChatRestriction
 		COMMENT Represents the restrictions on chat on a Minecraft client.
 		COMMENT

--- a/mappings/net/minecraft/client/gui/screen/option/TelemetryEventWidget.mapping
+++ b/mappings/net/minecraft/client/gui/screen/option/TelemetryEventWidget.mapping
@@ -1,0 +1,51 @@
+CLASS net/minecraft/class_7941 net/minecraft/client/gui/screen/option/TelemetryEventWidget
+	FIELD field_41355 MARGIN_X I
+	FIELD field_41356 REQUIRED_TRANSLATION_KEY Ljava/lang/String;
+	FIELD field_41357 OPTIONAL_TRANSLATION_KEY Ljava/lang/String;
+	FIELD field_41358 PROPERTY_TITLE_TEXT Lnet/minecraft/class_2561;
+	FIELD field_41359 textRenderer Lnet/minecraft/class_327;
+	FIELD field_41360 contents Lnet/minecraft/class_7941$class_7942;
+	FIELD field_41361 scrollConsumer Ljava/util/function/DoubleConsumer;
+	METHOD <init> (IIIILnet/minecraft/class_327;)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 width
+		ARG 4 height
+		ARG 5 textRenderer
+	METHOD method_47635 appendEventInfo (Lnet/minecraft/class_7941$class_7943;Lnet/minecraft/class_7966;)V
+		ARG 1 builder
+		ARG 2 eventType
+	METHOD method_47636 appendProperties (Lnet/minecraft/class_7966;Lnet/minecraft/class_7941$class_7943;)V
+		ARG 1 eventType
+		ARG 2 builder
+	METHOD method_47637 setScrollConsumer (Ljava/util/function/DoubleConsumer;)V
+		ARG 1 scrollConsumer
+	METHOD method_47638 refresh (Z)V
+		ARG 1 optionalTelemetryEnabled
+	METHOD method_47639 collectContents (Z)Lnet/minecraft/class_7941$class_7942;
+		ARG 1 optionalTelemetryEnabled
+	METHOD method_47640 getGridWidth ()I
+	CLASS class_7942 Contents
+		FIELD comp_1160 grid Lnet/minecraft/class_7845;
+		METHOD comp_1160 grid ()Lnet/minecraft/class_7845;
+	CLASS class_7943 ContentsBuilder
+		FIELD field_41362 gridWidth I
+		FIELD field_41363 grid Lnet/minecraft/class_7845;
+		FIELD field_41364 widgetAdder Lnet/minecraft/class_7845$class_7939;
+		FIELD field_41365 positioner Lnet/minecraft/class_7847;
+		FIELD field_41366 narration Lnet/minecraft/class_5250;
+		METHOD <init> (I)V
+			ARG 1 gridWidth
+		METHOD method_47641 build ()Lnet/minecraft/class_7941$class_7942;
+		METHOD method_47642 appendSpace (I)V
+			ARG 1 height
+		METHOD method_47643 appendTitle (Lnet/minecraft/class_327;Lnet/minecraft/class_2561;)V
+			ARG 1 textRenderer
+			ARG 2 title
+		METHOD method_47644 appndTitle (Lnet/minecraft/class_327;Lnet/minecraft/class_2561;I)V
+			ARG 1 textRenderer
+			ARG 2 title
+			ARG 3 marginBottom
+		METHOD method_47645 appendText (Lnet/minecraft/class_327;Lnet/minecraft/class_2561;)V
+			ARG 1 textRenderer
+			ARG 2 text

--- a/mappings/net/minecraft/client/gui/screen/option/TelemetryInfoScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/option/TelemetryInfoScreen.mapping
@@ -1,0 +1,30 @@
+CLASS net/minecraft/class_7944 net/minecraft/client/gui/screen/option/TelemetryInfoScreen
+	FIELD field_41367 MARGIN I
+	FIELD field_41368 FEEDBACK_URL Ljava/lang/String;
+	FIELD field_41369 TITLE_TEXT Lnet/minecraft/class_2561;
+	FIELD field_41370 DESCRIPTION_TEXT Lnet/minecraft/class_2561;
+	FIELD field_41371 GIVE_FEEDBACK_TEXT Lnet/minecraft/class_2561;
+	FIELD field_41372 SHOW_DATA_TEXT Lnet/minecraft/class_2561;
+	FIELD field_41373 parent Lnet/minecraft/class_437;
+	FIELD field_41374 options Lnet/minecraft/class_315;
+	FIELD field_41375 telemetryEventWidget Lnet/minecraft/class_7941;
+	FIELD field_41376 scroll D
+	METHOD <init> (Lnet/minecraft/class_437;Lnet/minecraft/class_315;)V
+		ARG 1 parent
+		ARG 2 options
+	METHOD method_47646 (D)V
+		ARG 1 scroll
+	METHOD method_47647 createButtonRow (Lnet/minecraft/class_339;Lnet/minecraft/class_339;)Lnet/minecraft/class_7845;
+		ARG 1 left
+		ARG 2 right
+	METHOD method_47648 goBack (Lnet/minecraft/class_4185;)V
+		ARG 1 button
+	METHOD method_47649 (Ljava/lang/Boolean;)V
+		ARG 1 value
+	METHOD method_47650 openFeedbackPage (Lnet/minecraft/class_4185;)V
+		ARG 1 button
+	METHOD method_47651 openLogDirectory (Lnet/minecraft/class_4185;)V
+		ARG 1 button
+	METHOD method_47652 (Z)V
+		ARG 1 confirmed
+	METHOD method_47653 createOptInButton ()Lnet/minecraft/class_339;

--- a/mappings/net/minecraft/client/network/ClientLoginNetworkHandler.mapping
+++ b/mappings/net/minecraft/client/network/ClientLoginNetworkHandler.mapping
@@ -6,11 +6,16 @@ CLASS net/minecraft/class_635 net/minecraft/client/network/ClientLoginNetworkHan
 	FIELD field_3710 LOGGER Lorg/slf4j/Logger;
 	FIELD field_3711 statusConsumer Ljava/util/function/Consumer;
 	FIELD field_40481 serverInfo Lnet/minecraft/class_642;
+	FIELD field_41383 newWorld Z
+	FIELD field_41384 worldLoadTime Ljava/time/Duration;
 	METHOD <init> (Lnet/minecraft/class_2535;Lnet/minecraft/class_310;Lnet/minecraft/class_642;Lnet/minecraft/class_437;ZLjava/time/Duration;Ljava/util/function/Consumer;)V
 		ARG 1 connection
 		ARG 2 client
 		ARG 3 serverInfo
 		ARG 4 parentScreen
+		ARG 5 newWorld
+		ARG 6 worldLoadTime
+		ARG 7 statusConsumer
 	METHOD method_2891 getSessionService ()Lcom/mojang/authlib/minecraft/MinecraftSessionService;
 	METHOD method_2892 joinServerSession (Ljava/lang/String;)Lnet/minecraft/class_2561;
 		ARG 1 serverId

--- a/mappings/net/minecraft/client/network/ClientPlayNetworkHandler.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayNetworkHandler.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/class_634 net/minecraft/client/network/ClientPlayNetworkHand
 	FIELD field_25063 combinedDynamicRegistries Lnet/minecraft/class_7780;
 	FIELD field_25273 worldKeys Ljava/util/Set;
 	FIELD field_26620 DISCONNECT_LOST_TEXT Lnet/minecraft/class_2561;
-	FIELD field_34963 telemetrySender Lnet/minecraft/class_7975;
+	FIELD field_34963 worldSession Lnet/minecraft/class_7975;
 	FIELD field_35164 simulationDistance I
 	FIELD field_3687 random Lnet/minecraft/class_5819;
 	FIELD field_3688 recipeManager Lnet/minecraft/class_1863;
@@ -38,7 +38,7 @@ CLASS net/minecraft/class_634 net/minecraft/client/network/ClientPlayNetworkHand
 		ARG 3 connection
 		ARG 4 serverInfo
 		ARG 5 profile
-		ARG 6 telemetrySender
+		ARG 6 worldSession
 	METHOD method_16690 getSessionId ()Ljava/util/UUID;
 	METHOD method_19691 getActiveTotemOfUndying (Lnet/minecraft/class_1657;)Lnet/minecraft/class_1799;
 		ARG 0 player
@@ -158,3 +158,6 @@ CLASS net/minecraft/class_634 net/minecraft/client/network/ClientPlayNetworkHand
 	METHOD method_46528 (Ljava/util/Optional;)V
 		ARG 1 keyPair
 	METHOD method_46529 isSecureChatEnforced ()Z
+	METHOD method_47657 updateKeyPair (Lnet/minecraft/class_7427;)V
+		ARG 1 keyPair
+	METHOD method_47658 clearWorld ()V

--- a/mappings/net/minecraft/client/option/GameOptions.mapping
+++ b/mappings/net/minecraft/client/option/GameOptions.mapping
@@ -209,6 +209,8 @@ CLASS net/minecraft/class_315 net/minecraft/client/option/GameOptions
 	FIELD field_39321 onlyShowSecureChat Lnet/minecraft/class_7172;
 	FIELD field_40382 panoramaSpeed Lnet/minecraft/class_7172;
 	FIELD field_41094 operatorItemsTab Lnet/minecraft/class_7172;
+	FIELD field_41335 TELEMETRY_TOOLTIP Lnet/minecraft/class_5250;
+	FIELD field_41336 telemetryOptInExtra Lnet/minecraft/class_7172;
 	METHOD <init> (Lnet/minecraft/class_310;Ljava/io/File;)V
 		ARG 1 client
 		ARG 2 optionsFile
@@ -564,6 +566,12 @@ CLASS net/minecraft/class_315 net/minecraft/client/option/GameOptions
 		ARG 0 value
 	METHOD method_47398 (Ljava/lang/Boolean;)Lnet/minecraft/class_7919;
 		ARG 0 value
+	METHOD method_47607 (Ljava/lang/Boolean;)V
+		ARG 0 value
+	METHOD method_47608 (Lnet/minecraft/class_2561;Ljava/lang/Boolean;)Lnet/minecraft/class_2561;
+		ARG 0 optionText
+		ARG 1 value
+	METHOD method_47609 getTelemetryOptInExtra ()Lnet/minecraft/class_7172;
 	CLASS 2
 		METHOD method_33676 find (Ljava/lang/String;)Ljava/lang/String;
 			ARG 1 key

--- a/mappings/net/minecraft/client/util/TelemetrySender.mapping
+++ b/mappings/net/minecraft/client/util/TelemetrySender.mapping
@@ -1,8 +1,0 @@
-CLASS net/minecraft/class_6628 net/minecraft/client/util/TelemetrySender
-	FIELD field_34948 NEXT_WORKER_ID Ljava/util/concurrent/atomic/AtomicInteger;
-	FIELD field_34949 EXECUTOR Ljava/util/concurrent/Executor;
-	METHOD <init> (Lnet/minecraft/class_310;Lcom/mojang/authlib/minecraft/UserApiService;Lnet/minecraft/class_320;)V
-		ARG 1 client
-		ARG 2 userApiService
-	METHOD method_38731 (Ljava/lang/Runnable;)Ljava/lang/Thread;
-		ARG 0 runnable

--- a/mappings/net/minecraft/client/util/telemetry/PerformanceMetricsEvent.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/PerformanceMetricsEvent.mapping
@@ -1,0 +1,14 @@
+CLASS net/minecraft/class_7977 net/minecraft/client/util/telemetry/PerformanceMetricsEvent
+	FIELD field_41510 MAX_MEMORY_KB J
+	FIELD field_41511 frameRateSamples Lit/unimi/dsi/fastutil/longs/LongList;
+	FIELD field_41512 renderTimeSamples Lit/unimi/dsi/fastutil/longs/LongList;
+	FIELD field_41513 usedMemorySamples Lit/unimi/dsi/fastutil/longs/LongList;
+	FIELD field_41514 sender Lnet/minecraft/class_7965;
+	METHOD <init> (Lnet/minecraft/class_7965;)V
+		ARG 1 sender
+	METHOD method_47785 toKilos (J)J
+		ARG 0 bytes
+	METHOD method_47787 (Lnet/minecraft/class_7973$class_7974;)V
+		ARG 1 builder
+	METHOD method_47788 clearSamples ()V
+	METHOD method_47789 sampleUsedMemory ()V

--- a/mappings/net/minecraft/client/util/telemetry/PropertyMap.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/PropertyMap.mapping
@@ -1,0 +1,40 @@
+CLASS net/minecraft/class_7973 net/minecraft/client/util/telemetry/PropertyMap
+	FIELD field_41496 backingMap Ljava/util/Map;
+	METHOD <init> (Ljava/util/Map;)V
+		ARG 1 backingMap
+	METHOD method_47759 builder ()Lnet/minecraft/class_7973$class_7974;
+	METHOD method_47760 get (Lnet/minecraft/class_7969;)Ljava/lang/Object;
+		ARG 1 property
+	METHOD method_47761 createCodec (Ljava/util/List;)Lcom/mojang/serialization/Codec;
+		ARG 0 properties
+	METHOD method_47762 keySet ()Ljava/util/Set;
+	CLASS 1
+		METHOD decode (Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/MapLike;)Lcom/mojang/serialization/DataResult;
+			ARG 1 ops
+			ARG 2 map
+		METHOD encode (Ljava/lang/Object;Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/RecordBuilder;)Lcom/mojang/serialization/RecordBuilder;
+			ARG 1 map
+			ARG 2 ops
+			ARG 3 builder
+		METHOD keys (Lcom/mojang/serialization/DynamicOps;)Ljava/util/stream/Stream;
+			ARG 1 ops
+		METHOD method_47763 decode (Lcom/mojang/serialization/DataResult;Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/MapLike;Lnet/minecraft/class_7969;)Lcom/mojang/serialization/DataResult;
+			ARG 1 result
+			ARG 2 ops
+			ARG 3 map
+			ARG 4 property
+		METHOD method_47764 (Lnet/minecraft/class_7969;Lnet/minecraft/class_7973$class_7974;Ljava/lang/Object;)Lnet/minecraft/class_7973$class_7974;
+			ARG 1 mapBuilder
+			ARG 2 value
+		METHOD method_47766 encode (Lnet/minecraft/class_7973;Lcom/mojang/serialization/RecordBuilder;Lnet/minecraft/class_7969;)Lcom/mojang/serialization/RecordBuilder;
+			ARG 1 map
+			ARG 2 builder
+			ARG 3 property
+	CLASS class_7974 Builder
+		FIELD field_41498 backingMap Ljava/util/Map;
+		METHOD method_47767 build ()Lnet/minecraft/class_7973;
+		METHOD method_47768 put (Lnet/minecraft/class_7969;Ljava/lang/Object;)Lnet/minecraft/class_7973$class_7974;
+			ARG 1 property
+			ARG 2 value
+		METHOD method_47769 putAll (Lnet/minecraft/class_7973;)Lnet/minecraft/class_7973$class_7974;
+			ARG 1 map

--- a/mappings/net/minecraft/client/util/telemetry/SampleEvent.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/SampleEvent.mapping
@@ -1,0 +1,14 @@
+CLASS net/minecraft/class_7976 net/minecraft/client/util/telemetry/SampleEvent
+	FIELD field_41505 INTERVAL_IN_MILLIS I
+	FIELD field_41506 BATCH_SIZE I
+	FIELD field_41507 sampleCount I
+	FIELD field_41508 enabled Z
+	FIELD field_41509 lastSampleTime Ljava/time/Instant;
+	METHOD method_47777 start ()V
+	METHOD method_47778 tick ()V
+	METHOD method_47779 shouldSample ()Z
+	METHOD method_47780 shouldSend ()Z
+	METHOD method_47781 disableSampling ()V
+	METHOD method_47782 getSampleCount ()I
+	METHOD method_47783 sample ()V
+	METHOD method_47784 send ()V

--- a/mappings/net/minecraft/client/util/telemetry/SentTelemetryEvent.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/SentTelemetryEvent.mapping
@@ -1,0 +1,6 @@
+CLASS net/minecraft/class_7962 net/minecraft/client/util/telemetry/SentTelemetryEvent
+	FIELD field_41430 CODEC Lcom/mojang/serialization/Codec;
+	METHOD method_47711 createEvent (Lcom/mojang/authlib/minecraft/TelemetrySession;)Lcom/mojang/authlib/minecraft/TelemetryEvent;
+		ARG 1 session
+	METHOD method_47712 (Lnet/minecraft/class_7966;Lnet/minecraft/class_7969;)V
+		ARG 1 property

--- a/mappings/net/minecraft/client/util/telemetry/TelemetryEvent.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/TelemetryEvent.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_7978 net/minecraft/client/util/telemetry/TelemetryEvent
+	METHOD method_47786 send (Lnet/minecraft/class_7965;)V
+		ARG 1 sender

--- a/mappings/net/minecraft/client/util/telemetry/TelemetryEventProperty.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/TelemetryEventProperty.mapping
@@ -1,0 +1,64 @@
+CLASS net/minecraft/class_7969 net/minecraft/client/util/telemetry/TelemetryEventProperty
+	FIELD field_41457 DATE_TIME_FORMATTER Ljava/time/format/DateTimeFormatter;
+	METHOD method_47743 getTitle ()Lnet/minecraft/class_5250;
+	METHOD method_47744 (Lcom/mojang/authlib/minecraft/TelemetryPropertyContainer;Ljava/lang/String;Lnet/minecraft/class_7969$class_7971;)V
+		ARG 0 container
+		ARG 1 exportKey
+		ARG 2 value
+	METHOD method_47745 (Lcom/mojang/authlib/minecraft/TelemetryPropertyContainer;Ljava/lang/String;Lnet/minecraft/class_7969$class_7972;)V
+		ARG 0 container
+		ARG 1 exportKey
+		ARG 2 value
+	METHOD method_47746 (Lcom/mojang/authlib/minecraft/TelemetryPropertyContainer;Ljava/lang/String;Lit/unimi/dsi/fastutil/longs/LongList;)V
+		ARG 0 container
+		ARG 1 exportKey
+		ARG 2 value
+	METHOD method_47747 (Lcom/mojang/authlib/minecraft/TelemetryPropertyContainer;Ljava/lang/String;Ljava/time/Instant;)V
+		ARG 0 container
+		ARG 1 exportKey
+		ARG 2 value
+	METHOD method_47748 (Lcom/mojang/authlib/minecraft/TelemetryPropertyContainer;Ljava/lang/String;Ljava/util/UUID;)V
+		ARG 0 container
+		ARG 1 exportKey
+		ARG 2 value
+	METHOD method_47749 addTo (Lnet/minecraft/class_7973;Lcom/mojang/authlib/minecraft/TelemetryPropertyContainer;)V
+		ARG 1 map
+		ARG 2 container
+	METHOD method_47750 ofBoolean (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/class_7969;
+		ARG 0 id
+		ARG 1 exportKey
+	METHOD method_47751 of (Ljava/lang/String;Ljava/lang/String;Lcom/mojang/serialization/Codec;Lnet/minecraft/class_7969$class_7970;)Lnet/minecraft/class_7969;
+		ARG 0 id
+		ARG 1 exportKey
+		ARG 2 codec
+		ARG 3 exporter
+	METHOD method_47752 ofString (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/class_7969;
+		ARG 0 id
+		ARG 1 exportKey
+	METHOD method_47753 ofInteger (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/class_7969;
+		ARG 0 id
+		ARG 1 exportKey
+	METHOD method_47754 ofUuid (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/class_7969;
+		ARG 0 id
+		ARG 1 exportKey
+	METHOD method_47755 ofLongList (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/class_7969;
+		ARG 0 id
+		ARG 1 exportKey
+	CLASS class_7970 PropertyExporter
+		METHOD apply (Lcom/mojang/authlib/minecraft/TelemetryPropertyContainer;Ljava/lang/String;Ljava/lang/Object;)V
+			ARG 1 container
+			ARG 2 key
+			ARG 3 value
+	CLASS class_7971 GameMode
+		FIELD field_41486 CODEC Lcom/mojang/serialization/Codec;
+		FIELD field_41487 id Ljava/lang/String;
+		FIELD field_41488 rawId I
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;I)V
+			ARG 3 id
+			ARG 4 rawId
+		METHOD method_47756 getRawId ()I
+	CLASS class_7972 ServerType
+		FIELD field_41493 CODEC Lcom/mojang/serialization/Codec;
+		FIELD field_41494 id Ljava/lang/String;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
+			ARG 3 id

--- a/mappings/net/minecraft/client/util/telemetry/TelemetryEventType.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/TelemetryEventType.mapping
@@ -1,0 +1,54 @@
+CLASS net/minecraft/class_7966 net/minecraft/client/util/telemetry/TelemetryEventType
+	FIELD field_41435 CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_41436 WORLD_LOADED Lnet/minecraft/class_7966;
+	FIELD field_41437 PERFORMANCE_METRICS Lnet/minecraft/class_7966;
+	FIELD field_41438 WORLD_LOAD_TIMES Lnet/minecraft/class_7966;
+	FIELD field_41439 WORLD_UNLOADED Lnet/minecraft/class_7966;
+	FIELD field_41440 TYPES Ljava/util/Map;
+	FIELD field_41441 BASIC_PROPERTIES Ljava/util/List;
+	FIELD field_41442 REQUIRED_PROPERTIES Ljava/util/List;
+	FIELD field_41443 id Ljava/lang/String;
+	FIELD field_41444 exportKey Ljava/lang/String;
+	FIELD field_41445 properties Ljava/util/List;
+	FIELD field_41446 optional Z
+	FIELD field_41447 codec Lcom/mojang/serialization/Codec;
+	METHOD <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Z)V
+		ARG 1 id
+		ARG 2 exportKey
+		ARG 3 properties
+		ARG 4 optional
+	METHOD method_47720 getId ()Ljava/lang/String;
+	METHOD method_47721 createEvent (Lcom/mojang/authlib/minecraft/TelemetrySession;Lnet/minecraft/class_7973;)Lcom/mojang/authlib/minecraft/TelemetryEvent;
+		ARG 1 session
+		ARG 2 properties
+	METHOD method_47722 hasProperty (Lnet/minecraft/class_7969;)Z
+		ARG 1 property
+	METHOD method_47723 (Lnet/minecraft/class_7973;)Lnet/minecraft/class_7962;
+		ARG 1 map
+	METHOD method_47724 getText (Ljava/lang/String;)Lnet/minecraft/class_5250;
+		ARG 1 key
+	METHOD method_47725 builder (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/class_7966$class_7967;
+		ARG 0 id
+		ARG 1 sentEventId
+	METHOD method_47726 getProperties ()Ljava/util/List;
+	METHOD method_47727 (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 0 id
+	METHOD method_47728 getCodec ()Lcom/mojang/serialization/Codec;
+	METHOD method_47729 isOptional ()Z
+	METHOD method_47730 getTitle ()Lnet/minecraft/class_5250;
+	METHOD method_47731 getDescription ()Lnet/minecraft/class_5250;
+	METHOD method_47732 getTypes ()Ljava/util/List;
+	CLASS class_7967 Builder
+		FIELD field_41448 id Ljava/lang/String;
+		FIELD field_41449 exportKey Ljava/lang/String;
+		FIELD field_41450 properties Ljava/util/List;
+		FIELD field_41451 optional Z
+		METHOD <init> (Ljava/lang/String;Ljava/lang/String;)V
+			ARG 1 id
+			ARG 2 exportKey
+		METHOD method_47733 optional ()Lnet/minecraft/class_7966$class_7967;
+		METHOD method_47734 properties (Lnet/minecraft/class_7969;)Lnet/minecraft/class_7966$class_7967;
+			ARG 1 property
+		METHOD method_47735 properties (Ljava/util/List;)Lnet/minecraft/class_7966$class_7967;
+			ARG 1 properties
+		METHOD method_47736 build ()Lnet/minecraft/class_7966;

--- a/mappings/net/minecraft/client/util/telemetry/TelemetryLogManager.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/TelemetryLogManager.mapping
@@ -1,0 +1,15 @@
+CLASS net/minecraft/class_7968 net/minecraft/client/util/telemetry/TelemetryLogManager
+	FIELD field_41452 LOGGER Lorg/slf4j/Logger;
+	FIELD field_41453 FILE_EXTENSION Ljava/lang/String;
+	FIELD field_41454 RETENTION_DAYS I
+	FIELD field_41455 compressor Lnet/minecraft/class_7929;
+	FIELD field_41456 writer Ljava/util/concurrent/CompletableFuture;
+	METHOD <init> (Lnet/minecraft/class_7929;)V
+		ARG 1 compressor
+	METHOD method_47737 getLogger ()Ljava/util/concurrent/CompletableFuture;
+	METHOD method_47738 create (Ljava/nio/file/Path;)Ljava/util/concurrent/CompletableFuture;
+		ARG 0 directory
+	METHOD method_47739 (Ljava/util/Optional;)V
+		ARG 0 writer
+	METHOD method_47742 (Ljava/util/Optional;)Ljava/util/Optional;
+		ARG 0 writer

--- a/mappings/net/minecraft/client/util/telemetry/TelemetryLogger.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/TelemetryLogger.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_7964 net/minecraft/client/util/telemetry/TelemetryLogger
+	METHOD log (Lnet/minecraft/class_7962;)V
+		ARG 1 event

--- a/mappings/net/minecraft/client/util/telemetry/TelemetryManager.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/TelemetryManager.mapping
@@ -1,0 +1,31 @@
+CLASS net/minecraft/class_6628 net/minecraft/client/util/telemetry/TelemetryManager
+	FIELD field_34948 NEXT_WORKER_ID Ljava/util/concurrent/atomic/AtomicInteger;
+	FIELD field_34949 EXECUTOR Ljava/util/concurrent/Executor;
+	FIELD field_41426 userApiService Lcom/mojang/authlib/minecraft/UserApiService;
+	FIELD field_41427 propertyMap Lnet/minecraft/class_7973;
+	FIELD field_41428 logDirectory Ljava/nio/file/Path;
+	FIELD field_41429 logManager Ljava/util/concurrent/CompletableFuture;
+	METHOD <init> (Lnet/minecraft/class_310;Lcom/mojang/authlib/minecraft/UserApiService;Lnet/minecraft/class_320;)V
+		ARG 1 client
+		ARG 2 userApiService
+		ARG 3 session
+	METHOD method_38731 (Ljava/lang/Runnable;)Ljava/lang/Thread;
+		ARG 0 runnable
+	METHOD method_47701 getLogManager ()Ljava/nio/file/Path;
+	METHOD method_47702 (Lnet/minecraft/class_7962;Lcom/mojang/authlib/minecraft/TelemetrySession;Ljava/util/Optional;)V
+		ARG 2 logger
+	METHOD method_47703 (Lnet/minecraft/class_7973$class_7974;Ljava/lang/String;)V
+		ARG 1 clientId
+	METHOD method_47704 (Ljava/util/Optional;)V
+		ARG 0 manager
+	METHOD method_47705 (Ljava/util/concurrent/CompletableFuture;Lcom/mojang/authlib/minecraft/TelemetrySession;Lnet/minecraft/class_7966;Ljava/util/function/Consumer;)V
+		ARG 1 eventType
+		ARG 2 propertyAdder
+	METHOD method_47706 createWorldSession (ZLjava/time/Duration;)Lnet/minecraft/class_7975;
+		ARG 1 newWorld
+		ARG 2 worldLoadTime
+	METHOD method_47707 getSender ()Lnet/minecraft/class_7965;
+	METHOD method_47708 (Lnet/minecraft/class_7973$class_7974;Ljava/lang/String;)V
+		ARG 1 xuid
+	METHOD method_47709 (Ljava/util/Optional;)Ljava/util/concurrent/CompletionStage;
+		ARG 0 manager

--- a/mappings/net/minecraft/client/util/telemetry/TelemetrySender.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/TelemetrySender.mapping
@@ -1,0 +1,15 @@
+CLASS net/minecraft/class_7965 net/minecraft/client/util/telemetry/TelemetrySender
+	FIELD field_41434 NOOP Lnet/minecraft/class_7965;
+	METHOD decorate (Ljava/util/function/Consumer;)Lnet/minecraft/class_7965;
+		ARG 1 decorationAdder
+	METHOD method_47717 (Lnet/minecraft/class_7966;Ljava/util/function/Consumer;)V
+		ARG 0 eventType
+		ARG 1 propertyAdder
+	METHOD method_47718 (Ljava/util/function/Consumer;Lnet/minecraft/class_7966;Ljava/util/function/Consumer;)V
+		ARG 2 eventType
+		ARG 3 propertyAdder
+	METHOD method_47719 (Ljava/util/function/Consumer;Ljava/util/function/Consumer;Lnet/minecraft/class_7973$class_7974;)V
+		ARG 2 builder
+	METHOD send (Lnet/minecraft/class_7966;Ljava/util/function/Consumer;)V
+		ARG 1 eventType
+		ARG 2 propertyAdder

--- a/mappings/net/minecraft/client/util/telemetry/ThreadedLogWriter.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/ThreadedLogWriter.mapping
@@ -1,0 +1,10 @@
+CLASS net/minecraft/class_7963 net/minecraft/client/util/telemetry/ThreadedLogWriter
+	FIELD field_41431 LOGGER Lorg/slf4j/Logger;
+	FIELD field_41432 writer Lnet/minecraft/class_7935;
+	FIELD field_41433 executor Lnet/minecraft/class_3846;
+	METHOD <init> (Ljava/nio/channels/FileChannel;Ljava/util/concurrent/Executor;)V
+		ARG 1 channel
+		ARG 2 executor
+	METHOD method_47713 getLogger ()Lnet/minecraft/class_7964;
+	METHOD method_47714 (Lnet/minecraft/class_7962;)V
+		ARG 1 event

--- a/mappings/net/minecraft/client/util/telemetry/WorldLoadTimesEvent.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/WorldLoadTimesEvent.mapping
@@ -1,0 +1,8 @@
+CLASS net/minecraft/class_7981 net/minecraft/client/util/telemetry/WorldLoadTimesEvent
+	FIELD field_41519 newWorld Z
+	FIELD field_41520 worldLoadTime Ljava/time/Duration;
+	METHOD <init> (ZLjava/time/Duration;)V
+		ARG 1 newWorld
+		ARG 2 worldLoadTime
+	METHOD method_47796 (Lnet/minecraft/class_7973$class_7974;)V
+		ARG 1 builder

--- a/mappings/net/minecraft/client/util/telemetry/WorldLoadedEvent.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/WorldLoadedEvent.mapping
@@ -1,0 +1,19 @@
+CLASS net/minecraft/class_7979 net/minecraft/client/util/telemetry/WorldLoadedEvent
+	FIELD field_41515 callback Lnet/minecraft/class_7979$class_7980;
+	FIELD field_41516 sent Z
+	FIELD field_41517 gameMode Lnet/minecraft/class_7969$class_7971;
+	FIELD field_41518 brand Ljava/lang/String;
+	METHOD <init> (Lnet/minecraft/class_7979$class_7980;)V
+		ARG 1 callback
+	METHOD method_47790 getBrand ()Ljava/lang/String;
+	METHOD method_47791 setGameMode (Lnet/minecraft/class_1934;Z)V
+		ARG 1 gameMode
+		ARG 2 hardcore
+	METHOD method_47792 putServerType (Lnet/minecraft/class_7973$class_7974;)V
+		ARG 1 builder
+	METHOD method_47793 setBrand (Ljava/lang/String;)V
+		ARG 1 brand
+	METHOD method_47794 getServerType ()Lnet/minecraft/class_7969$class_7972;
+	METHOD method_47795 (Lnet/minecraft/class_7973$class_7974;)V
+		ARG 1 builder
+	CLASS class_7980 Callback

--- a/mappings/net/minecraft/client/util/telemetry/WorldSession.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/WorldSession.mapping
@@ -1,0 +1,23 @@
+CLASS net/minecraft/class_7975 net/minecraft/client/util/telemetry/WorldSession
+	FIELD field_41499 sessionId Ljava/util/UUID;
+	FIELD field_41500 sender Lnet/minecraft/class_7965;
+	FIELD field_41501 worldLoadedEvent Lnet/minecraft/class_7979;
+	FIELD field_41502 worldUnloadedEvent Lnet/minecraft/class_7982;
+	FIELD field_41503 performanceMetricsEvent Lnet/minecraft/class_7977;
+	FIELD field_41504 worldLoadTimesEvent Lnet/minecraft/class_7981;
+	METHOD <init> (Lnet/minecraft/class_7965;ZLjava/time/Duration;)V
+		ARG 1 sender
+		ARG 2 newWorld
+		ARG 3 worldLoadTime
+	METHOD method_47770 tick ()V
+	METHOD method_47771 setTick (J)V
+		ARG 1 tick
+	METHOD method_47772 setGameMode (Lnet/minecraft/class_1934;Z)V
+		ARG 1 gameMode
+		ARG 2 hardcore
+	METHOD method_47773 (Lnet/minecraft/class_7973$class_7974;)V
+		ARG 1 builder
+	METHOD method_47774 setBrand (Ljava/lang/String;)V
+		ARG 1 brand
+	METHOD method_47775 onLoad ()V
+	METHOD method_47776 onUnload ()V

--- a/mappings/net/minecraft/client/util/telemetry/WorldUnloadedEvent.mapping
+++ b/mappings/net/minecraft/client/util/telemetry/WorldUnloadedEvent.mapping
@@ -1,0 +1,13 @@
+CLASS net/minecraft/class_7982 net/minecraft/client/util/telemetry/WorldUnloadedEvent
+	FIELD field_41521 startTime Ljava/util/Optional;
+	FIELD field_41522 ticksSinceLoad J
+	FIELD field_41523 lastTick J
+	METHOD method_47797 setStartTime ()V
+	METHOD method_47798 setTick (J)V
+		ARG 1 tick
+	METHOD method_47799 (Lnet/minecraft/class_7965;Ljava/time/Instant;)V
+		ARG 2 startTime
+	METHOD method_47800 getSecondsSinceLoad (Ljava/time/Instant;)I
+		ARG 1 startTime
+	METHOD method_47801 (Ljava/time/Instant;Lnet/minecraft/class_7973$class_7974;)V
+		ARG 2 builder

--- a/mappings/net/minecraft/util/logging/LogFileCompressor.mapping
+++ b/mappings/net/minecraft/util/logging/LogFileCompressor.mapping
@@ -1,0 +1,47 @@
+CLASS net/minecraft/class_7929 net/minecraft/util/logging/LogFileCompressor
+	FIELD field_41288 LOGGER Lorg/slf4j/Logger;
+	FIELD field_41289 COMPRESSION_BUFFER_SIZE I
+	FIELD field_41290 GZ_EXTENSION Ljava/lang/String;
+	FIELD field_41291 directory Ljava/nio/file/Path;
+	FIELD field_41292 extension Ljava/lang/String;
+	METHOD <init> (Ljava/nio/file/Path;Ljava/lang/String;)V
+		ARG 1 directory
+		ARG 2 extension
+	METHOD method_47549 getAll ()Lnet/minecraft/class_7929$class_7933;
+	METHOD method_47550 compress (Ljava/nio/channels/ReadableByteChannel;Ljava/nio/file/Path;)V
+		ARG 0 source
+		ARG 1 outputPath
+	METHOD method_47551 get (Ljava/nio/file/Path;)Lnet/minecraft/class_7929$class_7931;
+		ARG 1 path
+	METHOD method_47552 create (Ljava/nio/file/Path;Ljava/lang/String;)Lnet/minecraft/class_7929;
+		ARG 0 directory
+		ARG 1 extension
+	METHOD method_47553 compress (Ljava/nio/file/Path;Ljava/nio/file/Path;)V
+		ARG 0 from
+		ARG 1 to
+	METHOD method_47554 createLogFile (Ljava/time/LocalDate;)Lnet/minecraft/class_7929$class_7934;
+		ARG 1 date
+	CLASS class_7930 Compressed
+	CLASS class_7931 LogFile
+		METHOD method_47556 getReader ()Ljava/io/Reader;
+		METHOD method_47557 compress ()Lnet/minecraft/class_7929$class_7930;
+	CLASS class_7932 LogId
+		FIELD field_41293 DATE_TIME_FORMATTER Ljava/time/format/DateTimeFormatter;
+		METHOD method_47558 fromFileName (Ljava/lang/String;)Lnet/minecraft/class_7929$class_7932;
+			ARG 0 fileName
+		METHOD method_47559 getFileName (Ljava/lang/String;)Ljava/lang/String;
+			ARG 1 extension
+	CLASS class_7933 LogFileIterable
+		FIELD field_41294 logs Ljava/util/List;
+		METHOD <init> (Ljava/util/List;)V
+			ARG 1 logs
+		METHOD method_47560 compressAll ()Lnet/minecraft/class_7929$class_7933;
+		METHOD method_47561 (ILjava/time/LocalDate;Lnet/minecraft/class_7929$class_7931;)Z
+			ARG 2 log
+		METHOD method_47562 removeExpired (Ljava/time/LocalDate;I)Lnet/minecraft/class_7929$class_7933;
+			ARG 1 currentDate
+			ARG 2 retentionDays
+		METHOD method_47563 stream ()Ljava/util/stream/Stream;
+		METHOD method_47564 toIdSet ()Ljava/util/Set;
+	CLASS class_7934 Uncompressed
+		METHOD method_47565 open ()Ljava/nio/channels/FileChannel;

--- a/mappings/net/minecraft/util/logging/LogReader.mapping
+++ b/mappings/net/minecraft/util/logging/LogReader.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_7936 net/minecraft/util/logging/LogReader
+	METHOD method_47570 read ()Ljava/lang/Object;
+	METHOD method_47571 create (Lcom/mojang/serialization/Codec;Ljava/io/Reader;)Lnet/minecraft/class_7936;
+		ARG 0 codec
+		ARG 1 reader

--- a/mappings/net/minecraft/util/logging/LogWriter.mapping
+++ b/mappings/net/minecraft/util/logging/LogWriter.mapping
@@ -1,0 +1,17 @@
+CLASS net/minecraft/class_7935 net/minecraft/util/logging/LogWriter
+	FIELD field_41295 GSON Lcom/google/gson/Gson;
+	FIELD field_41296 codec Lcom/mojang/serialization/Codec;
+	FIELD field_41297 channel Ljava/nio/channels/FileChannel;
+	FIELD field_41298 refCount Ljava/util/concurrent/atomic/AtomicInteger;
+	METHOD <init> (Lcom/mojang/serialization/Codec;Ljava/nio/channels/FileChannel;)V
+		ARG 1 codec
+		ARG 2 channel
+	METHOD method_47566 getReader ()Lnet/minecraft/class_7936;
+	METHOD method_47567 create (Lcom/mojang/serialization/Codec;Ljava/nio/file/Path;)Lnet/minecraft/class_7935;
+		ARG 0 codec
+		ARG 1 path
+	METHOD method_47568 write (Ljava/lang/Object;)V
+		ARG 1 object
+	METHOD method_47569 closeIfNotReferenced ()V
+	CLASS 1
+		FIELD field_41301 pos J


### PR DESCRIPTION
- Repackages `TelemetrySender` to `net.minecraft.client.util.telemetry` (Welcome back!) and renames it to `TelemetryManager`
- Maps common log compression stuff, packaged at `net.minecraft.util.logging`
- Maps telemetry stuff
- Maps methods and fields related to telemetry