### PR TITLE
migrate from openjdk base image to eclipse-temurin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
         java: [17-jdk, 18-jdk]
     runs-on: ubuntu-22.04
     container:
-      image: openjdk:${{ matrix.java }}
+      image: eclipse-temurin:${{ matrix.java }}
       options: --user root
     steps:
       - uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
   test-build-logic:
     runs-on: ubuntu-22.04
     container:
-      image: openjdk:18-jdk
+      image: eclipse-temurin:18-jdk
       options: --user root
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ jobs:
     if: ${{ github.repository_owner == 'FabricMC' }}
     runs-on: ubuntu-22.04
     container:
-      image: openjdk:18-jdk
+      image: eclipse-temurin:18-jdk
       options: --user root
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release-filament.yml
+++ b/.github/workflows/release-filament.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     container:
-      image: openjdk:18-jdk
+      image: eclipse-temurin:18-jdk
       options: --user root
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
https://hub.docker.com/_/openjdk has been deprecated for some time and will no longer get security updates