### PR TITLE
Fix some data fix classes not being suffixed

### DIFF
--- a/mappings/net/minecraft/datafixer/fix/BlockEntityKeepPackedFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/BlockEntityKeepPackedFix.mapping
@@ -1,2 +1,2 @@
-CLASS net/minecraft/class_3574 net/minecraft/datafixer/fix/BlockEntityKeepPacked
+CLASS net/minecraft/class_3574 net/minecraft/datafixer/fix/BlockEntityKeepPackedFix
 	METHOD method_15579 keepPacked (Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/Dynamic;

--- a/mappings/net/minecraft/datafixer/fix/EntityTheRenameningBlockFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/EntityTheRenameningBlockFix.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_1170 net/minecraft/datafixer/fix/EntityTheRenameningBlock
+CLASS net/minecraft/class_1170 net/minecraft/datafixer/fix/EntityTheRenameningBlockFix
 	FIELD field_5671 ENTITIES Ljava/util/Map;
 	FIELD field_5672 BLOCKS Ljava/util/Map;
 	FIELD field_5673 ITEMS Ljava/util/Map;


### PR DESCRIPTION
Fixes #3468

Unsuffixed data fix classes can be found with:

```sh
ls -I "*Fix.mapping" ./mappings/net/minecraft/datafixer/fix
```

The remaining classes are exceptions:

- `BlockStateFlattening` is a utility class that does not extend `DataFix`
- `ChunkStatusFix2` is suffixed by `Fix` and a number to avoid conflicting with `ChunkStatusFix`