### PR TITLE
Fix class name possibly being null during RemapUnpickDefinitionsTask

### DIFF
--- a/filament/src/main/java/net/fabricmc/filament/task/RemapUnpickDefinitionsTask.java
+++ b/filament/src/main/java/net/fabricmc/filament/task/RemapUnpickDefinitionsTask.java
@@ -105,10 +105,8 @@ public abstract class RemapUnpickDefinitionsTask extends DefaultTask {
 					String fromClass = classDef.getName(fromM);
 					String toClass = classDef.getName(toM);
 
-					if (fromClass == null || fromClass.isEmpty()) {
-						fromClass = toClass;
-					} else if (toClass == null || toClass.isEmpty()) {
-						toClass = fromClass;
+					if (fromClass == null || toClass == null) {
+						contiune;
 					}
 
 					classMappings.put(fromClass, toClass);

--- a/filament/src/main/java/net/fabricmc/filament/task/RemapUnpickDefinitionsTask.java
+++ b/filament/src/main/java/net/fabricmc/filament/task/RemapUnpickDefinitionsTask.java
@@ -102,18 +102,27 @@ public abstract class RemapUnpickDefinitionsTask extends DefaultTask {
 				final int toM = mappingTree.getNamespaceId(getParameters().getTargetNamespace().get());
 
 				for (MappingTree.ClassMapping classDef : mappingTree.getClasses()) {
-					classMappings.put(classDef.getName(fromM), classDef.getName(toM));
+					String fromClass = classDef.getName(fromM);
+					String toClass = classDef.getName(toM);
+
+					if (fromClass == null || fromClass.isEmpty()) {
+						fromClass = toClass;
+					} else if (toClass == null || toClass.isEmpty()) {
+						toClass = fromClass;
+					}
+
+					classMappings.put(fromClass, toClass);
 
 					for (MappingTree.MethodMapping methodDef : classDef.getMethods()) {
 						methodMappings.put(
-								new MethodKey(classDef.getName(fromM), methodDef.getName(fromM), methodDef.getDesc(fromM)),
+								new MethodKey(fromClass, methodDef.getName(fromM), methodDef.getDesc(fromM)),
 								methodDef.getName(toM)
 						);
 					}
 
 					for (MappingTree.FieldMapping fieldDef : classDef.getFields()) {
 						fieldMappings.put(
-								new FieldKey(classDef.getName(fromM), fieldDef.getName(fromM)),
+								new FieldKey(fromClass, fieldDef.getName(fromM)),
 								fieldDef.getName(toM)
 						);
 					}

--- a/filament/src/main/java/net/fabricmc/filament/task/RemapUnpickDefinitionsTask.java
+++ b/filament/src/main/java/net/fabricmc/filament/task/RemapUnpickDefinitionsTask.java
@@ -106,7 +106,7 @@ public abstract class RemapUnpickDefinitionsTask extends DefaultTask {
 					String toClass = classDef.getName(toM);
 
 					if (fromClass == null || toClass == null) {
-						contiune;
+						continue;
 					}
 
 					classMappings.put(fromClass, toClass);


### PR DESCRIPTION
Mappings tree doesn't seems to be constructed the same way in mappings-io and tiny-parser during mappings read.
When an entry is the same for all namespaces in tinyv2, it is written only one time.
Then when it is read by tiny-parser, all namespace names of the entry are filled with the same value.
When it is read by mappings-io, only the first namespace of the mappings has a value and the list of names for other namespaces is empty for the entry.