### PR TITLE
Fix typos in Registries

### DIFF
--- a/mappings/net/minecraft/registry/Registries.mapping
+++ b/mappings/net/minecraft/registry/Registries.mapping
@@ -23,7 +23,7 @@ CLASS net/minecraft/class_7923 net/minecraft/registry/Registries
 	FIELD field_41149 BLOCK_STATE_PROVIDER_TYPE Lnet/minecraft/class_2378;
 	FIELD field_41150 FOLIAGE_PLACER_TYPE Lnet/minecraft/class_2378;
 	FIELD field_41151 TRUNK_PLACER_TYPE Lnet/minecraft/class_2378;
-	FIELD field_41152 ROOT_PLAYER_TYPE Lnet/minecraft/class_2378;
+	FIELD field_41152 ROOT_PLACER_TYPE Lnet/minecraft/class_2378;
 	FIELD field_41153 TREE_DECORATOR_TYPE Lnet/minecraft/class_2378;
 	FIELD field_41154 ROOT_KEY Lnet/minecraft/class_2960;
 	FIELD field_41155 FEATURE_SIZE_TYPE Lnet/minecraft/class_2378;

--- a/mappings/net/minecraft/registry/Registries.mapping
+++ b/mappings/net/minecraft/registry/Registries.mapping
@@ -10,7 +10,7 @@ CLASS net/minecraft/class_7923 net/minecraft/registry/Registries
 	FIELD field_41136 LOOT_NUMBER_PROVIDER_TYPE Lnet/minecraft/class_2378;
 	FIELD field_41137 LOOT_NBT_PROVIDER_TYPE Lnet/minecraft/class_2378;
 	FIELD field_41138 LOOT_SCORE_PROVIDER_TYPE Lnet/minecraft/class_2378;
-	FIELD field_41139 FLOAT_PROIDER_TYPE Lnet/minecraft/class_2378;
+	FIELD field_41139 FLOAT_PROVIDER_TYPE Lnet/minecraft/class_2378;
 	FIELD field_41140 INT_PROVIDER_TYPE Lnet/minecraft/class_2378;
 	FIELD field_41141 HEIGHT_PROVIDER_TYPE Lnet/minecraft/class_2378;
 	FIELD field_41142 BLOCK_PREDICATE_TYPE Lnet/minecraft/class_2378;

--- a/mappings/net/minecraft/registry/RegistryKeys.mapping
+++ b/mappings/net/minecraft/registry/RegistryKeys.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_7924 net/minecraft/registry/RegistryKeys
 	FIELD field_41207 SCREEN_HANDLER Lnet/minecraft/class_5321;
 	FIELD field_41208 STATUS_EFFECT Lnet/minecraft/class_5321;
 	FIELD field_41211 PLACEMENT_MODIFIER_TYPE Lnet/minecraft/class_5321;
-	FIELD field_41218 ROOT_PLAYER_TYPE Lnet/minecraft/class_5321;
+	FIELD field_41218 ROOT_PLACER_TYPE Lnet/minecraft/class_5321;
 	FIELD field_41223 WORLD Lnet/minecraft/class_5321;
 	FIELD field_41224 DIMENSION Lnet/minecraft/class_5321;
 	FIELD field_41227 STRUCTURE_PIECE Lnet/minecraft/class_5321;


### PR DESCRIPTION
- `Registries.FLOAT_PROIDER_TYPE` -> `FLOAT_PROVIDER_TYPE`
- `Registries.ROOT_PLAYER_TYPE` -> `ROOT_PLACER_TYPE` (also in RegistryKeys)