### PR TITLE
ChunkNoiseSampler and DensityFunction renames and documentation

### DIFF
--- a/mappings/net/minecraft/world/gen/chunk/BlendingData.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/BlendingData.mapping
@@ -104,7 +104,7 @@ CLASS net/minecraft/class_6749 net/minecraft/world/gen/chunk/BlendingData
 			COMMENT the chunk-local biome Z coordinate
 	METHOD method_39583 getBottomHalfSectionY ()I
 	METHOD method_39905 getAboveCollidableBlockValue (Lnet/minecraft/class_2791;Lnet/minecraft/class_2338$class_2339;)D
-		COMMENT {@return {@code 1.0} if there is a collidable block below, otherwise {@code -1}.}
+		COMMENT {@return {@code 1.0} if there is a collidable block below, otherwise {@code -1}}
 		ARG 0 chunk
 		ARG 1 mutablePos
 			COMMENT will be moved down by one block by this method

--- a/mappings/net/minecraft/world/gen/chunk/ChunkNoiseSampler.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/ChunkNoiseSampler.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
-	FIELD field_34598 cellHeight I
+	FIELD field_34598 verticalCellCount I
 	FIELD field_34599 horizontalCellCount I
 	FIELD field_34600 minimumCellY I
 	FIELD field_34601 startCellX I
@@ -19,7 +19,11 @@ CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
 	FIELD field_36577 sampleUniqueIndex J
 	FIELD field_36578 cacheOnceUniqueIndex J
 	FIELD field_36579 index I
-	FIELD field_36580 eachApplier Lnet/minecraft/class_6910$class_6911;
+	FIELD field_36580 interpolationEachApplier Lnet/minecraft/class_6910$class_6911;
+		COMMENT The implementation of {@code EachApplier} that is used for filling the
+		COMMENT interpolators' density buffers.
+		COMMENT It runs on a vertical column of cells, with the density being sampled at the first
+		COMMENT block in the cell (cell-local coordinate {@code 0} for X, Y and Z).
 	FIELD field_36581 caches Ljava/util/List;
 	FIELD field_36582 actualDensityFunctionCache Ljava/util/Map;
 	FIELD field_36583 initialDensityWithoutJaggedness Lnet/minecraft/class_6910;
@@ -29,10 +33,10 @@ CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
 	FIELD field_36587 lastBlendingColumnPos J
 	FIELD field_36588 lastBlendingResult Lnet/minecraft/class_6748$class_6956;
 	FIELD field_36589 horizontalBiomeEnd I
-	FIELD field_36590 horizontalCellSize I
-	FIELD field_36591 verticalCellSize I
+	FIELD field_36590 horizontalCellBlockCount I
+	FIELD field_36591 verticalCellBlockCount I
 	FIELD field_36592 isInInterpolationLoop Z
-	FIELD field_36593 isSamplingNoise Z
+	FIELD field_36593 isSamplingForCaches Z
 	FIELD field_36594 startBlockX I
 	FIELD field_37113 beardifying Lnet/minecraft/class_6916$class_7050;
 	METHOD <init> (ILnet/minecraft/class_7138;IILnet/minecraft/class_5309;Lnet/minecraft/class_6916$class_7050;Lnet/minecraft/class_5284;Lnet/minecraft/class_6350$class_6565;Lnet/minecraft/class_6748;)V
@@ -45,31 +49,54 @@ CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
 		ARG 7 chunkGeneratorSettings
 		ARG 8 fluidLevelSampler
 		ARG 9 blender
-	METHOD method_38336 sampleStartNoise ()V
-	METHOD method_38337 sampleNoiseY (ID)V
+	METHOD method_38336 sampleStartDensity ()V
+		COMMENT Samples the density values for all cells in the chunk with the first X coordinate.
+		COMMENT This is done for every {@code interpolated} function. The resulting density values
+		COMMENT will be stored in the interpolator's start density buffer.
+	METHOD method_38337 interpolateY (ID)V
+		COMMENT Interpolates density values on the Y axis for every interpolator.
 		ARG 1 blockY
-		ARG 2 cellDeltaY
+			COMMENT the absolute block Y coordinate
+		ARG 2 deltaY
+			COMMENT the cell-local block Y coordinate divided by the number of blocks in a cell vertically
 	METHOD method_38338 (DLnet/minecraft/class_6568$class_5917;)V
 		ARG 2 interpolator
-	METHOD method_38339 sampleEndNoise (I)V
+	METHOD method_38339 sampleEndDensity (I)V
+		COMMENT Samples the density values for all cells in the chunk with the given X coordinate.
+		COMMENT This is done for every {@code interpolated} function. The resulting density values
+		COMMENT will be stored in the interpolator's end density buffer.
 		ARG 1 cellX
+			COMMENT the chunk-local cell X coordinate
 	METHOD method_38342 (IILnet/minecraft/class_6568$class_5917;)V
 		ARG 2 interpolator
 	METHOD method_38348 swapBuffers ()V
-	METHOD method_38349 sampleNoiseX (ID)V
+		COMMENT Swaps the start and end density buffers of every interpolator.
+	METHOD method_38349 interpolateX (ID)V
+		COMMENT Interpolates density values on the X axis for every interpolator.
 		ARG 1 blockX
-		ARG 2 cellDeltaX
+			COMMENT the absolute block X coordinate
+		ARG 2 deltaX
+			COMMENT the cell-local block X coordinate divided by the number of blocks in a cell horizontally
 	METHOD method_38350 (DLnet/minecraft/class_6568$class_5917;)V
 		ARG 2 interpolator
 	METHOD method_38354 getAquiferSampler ()Lnet/minecraft/class_6350;
-	METHOD method_38355 sampleNoiseZ (ID)V
+	METHOD method_38355 interpolateZ (ID)V
+		COMMENT Interpolates density values on the Z axis for every interpolator.
 		ARG 1 blockZ
-		ARG 2 cellDeltaZ
+			COMMENT the absolute block Z coordinate
+		ARG 2 deltaZ
+			COMMENT the cell-local block Z coordinate divided by the number of blocks in a cell vertically
 	METHOD method_38356 (DLnet/minecraft/class_6568$class_5917;)V
 		ARG 2 interpolator
-	METHOD method_38362 sampleNoiseCorners (II)V
+	METHOD method_38362 onSampledCellCorners (II)V
+		COMMENT This should be called when the start and end density buffers are
+		COMMENT correctly filled for the current cell.
+		COMMENT
+		COMMENT This starts the interpolators and fills the cell caches.
 		ARG 1 cellY
+			COMMENT the chunk-local cell Y coordinate
 		ARG 2 cellZ
+			COMMENT the chunk-local cell Z coordinate
 	METHOD method_39543 create (Lnet/minecraft/class_2791;Lnet/minecraft/class_7138;Lnet/minecraft/class_6916$class_7050;Lnet/minecraft/class_5284;Lnet/minecraft/class_6350$class_6565;Lnet/minecraft/class_6748;)Lnet/minecraft/class_6568;
 		ARG 0 chunk
 		ARG 1 noiseConfig
@@ -89,9 +116,13 @@ CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
 	METHOD method_40531 createMultiNoiseSampler (Lnet/minecraft/class_6953;Ljava/util/List;)Lnet/minecraft/class_6544$class_6552;
 		ARG 1 noiseRouter
 		ARG 2 spawnTarget
-	METHOD method_40532 sampleNoise (ZI)V
+	METHOD method_40532 sampleDensity (ZI)V
+		COMMENT Samples the density values for all cells in the chunk with the given X coordinate.
+		COMMENT This is done for every {@code interpolated} function.
 		ARG 1 start
-		ARG 2 nextCellX
+			COMMENT whether to store the results in the start or end density buffer
+		ARG 2 cellX
+			COMMENT the current cell X coordinate
 	METHOD method_40533 getActualDensityFunctionImpl (Lnet/minecraft/class_6910;)Lnet/minecraft/class_6910;
 		ARG 1 densityFunction
 	METHOD method_40535 calculateBlendResult (II)Lnet/minecraft/class_6748$class_6956;
@@ -99,11 +130,12 @@ CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
 		ARG 2 blockZ
 	METHOD method_40536 sampleBlockState ()Lnet/minecraft/class_2680;
 	METHOD method_40537 stopInterpolation ()V
-	METHOD method_42361 getHorizontalCellSize ()I
-	METHOD method_42362 getVerticalCellSize ()I
-	CLASS class_5917 NoiseInterpolator
-		FIELD field_29227 startNoiseBuffer [[D
-		FIELD field_29228 endNoiseBuffer [[D
+		COMMENT Stops the interpolation loop for this chunk.
+	METHOD method_42361 getHorizontalCellBlockCount ()I
+	METHOD method_42362 getVerticalCellBlockCount ()I
+	CLASS class_5917 DensityInterpolator
+		FIELD field_29227 startDensityBuffer [[D
+		FIELD field_29228 endDensityBuffer [[D
 		FIELD field_29233 x0y0z0 D
 		FIELD field_29234 x0y0z1 D
 		FIELD field_29235 x1y0z0 D
@@ -118,22 +150,29 @@ CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
 		FIELD field_29244 x1z1 D
 		FIELD field_29245 z0 D
 		FIELD field_29246 z1 D
-		FIELD field_34623 columnSampler Lnet/minecraft/class_6910;
+		FIELD field_34623 delegate Lnet/minecraft/class_6910;
 		FIELD field_34624 result D
 		METHOD <init> (Lnet/minecraft/class_6568;Lnet/minecraft/class_6910;)V
-			ARG 2 columnSampler
-		METHOD method_34287 sampleNoiseY (D)V
+			ARG 2 delegate
+		METHOD method_34287 interpolateY (D)V
+			COMMENT Interpolates the eight densities on the Y axis.
 			ARG 1 deltaY
-		METHOD method_34289 sampleNoiseCorners (II)V
-			ARG 1 noiseY
-			ARG 2 noiseZ
+		METHOD method_34289 onSampledCellCorners (II)V
+			COMMENT Copies the densities of the eight corners of the current cell into their
+			COMMENT respective fields.
+			ARG 1 cellY
+				COMMENT the cell's Y coordinate
+			ARG 2 cellZ
+				COMMENT the cell's chunk-local Z coordinate
 		METHOD method_34291 swapBuffers ()V
-		METHOD method_34292 sampleNoiseX (D)V
+		METHOD method_34292 interpolateX (D)V
+			COMMENT Interpolates the four remaining densities on the X axis.
 			ARG 1 deltaX
 		METHOD method_34293 createBuffer (II)[[D
 			ARG 1 sizeZ
 			ARG 2 sizeX
-		METHOD method_38363 sampleNoiseZ (D)V
+		METHOD method_38363 interpolateZ (D)V
+			COMMENT Interpolates the two remaining densities on the Z axis.
 			ARG 1 deltaZ
 	CLASS class_6569 BlockStateSampler
 		METHOD calculate sample (Lnet/minecraft/class_6910$class_6912;)Lnet/minecraft/class_2680;
@@ -159,7 +198,7 @@ CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
 		FIELD field_36610 cache [D
 		METHOD <init> (Lnet/minecraft/class_6568;Lnet/minecraft/class_6910;)V
 			ARG 2 delegate
-	CLASS class_6951 FlatCacheDensityFunction
+	CLASS class_6951 FlatCache
 		FIELD field_36612 delegate Lnet/minecraft/class_6910;
 		FIELD field_36613 cache [[D
 		METHOD <init> (Lnet/minecraft/class_6568;Lnet/minecraft/class_6910;Z)V

--- a/mappings/net/minecraft/world/gen/chunk/ChunkNoiseSampler.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/ChunkNoiseSampler.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
 	COMMENT the cells in each chunk, managing caches and interpolators, the {@code Blender},
 	COMMENT and the block state samplers.
 	COMMENT
-	COMMENT An instance of this is created for every chunk.
+	COMMENT <p>An instance of this is created for every chunk.
 	FIELD field_34598 verticalCellCount I
 	FIELD field_34599 horizontalCellCount I
 	FIELD field_34600 minimumCellY I
@@ -27,7 +27,8 @@ CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
 	FIELD field_36580 interpolationEachApplier Lnet/minecraft/class_6910$class_6911;
 		COMMENT The implementation of {@code EachApplier} that is used for filling the
 		COMMENT interpolators' density buffers.
-		COMMENT It runs on a vertical column of cells, with the density being sampled at the first
+		COMMENT
+		COMMENT <p>It runs on a vertical column of cells, with the density being sampled at the first
 		COMMENT block in the cell (cell-local coordinate {@code 0} for X, Y and Z).
 	FIELD field_36581 caches Ljava/util/List;
 	FIELD field_36582 actualDensityFunctionCache Ljava/util/Map;
@@ -97,9 +98,10 @@ CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
 		COMMENT This should be called when the start and end density buffers are
 		COMMENT correctly filled for the current cell.
 		COMMENT
-		COMMENT This starts the interpolators and fills the cell caches.
+		COMMENT <p>This starts the interpolators and fills the cell caches.
 		COMMENT
-		COMMENT @implNote For filling the cell caches, {@code this} is used as the {@link EachApplier}.
+		COMMENT @implNote For filling the cell caches, {@code this} is used as the
+		COMMENT {@link net.minecraft.world.gen.densityfunction.DensityFunction.EachApplier EachApplier}.
 		ARG 1 cellY
 			COMMENT the chunk-local cell Y coordinate
 		ARG 2 cellZ
@@ -117,9 +119,9 @@ CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
 		ARG 1 blockX
 		ARG 2 blockZ
 	METHOD method_40529 getActualDensityFunction (Lnet/minecraft/class_6910;)Lnet/minecraft/class_6910;
-		COMMENT {@return the actual density function for a given density function}.
+		COMMENT {@return the actual density function for a given density function}
 		COMMENT
-		COMMENT The classes in {@link DensityFunctionTypes} for caches, interpolators,
+		COMMENT <p>The classes in {@link DensityFunctionTypes} for caches, interpolators,
 		COMMENT {@code blend_alpha} and {@code blend_offset} use simple stub implementations
 		COMMENT that get replaced with their actual implementation by calling this method.
 		ARG 1 function
@@ -137,7 +139,7 @@ CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
 		ARG 2 cellX
 			COMMENT the current cell X coordinate
 	METHOD method_40533 getActualDensityFunctionImpl (Lnet/minecraft/class_6910;)Lnet/minecraft/class_6910;
-		COMMENT {@return the actual density function for a given density function}.
+		COMMENT {@return the actual density function for a given density function}
 		ARG 1 function
 	METHOD method_40535 calculateBlendResult (II)Lnet/minecraft/class_6748$class_6956;
 		ARG 1 blockX

--- a/mappings/net/minecraft/world/gen/chunk/ChunkNoiseSampler.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/ChunkNoiseSampler.mapping
@@ -1,4 +1,9 @@
 CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
+	COMMENT {@code ChunkNoiseSampler} is responsible for sampling the density functions for
+	COMMENT the cells in each chunk, managing caches and interpolators, the {@code Blender},
+	COMMENT and the block state samplers.
+	COMMENT
+	COMMENT An instance of this is created for every chunk.
 	FIELD field_34598 verticalCellCount I
 	FIELD field_34599 horizontalCellCount I
 	FIELD field_34600 minimumCellY I
@@ -93,6 +98,8 @@ CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
 		COMMENT correctly filled for the current cell.
 		COMMENT
 		COMMENT This starts the interpolators and fills the cell caches.
+		COMMENT
+		COMMENT @implNote For filling the cell caches, {@code this} is used as the {@link EachApplier}.
 		ARG 1 cellY
 			COMMENT the chunk-local cell Y coordinate
 		ARG 2 cellZ
@@ -110,7 +117,13 @@ CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
 		ARG 1 blockX
 		ARG 2 blockZ
 	METHOD method_40529 getActualDensityFunction (Lnet/minecraft/class_6910;)Lnet/minecraft/class_6910;
-		ARG 1 densityFunction
+		COMMENT {@return the actual density function for a given density function}.
+		COMMENT
+		COMMENT The classes in {@link DensityFunctionTypes} for caches, interpolators,
+		COMMENT {@code blend_alpha} and {@code blend_offset} use simple stub implementations
+		COMMENT that get replaced with their actual implementation by calling this method.
+		ARG 1 function
+			COMMENT the density function to get an actual implementation for
 	METHOD method_40530 (Lnet/minecraft/class_6910;Lnet/minecraft/class_6910$class_6912;)Lnet/minecraft/class_2680;
 		ARG 2 pos
 	METHOD method_40531 createMultiNoiseSampler (Lnet/minecraft/class_6953;Ljava/util/List;)Lnet/minecraft/class_6544$class_6552;
@@ -124,7 +137,8 @@ CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
 		ARG 2 cellX
 			COMMENT the current cell X coordinate
 	METHOD method_40533 getActualDensityFunctionImpl (Lnet/minecraft/class_6910;)Lnet/minecraft/class_6910;
-		ARG 1 densityFunction
+		COMMENT {@return the actual density function for a given density function}.
+		ARG 1 function
 	METHOD method_40535 calculateBlendResult (II)Lnet/minecraft/class_6748$class_6956;
 		ARG 1 blockX
 		ARG 2 blockZ

--- a/mappings/net/minecraft/world/gen/chunk/GenerationShapeConfig.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/GenerationShapeConfig.mapping
@@ -27,7 +27,7 @@ CLASS net/minecraft/class_5309 net/minecraft/world/gen/chunk/GenerationShapeConf
 		ARG 0 config
 	METHOD method_32996 (Lcom/mojang/serialization/DataResult$PartialResult;)V
 		ARG 0 result
-	METHOD method_39545 verticalCellSize ()I
-	METHOD method_39546 horizontalCellSize ()I
+	METHOD method_39545 verticalCellBlockCount ()I
+	METHOD method_39546 horizontalCellBlockCount ()I
 	METHOD method_42368 trimHeight (Lnet/minecraft/class_5539;)Lnet/minecraft/class_5309;
 		ARG 1 world

--- a/mappings/net/minecraft/world/gen/densityfunction/DensityFunction.mapping
+++ b/mappings/net/minecraft/world/gen/densityfunction/DensityFunction.mapping
@@ -1,14 +1,14 @@
 CLASS net/minecraft/class_6910 net/minecraft/world/gen/densityfunction/DensityFunction
 	COMMENT Represents a function that maps from a block position to a density value.
 	COMMENT
-	COMMENT It can be defined in code or in data packs by using pre-defined function types
+	COMMENT <p>It can be defined in code or in data packs by using pre-defined function types
 	COMMENT like constant values or {@code add}, which in turn use other density functions
 	COMMENT to define their operands.
 	FIELD field_37057 CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_37058 REGISTRY_ENTRY_CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_37059 FUNCTION_CODEC Lcom/mojang/serialization/Codec;
 	METHOD method_40464 sample (Lnet/minecraft/class_6910$class_6912;)D
-		COMMENT {@return the density value for the given block position}.
+		COMMENT {@return the density value for the given block position}
 		ARG 1 pos
 			COMMENT the block position
 	METHOD method_40468 clamp (DD)Lnet/minecraft/class_6910;
@@ -40,13 +40,14 @@ CLASS net/minecraft/class_6910 net/minecraft/world/gen/densityfunction/DensityFu
 		COMMENT {@code EachApplier} is used to fill an array of densities, like a density buffer
 		COMMENT or cache, with values from a density function.
 		COMMENT
-		COMMENT This exists because {@link ChunkNoiseSampler} uses itself as the block position
-		COMMENT passed to density functions and needs to set the position fields correctly before
-		COMMENT calling {@code sample}, as well as setting fields for the implementation of caches.
+		COMMENT <p>This exists because {@link net.minecraft.world.gen.chunk.ChunkNoiseSampler ChunkNoiseSampler}
+		COMMENT uses itself as the block position passed to density functions and needs to set the
+		COMMENT position fields correctly before calling {@code sample}, as well as setting fields
+		COMMENT for the implementation of caches.
 		METHOD method_40477 at (I)Lnet/minecraft/class_6910$class_6912;
-			COMMENT {@return the block position at a specific index of the density array}.
+			COMMENT {@return the block position at a specific index of the density array}
 			COMMENT
-			COMMENT If you want to manually iterate the array and call {@link DensityFunction#sample}
+			COMMENT <p>If you want to manually iterate the array and call {@link DensityFunction#sample}
 			COMMENT to set the individual elements in an implementation of {@link DensityFunction#fill},
 			COMMENT this method can be used to get the block position required for that.
 			COMMENT
@@ -62,12 +63,12 @@ CLASS net/minecraft/class_6910 net/minecraft/world/gen/densityfunction/DensityFu
 		COMMENT {@code NoisePos} represents the absolute block position that is passed
 		COMMENT to density functions.
 		COMMENT
-		COMMENT It also has a way to get the currently active {@link Blender}.
+		COMMENT <p>It also has a way to get the currently active {@link Blender}.
 		METHOD method_39327 getBlender ()Lnet/minecraft/class_6748;
 	CLASS class_6913 Base
 		COMMENT Represents a density function that has no other density functions as an argument,
 		COMMENT and provides default implementations of {@link #fill} and
-		COMMENT {@link #apply(DensityFunctionVisitor} for this case.
+		COMMENT {@link #apply(DensityFunctionVisitor)} for this case.
 	CLASS class_6914 UnblendedNoisePos
 	CLASS class_6915 DensityFunctionVisitor
 		METHOD apply (Lnet/minecraft/class_6910;)Lnet/minecraft/class_6910;

--- a/mappings/net/minecraft/world/gen/densityfunction/DensityFunction.mapping
+++ b/mappings/net/minecraft/world/gen/densityfunction/DensityFunction.mapping
@@ -23,8 +23,14 @@ CLASS net/minecraft/class_6910 net/minecraft/world/gen/densityfunction/DensityFu
 	METHOD method_41062 getCodecHolder ()Lnet/minecraft/class_7243;
 	CLASS class_6911 EachApplier
 		METHOD method_40477 getPosAt (I)Lnet/minecraft/class_6910$class_6912;
+			COMMENT Gets the block position at a specific index of the density array.
+			COMMENT
+			COMMENT @implNote This can have side effects.
 			ARG 1 index
 		METHOD method_40478 applyEach ([DLnet/minecraft/class_6910;)V
+			COMMENT Fills the density array using a density function.
+			COMMENT
+			COMMENT @implNote This can have side effects.
 			ARG 1 densities
 			ARG 2 densityFunction
 	CLASS class_6912 NoisePos

--- a/mappings/net/minecraft/world/gen/densityfunction/DensityFunction.mapping
+++ b/mappings/net/minecraft/world/gen/densityfunction/DensityFunction.mapping
@@ -1,17 +1,32 @@
 CLASS net/minecraft/class_6910 net/minecraft/world/gen/densityfunction/DensityFunction
+	COMMENT Represents a function that maps from a block position to a density value.
+	COMMENT
+	COMMENT It can be defined in code or in data packs by using pre-defined function types
+	COMMENT like constant values or {@code add}, which in turn use other density functions
+	COMMENT to define their operands.
 	FIELD field_37057 CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_37058 REGISTRY_ENTRY_CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_37059 FUNCTION_CODEC Lcom/mojang/serialization/Codec;
 	METHOD method_40464 sample (Lnet/minecraft/class_6910$class_6912;)D
+		COMMENT {@return the density value for the given block position}.
 		ARG 1 pos
+			COMMENT the block position
 	METHOD method_40468 clamp (DD)Lnet/minecraft/class_6910;
 		ARG 1 min
 		ARG 3 max
 	METHOD method_40469 apply (Lnet/minecraft/class_6910$class_6915;)Lnet/minecraft/class_6910;
+		COMMENT Applies the visitor to every child density function and {@code this}.
+		COMMENT
+		COMMENT @return the resulting density function
 		ARG 1 visitor
-	METHOD method_40470 applyEach ([DLnet/minecraft/class_6910$class_6911;)V
+			COMMENT the visitor that should be applied to this density function
+	METHOD method_40470 fill ([DLnet/minecraft/class_6910$class_6911;)V
+		COMMENT Fills an array of densities using {@code this} density function and
+		COMMENT the {@link EachApplier}.
 		ARG 1 densities
+			COMMENT the array of densities to fill, like a buffer or a cache
 		ARG 2 applier
+			COMMENT the {@code EachApplier} to use. It has a method for filling the array, as well as to get a block position for an index
 	METHOD method_40471 abs ()Lnet/minecraft/class_6910;
 	METHOD method_40472 square ()Lnet/minecraft/class_6910;
 	METHOD method_40473 cube ()Lnet/minecraft/class_6910;
@@ -22,20 +37,37 @@ CLASS net/minecraft/class_6910 net/minecraft/world/gen/densityfunction/DensityFu
 		ARG 0 function
 	METHOD method_41062 getCodecHolder ()Lnet/minecraft/class_7243;
 	CLASS class_6911 EachApplier
-		METHOD method_40477 getPosAt (I)Lnet/minecraft/class_6910$class_6912;
-			COMMENT Gets the block position at a specific index of the density array.
+		COMMENT {@code EachApplier} is used to fill an array of densities, like a density buffer
+		COMMENT or cache, with values from a density function.
+		COMMENT
+		COMMENT This exists because {@link ChunkNoiseSampler} uses itself as the block position
+		COMMENT passed to density functions and needs to set the position fields correctly before
+		COMMENT calling {@code sample}, as well as setting fields for the implementation of caches.
+		METHOD method_40477 at (I)Lnet/minecraft/class_6910$class_6912;
+			COMMENT {@return the block position at a specific index of the density array}.
+			COMMENT
+			COMMENT If you want to manually iterate the array and call {@link DensityFunction#sample}
+			COMMENT to set the individual elements in an implementation of {@link DensityFunction#fill},
+			COMMENT this method can be used to get the block position required for that.
 			COMMENT
 			COMMENT @implNote This can have side effects.
 			ARG 1 index
-		METHOD method_40478 applyEach ([DLnet/minecraft/class_6910;)V
+		METHOD method_40478 fill ([DLnet/minecraft/class_6910;)V
 			COMMENT Fills the density array using a density function.
 			COMMENT
 			COMMENT @implNote This can have side effects.
 			ARG 1 densities
 			ARG 2 densityFunction
 	CLASS class_6912 NoisePos
+		COMMENT {@code NoisePos} represents the absolute block position that is passed
+		COMMENT to density functions.
+		COMMENT
+		COMMENT It also has a way to get the currently active {@link Blender}.
 		METHOD method_39327 getBlender ()Lnet/minecraft/class_6748;
 	CLASS class_6913 Base
+		COMMENT Represents a density function that has no other density functions as an argument,
+		COMMENT and provides default implementations of {@link #fill} and
+		COMMENT {@link #apply(DensityFunctionVisitor} for this case.
 	CLASS class_6914 UnblendedNoisePos
 	CLASS class_6915 DensityFunctionVisitor
 		METHOD apply (Lnet/minecraft/class_6910;)Lnet/minecraft/class_6910;


### PR DESCRIPTION
Changes:
- Renames `noise` to `density` in some places (`NoiseInterpolator` -> `DensityInterpolator`)
- Miscellaneous renames in `ChunkNoiseSampler`
- Adds documentation to density functions and some of the things `ChunkNoiseSampler` does (I'm not sure if the JavaDocs are formatted correctly, though)

Potential further renames:
- `ChunkNoiseSampler`: it doesn't actually sample noise, but rather density functions and also does some other things
- `DensityFunction.EachApplier`: this should have some kind of name related to filling density arrays, because that's what it does