### PR TITLE
Improve option widget names

### DIFF
--- a/mappings/net/minecraft/client/gui/widget/OptionListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/OptionListWidget.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_353 net/minecraft/client/gui/widget/ButtonListWidget
+CLASS net/minecraft/class_353 net/minecraft/client/gui/widget/OptionListWidget
 	METHOD method_20406 addSingleOptionEntry (Lnet/minecraft/class_7172;)I
 		ARG 1 option
 	METHOD method_20407 addOptionEntry (Lnet/minecraft/class_7172;Lnet/minecraft/class_7172;)V
@@ -6,18 +6,18 @@ CLASS net/minecraft/class_353 net/minecraft/client/gui/widget/ButtonListWidget
 		ARG 2 secondOption
 	METHOD method_20408 addAll ([Lnet/minecraft/class_7172;)V
 		ARG 1 options
-	METHOD method_29624 getHoveredButton (DD)Ljava/util/Optional;
+	METHOD method_29624 getHoveredWidget (DD)Ljava/util/Optional;
 		ARG 1 mouseX
 		ARG 3 mouseY
-	METHOD method_31046 getButtonFor (Lnet/minecraft/class_7172;)Lnet/minecraft/class_339;
+	METHOD method_31046 getWidgetFor (Lnet/minecraft/class_7172;)Lnet/minecraft/class_339;
 		ARG 1 option
-	CLASS class_354 ButtonEntry
-		FIELD field_18214 buttons Ljava/util/List;
-		FIELD field_27983 optionsToButtons Ljava/util/Map;
+	CLASS class_354 WidgetEntry
+		FIELD field_18214 widgets Ljava/util/List;
+		FIELD field_27983 optionsToWidgets Ljava/util/Map;
 		METHOD <init> (Ljava/util/Map;)V
-			ARG 1 optionsToButtons
+			ARG 1 optionsToWidgets
 		METHOD method_18622 (ILnet/minecraft/class_4587;IIFLnet/minecraft/class_339;)V
-			ARG 5 button
+			ARG 5 widget
 		METHOD method_20409 create (Lnet/minecraft/class_315;ILnet/minecraft/class_7172;)Lnet/minecraft/class_353$class_354;
 			ARG 0 options
 			ARG 1 width

--- a/mappings/net/minecraft/client/option/SimpleOption.mapping
+++ b/mappings/net/minecraft/client/option/SimpleOption.mapping
@@ -91,7 +91,7 @@ CLASS net/minecraft/class_7172 net/minecraft/client/option/SimpleOption
 		ARG 4 callbacks
 		ARG 5 defaultValue
 		ARG 6 changeCallback
-	METHOD method_18520 createButton (Lnet/minecraft/class_315;III)Lnet/minecraft/class_339;
+	METHOD method_18520 createWidget (Lnet/minecraft/class_315;III)Lnet/minecraft/class_339;
 		ARG 1 options
 		ARG 2 x
 		ARG 3 y
@@ -154,7 +154,7 @@ CLASS net/minecraft/class_7172 net/minecraft/client/option/SimpleOption
 		ARG 1 value
 	METHOD method_47394 (Ljava/lang/Object;)Lnet/minecraft/class_7919;
 		ARG 0 value
-	METHOD method_47603 createButton (Lnet/minecraft/class_315;IIILjava/util/function/Consumer;)Lnet/minecraft/class_339;
+	METHOD method_47603 createWidget (Lnet/minecraft/class_315;IIILjava/util/function/Consumer;)Lnet/minecraft/class_339;
 		ARG 1 options
 		ARG 2 x
 		ARG 3 y
@@ -228,10 +228,11 @@ CLASS net/minecraft/class_7172 net/minecraft/client/option/SimpleOption
 		COMMENT A set of callbacks to customize an option's behavior.
 		COMMENT
 		COMMENT @see <a href="SimpleOption.html#callbacks">Callbacks</a>
-		METHOD method_41756 getButtonCreator (Lnet/minecraft/class_7172$class_7277;Lnet/minecraft/class_315;IIILjava/util/function/Consumer;)Ljava/util/function/Function;
-			COMMENT {@return the button creator}
+		METHOD method_41756 getWidgetCreator (Lnet/minecraft/class_7172$class_7277;Lnet/minecraft/class_315;IIILjava/util/function/Consumer;)Ljava/util/function/Function;
+			COMMENT {@return the widget creator}
 			COMMENT
-			COMMENT <p>Button creators are responsible for rendering the option.
+			COMMENT <p>Widget creators are responsible for rendering the option into
+			COMMENT a {@link ClickableWidget}.
 			ARG 1 tooltipFactory
 			ARG 2 gameOptions
 			ARG 3 x


### PR DESCRIPTION
- "button" -> "widget" in many places as the widgets are often sliders and can be any ClickableWidget
- ButtonListWidget -> OptionListWidget, since it's only used and usable for options and can contain any option widget (closes #2932)