### PR TITLE
Rename Sprite.getId to getAtlasId

### DIFF
--- a/mappings/net/minecraft/client/texture/Sprite.mapping
+++ b/mappings/net/minecraft/client/texture/Sprite.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_1058 net/minecraft/client/texture/Sprite
-	FIELD field_40552 id Lnet/minecraft/class_2960;
+	FIELD field_40552 atlasId Lnet/minecraft/class_2960;
 	FIELD field_40553 contents Lnet/minecraft/class_7764;
 	FIELD field_5256 y I
 	FIELD field_5258 x I
@@ -8,7 +8,7 @@ CLASS net/minecraft/class_1058 net/minecraft/client/texture/Sprite
 	FIELD field_5269 uMax F
 	FIELD field_5270 uMin F
 	METHOD <init> (Lnet/minecraft/class_2960;Lnet/minecraft/class_7764;IIII)V
-		ARG 1 id
+		ARG 1 atlasId
 		ARG 2 contents
 		ARG 3 maxLevel
 		ARG 4 atlasWidth
@@ -29,7 +29,7 @@ CLASS net/minecraft/class_1058 net/minecraft/client/texture/Sprite
 		ARG 1 frame
 	METHOD method_4584 upload ()V
 	METHOD method_45851 getContents ()Lnet/minecraft/class_7764;
-	METHOD method_45852 getId ()Lnet/minecraft/class_2960;
+	METHOD method_45852 getAtlasId ()Lnet/minecraft/class_2960;
 	METHOD method_4593 getMinV ()F
 	METHOD method_4594 getMinU ()F
 	CLASS class_7770 TickableAnimation


### PR DESCRIPTION
This is an identifier of the parent atlas texture. The issue was reported by glisco in fabric discord. https://discord.com/channels/507304429255393322/521545796882006027/1043983765996847114
