### PR TITLE
Fix getRenderTypeCrumblingShader and getRenderTypeEntityTranslucentEmissiveShader

### DIFF
--- a/mappings/net/minecraft/client/render/GameRenderer.mapping
+++ b/mappings/net/minecraft/client/render/GameRenderer.mapping
@@ -228,7 +228,7 @@ CLASS net/minecraft/class_757 net/minecraft/client/render/GameRenderer
 		COMMENT <p>The width of the line can be set with {@link
 		COMMENT com.mojang.blaze3d.systems.RenderSystem#lineWidth
 		COMMENT RenderSystem#lineWidth}.
-	METHOD method_34536 getRenderTypeCrumblingShader ()Lnet/minecraft/class_5944;
+	METHOD method_34536 getRenderTypeCrumblingProgram ()Lnet/minecraft/class_5944;
 	METHOD method_34537 clearPrograms ()V
 	METHOD method_34538 loadPrograms (Lnet/minecraft/class_5912;)V
 		ARG 1 factory
@@ -378,7 +378,7 @@ CLASS net/minecraft/class_757 net/minecraft/client/render/GameRenderer
 		ARG 1 path
 	METHOD method_42594 (Lnet/minecraft/class_5944;)V
 		ARG 0 program
-	METHOD method_42595 getRenderTypeEntityTranslucentEmissiveShader ()Lnet/minecraft/class_5944;
+	METHOD method_42595 getRenderTypeEntityTranslucentEmissiveProgram ()Lnet/minecraft/class_5944;
 	METHOD method_45774 createProgramReloader ()Lnet/minecraft/class_3302;
 	CLASS 1
 		METHOD method_45775 (Lnet/minecraft/class_2960;)Z


### PR DESCRIPTION
I accidentally merged the old PR to 22w46a branch 🤦🏼 