### PR TITLE
Loot additions and corrections

### DIFF
--- a/mappings/net/minecraft/advancement/criterion/ItemCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/ItemCriterion.mapping
@@ -2,15 +2,31 @@ CLASS net/minecraft/class_4711 net/minecraft/advancement/criterion/ItemCriterion
 	FIELD field_21576 id Lnet/minecraft/class_2960;
 	METHOD <init> (Lnet/minecraft/class_2960;)V
 		ARG 1 id
+	METHOD method_23888 (Lnet/minecraft/class_47;Lnet/minecraft/class_4711$class_4712;)Z
+		ARG 1 conditions
 	METHOD method_23889 trigger (Lnet/minecraft/class_3222;Lnet/minecraft/class_2338;Lnet/minecraft/class_1799;)V
+		ARG 1 player
+		ARG 2 pos
+		ARG 3 stack
 	CLASS class_4712 Conditions
 		FIELD field_24495 location Lnet/minecraft/class_5258;
 		METHOD <init> (Lnet/minecraft/class_2960;Lnet/minecraft/class_5258;Lnet/minecraft/class_5258;)V
 			ARG 1 id
 			ARG 2 entity
+			ARG 3 location
 		METHOD method_27981 create (Lnet/minecraft/class_2090$class_2091;Lnet/minecraft/class_2073$class_2074;)Lnet/minecraft/class_4711$class_4712;
 			ARG 0 location
 			ARG 1 item
 		METHOD method_43125 createAllayDropItemOnBlock (Lnet/minecraft/class_2090$class_2091;Lnet/minecraft/class_2073$class_2074;)Lnet/minecraft/class_4711$class_4712;
 			ARG 0 location
 			ARG 1 item
+		METHOD method_51709 create (Lnet/minecraft/class_2090$class_2091;Lnet/minecraft/class_2073$class_2074;Lnet/minecraft/class_2960;)Lnet/minecraft/class_4711$class_4712;
+			ARG 0 location
+			ARG 1 tool
+			ARG 2 id
+		METHOD method_51710 createPlacedBlock (Lnet/minecraft/class_2248;)Lnet/minecraft/class_4711$class_4712;
+			ARG 0 block
+		METHOD method_51711 testLocation (Lnet/minecraft/class_47;)Z
+			ARG 1 context
+		METHOD method_51712 createPlacedBlock ([Lnet/minecraft/class_5341$class_210;)Lnet/minecraft/class_4711$class_4712;
+			ARG 0 location

--- a/mappings/net/minecraft/loot/condition/AllOfLootCondition.mapping
+++ b/mappings/net/minecraft/loot/condition/AllOfLootCondition.mapping
@@ -1,0 +1,7 @@
+CLASS net/minecraft/class_8548 net/minecraft/loot/condition/AllOfLootCondition
+	METHOD <init> ([Lnet/minecraft/class_5341;)V
+		ARG 1 terms
+	METHOD method_51723 builder ([Lnet/minecraft/class_5341$class_210;)Lnet/minecraft/class_8548$class_8549;
+		ARG 0 builders
+	CLASS class_8549 Builder
+	CLASS class_8550 Serializer

--- a/mappings/net/minecraft/loot/condition/AlternativeLootCondition.mapping
+++ b/mappings/net/minecraft/loot/condition/AlternativeLootCondition.mapping
@@ -1,10 +1,19 @@
 CLASS net/minecraft/class_186 net/minecraft/loot/condition/AlternativeLootCondition
 	FIELD field_1246 terms [Lnet/minecraft/class_5341;
 	FIELD field_1247 predicate Ljava/util/function/Predicate;
+	METHOD <init> ([Lnet/minecraft/class_5341;Ljava/util/function/Predicate;)V
+		ARG 1 terms
+		ARG 2 predicate
 	METHOD test (Ljava/lang/Object;)Z
 		ARG 1 context
 	CLASS class_187 Builder
 		FIELD field_1248 terms Ljava/util/List;
 		METHOD <init> ([Lnet/minecraft/class_5341$class_210;)V
 			ARG 1 terms
+		METHOD method_51724 build ([Lnet/minecraft/class_5341;)Lnet/minecraft/class_5341;
+			ARG 1 terms
+		METHOD method_51730 add (Lnet/minecraft/class_5341$class_210;)V
+			ARG 1 builder
 	CLASS class_188 Serializer
+		METHOD method_51726 fromTerms ([Lnet/minecraft/class_5341;)Lnet/minecraft/class_186;
+			ARG 1 terms

--- a/mappings/net/minecraft/loot/condition/AnyOfLootCondition.mapping
+++ b/mappings/net/minecraft/loot/condition/AnyOfLootCondition.mapping
@@ -1,0 +1,7 @@
+CLASS net/minecraft/class_8551 net/minecraft/loot/condition/AnyOfLootCondition
+	METHOD <init> ([Lnet/minecraft/class_5341;)V
+		ARG 1 terms
+	METHOD method_51727 builder ([Lnet/minecraft/class_5341$class_210;)Lnet/minecraft/class_8551$class_8552;
+		ARG 0 builders
+	CLASS class_8552 Builder
+	CLASS class_8553 Serializer

--- a/mappings/net/minecraft/loot/condition/LootCondition.mapping
+++ b/mappings/net/minecraft/loot/condition/LootCondition.mapping
@@ -1,6 +1,11 @@
 CLASS net/minecraft/class_5341 net/minecraft/loot/condition/LootCondition
+	COMMENT Loot conditions, officially {@index predicate}s, are JSON-based conditions to test
+	COMMENT against in world. It's used in loot tables, advancements, and commands, and can be
+	COMMENT defined by data packs.
 	METHOD method_29325 getType ()Lnet/minecraft/class_5342;
 	CLASS class_210 Builder
+		METHOD and (Lnet/minecraft/class_5341$class_210;)Lnet/minecraft/class_8548$class_8549;
+			ARG 1 condition
 		METHOD method_16780 invert ()Lnet/minecraft/class_5341$class_210;
 		METHOD method_893 or (Lnet/minecraft/class_5341$class_210;)Lnet/minecraft/class_8551$class_8552;
 			ARG 1 condition

--- a/mappings/net/minecraft/loot/condition/LootConditionTypes.mapping
+++ b/mappings/net/minecraft/loot/condition/LootConditionTypes.mapping
@@ -5,9 +5,13 @@ CLASS net/minecraft/class_217 net/minecraft/loot/condition/LootConditionTypes
 		ARG 1 serializer
 	METHOD method_921 (Ljava/lang/Object;)Z
 		ARG 0 predicates
-	METHOD method_924 joinAnd ([Ljava/util/function/Predicate;)Ljava/util/function/Predicate;
+	METHOD method_924 matchingAll ([Ljava/util/function/Predicate;)Ljava/util/function/Predicate;
+		COMMENT Returns a predicate that returns true only if all its element predicates
+		COMMENT return true, as if applied by logical and.
 		ARG 0 predicates
-	METHOD method_925 joinOr ([Ljava/util/function/Predicate;)Ljava/util/function/Predicate;
+	METHOD method_925 matchingAny ([Ljava/util/function/Predicate;)Ljava/util/function/Predicate;
+		COMMENT Returns a predicate that returns true if any its element predicates
+		COMMENT return true, as if applied by logical or.
 		ARG 0 predicates
 	METHOD method_927 ([Ljava/util/function/Predicate;Ljava/lang/Object;)Z
 		ARG 1 operand

--- a/mappings/net/minecraft/predicate/entity/AdvancementEntityPredicateDeserializer.mapping
+++ b/mappings/net/minecraft/predicate/entity/AdvancementEntityPredicateDeserializer.mapping
@@ -2,9 +2,10 @@ CLASS net/minecraft/class_5257 net/minecraft/predicate/entity/AdvancementEntityP
 	FIELD field_24383 LOGGER Lorg/slf4j/Logger;
 	FIELD field_24384 advancementId Lnet/minecraft/class_2960;
 	FIELD field_24386 gson Lcom/google/gson/Gson;
+	FIELD field_44474 lootManager Lnet/minecraft/class_60;
 	METHOD <init> (Lnet/minecraft/class_2960;Lnet/minecraft/class_60;)V
 		ARG 1 advancementId
-		ARG 2 conditionManager
+		ARG 2 lootManager
 	METHOD method_27795 getAdvancementId ()Lnet/minecraft/class_2960;
 	METHOD method_27796 loadConditions (Lcom/google/gson/JsonArray;Ljava/lang/String;Lnet/minecraft/class_176;)[Lnet/minecraft/class_5341;
 		ARG 1 array

--- a/mappings/net/minecraft/predicate/entity/EntityConditions.mapping
+++ b/mappings/net/minecraft/predicate/entity/EntityConditions.mapping
@@ -1,4 +1,6 @@
-CLASS net/minecraft/class_5258 net/minecraft/predicate/entity/Extended
+CLASS net/minecraft/class_5258 net/minecraft/predicate/entity/EntityConditions
+	COMMENT A list of loot conditions applied to entities. All conditions must match for this
+	COMMENT unified conditions to {@linkplain #test match}. Mainly used by advancements.
 	FIELD field_24388 EMPTY Lnet/minecraft/class_5258;
 	FIELD field_24389 conditions [Lnet/minecraft/class_5341;
 	FIELD field_24390 combinedCondition Ljava/util/function/Predicate;
@@ -10,8 +12,9 @@ CLASS net/minecraft/class_5258 net/minecraft/predicate/entity/Extended
 		ARG 1 context
 	METHOD method_27807 fromJson (Ljava/lang/String;Lnet/minecraft/class_5257;Lcom/google/gson/JsonElement;Lnet/minecraft/class_176;)Lnet/minecraft/class_5258;
 		ARG 0 key
-		ARG 1 predicateDeserializer
+		ARG 1 deserializer
 		ARG 2 json
+		ARG 3 contextType
 	METHOD method_27808 toPredicatesJsonArray ([Lnet/minecraft/class_5258;Lnet/minecraft/class_5267;)Lcom/google/gson/JsonElement;
 		ARG 0 predicates
 		ARG 1 predicateSerializer

--- a/mappings/net/minecraft/predicate/entity/EntityConditions.mapping
+++ b/mappings/net/minecraft/predicate/entity/EntityConditions.mapping
@@ -12,7 +12,7 @@ CLASS net/minecraft/class_5258 net/minecraft/predicate/entity/EntityConditions
 		ARG 1 context
 	METHOD method_27807 fromJson (Ljava/lang/String;Lnet/minecraft/class_5257;Lcom/google/gson/JsonElement;Lnet/minecraft/class_176;)Lnet/minecraft/class_5258;
 		ARG 0 key
-		ARG 1 deserializer
+		ARG 1 predicateDeserializer
 		ARG 2 json
 		ARG 3 contextType
 	METHOD method_27808 toPredicatesJsonArray ([Lnet/minecraft/class_5258;Lnet/minecraft/class_5267;)Lcom/google/gson/JsonElement;

--- a/mappings/net/minecraft/predicate/entity/EntityPredicate.mapping
+++ b/mappings/net/minecraft/predicate/entity/EntityPredicate.mapping
@@ -43,6 +43,27 @@ CLASS net/minecraft/class_2048 net/minecraft/predicate/entity/EntityPredicate
 		ARG 1 target
 	METHOD method_37227 (Lnet/minecraft/class_3218;Lnet/minecraft/class_243;Lnet/minecraft/class_1297;)Z
 		ARG 3 entity
+	METHOD method_51704 toConditions (Lnet/minecraft/class_2048;)Lnet/minecraft/class_5258;
+		COMMENT Converts a single entity predicates into a predicate (loot condition) list.
+		COMMENT The returned list will have zero or one elements.
+		ARG 0 predicate
+	METHOD method_51705 toConditions (Lcom/google/gson/JsonObject;Ljava/lang/String;Lnet/minecraft/class_5257;)Lnet/minecraft/class_5258;
+		COMMENT Deserializes a single entity predicate or a list of entity predicates in a JSON
+		COMMENT object's {@code key} field as a list of conditions.
+		ARG 0 obj
+		ARG 1 key
+		ARG 2 deserializer
+	METHOD method_51706 asPredicateList (Ljava/lang/String;Lnet/minecraft/class_5257;Lcom/google/gson/JsonElement;)Lnet/minecraft/class_5258;
+		ARG 0 key
+		ARG 1 deserializer
+		ARG 2 json
+	METHOD method_51707 toConditonsArray (Lcom/google/gson/JsonObject;Ljava/lang/String;Lnet/minecraft/class_5257;)[Lnet/minecraft/class_5258;
+		COMMENT Deserializes a list of entity predicates in a JSON object's {@code key} array field,
+		COMMENT where each array element can be a single entity predicate or a list of entity
+		COMMENT predicates.
+		ARG 0 obj
+		ARG 1 key
+		ARG 2 deserializer
 	METHOD method_8909 test (Lnet/minecraft/class_3218;Lnet/minecraft/class_243;Lnet/minecraft/class_1297;)Z
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/predicate/entity/EntityPredicate.mapping
+++ b/mappings/net/minecraft/predicate/entity/EntityPredicate.mapping
@@ -53,7 +53,7 @@ CLASS net/minecraft/class_2048 net/minecraft/predicate/entity/EntityPredicate
 		ARG 0 obj
 		ARG 1 key
 		ARG 2 deserializer
-	METHOD method_51706 asPredicateList (Ljava/lang/String;Lnet/minecraft/class_5257;Lcom/google/gson/JsonElement;)Lnet/minecraft/class_5258;
+	METHOD method_51706 asConditions (Ljava/lang/String;Lnet/minecraft/class_5257;Lcom/google/gson/JsonElement;)Lnet/minecraft/class_5258;
 		ARG 0 key
 		ARG 1 deserializer
 		ARG 2 json

--- a/mappings/net/minecraft/predicate/entity/PlayerPredicate.mapping
+++ b/mappings/net/minecraft/predicate/entity/PlayerPredicate.mapping
@@ -4,6 +4,7 @@ CLASS net/minecraft/class_4553 net/minecraft/predicate/entity/PlayerPredicate
 	FIELD field_20725 stats Ljava/util/Map;
 	FIELD field_20726 recipes Lit/unimi/dsi/fastutil/objects/Object2BooleanMap;
 	FIELD field_20727 advancements Ljava/util/Map;
+	FIELD field_33928 LOOKING_AT_DISTANCE I
 	FIELD field_33929 lookingAt Lnet/minecraft/class_2048;
 	METHOD <init> (Lnet/minecraft/class_2096$class_2100;Lnet/minecraft/class_1934;Ljava/util/Map;Lit/unimi/dsi/fastutil/objects/Object2BooleanMap;Ljava/util/Map;Lnet/minecraft/class_2048;)V
 		ARG 1 experienceLevel


### PR DESCRIPTION
Refactors:
1. joinAnd/Or -> matchingAll/Any (closer to stream names and loot condition type names)
2. `Extended` renamed to `EntityConditions`, probably an oversight as part of inner class migrations