### PR TITLE
Fix mixed up getRed/getBlue names in ColorHelper.Abgr (23w14a)

### DIFF
--- a/mappings/net/minecraft/util/math/ColorHelper.mapping
+++ b/mappings/net/minecraft/util/math/ColorHelper.mapping
@@ -47,11 +47,11 @@ CLASS net/minecraft/class_5253 net/minecraft/util/math/ColorHelper
 			ARG 1 b
 			ARG 2 g
 			ARG 3 r
-		METHOD method_48345 getBlue (I)I
+		METHOD method_48345 getRed (I)I
 			ARG 0 abgr
 		METHOD method_48346 getGreen (I)I
 			ARG 0 abgr
-		METHOD method_48347 getRed (I)I
+		METHOD method_48347 getBlue (I)I
 			ARG 0 abgr
 		METHOD method_48348 getBgr (I)I
 			ARG 0 abgr


### PR DESCRIPTION
Snapshot branch PR for #3541 