### PR TITLE
Improve methods related to closing handled screens

### DIFF
--- a/mappings/net/minecraft/block/entity/ChestBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/ChestBlockEntity.mapping
@@ -11,7 +11,7 @@ CLASS net/minecraft/class_2595 net/minecraft/block/entity/ChestBlockEntity
 	METHOD method_11048 getPlayersLookingInChestCount (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)I
 		ARG 0 world
 		ARG 1 pos
-	METHOD method_11049 onInvOpenOrClose (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;II)V
+	METHOD method_11049 onViewerCountUpdate (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;II)V
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 state

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -45,9 +45,9 @@ CLASS net/minecraft/class_1657 net/minecraft/entity/player/PlayerEntity
 		ARG 2 pos
 		ARG 3 yaw
 		ARG 4 gameProfile
-	METHOD method_14247 closeScreenHandler ()V
+	METHOD method_14247 onHandledScreenClosed ()V
 		COMMENT Runs closing tasks for the current screen handler and
-		COMMENT sets it to the {@code playerScreenHandler}.
+		COMMENT sets it to the {@link #playerScreenHandler}.
 	METHOD method_16354 openJigsawScreen (Lnet/minecraft/class_3751;)V
 		ARG 1 jigsaw
 	METHOD method_16475 spawnParticles (Lnet/minecraft/class_2394;)V

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -289,6 +289,11 @@ CLASS net/minecraft/class_1657 net/minecraft/entity/player/PlayerEntity
 	METHOD method_7345 setShoulderEntityRight (Lnet/minecraft/class_2487;)V
 		ARG 1 entityNbt
 	METHOD method_7346 closeHandledScreen ()V
+		COMMENT Closes the currently open {@linkplain net.minecraft.client.gui.screen.ingame.HandledScreen
+		COMMENT handled screen}.
+		COMMENT
+		COMMENT <p>This method can be called on either logical side, and it will synchronize
+		COMMENT the closing automatically to the other.
 	METHOD method_7348 isPartVisible (Lnet/minecraft/class_1664;)Z
 		ARG 1 modelPart
 	METHOD method_7349 getNextLevelExperience ()I

--- a/mappings/net/minecraft/screen/ScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/ScreenHandler.mapping
@@ -278,8 +278,8 @@ CLASS net/minecraft/class_1703 net/minecraft/screen/ScreenHandler
 		ARG 4 player
 	METHOD method_7594 unpackQuickCraftStage (I)I
 		ARG 0 quickCraftData
-	METHOD method_7595 close (Lnet/minecraft/class_1657;)V
-		COMMENT Closes this screen handler.
+	METHOD method_7595 onClosed (Lnet/minecraft/class_1657;)V
+		COMMENT Called when this screen handler is closed.
 		COMMENT
 		COMMENT <p>To close a screen handler, call {@link PlayerEntity#closeHandledScreen}
 		COMMENT on the server instead of this method.


### PR DESCRIPTION
- `ChestBlockEntity.onInvOpenOrClose` -> `onViewerCountUpdate`: the method is only used for responding to viewer count updates, and it takes the old and new counts as parameters
- `ScreenHandler.close` -> `onClosed` (fixes #3503): doesn't close anything but is called when the screen is closed
- `PlayerEntity.closeScreenHandler` -> `onHandledScreenClosed` (fixes #2612): same as above
- Documented `PlayerEntity.closeHandledScreen`