### PR TITLE
Minor fixes

### DIFF
--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -671,7 +671,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos
-		ARG 4 stack
+		ARG 4 tool
 		ARG 5 dropExperience
 	METHOD method_9569 mirror (Lnet/minecraft/class_2680;Lnet/minecraft/class_2415;)Lnet/minecraft/class_2680;
 		COMMENT {@return {@code state} mirrored by {@code mirror}}
@@ -1095,7 +1095,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		METHOD method_26180 onStacksDropped (Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;Lnet/minecraft/class_1799;Z)V
 			ARG 1 world
 			ARG 2 pos
-			ARG 3 stack
+			ARG 3 tool
 			ARG 4 dropExperience
 		METHOD method_26181 neighborUpdate (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2248;Lnet/minecraft/class_2338;Z)V
 			ARG 1 world

--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -1038,7 +1038,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 			ARG 3 pos
 		METHOD method_26166 canReplace (Lnet/minecraft/class_1750;)Z
 			ARG 1 context
-		METHOD method_26167 isTranslucent (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z
+		METHOD method_26167 isTransparent (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z
 			ARG 1 world
 			ARG 2 pos
 		METHOD method_26168 hasSolidTopSurface (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;Lnet/minecraft/class_1297;)Z
@@ -1286,7 +1286,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		METHOD method_49228 hasModelOffset ()Z
 		CLASS class_3752 ShapeCache
 			FIELD field_16555 lightSubtracted I
-			FIELD field_16556 translucent Z
+			FIELD field_16556 transparent Z
 			FIELD field_16557 fullOpaque Z
 			FIELD field_16559 DIRECTIONS [Lnet/minecraft/class_2350;
 			FIELD field_16560 extrudedFaces [Lnet/minecraft/class_265;

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -172,7 +172,7 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 		ARG 2 pos
 		ARG 3 blockEntity
 		ARG 4 entity
-		ARG 5 stack
+		ARG 5 tool
 	METHOD method_9515 appendProperties (Lnet/minecraft/class_2689$class_2690;)V
 		COMMENT Appends block state properties to this block. To use this, override and call {@link
 		COMMENT StateManager.Builder#add} inside the method. See {@link
@@ -246,7 +246,7 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 		ARG 3 pos
 		ARG 4 state
 		ARG 5 blockEntity
-		ARG 6 stack
+		ARG 6 tool
 	METHOD method_9562 getDroppedStacks (Lnet/minecraft/class_2680;Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;Lnet/minecraft/class_2586;)Ljava/util/List;
 		ARG 0 state
 		ARG 1 world

--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -317,7 +317,7 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 		ARG 0 world
 		ARG 1 pos
 		ARG 2 stack
-	METHOD method_9579 isTranslucent (Lnet/minecraft/class_2680;Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z
+	METHOD method_9579 isTransparent (Lnet/minecraft/class_2680;Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z
 		ARG 1 state
 		ARG 2 world
 		ARG 3 pos

--- a/mappings/net/minecraft/client/gl/GlImportProcessor.mapping
+++ b/mappings/net/minecraft/client/gl/GlImportProcessor.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_5913 net/minecraft/client/gl/GLImportProcessor
+CLASS net/minecraft/class_5913 net/minecraft/client/gl/GlImportProcessor
 	COMMENT Handles the flattening of "moj_" import strings in the loaded GLSL shader file.
 	COMMENT Instances of an import are replaced by the contents of the referenced file
 	COMMENT prefixed by a comment describing the line position and original file location

--- a/mappings/net/minecraft/client/render/block/BlockRenderManager.mapping
+++ b/mappings/net/minecraft/client/render/block/BlockRenderManager.mapping
@@ -28,7 +28,7 @@ CLASS net/minecraft/class_776 net/minecraft/client/render/block/BlockRenderManag
 	METHOD method_3353 renderBlockAsEntity (Lnet/minecraft/class_2680;Lnet/minecraft/class_4587;Lnet/minecraft/class_4597;II)V
 		ARG 1 state
 		ARG 2 matrices
-		ARG 3 vertexConsumer
+		ARG 3 vertexConsumers
 		ARG 4 light
 		ARG 5 overlay
 	METHOD method_3355 renderBlock (Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;Lnet/minecraft/class_1920;Lnet/minecraft/class_4587;Lnet/minecraft/class_4588;ZLnet/minecraft/class_5819;)V

--- a/mappings/net/minecraft/screen/ScreenHandlerFactory.mapping
+++ b/mappings/net/minecraft/screen/ScreenHandlerFactory.mapping
@@ -16,5 +16,5 @@ CLASS net/minecraft/class_1270 net/minecraft/screen/ScreenHandlerFactory
 	COMMENT @see NamedScreenHandlerFactory
 	METHOD createMenu (ILnet/minecraft/class_1661;Lnet/minecraft/class_1657;)Lnet/minecraft/class_1703;
 		ARG 1 syncId
-		ARG 2 inv
+		ARG 2 playerInventory
 		ARG 3 player


### PR DESCRIPTION
- Fix casing in the name of `GlImportProcessor`, fixes #3488
- Use full word "playerInventory" instead of "inv" in `ScreenHandlerFactory` for clarity. The conventions instruct to avoid unnecessary abbreviations and this name could be mistaken for the inventory of the block that the screen handler is for.
- `BlockRenderManager.renderBlockAsEntity`: `vertexConsumer` -> `vertexConsumers` since it's a `VertexConsumerProvider`
- Rename `stack` parameter in block breaking methods to `tool` for clarity (closes #2988)
- `Block/AbstractBlockState.isTranslucent` -> `isTransparent` (fixes #2926): It's true for any block with a non-full shape as well as vines, (colourless) glass and plants - none of these are translucent.