### PR TITLE
Update World Events unpick

### DIFF
--- a/mappings/net/minecraft/block/entity/SignBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/SignBlockEntity.mapping
@@ -49,7 +49,7 @@ CLASS net/minecraft/class_2625 net/minecraft/block/entity/SignBlockEntity
 		ARG 3 text
 	METHOD method_49846 setFrontText (Lnet/minecraft/class_8242;)Z
 		ARG 1 frontText
-	METHOD method_49847 canPlayerEdit (Ljava/util/UUID;)Z
+	METHOD method_49847 isPlayerTooFarToEdit (Ljava/util/UUID;)Z
 		ARG 1 uuid
 	METHOD method_49849 setWaxed (Z)Z
 		ARG 1 waxed

--- a/mappings/net/minecraft/world/WorldEvents.mapping
+++ b/mappings/net/minecraft/world/WorldEvents.mapping
@@ -298,10 +298,29 @@ CLASS net/minecraft/class_6088 net/minecraft/world/WorldEvents
 		COMMENT an anonymous class in {@link net.minecraft.block.dispenser.DispenserBehavior#registerDefaults() DispenserBehavior#registerDefaults},
 		COMMENT and {@link net.minecraft.entity.ai.brain.task.BoneMealTask#keepRunning(net.minecraft.server.world.ServerWorld, net.minecraft.entity.passive.VillagerEntity, long) BoneMealTask#keepRunning}
 	FIELD field_37586 SCULK_CHARGE I
-		COMMENT Sculk... charges? Sculk is weird.
+		COMMENT Sculk releases a charge.
 		COMMENT <br>Spawns sculk charge particles.
-		COMMENT <br>Called by {@link net.minecraft.block.entity.SculkSpreadManager#tick(net.minecraft.world.WorldAccess, net.minecraft.util.math.BlockPos,  net.minecraft.util.math.random.Random, boolean) SculkSpreadManager#tick}
+		COMMENT <p>Called by {@link net.minecraft.block.entity.SculkSpreadManager#tick(net.minecraft.world.WorldAccess, net.minecraft.util.math.BlockPos,  net.minecraft.util.math.random.Random, boolean) SculkSpreadManager#tick}
 	FIELD field_38228 SCULK_SHRIEKS I
 		COMMENT A sculk shrieker shrieks.
 		COMMENT <br>Spawns shriek particles and plays the shriek sound event.
-		COMMENT <br>Called by {@link net.minecraft.block.entity.SculkShriekerBlockEntity#shriek(net.minecraft.server.world.ServerWorld, net.minecraft.entity.Entity) SculkShriekerBlockEntity#shriek}
+		COMMENT <p>Called by {@link net.minecraft.block.entity.SculkShriekerBlockEntity#shriek(net.minecraft.server.world.ServerWorld, net.minecraft.entity.Entity) SculkShriekerBlockEntity#shriek}
+	FIELD field_42759 BLOCK_FINISHED_BRUSHING I
+		COMMENT A block has been completely brushed.
+		COMMENT <br>Spawns block break particles and plays the block's brushing complete sound.
+		COMMENT <p>The block's raw ID must be supplied as extra data.
+		COMMENT <p>Called by {@link net.minecraft.block.entity.BrushableBlockEntity#finishBrushing(net.minecraft.entity.player.PlayerEntity) BrushableBlockEntity#finishBrushing}
+	FIELD field_42760 JUKEBOX_STARTS_PLAYING I
+		COMMENT A jukebox starts playing a music disc.
+		COMMENT <br>Plays the appropriate music.
+		COMMENT <p>The raw ID of the music disc item must be supplied as extra data.
+		COMMENT <p>Called by {@link net.minecraft.block.entity.JukeboxBlockEntity#startPlaying() JukeboxBlockEntity#startPlaying}
+	FIELD field_42761 JUKEBOX_STOPS_PLAYING I
+		COMMENT A jukebox stops playing a music disc.
+		COMMENT <br>Stops any music currently playing.
+		COMMENT <p>Called by {@link net.minecraft.block.entity.JukeboxBlockEntity#stopPlaying() JukeboxBlockEntity#stopPlaying}
+	FIELD field_43238 SNIFFER_EGG_CRACKS I
+		COMMENT A sniffer egg cracks.
+		COMMENT <br>Spawns between 1 and 3 egg crack particles.
+		COMMENT <p>If a {@code 1} is passed as extra data, between 3 and 6 egg crack particles are spawned instead.
+		COMMENT <p>Called by {@link net.minecraft.block.SnifferEggBlock#onBlockAdded(net.minecraft.block.BlockState, net.minecraft.world.World, net.minecraft.util.math.BlockPos, net.minecraft.block.BlockState, boolean) SnifferEggBlock#onBlockAdded}

--- a/unpick-definitions/world_events.unpick
+++ b/unpick-definitions/world_events.unpick
@@ -5,16 +5,9 @@ constant world_events net/minecraft/world/WorldEvents DISPENSER_FAILS
 constant world_events net/minecraft/world/WorldEvents DISPENSER_LAUNCHES_PROJECTILE
 constant world_events net/minecraft/world/WorldEvents EYE_OF_ENDER_LAUNCHES
 constant world_events net/minecraft/world/WorldEvents FIREWORK_ROCKET_SHOOTS
-constant world_events net/minecraft/world/WorldEvents IRON_DOOR_OPENS
-constant world_events net/minecraft/world/WorldEvents WOODEN_DOOR_OPENS
-constant world_events net/minecraft/world/WorldEvents WOODEN_TRAPDOOR_OPENS
-constant world_events net/minecraft/world/WorldEvents FENCE_GATE_OPENS
 constant world_events net/minecraft/world/WorldEvents FIRE_EXTINGUISHED
-constant world_events net/minecraft/world/WorldEvents MUSIC_DISC_PLAYED
-constant world_events net/minecraft/world/WorldEvents IRON_DOOR_CLOSES
-constant world_events net/minecraft/world/WorldEvents WOODEN_DOOR_CLOSES
-constant world_events net/minecraft/world/WorldEvents WOODEN_TRAPDOOR_CLOSES
-constant world_events net/minecraft/world/WorldEvents FENCE_GATE_CLOSES
+constant world_events net/minecraft/world/WorldEvents JUKEBOX_STARTS_PLAYING
+constant world_events net/minecraft/world/WorldEvents JUKEBOX_STOPS_PLAYING
 constant world_events net/minecraft/world/WorldEvents GHAST_WARNS
 constant world_events net/minecraft/world/WorldEvents GHAST_SHOOTS
 constant world_events net/minecraft/world/WorldEvents ENDER_DRAGON_SHOOTS
@@ -36,8 +29,6 @@ constant world_events net/minecraft/world/WorldEvents TRAVEL_THROUGH_PORTAL
 constant world_events net/minecraft/world/WorldEvents CHORUS_FLOWER_GROWS
 constant world_events net/minecraft/world/WorldEvents CHORUS_FLOWER_DIES
 constant world_events net/minecraft/world/WorldEvents BREWING_STAND_BREWS
-constant world_events net/minecraft/world/WorldEvents IRON_TRAPDOOR_CLOSES
-constant world_events net/minecraft/world/WorldEvents IRON_TRAPDOOR_OPENS
 constant world_events net/minecraft/world/WorldEvents END_PORTAL_OPENED
 constant world_events net/minecraft/world/WorldEvents PHANTOM_BITES
 constant world_events net/minecraft/world/WorldEvents ZOMBIE_CONVERTS_TO_DROWNED
@@ -73,6 +64,8 @@ constant world_events net/minecraft/world/WorldEvents BLOCK_SCRAPED
 constant world_events net/minecraft/world/WorldEvents BONE_MEAL_USED
 constant world_events net/minecraft/world/WorldEvents SCULK_CHARGE
 constant world_events net/minecraft/world/WorldEvents SCULK_SHRIEKS
+constant world_events net/minecraft/world/WorldEvents BLOCK_FINISHED_BRUSHING
+constant world_events net/minecraft/world/WorldEvents SNIFFER_EGG_CRACKS
 
 target_method net/minecraft/world/WorldAccess syncWorldEvent (Lnet/minecraft/entity/player/PlayerEntity;ILnet/minecraft/util/math/BlockPos;I)V
 	param 1 world_events
@@ -87,8 +80,4 @@ target_method net/minecraft/client/render/WorldRenderer processGlobalEvent (ILne
 target_method net/minecraft/network/packet/s2c/play/WorldEventS2CPacket <init> (ILnet/minecraft/util/math/BlockPos;IZ)V
 	param 0 world_events
 target_method net/minecraft/network/packet/s2c/play/WorldEventS2CPacket getEventId ()I
-	return world_events
-target_method net/minecraft/block/DoorBlock getOpenSoundEventId ()I
-	return world_events
-target_method net/minecraft/block/DoorBlock getCloseSoundEventId ()I
 	return world_events


### PR DESCRIPTION
Maps and documents new world events, and updates the unpick to match as well as remove events that no longer exist. Also fixes an incorrect name from #3525