### PR TITLE
Mapping some fields of IntProperty.

### DIFF
--- a/mappings/net/minecraft/state/property/IntProperty.mapping
+++ b/mappings/net/minecraft/state/property/IntProperty.mapping
@@ -4,6 +4,8 @@ CLASS net/minecraft/class_2758 net/minecraft/state/property/IntProperty
 	COMMENT <p>See {@link net.minecraft.state.property.Properties} for example
 	COMMENT usages.
 	FIELD field_12614 values Lcom/google/common/collect/ImmutableSet;
+	FIELD field_37655 min I
+	FIELD field_37656 max I
 	METHOD <init> (Ljava/lang/String;II)V
 		ARG 1 name
 		ARG 2 min


### PR DESCRIPTION
Hello guys! I'm modding recently and found two fields in `IntProperty` that have obvious meaning that don't seem to be mapped, so I thought I'd try contributing to yarn, how about this?

- `field_37655` to `min`
- `field_37656` to `max`

This is my first contribution to yarn mapping, if I have done something wrong please do not hesitate to advise :>