### PR TITLE
ItemUsageContext.getPlayerFacing -> getHorizontalPlayerFacing

### DIFF
--- a/mappings/net/minecraft/item/ItemUsageContext.mapping
+++ b/mappings/net/minecraft/item/ItemUsageContext.mapping
@@ -22,7 +22,11 @@ CLASS net/minecraft/class_1838 net/minecraft/item/ItemUsageContext
 	METHOD method_8037 getBlockPos ()Lnet/minecraft/class_2338;
 	METHOD method_8038 getSide ()Lnet/minecraft/class_2350;
 	METHOD method_8041 getStack ()Lnet/minecraft/class_1799;
-	METHOD method_8042 getPlayerFacing ()Lnet/minecraft/class_2350;
+	METHOD method_8042 getHorizontalPlayerFacing ()Lnet/minecraft/class_2350;
+		COMMENT {@return the {@linkplain PlayerEntity#getHorizontalFacing horizontal facing
+		COMMENT direction} of the player}
+		COMMENT
+		COMMENT @implSpec If the player is {@code null}, returns {@link Direction#NORTH}.
 	METHOD method_8044 getPlayerYaw ()F
 	METHOD method_8045 getWorld ()Lnet/minecraft/class_1937;
 	METHOD method_8046 shouldCancelInteraction ()Z


### PR DESCRIPTION
Closes #2028. The previous name can easily be confused with `ItemPlacementContext.getPlayerLookDirection`. The rename shows that it's specifically horizontal and also matches `PlayerEntity.getHorizontalFacing`.

(This essentially reverts a rename from #712, albeit with a more natural order for the words in the name now.)

I didn't do the other rename of `getPlayerLookDirection` -> `getPlayerFacing` mentioned in #2028 since it would've led to a situation where `getPlayerFacing` still exists but means something else (easy source of bugs!). "Facing" is the word used in the debug HUD for the horizontal facing specifically, so I think it's fine to leave the others intact. (`/teleport` does use "facing" to mean any direction, however)