### PR TITLE
Map ChestBlockEntity.VIEWER_COUNT_UPDATE_EVENT_TYPE

### DIFF
--- a/mappings/net/minecraft/block/entity/ChestBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/ChestBlockEntity.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/class_2595 net/minecraft/block/entity/ChestBlockEntity
 	FIELD field_11927 inventory Lnet/minecraft/class_2371;
 	FIELD field_27209 stateManager Lnet/minecraft/class_5561;
 	FIELD field_27210 lidAnimator Lnet/minecraft/class_5560;
+	FIELD field_31332 VIEWER_COUNT_UPDATE_EVENT_TYPE I
 	METHOD <init> (Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)V
 		ARG 1 pos
 		ARG 2 state


### PR DESCRIPTION
The type of the synced block event to update the chest viewer count is the only usage of that constant in the class.