### PR TITLE
Rename `FilledMapItem#getOrCreateMapState` to `getMapState`

### DIFF
--- a/mappings/net/minecraft/item/FilledMapItem.mapping
+++ b/mappings/net/minecraft/item/FilledMapItem.mapping
@@ -49,7 +49,7 @@ CLASS net/minecraft/class_1806 net/minecraft/item/FilledMapItem
 		ARG 5 showIcons
 		ARG 6 unlimitedTracking
 		ARG 7 dimension
-	METHOD method_8001 getOrCreateMapState (Lnet/minecraft/class_1799;Lnet/minecraft/class_1937;)Lnet/minecraft/class_22;
+	METHOD method_8001 getMapState (Lnet/minecraft/class_1799;Lnet/minecraft/class_1937;)Lnet/minecraft/class_22;
 		ARG 0 map
 		ARG 1 world
 	METHOD method_8002 fillExplorationMap (Lnet/minecraft/class_3218;Lnet/minecraft/class_1799;)V


### PR DESCRIPTION
This method doesn't create map states for unknown maps