### PR TITLE
Map class_8012

### DIFF
--- a/mappings/net/minecraft/util/Colors.mapping
+++ b/mappings/net/minecraft/util/Colors.mapping
@@ -1,0 +1,10 @@
+CLASS net/minecraft/class_8012 net/minecraft/util/Colors
+	COMMENT Contains constants for commonly used colors in {@code 0xAARRGGBB} format.
+	FIELD field_41758 RED I
+		COMMENT Represents the color red, {@code 0xFFFF0000}.
+	FIELD field_42973 WHITE I
+		COMMENT Represents the color white, {@code 0xFFFFFFFF}.
+	FIELD field_42974 BLACK I
+		COMMENT Represents the color black, {@code 0xFF000000}.
+	FIELD field_44941 GRAY I
+		COMMENT Represents the color gray, {@code 0xFFA0A0A0}.


### PR DESCRIPTION
This is one of the three mystery constant classes.

I diffed the pre4-pre5 and noticed that a new field was added here. I checked the usage of the newly added `field_44941` in the code diff, and it was used in `RealmsInviteScreen` as a gray color.

I then converted each field to hexadecimal unsigned int - and tada! It was all something that were meaningful as colors; white, black, and red.