### PR TITLE
Fix `body`, `footer` and related methods incorrectly named in `ThreePartsLayoutWidget`

### DIFF
--- a/mappings/net/minecraft/client/gui/widget/ThreePartsLayoutWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ThreePartsLayoutWidget.mapping
@@ -1,8 +1,8 @@
 CLASS net/minecraft/class_8132 net/minecraft/client/gui/widget/ThreePartsLayoutWidget
 	FIELD field_42490 DEFAULT_HEADER_FOOTER_HEIGHT I
 	FIELD field_42491 header Lnet/minecraft/class_7843;
-	FIELD field_42492 body Lnet/minecraft/class_7843;
-	FIELD field_42493 footer Lnet/minecraft/class_7843;
+	FIELD field_42492 footer Lnet/minecraft/class_7843;
+	FIELD field_42493 body Lnet/minecraft/class_7843;
 	FIELD field_42494 screen Lnet/minecraft/class_437;
 	FIELD field_42495 headerHeight I
 	FIELD field_42496 footerHeight I
@@ -26,17 +26,17 @@ CLASS net/minecraft/class_8132 net/minecraft/client/gui/widget/ThreePartsLayoutW
 	METHOD method_48994 getFooterHeight ()I
 	METHOD method_48995 setHeaderHeight (I)V
 		ARG 1 headerHeight
-	METHOD method_48996 addBody (Lnet/minecraft/class_8021;)Lnet/minecraft/class_8021;
+	METHOD method_48996 addFooter (Lnet/minecraft/class_8021;)Lnet/minecraft/class_8021;
 		ARG 1 widget
-	METHOD method_48997 addBody (Lnet/minecraft/class_8021;Lnet/minecraft/class_7847;)Lnet/minecraft/class_8021;
+	METHOD method_48997 addFooter (Lnet/minecraft/class_8021;Lnet/minecraft/class_7847;)Lnet/minecraft/class_8021;
 		ARG 1 widget
 		ARG 2 positioner
 	METHOD method_48998 getHeaderHeight ()I
-	METHOD method_48999 addFooter (Lnet/minecraft/class_8021;)Lnet/minecraft/class_8021;
+	METHOD method_48999 addBody (Lnet/minecraft/class_8021;)Lnet/minecraft/class_8021;
 		ARG 1 widget
-	METHOD method_49000 addFooter (Lnet/minecraft/class_8021;Lnet/minecraft/class_7847;)Lnet/minecraft/class_8021;
+	METHOD method_49000 addBody (Lnet/minecraft/class_8021;Lnet/minecraft/class_7847;)Lnet/minecraft/class_8021;
 		ARG 1 widget
 		ARG 2 positioner
 	METHOD method_49001 copyHeaderPositioner ()Lnet/minecraft/class_7847;
-	METHOD method_49002 copyFooterPositioner ()Lnet/minecraft/class_7847;
-	METHOD method_49003 copyBodyPositioner ()Lnet/minecraft/class_7847;
+	METHOD method_49002 copyBodyPositioner ()Lnet/minecraft/class_7847;
+	METHOD method_49003 copyFooterPositioner ()Lnet/minecraft/class_7847;


### PR DESCRIPTION
Fixes #3564