### PR TITLE
Move Tooltip to tooltip package

### DIFF
--- a/mappings/net/minecraft/client/gui/tooltip/Tooltip.mapping
+++ b/mappings/net/minecraft/client/gui/tooltip/Tooltip.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_7919 net/minecraft/client/gui/screen/Tooltip
+CLASS net/minecraft/class_7919 net/minecraft/client/gui/tooltip/Tooltip
 	FIELD field_41101 ROW_LENGTH I
 	FIELD field_41102 content Lnet/minecraft/class_2561;
 	FIELD field_41103 lines Ljava/util/List;


### PR DESCRIPTION
See #3427. Should not be impactful since it was introduced a few weeks ago and I believe the Text overload of `setTooltip` is more common.