### PR TITLE
#3308 - Rename scoreboardTag methods to commandTag

### DIFF
--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -208,7 +208,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	FIELD field_6021 uuid Ljava/util/UUID;
 	FIELD field_6025 NULL_BOX Lnet/minecraft/class_238;
 	FIELD field_6027 CUSTOM_NAME Lnet/minecraft/class_2940;
-	FIELD field_6029 scoreboardTags Ljava/util/Set;
+	FIELD field_6029 commandTags Ljava/util/Set;
 	FIELD field_6030 EMPTY_STACK_LIST Ljava/util/List;
 	FIELD field_6031 yaw F
 	FIELD field_6032 AIR Lnet/minecraft/class_2940;
@@ -1521,12 +1521,12 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT @see #streamPassengersAndSelf
 	METHOD method_5737 getSwimSound ()Lnet/minecraft/class_3414;
 	METHOD method_5738 removeScoreboardTag (Ljava/lang/String;)Z
-		COMMENT Removes a scoreboard tag from this entity.
+		COMMENT Removes a command tag from this entity.
 		COMMENT
-		COMMENT <p>Scoreboard tags are set using the {@linkplain net.minecraft.server.command.TagCommand
+		COMMENT <p>Command tags are set using the {@linkplain net.minecraft.server.command.TagCommand
 		COMMENT /tag command}, and is different from entity type tags defined in data packs.
 		COMMENT
-		COMMENT @return whether the scoreboard tag was successfully removed
+		COMMENT @return whether the command tag was successfully removed
 		ARG 1 tag
 	METHOD method_5739 distanceTo (Lnet/minecraft/class_1297;)F
 		COMMENT {@return the distance between this entity and {@code entity}}
@@ -1601,8 +1601,8 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT <p>This is used for calculating the leash offset.
 		COMMENT
 		COMMENT @see #getLeashOffset
-	METHOD method_5752 getScoreboardTags ()Ljava/util/Set;
-		COMMENT {@return all scoreboard tags the entity belongs to}
+	METHOD method_5752 getCommandTags ()Ljava/util/Set;
+		COMMENT {@return all command tags the entity belongs to}
 		COMMENT
 		COMMENT <p>Scoreboard tags are set using the {@linkplain net.minecraft.server.command.TagCommand
 		COMMENT /tag command}, and is different from entity type tags defined in data packs.
@@ -1734,14 +1734,14 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT An ender dragon is composed of several entity parts; each part returns {@code true}
 		COMMENT for {@code part.isPartOf(dragon)}.
 		ARG 1 entity
-	METHOD method_5780 addScoreboardTag (Ljava/lang/String;)Z
-		COMMENT Adds a scoreboard tag to this entity. An entity can have up to {@code 1024}
-		COMMENT scoreboard tags.
+	METHOD method_5780 addCommandTag (Ljava/lang/String;)Z
+		COMMENT Adds a command tag to this entity. An entity can have up to {@code 1024}
+		COMMENT command tags.
 		COMMENT
-		COMMENT <p>Scoreboard tags are set using the {@linkplain net.minecraft.server.command.TagCommand
+		COMMENT <p>Command tags are set using the {@linkplain net.minecraft.server.command.TagCommand
 		COMMENT /tag command}, and is different from entity type tags defined in data packs.
 		COMMENT
-		COMMENT @return whether the scoreboard tag was successfully added
+		COMMENT @return whether the command tag was successfully added
 		ARG 1 tag
 	METHOD method_5781 getScoreboardTeam ()Lnet/minecraft/class_270;
 		COMMENT {@return the scoreboard team the entity belongs to, or {@code null} if there is none}


### PR DESCRIPTION
The tags are not specifically used by the scoreboard anymore - they can be read and written to by the `/tag` command.

Initially, the issue suggested simply renaming it from `~scoreboardTag` to `~tag` - however, this would have caused some confusion with the datapack tags.

Updated javadoc accordingly.

https://github.com/FabricMC/yarn/issues/3308#issue-1400175518