### PR TITLE
Revert some shader renames for ease of porting to 1.19.3

### DIFF
--- a/mappings/net/minecraft/client/render/BufferRenderer.mapping
+++ b/mappings/net/minecraft/client/render/BufferRenderer.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_286 net/minecraft/client/render/BufferRenderer
 	COMMENT BufferBuilder}.
 	FIELD field_38982 currentVertexBuffer Lnet/minecraft/class_291;
 	METHOD method_34420 reset ()V
-	METHOD method_43433 drawWithGlobalProgram (Lnet/minecraft/class_287$class_7433;)V
+	METHOD method_43433 drawWithShader (Lnet/minecraft/class_287$class_7433;)V
 		COMMENT Draws {@code buffer} using the shader program specified with {@link
 		COMMENT com.mojang.blaze3d.systems.RenderSystem#setShader
 		COMMENT RenderSystem#setShader}
@@ -16,12 +16,12 @@ CLASS net/minecraft/class_286 net/minecraft/client/render/BufferRenderer
 	METHOD method_43437 draw (Lnet/minecraft/class_287$class_7433;)V
 		COMMENT Draws {@code buffer}.
 		COMMENT
-		COMMENT <p>Unlike {@link #drawWithGlobalProgram}, the shader program cannot be
+		COMMENT <p>Unlike {@link #drawWithShader}, the shader program cannot be
 		COMMENT specified with {@link com.mojang.blaze3d.systems.RenderSystem#setShader
 		COMMENT RenderSystem#setShader}. The caller of this method must manually bind a
 		COMMENT shader program before calling this method.
 		ARG 0 buffer
-	METHOD method_43438 drawWithGlobalProgramInternal (Lnet/minecraft/class_287$class_7433;)V
+	METHOD method_43438 drawWithShaderInternal (Lnet/minecraft/class_287$class_7433;)V
 		ARG 0 buffer
 	METHOD method_43439 upload (Lnet/minecraft/class_287$class_7433;)Lnet/minecraft/class_291;
 		ARG 0 buffer

--- a/mappings/net/minecraft/client/render/GameRenderer.mapping
+++ b/mappings/net/minecraft/client/render/GameRenderer.mapping
@@ -4,59 +4,59 @@ CLASS net/minecraft/class_757 net/minecraft/client/render/GameRenderer
 	FIELD field_20949 overlayTexture Lnet/minecraft/class_4608;
 	FIELD field_26730 NAUSEA_OVERLAY Lnet/minecraft/class_2960;
 	FIELD field_29350 programs Ljava/util/Map;
-	FIELD field_29351 positionProgram Lnet/minecraft/class_5944;
-	FIELD field_29352 positionColorProgram Lnet/minecraft/class_5944;
-	FIELD field_29353 positionColorTexProgram Lnet/minecraft/class_5944;
-	FIELD field_29354 positionTexProgram Lnet/minecraft/class_5944;
-	FIELD field_29355 positionTexColorProgram Lnet/minecraft/class_5944;
-	FIELD field_29356 blockProgram Lnet/minecraft/class_5944;
-	FIELD field_29357 newEntityProgram Lnet/minecraft/class_5944;
-	FIELD field_29358 particleProgram Lnet/minecraft/class_5944;
-	FIELD field_29359 positionColorLightmapProgram Lnet/minecraft/class_5944;
-	FIELD field_29360 positionColorTexLightmapProgram Lnet/minecraft/class_5944;
-	FIELD field_29361 positionTexColorNormalProgram Lnet/minecraft/class_5944;
-	FIELD field_29362 positionTexLightmapColorProgram Lnet/minecraft/class_5944;
-	FIELD field_29363 renderTypeSolidProgram Lnet/minecraft/class_5944;
-	FIELD field_29364 renderTypeCutoutMippedProgram Lnet/minecraft/class_5944;
-	FIELD field_29365 renderTypeCutoutProgram Lnet/minecraft/class_5944;
-	FIELD field_29366 renderTypeTranslucentProgram Lnet/minecraft/class_5944;
-	FIELD field_29367 renderTypeEntityGlintProgram Lnet/minecraft/class_5944;
-	FIELD field_29368 renderTypeEntityGlintDirectProgram Lnet/minecraft/class_5944;
-	FIELD field_29369 renderTypeTextProgram Lnet/minecraft/class_5944;
-	FIELD field_29370 renderTypeTextSeeThroughProgram Lnet/minecraft/class_5944;
-	FIELD field_29371 renderTypeLightningProgram Lnet/minecraft/class_5944;
-	FIELD field_29372 renderTypeTripwireProgram Lnet/minecraft/class_5944;
-	FIELD field_29373 renderTypeEndPortalProgram Lnet/minecraft/class_5944;
-	FIELD field_29374 renderTypeEndGatewayProgram Lnet/minecraft/class_5944;
-	FIELD field_29375 renderTypeLinesProgram Lnet/minecraft/class_5944;
-	FIELD field_29376 renderTypeCrumblingProgram Lnet/minecraft/class_5944;
-	FIELD field_29377 renderTypeTranslucentMovingBlockProgram Lnet/minecraft/class_5944;
-	FIELD field_29378 renderTypeTranslucentNoCrumblingProgram Lnet/minecraft/class_5944;
-	FIELD field_29379 renderTypeArmorCutoutNoCullProgram Lnet/minecraft/class_5944;
-	FIELD field_29380 renderTypeEntitySolidProgram Lnet/minecraft/class_5944;
-	FIELD field_29381 renderTypeEntityCutoutProgram Lnet/minecraft/class_5944;
-	FIELD field_29382 renderTypeEntityCutoutNoNullProgram Lnet/minecraft/class_5944;
-	FIELD field_29383 renderTypeEntityCutoutNoNullZOffsetProgram Lnet/minecraft/class_5944;
-	FIELD field_29384 renderTypeItemEntityTranslucentCullProgram Lnet/minecraft/class_5944;
-	FIELD field_29385 renderTypeEntityTranslucentCullProgram Lnet/minecraft/class_5944;
-	FIELD field_29386 renderTypeEntityTranslucentProgram Lnet/minecraft/class_5944;
-	FIELD field_29387 renderTypeEntitySmoothCutoutProgram Lnet/minecraft/class_5944;
-	FIELD field_29388 renderTypeBeaconBeamProgram Lnet/minecraft/class_5944;
-	FIELD field_29389 renderTypeEntityDecalProgram Lnet/minecraft/class_5944;
-	FIELD field_29390 renderTypeEntityNoOutlineProgram Lnet/minecraft/class_5944;
-	FIELD field_29391 renderTypeEntityShadowProgram Lnet/minecraft/class_5944;
-	FIELD field_29392 renderTypeEntityAlphaProgram Lnet/minecraft/class_5944;
-	FIELD field_29393 renderTypeEyesProgram Lnet/minecraft/class_5944;
-	FIELD field_29394 renderTypeEnergySwirlProgram Lnet/minecraft/class_5944;
-	FIELD field_29395 renderTypeLeashProgram Lnet/minecraft/class_5944;
-	FIELD field_29396 renderTypeWaterMaskProgram Lnet/minecraft/class_5944;
-	FIELD field_29397 renderTypeOutlineProgram Lnet/minecraft/class_5944;
-	FIELD field_29398 renderTypeArmorGlintProgram Lnet/minecraft/class_5944;
-	FIELD field_29399 renderTypeArmorEntityGlintProgram Lnet/minecraft/class_5944;
-	FIELD field_29400 renderTypeGlintTranslucentProgram Lnet/minecraft/class_5944;
-	FIELD field_29401 renderTypeGlintProgram Lnet/minecraft/class_5944;
-	FIELD field_29402 renderTypeGlintDirectProgram Lnet/minecraft/class_5944;
-	FIELD field_29403 blitScreenProgram Lnet/minecraft/class_5944;
+	FIELD field_29351 positionShader Lnet/minecraft/class_5944;
+	FIELD field_29352 positionColorShader Lnet/minecraft/class_5944;
+	FIELD field_29353 positionColorTexShader Lnet/minecraft/class_5944;
+	FIELD field_29354 positionTexShader Lnet/minecraft/class_5944;
+	FIELD field_29355 positionTexColorShader Lnet/minecraft/class_5944;
+	FIELD field_29356 blockShader Lnet/minecraft/class_5944;
+	FIELD field_29357 newEntityShader Lnet/minecraft/class_5944;
+	FIELD field_29358 particleShader Lnet/minecraft/class_5944;
+	FIELD field_29359 positionColorLightmapShader Lnet/minecraft/class_5944;
+	FIELD field_29360 positionColorTexLightmapShader Lnet/minecraft/class_5944;
+	FIELD field_29361 positionTexColorNormalShader Lnet/minecraft/class_5944;
+	FIELD field_29362 positionTexLightmapColorShader Lnet/minecraft/class_5944;
+	FIELD field_29363 renderTypeSolidShader Lnet/minecraft/class_5944;
+	FIELD field_29364 renderTypeCutoutMippedShader Lnet/minecraft/class_5944;
+	FIELD field_29365 renderTypeCutoutShader Lnet/minecraft/class_5944;
+	FIELD field_29366 renderTypeTranslucentShader Lnet/minecraft/class_5944;
+	FIELD field_29367 renderTypeEntityGlintShader Lnet/minecraft/class_5944;
+	FIELD field_29368 renderTypeEntityGlintDirectShader Lnet/minecraft/class_5944;
+	FIELD field_29369 renderTypeTextShader Lnet/minecraft/class_5944;
+	FIELD field_29370 renderTypeTextSeeThroughShader Lnet/minecraft/class_5944;
+	FIELD field_29371 renderTypeLightningShader Lnet/minecraft/class_5944;
+	FIELD field_29372 renderTypeTripwireShader Lnet/minecraft/class_5944;
+	FIELD field_29373 renderTypeEndPortalShader Lnet/minecraft/class_5944;
+	FIELD field_29374 renderTypeEndGatewayShader Lnet/minecraft/class_5944;
+	FIELD field_29375 renderTypeLinesShader Lnet/minecraft/class_5944;
+	FIELD field_29376 renderTypeCrumblingShader Lnet/minecraft/class_5944;
+	FIELD field_29377 renderTypeTranslucentMovingBlockShader Lnet/minecraft/class_5944;
+	FIELD field_29378 renderTypeTranslucentNoCrumblingShader Lnet/minecraft/class_5944;
+	FIELD field_29379 renderTypeArmorCutoutNoCullShader Lnet/minecraft/class_5944;
+	FIELD field_29380 renderTypeEntitySolidShader Lnet/minecraft/class_5944;
+	FIELD field_29381 renderTypeEntityCutoutShader Lnet/minecraft/class_5944;
+	FIELD field_29382 renderTypeEntityCutoutNoNullShader Lnet/minecraft/class_5944;
+	FIELD field_29383 renderTypeEntityCutoutNoNullZOffsetShader Lnet/minecraft/class_5944;
+	FIELD field_29384 renderTypeItemEntityTranslucentCullShader Lnet/minecraft/class_5944;
+	FIELD field_29385 renderTypeEntityTranslucentCullShader Lnet/minecraft/class_5944;
+	FIELD field_29386 renderTypeEntityTranslucentShader Lnet/minecraft/class_5944;
+	FIELD field_29387 renderTypeEntitySmoothCutoutShader Lnet/minecraft/class_5944;
+	FIELD field_29388 renderTypeBeaconBeamShader Lnet/minecraft/class_5944;
+	FIELD field_29389 renderTypeEntityDecalShader Lnet/minecraft/class_5944;
+	FIELD field_29390 renderTypeEntityNoOutlineShader Lnet/minecraft/class_5944;
+	FIELD field_29391 renderTypeEntityShadowShader Lnet/minecraft/class_5944;
+	FIELD field_29392 renderTypeEntityAlphaShader Lnet/minecraft/class_5944;
+	FIELD field_29393 renderTypeEyesShader Lnet/minecraft/class_5944;
+	FIELD field_29394 renderTypeEnergySwirlShader Lnet/minecraft/class_5944;
+	FIELD field_29395 renderTypeLeashShader Lnet/minecraft/class_5944;
+	FIELD field_29396 renderTypeWaterMaskShader Lnet/minecraft/class_5944;
+	FIELD field_29397 renderTypeOutlineShader Lnet/minecraft/class_5944;
+	FIELD field_29398 renderTypeArmorGlintShader Lnet/minecraft/class_5944;
+	FIELD field_29399 renderTypeArmorEntityGlintShader Lnet/minecraft/class_5944;
+	FIELD field_29400 renderTypeGlintTranslucentShader Lnet/minecraft/class_5944;
+	FIELD field_29401 renderTypeGlintShader Lnet/minecraft/class_5944;
+	FIELD field_29402 renderTypeGlintDirectShader Lnet/minecraft/class_5944;
+	FIELD field_29403 blitScreenShader Lnet/minecraft/class_5944;
 	FIELD field_32686 CAMERA_DEPTH F
 		COMMENT Since the camera is conceptualized as a single point, a depth of {@value}
 		COMMENT blocks is used to define a rectangular area to be rendered.
@@ -165,51 +165,51 @@ CLASS net/minecraft/class_757 net/minecraft/client/render/GameRenderer
 	METHOD method_3202 shouldRenderBlockOutline ()Z
 	METHOD method_3203 reset ()V
 	METHOD method_3207 disablePostProcessor ()V
-	METHOD method_34495 getRenderTypeSolidProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34496 getRenderTypeCutoutMippedProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34497 getRenderTypeCutoutProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34498 getRenderTypeTranslucentProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34499 getRenderTypeTranslucentMovingBlockProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34500 getRenderTypeTranslucentNoCrumblingProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34501 getRenderTypeArmorCutoutNoCullProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34502 getRenderTypeEntitySolidProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34503 getRenderTypeEntityCutoutProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34504 getRenderTypeEntityCutoutNoNullProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34505 getRenderTypeEntityCutoutNoNullZOffsetProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34506 getRenderTypeItemEntityTranslucentCullProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34507 getRenderTypeEntityTranslucentCullProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34508 getRenderTypeEntityTranslucentProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34509 getRenderTypeEntitySmoothCutoutProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34510 getRenderTypeBeaconBeamProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34511 getRenderTypeEntityDecalProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34512 getRenderTypeEntityNoOutlineProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34513 getRenderTypeEntityShadowProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34514 getRenderTypeEntityAlphaProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34515 getRenderTypeEyesProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34516 getRenderTypeEnergySwirlProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34517 getRenderTypeLeashProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34518 getRenderTypeWaterMaskProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34519 getRenderTypeOutlineProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34520 getRenderTypeArmorGlintProgram ()Lnet/minecraft/class_5944;
+	METHOD method_34495 getRenderTypeSolidShader ()Lnet/minecraft/class_5944;
+	METHOD method_34496 getRenderTypeCutoutMippedShader ()Lnet/minecraft/class_5944;
+	METHOD method_34497 getRenderTypeCutoutShader ()Lnet/minecraft/class_5944;
+	METHOD method_34498 getRenderTypeTranslucentShader ()Lnet/minecraft/class_5944;
+	METHOD method_34499 getRenderTypeTranslucentMovingBlockShader ()Lnet/minecraft/class_5944;
+	METHOD method_34500 getRenderTypeTranslucentNoCrumblingShader ()Lnet/minecraft/class_5944;
+	METHOD method_34501 getRenderTypeArmorCutoutNoCullShader ()Lnet/minecraft/class_5944;
+	METHOD method_34502 getRenderTypeEntitySolidShader ()Lnet/minecraft/class_5944;
+	METHOD method_34503 getRenderTypeEntityCutoutShader ()Lnet/minecraft/class_5944;
+	METHOD method_34504 getRenderTypeEntityCutoutNoNullShader ()Lnet/minecraft/class_5944;
+	METHOD method_34505 getRenderTypeEntityCutoutNoNullZOffsetShader ()Lnet/minecraft/class_5944;
+	METHOD method_34506 getRenderTypeItemEntityTranslucentCullShader ()Lnet/minecraft/class_5944;
+	METHOD method_34507 getRenderTypeEntityTranslucentCullShader ()Lnet/minecraft/class_5944;
+	METHOD method_34508 getRenderTypeEntityTranslucentShader ()Lnet/minecraft/class_5944;
+	METHOD method_34509 getRenderTypeEntitySmoothCutoutShader ()Lnet/minecraft/class_5944;
+	METHOD method_34510 getRenderTypeBeaconBeamShader ()Lnet/minecraft/class_5944;
+	METHOD method_34511 getRenderTypeEntityDecalShader ()Lnet/minecraft/class_5944;
+	METHOD method_34512 getRenderTypeEntityNoOutlineShader ()Lnet/minecraft/class_5944;
+	METHOD method_34513 getRenderTypeEntityShadowShader ()Lnet/minecraft/class_5944;
+	METHOD method_34514 getRenderTypeEntityAlphaShader ()Lnet/minecraft/class_5944;
+	METHOD method_34515 getRenderTypeEyesShader ()Lnet/minecraft/class_5944;
+	METHOD method_34516 getRenderTypeEnergySwirlShader ()Lnet/minecraft/class_5944;
+	METHOD method_34517 getRenderTypeLeashShader ()Lnet/minecraft/class_5944;
+	METHOD method_34518 getRenderTypeWaterMaskShader ()Lnet/minecraft/class_5944;
+	METHOD method_34519 getRenderTypeOutlineShader ()Lnet/minecraft/class_5944;
+	METHOD method_34520 getRenderTypeArmorGlintShader ()Lnet/minecraft/class_5944;
 	METHOD method_34521 preloadPrograms (Lnet/minecraft/class_5912;)V
 		ARG 1 factory
 	METHOD method_34522 preloadProgram (Lnet/minecraft/class_5912;Ljava/lang/String;Lnet/minecraft/class_293;)Lnet/minecraft/class_5944;
 		ARG 1 factory
 		ARG 2 name
 		ARG 3 format
-	METHOD method_34523 getRenderTypeArmorEntityGlintProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34524 getRenderTypeGlintTranslucentProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34525 getRenderTypeGlintProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34526 getRenderTypeGlintDirectProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34527 getRenderTypeEntityGlintProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34528 getRenderTypeEntityGlintDirectProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34529 getRenderTypeTextProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34530 getRenderTypeTextSeeThroughProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34531 getRenderTypeLightningProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34532 getRenderTypeTripwireProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34533 getRenderTypeEndPortalProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34534 getRenderTypeEndGatewayProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34535 getRenderTypeLinesProgram ()Lnet/minecraft/class_5944;
+	METHOD method_34523 getRenderTypeArmorEntityGlintShader ()Lnet/minecraft/class_5944;
+	METHOD method_34524 getRenderTypeGlintTranslucentShader ()Lnet/minecraft/class_5944;
+	METHOD method_34525 getRenderTypeGlintShader ()Lnet/minecraft/class_5944;
+	METHOD method_34526 getRenderTypeGlintDirectShader ()Lnet/minecraft/class_5944;
+	METHOD method_34527 getRenderTypeEntityGlintShader ()Lnet/minecraft/class_5944;
+	METHOD method_34528 getRenderTypeEntityGlintDirectShader ()Lnet/minecraft/class_5944;
+	METHOD method_34529 getRenderTypeTextShader ()Lnet/minecraft/class_5944;
+	METHOD method_34530 getRenderTypeTextSeeThroughShader ()Lnet/minecraft/class_5944;
+	METHOD method_34531 getRenderTypeLightningShader ()Lnet/minecraft/class_5944;
+	METHOD method_34532 getRenderTypeTripwireShader ()Lnet/minecraft/class_5944;
+	METHOD method_34533 getRenderTypeEndPortalShader ()Lnet/minecraft/class_5944;
+	METHOD method_34534 getRenderTypeEndGatewayShader ()Lnet/minecraft/class_5944;
+	METHOD method_34535 getRenderTypeLinesShader ()Lnet/minecraft/class_5944;
 		COMMENT {@return the {@code rendertype_lines} shader program}
 		COMMENT
 		COMMENT <p>This shader program draws a line by drawing a quad (two triangles
@@ -228,22 +228,22 @@ CLASS net/minecraft/class_757 net/minecraft/client/render/GameRenderer
 		COMMENT <p>The width of the line can be set with {@link
 		COMMENT com.mojang.blaze3d.systems.RenderSystem#lineWidth
 		COMMENT RenderSystem#lineWidth}.
-	METHOD method_34536 getRenderTypeCrumblingProgram ()Lnet/minecraft/class_5944;
+	METHOD method_34536 getRenderTypeCrumblingShader ()Lnet/minecraft/class_5944;
 	METHOD method_34537 clearPrograms ()V
 	METHOD method_34538 loadPrograms (Lnet/minecraft/class_5912;)V
 		ARG 1 factory
-	METHOD method_34539 getPositionProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34540 getPositionColorProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34541 getPositionColorTexProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34542 getPositionTexProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34543 getPositionTexColorProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34544 getBlockProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34545 getNewEntityProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34546 getParticleProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34547 getPositionColorLightmapProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34548 getPositionColorTexLightmapProgram ()Lnet/minecraft/class_5944;
-	METHOD method_34549 getPositionTexColorNormalProgram ()Lnet/minecraft/class_5944;
-	METHOD method_35764 getPositionTexLightmapColorProgram ()Lnet/minecraft/class_5944;
+	METHOD method_34539 getPositionShader ()Lnet/minecraft/class_5944;
+	METHOD method_34540 getPositionColorShader ()Lnet/minecraft/class_5944;
+	METHOD method_34541 getPositionColorTexShader ()Lnet/minecraft/class_5944;
+	METHOD method_34542 getPositionTexShader ()Lnet/minecraft/class_5944;
+	METHOD method_34543 getPositionTexColorShader ()Lnet/minecraft/class_5944;
+	METHOD method_34544 getBlockShader ()Lnet/minecraft/class_5944;
+	METHOD method_34545 getNewEntityShader ()Lnet/minecraft/class_5944;
+	METHOD method_34546 getParticleShader ()Lnet/minecraft/class_5944;
+	METHOD method_34547 getPositionColorLightmapShader ()Lnet/minecraft/class_5944;
+	METHOD method_34548 getPositionColorTexLightmapShader ()Lnet/minecraft/class_5944;
+	METHOD method_34549 getPositionTexColorNormalShader ()Lnet/minecraft/class_5944;
+	METHOD method_35764 getPositionTexLightmapColorShader ()Lnet/minecraft/class_5944;
 	METHOD method_35765 isRenderingPanorama ()Z
 	METHOD method_35766 renderWithZoom (FFF)V
 		ARG 1 zoom
@@ -259,8 +259,8 @@ CLASS net/minecraft/class_757 net/minecraft/client/render/GameRenderer
 		ARG 1 renderingPanorama
 	METHOD method_35771 cycleSuperSecretSetting ()V
 	METHOD method_35772 getClient ()Lnet/minecraft/class_310;
-	METHOD method_36432 getRenderTypeTextIntensityProgram ()Lnet/minecraft/class_5944;
-	METHOD method_36433 getRenderTypeTextIntensitySeeThroughProgram ()Lnet/minecraft/class_5944;
+	METHOD method_36432 getRenderTypeTextIntensityShader ()Lnet/minecraft/class_5944;
+	METHOD method_36433 getRenderTypeTextIntensitySeeThroughShader ()Lnet/minecraft/class_5944;
 	METHOD method_36486 (Lnet/minecraft/class_5944;)V
 		ARG 0 program
 	METHOD method_36487 (Lnet/minecraft/class_5944;)V
@@ -378,7 +378,7 @@ CLASS net/minecraft/class_757 net/minecraft/client/render/GameRenderer
 		ARG 1 path
 	METHOD method_42594 (Lnet/minecraft/class_5944;)V
 		ARG 0 program
-	METHOD method_42595 getRenderTypeEntityTranslucentEmissiveProgram ()Lnet/minecraft/class_5944;
+	METHOD method_42595 getRenderTypeEntityTranslucentEmissiveShader ()Lnet/minecraft/class_5944;
 	METHOD method_45774 createProgramReloader ()Lnet/minecraft/class_3302;
 	CLASS 1
 		METHOD method_45775 (Lnet/minecraft/class_2960;)Z


### PR DESCRIPTION
Reverts small but impactful parts of #3384.

- `BufferRenderer.drawWithGlobalProgram` -> `drawWithShader`: The old name matches `RenderSystem.setShader` and it's also more clear IMO.
- `GameRenderer` shader programs and their getters. These are **very often** user-facing and cause a lot of headaches when porting. We also have to consider that not every developer can use `migrateMappings` (Kotlin users, for example).

There are also some less often used methods in `GameRenderer` that just refer to "programs" where "shader programs" would be more clear, but that's out of scope for this PR.