### PR TITLE
Rename tree/mushroom modifier methods in VegetationPlacedFeatures

### DIFF
--- a/mappings/net/minecraft/world/gen/feature/VegetationPlacedFeatures.mapping
+++ b/mappings/net/minecraft/world/gen/feature/VegetationPlacedFeatures.mapping
@@ -77,15 +77,15 @@ CLASS net/minecraft/class_6819 net/minecraft/world/gen/feature/VegetationPlacedF
 	FIELD field_42965 TREES_CHERRY Lnet/minecraft/class_5321;
 	METHOD method_39738 modifiers (I)Ljava/util/List;
 		ARG 0 count
-	METHOD method_39739 modifiersWithChance (ILnet/minecraft/class_6797;)Ljava/util/List;
+	METHOD method_39739 mushroomModifiers (ILnet/minecraft/class_6797;)Ljava/util/List;
 		ARG 0 chance
 		ARG 1 modifier
-	METHOD method_39740 modifiers (Lnet/minecraft/class_6797;)Ljava/util/List;
+	METHOD method_39740 treeModifiers (Lnet/minecraft/class_6797;)Ljava/util/List;
 		ARG 0 modifier
-	METHOD method_39741 modifiersWithWouldSurvive (Lnet/minecraft/class_6797;Lnet/minecraft/class_2248;)Ljava/util/List;
+	METHOD method_39741 treeModifiersWithWouldSurvive (Lnet/minecraft/class_6797;Lnet/minecraft/class_2248;)Ljava/util/List;
 		ARG 0 modifier
 		ARG 1 block
-	METHOD method_39742 modifiersBuilder (Lnet/minecraft/class_6797;)Lcom/google/common/collect/ImmutableList$Builder;
+	METHOD method_39742 treeModifiersBuilder (Lnet/minecraft/class_6797;)Lcom/google/common/collect/ImmutableList$Builder;
 		ARG 0 countModifier
 	METHOD method_46867 bootstrap (Lnet/minecraft/class_7891;)V
 		ARG 0 featureRegisterable


### PR DESCRIPTION
Fixes #2923. These methods are only used for trees/mushrooms, and can be confused with the more generic `modifiers(int)` only used for other vegetation. (See the issue for more details)