### PR TITLE
Rename `AbstractBlock.Settings.of()` to `AbstractBlock.Settings.create()`

### DIFF
--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -991,7 +991,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 			COMMENT Specifies that a block should have no collision bounds.
 			COMMENT
 			COMMENT <p>This also marks a block as non-opaque.
-		METHOD method_9637 of ()Lnet/minecraft/class_4970$class_2251;
+		METHOD method_9637 create ()Lnet/minecraft/class_4970$class_2251;
 		METHOD method_9640 ticksRandomly ()Lnet/minecraft/class_4970$class_2251;
 	CLASS class_4971 AbstractBlockState
 		FIELD field_23166 shapeCache Lnet/minecraft/class_4970$class_4971$class_3752;


### PR DESCRIPTION
This method no longer takes an argument, so `of` doesnt make the most sense.

I went with `create` vs `builder` as its technically not a builder.

Will also need a Fabric API change to go alongside this. Im very open for discussion on this.