### PR TITLE
Fix wrong name of `method_10772`.

### DIFF
--- a/mappings/net/minecraft/network/ClientConnection.mapping
+++ b/mappings/net/minecraft/network/ClientConnection.mapping
@@ -101,7 +101,7 @@ CLASS net/minecraft/class_2535 net/minecraft/network/ClientConnection
 	METHOD method_10769 connectLocal (Ljava/net/SocketAddress;)Lnet/minecraft/class_2535;
 		ARG 0 address
 	METHOD method_10771 isEncrypted ()Z
-	METHOD method_10772 hasChannel ()Z
+	METHOD method_10772 isChannelAbsent ()Z
 	METHOD method_30615 updateStats ()V
 	METHOD method_32306 getState ()Lnet/minecraft/class_2539;
 		COMMENT Returns the current network state of this connection.


### PR DESCRIPTION
Method `hasChannel` (`method_10772`) in class `net/minecraft/network/ClientConnection` (`class_2535`) has a wrong name. Its decompiled code generated by yarn is:

```java
public boolean hasChannel() {
    return this.channel == null;
}
```

The method returns true if the internal channel of `ClientConnection` is null. However the name contradicts to what the method has done.

I have read the name convention documented in `CONVENTIONS.md`, but it doesn't state how we should name an inversed getter method. This pull request renames `hasChannel` to `isChannelAbsent`. Please let me know if there is a better choice!