### PR TITLE
Font type stuff

### DIFF
--- a/mappings/net/minecraft/client/font/BitmapFont.mapping
+++ b/mappings/net/minecraft/client/font/BitmapFont.mapping
@@ -10,6 +10,8 @@ CLASS net/minecraft/class_386 net/minecraft/client/font/BitmapFont
 		FIELD comp_1520 height I
 		FIELD comp_1521 ascent I
 		FIELD comp_1522 chars [[I
+		FIELD field_44799 CODEC Lcom/mojang/serialization/MapCodec;
+		FIELD field_44800 STRINGS_CODEPOINT_GRID_CODEC Lcom/mojang/serialization/Codec;
 		METHOD <init> (Lnet/minecraft/class_2960;II[[I)V
 			ARG 1 id
 			ARG 2 height
@@ -25,6 +27,17 @@ CLASS net/minecraft/class_386 net/minecraft/client/font/BitmapFont
 			ARG 4 charPosX
 			ARG 5 charPosY
 		METHOD method_2039 load (Lnet/minecraft/class_3300;)Lnet/minecraft/class_390;
+			ARG 1 resourceManager
+		METHOD method_51748 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+			ARG 0 instance
+		METHOD method_51749 validate (Lnet/minecraft/class_386$class_387;)Lcom/mojang/serialization/DataResult;
+			ARG 0 loader
+		METHOD method_51750 (Ljava/util/List;)[[I
+			ARG 0 strings
+		METHOD method_51752 validate ([[I)Lcom/mojang/serialization/DataResult;
+			ARG 0 codePointGrid
+		METHOD method_51754 ([[I)Ljava/util/List;
+			ARG 0 codePointGrid
 	CLASS class_388 BitmapFontGlyph
 		FIELD comp_603 scaleFactor F
 		FIELD comp_604 image Lnet/minecraft/class_1011;

--- a/mappings/net/minecraft/client/font/FontLoader.mapping
+++ b/mappings/net/minecraft/client/font/FontLoader.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_389 net/minecraft/client/font/FontLoader
+	FIELD field_44801 CODEC Lcom/mojang/serialization/Codec;
+	METHOD method_51731 getType ()Lnet/minecraft/class_394;
 	METHOD method_51734 build ()Lcom/mojang/datafixers/util/Either;
 	CLASS class_8539 Loadable
 		METHOD load (Lnet/minecraft/class_3300;)Lnet/minecraft/class_390;

--- a/mappings/net/minecraft/client/font/FontType.mapping
+++ b/mappings/net/minecraft/client/font/FontType.mapping
@@ -1,4 +1,8 @@
 CLASS net/minecraft/class_394 net/minecraft/client/font/FontType
 	FIELD field_2314 id Ljava/lang/String;
+	FIELD field_44802 CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_44803 codec Lcom/mojang/serialization/MapCodec;
 	METHOD <init> (Ljava/lang/String;ILjava/lang/String;Lcom/mojang/serialization/MapCodec;)V
 		ARG 3 id
+		ARG 4 codec
+	METHOD method_51758 getLoaderCodec ()Lcom/mojang/serialization/MapCodec;

--- a/mappings/net/minecraft/client/font/SpaceFont.mapping
+++ b/mappings/net/minecraft/client/font/SpaceFont.mapping
@@ -1,2 +1,13 @@
 CLASS net/minecraft/class_7166 net/minecraft/client/font/SpaceFont
 	FIELD field_37842 codePointsToGlyphs Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
+	METHOD <init> (Ljava/util/Map;)V
+		ARG 1 codePointsToAdvances
+	METHOD method_41716 (Ljava/lang/Integer;Ljava/lang/Float;)V
+		ARG 1 codec
+		ARG 2 glyph
+	CLASS class_8554 Loader
+		FIELD field_44791 CODEC Lcom/mojang/serialization/MapCodec;
+		METHOD method_51732 (Lnet/minecraft/class_3300;)Lnet/minecraft/class_390;
+			ARG 1 resourceManager
+		METHOD method_51733 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+			ARG 0 instance

--- a/mappings/net/minecraft/client/font/TrueTypeFontLoader.mapping
+++ b/mappings/net/minecraft/client/font/TrueTypeFontLoader.mapping
@@ -1,0 +1,22 @@
+CLASS net/minecraft/class_8557 net/minecraft/client/font/TrueTypeFontLoader
+	FIELD field_44804 CODEC Lcom/mojang/serialization/MapCodec;
+	FIELD field_44805 SKIP_CODEC Lcom/mojang/serialization/Codec;
+	METHOD method_51759 load (Lnet/minecraft/class_3300;)Lnet/minecraft/class_390;
+		ARG 1 resourceManager
+	METHOD method_51760 (Lcom/mojang/datafixers/util/Either;)Ljava/lang/String;
+		ARG 0 either
+	METHOD method_51761 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance
+	METHOD method_51762 (Ljava/lang/String;)Ljava/lang/String;
+		ARG 0 string
+	METHOD method_51763 (Ljava/util/List;)Ljava/lang/String;
+		ARG 0 list
+	CLASS class_8558 Shift
+		FIELD field_44806 NONE Lnet/minecraft/class_8557$class_8558;
+		FIELD field_44807 CODEC Lcom/mojang/serialization/Codec;
+		METHOD method_51764 (Lnet/minecraft/class_8557$class_8558;)Ljava/util/List;
+			ARG 0 shift
+		METHOD method_51765 (Ljava/util/List;)Lcom/mojang/serialization/DataResult;
+			ARG 0 floatList
+		METHOD method_51766 (Ljava/util/List;)Lnet/minecraft/class_8557$class_8558;
+			ARG 0 floatList

--- a/mappings/net/minecraft/client/font/UnihexFont.mapping
+++ b/mappings/net/minecraft/client/font/UnihexFont.mapping
@@ -47,6 +47,8 @@ CLASS net/minecraft/class_391 net/minecraft/client/font/UnihexFont
 			ARG 1 stream
 		METHOD method_51665 (Lnet/minecraft/class_391$class_392;)Lnet/minecraft/class_2960;
 			ARG 0 loader
+		METHOD method_51666 (I)[[Lnet/minecraft/class_391$class_8544;
+			ARG 0 rows
 	CLASS class_393 UnicodeTextureGlyph
 		METHOD method_51675 width ()I
 	CLASS class_7736 FontImage8x16

--- a/mappings/net/minecraft/util/Util.mapping
+++ b/mappings/net/minecraft/util/Util.mapping
@@ -96,7 +96,7 @@ CLASS net/minecraft/class_156 net/minecraft/util/Util
 		ARG 1 consumer
 	METHOD method_29189 (Ljava/util/function/Consumer;Ljava/lang/String;Ljava/lang/String;)V
 		ARG 2 string
-	METHOD method_29190 toArray (Ljava/util/stream/IntStream;I)Lcom/mojang/serialization/DataResult;
+	METHOD method_29190 decodeFixedLengthArray (Ljava/util/stream/IntStream;I)Lcom/mojang/serialization/DataResult;
 		ARG 0 stream
 		ARG 1 length
 	METHOD method_29191 getChoiceTypeInternal (Lcom/mojang/datafixers/DSL$TypeReference;Ljava/lang/String;)Lcom/mojang/datafixers/types/Type;
@@ -142,7 +142,7 @@ CLASS net/minecraft/class_156 net/minecraft/util/Util
 		COMMENT @see #getRandomOrEmpty
 		ARG 0 list
 		ARG 1 random
-	METHOD method_33141 toArray (Ljava/util/List;I)Lcom/mojang/serialization/DataResult;
+	METHOD method_33141 decodeFixedLengthList (Ljava/util/List;I)Lcom/mojang/serialization/DataResult;
 		ARG 0 list
 		ARG 1 length
 	METHOD method_33559 error (Ljava/lang/String;)V

--- a/mappings/net/minecraft/util/dynamic/Codecs.mapping
+++ b/mappings/net/minecraft/util/dynamic/Codecs.mapping
@@ -256,6 +256,9 @@ CLASS net/minecraft/class_5699 net/minecraft/util/dynamic/Codecs
 		ARG 0 json
 	METHOD method_51494 (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
 		ARG 0 string
+	METHOD method_51699 validateMap (Lcom/mojang/serialization/MapCodec;Ljava/util/function/Function;)Lcom/mojang/serialization/MapCodec;
+		ARG 0 codec
+		ARG 1 validator
 	CLASS 1
 		METHOD apply (Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;Lcom/mojang/serialization/DataResult;)Lcom/mojang/serialization/DataResult;
 			ARG 1 ops


### PR DESCRIPTION
Also renamed two misleading Util methods. They are like:
```java
    public static DataResult<int[]> decodeFixedLengthArray(IntStream stream, int length) {
        int[] is = stream.limit(length + 1).toArray();
        if (is.length != length) {
            Supplier<String> supplier = () -> "Input is not a list of " + length + " ints";
            if (is.length >= length) {
                return DataResult.error(supplier, (Object)Arrays.copyOf(is, length));
            }
            return DataResult.error(supplier);
        }
        return DataResult.success((Object)is);
    }

    public static <T> DataResult<List<T>> decodeFixedLengthList(List<T> list, int length) {
        if (list.size() != length) {
            Supplier<String> supplier = () -> "Input is not a list of " + length + " elements";
            if (list.size() >= length) {
                return DataResult.error(supplier, list.subList(0, length));
            }
            return DataResult.error(supplier);
        }
        return DataResult.success(list);
    }

```
`toArray` is misleading for the first and wrong for the second.