### PR TITLE
Rename the StatusEffectUtil.durationToString method to getDurationText

### DIFF
--- a/mappings/net/minecraft/entity/effect/StatusEffectUtil.mapping
+++ b/mappings/net/minecraft/entity/effect/StatusEffectUtil.mapping
@@ -16,6 +16,6 @@ CLASS net/minecraft/class_1292 net/minecraft/entity/effect/StatusEffectUtil
 		ARG 0 entity
 	METHOD method_5576 hasHaste (Lnet/minecraft/class_1309;)Z
 		ARG 0 entity
-	METHOD method_5577 durationToString (Lnet/minecraft/class_1293;F)Lnet/minecraft/class_2561;
+	METHOD method_5577 getDurationText (Lnet/minecraft/class_1293;F)Lnet/minecraft/class_2561;
 		ARG 0 effect
 		ARG 1 multiplier


### PR DESCRIPTION
Fixes #3544