### PR TITLE
Rename the Vec3d#withBias method to offset

### DIFF
--- a/mappings/net/minecraft/util/math/Vec3d.mapping
+++ b/mappings/net/minecraft/util/math/Vec3d.mapping
@@ -230,7 +230,7 @@ CLASS net/minecraft/class_243 net/minecraft/util/math/Vec3d
 		ARG 0 coords
 	METHOD method_42396 (Lnet/minecraft/class_243;)Ljava/util/List;
 		ARG 0 vec
-	METHOD method_43206 withBias (Lnet/minecraft/class_2350;D)Lnet/minecraft/class_243;
+	METHOD method_43206 offset (Lnet/minecraft/class_2350;D)Lnet/minecraft/class_243;
 		ARG 1 direction
 		ARG 2 value
 	METHOD method_46409 toVector3f ()Lorg/joml/Vector3f;


### PR DESCRIPTION
This pull request simply renames the `Vec3d#withBias` method to match the existing `Vec3i#offset` and `BlockPos#offset` methods.