### PR TITLE
1.20-pre7 symlink stuff

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/world/SymlinkWarningScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/world/SymlinkWarningScreen.mapping
@@ -1,0 +1,13 @@
+CLASS net/minecraft/class_8586 net/minecraft/client/gui/screen/world/SymlinkWarningScreen
+	FIELD field_44964 TITLE Lnet/minecraft/class_2561;
+	FIELD field_44965 MESSAGE Lnet/minecraft/class_2561;
+	FIELD field_44966 parent Lnet/minecraft/class_437;
+	FIELD field_44967 grid Lnet/minecraft/class_7845;
+	METHOD <init> (Lnet/minecraft/class_437;)V
+		ARG 1 parent
+	METHOD method_52262 (Lnet/minecraft/class_4185;)V
+		ARG 1 button
+	METHOD method_52263 (Lnet/minecraft/class_4185;)V
+		ARG 1 button
+	METHOD method_52264 (Lnet/minecraft/class_4185;)V
+		ARG 0 button

--- a/mappings/net/minecraft/client/gui/screen/world/WorldListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/screen/world/WorldListWidget.mapping
@@ -75,6 +75,7 @@ CLASS net/minecraft/class_528 net/minecraft/client/gui/screen/world/WorldListWid
 		METHOD method_33685 delete ()V
 		METHOD method_35740 getLevelDisplayName ()Ljava/lang/String;
 		METHOD method_52205 loadIcon ()V
+		METHOD method_52265 validateIconPath ()V
 	CLASS class_7414 Entry
 		METHOD method_43465 isAvailable ()Z
 	CLASS class_7415 LoadingEntry

--- a/mappings/net/minecraft/screen/ScreenTexts.mapping
+++ b/mappings/net/minecraft/screen/ScreenTexts.mapping
@@ -17,6 +17,8 @@ CLASS net/minecraft/class_5244 net/minecraft/screen/ScreenTexts
 	FIELD field_41874 SPACE Lnet/minecraft/class_2561;
 	FIELD field_43109 TO_TITLE Lnet/minecraft/class_2561;
 	FIELD field_44914 OK Lnet/minecraft/class_2561;
+	FIELD field_44968 OPEN_LINK Lnet/minecraft/class_2561;
+	FIELD field_44969 COPY_LINK_TO_CLIPBOARD Lnet/minecraft/class_2561;
 	METHOD method_30619 composeToggleText (Lnet/minecraft/class_2561;Z)Lnet/minecraft/class_5250;
 		ARG 0 text
 		ARG 1 value

--- a/mappings/net/minecraft/util/Urls.mapping
+++ b/mappings/net/minecraft/util/Urls.mapping
@@ -17,6 +17,7 @@ CLASS net/minecraft/class_8216 net/minecraft/util/Urls
 	FIELD field_43132 REALMS_TERMS Ljava/lang/String;
 	FIELD field_43133 REALMS_CONTENT_CREATOR Ljava/lang/String;
 	FIELD field_43134 UPDATE_MOJANG_ACCOUNT Ljava/lang/String;
+	FIELD field_44949 MINECRAFT_SYMLINKS Ljava/lang/String;
 	METHOD method_49719 getExtendJavaRealmsUrl (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 		ARG 0 subscriptionId
 		ARG 1 profileId

--- a/mappings/net/minecraft/util/path/AllowedSymlinkPathMatcher.mapping
+++ b/mappings/net/minecraft/util/path/AllowedSymlinkPathMatcher.mapping
@@ -1,0 +1,47 @@
+CLASS net/minecraft/class_8582 net/minecraft/util/path/AllowedSymlinkPathMatcher
+	FIELD field_44958 LOGGER Lorg/slf4j/Logger;
+	FIELD field_44959 COMMENT_LINE_PREFIX Ljava/lang/String;
+	FIELD field_44960 allowedEntries Ljava/util/List;
+	FIELD field_44961 matcherCache Ljava/util/Map;
+	METHOD <init> (Ljava/util/List;)V
+		ARG 1 allowedEntries
+	METHOD matches (Ljava/nio/file/Path;)Z
+		ARG 1 path
+	METHOD method_52247 fromReader (Ljava/io/BufferedReader;)Lnet/minecraft/class_8582;
+		ARG 0 reader
+	METHOD method_52248 (Ljava/lang/String;)Ljava/util/stream/Stream;
+		ARG 0 line
+	METHOD method_52249 get (Ljava/nio/file/FileSystem;)Ljava/nio/file/PathMatcher;
+		ARG 1 fileSystem
+	METHOD method_52250 (Ljava/nio/file/FileSystem;Lnet/minecraft/class_8582$class_8583;)Ljava/nio/file/PathMatcher;
+		ARG 1 entry
+	METHOD method_52251 (Ljava/nio/file/FileSystem;Ljava/lang/String;)Ljava/nio/file/PathMatcher;
+		ARG 2 scheme
+	METHOD method_52252 (Ljava/nio/file/Path;)Z
+		ARG 0 path
+	METHOD method_52253 (Ljava/util/List;Ljava/nio/file/Path;)Z
+		ARG 1 path
+	METHOD method_52254 (Ljava/nio/file/Path;)Z
+		ARG 0 path
+	CLASS class_8583 Entry
+		METHOD method_52255 readLine (Ljava/lang/String;)Ljava/util/Optional;
+			ARG 0 line
+		METHOD method_52256 compile (Ljava/nio/file/FileSystem;)Ljava/nio/file/PathMatcher;
+			ARG 1 fileSystem
+		METHOD method_52257 glob (Ljava/lang/String;)Lnet/minecraft/class_8582$class_8583;
+			ARG 0 pattern
+		METHOD method_52258 regex (Ljava/lang/String;)Lnet/minecraft/class_8582$class_8583;
+			ARG 0 pattern
+		METHOD method_52259 prefix (Ljava/lang/String;)Lnet/minecraft/class_8582$class_8583;
+			ARG 0 prefix
+	CLASS class_8584 EntryType
+		FIELD field_44962 DEFAULT Lnet/minecraft/class_8582$class_8584;
+		FIELD field_44963 PREFIX Lnet/minecraft/class_8582$class_8584;
+		METHOD compile (Ljava/nio/file/FileSystem;Ljava/lang/String;)Ljava/nio/file/PathMatcher;
+			ARG 1 fileSystem
+			ARG 2 pattern
+		METHOD method_52260 (Ljava/lang/String;Ljava/nio/file/Path;)Z
+			ARG 1 path
+		METHOD method_52261 (Ljava/nio/file/FileSystem;Ljava/lang/String;)Ljava/nio/file/PathMatcher;
+			ARG 0 fileSystem
+			ARG 1 prefix

--- a/mappings/net/minecraft/util/path/SymlinkEntry.mapping
+++ b/mappings/net/minecraft/util/path/SymlinkEntry.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_8581 net/minecraft/util/path/SymlinkEntry

--- a/mappings/net/minecraft/util/path/SymlinkFinder.mapping
+++ b/mappings/net/minecraft/util/path/SymlinkFinder.mapping
@@ -1,0 +1,20 @@
+CLASS net/minecraft/class_8580 net/minecraft/util/path/SymlinkFinder
+	FIELD field_44955 matcher Lnet/minecraft/class_8582;
+	METHOD <init> (Lnet/minecraft/class_8582;)V
+		ARG 1 matcher
+	METHOD method_52242 validate (Ljava/nio/file/Path;Ljava/util/List;)V
+		ARG 1 path
+		ARG 2 results
+	METHOD method_52243 collect (Ljava/nio/file/Path;Z)Ljava/util/List;
+		ARG 1 path
+		ARG 2 resolveSymlink
+	CLASS 1
+		METHOD method_52246 validate (Ljava/nio/file/Path;Ljava/nio/file/attribute/BasicFileAttributes;)V
+			ARG 1 path
+			ARG 2 attributes
+		METHOD preVisitDirectory (Ljava/lang/Object;Ljava/nio/file/attribute/BasicFileAttributes;)Ljava/nio/file/FileVisitResult;
+			ARG 1 path
+			ARG 2 attributes
+		METHOD visitFile (Ljava/lang/Object;Ljava/nio/file/attribute/BasicFileAttributes;)Ljava/nio/file/FileVisitResult;
+			ARG 1 path
+			ARG 2 attributes

--- a/mappings/net/minecraft/util/path/SymlinkValidationException.mapping
+++ b/mappings/net/minecraft/util/path/SymlinkValidationException.mapping
@@ -1,0 +1,11 @@
+CLASS net/minecraft/class_8579 net/minecraft/util/path/SymlinkValidationException
+	FIELD field_44953 path Ljava/nio/file/Path;
+	FIELD field_44954 symlinks Ljava/util/List;
+	METHOD <init> (Ljava/nio/file/Path;Ljava/util/List;)V
+		ARG 1 path
+		ARG 2 symlinks
+	METHOD method_52240 (Lnet/minecraft/class_8581;)Ljava/lang/String;
+		ARG 0 symlink
+	METHOD method_52241 getMessage (Ljava/nio/file/Path;Ljava/util/List;)Ljava/lang/String;
+		ARG 0 path
+		ARG 1 symlinks

--- a/mappings/net/minecraft/world/level/storage/LevelStorage.mapping
+++ b/mappings/net/minecraft/world/level/storage/LevelStorage.mapping
@@ -6,9 +6,14 @@ CLASS net/minecraft/class_32 net/minecraft/world/level/storage/LevelStorage
 	FIELD field_200 TIME_FORMATTER Ljava/time/format/DateTimeFormatter;
 	FIELD field_25020 GENERATOR_OPTION_KEYS Lcom/google/common/collect/ImmutableList;
 	FIELD field_36348 DATA_KEY Ljava/lang/String;
+	FIELD field_44950 ALLOWED_SYMLINKS_FILE_NAME Ljava/lang/String;
+	FIELD field_44951 DEFAULT_ALLOWED_SYMLINK_MATCHER Lnet/minecraft/class_8582;
+	FIELD field_44952 symlinkFinder Lnet/minecraft/class_8580;
 	METHOD <init> (Ljava/nio/file/Path;Ljava/nio/file/Path;Lnet/minecraft/class_8580;Lcom/mojang/datafixers/DataFixer;)V
 		ARG 1 savesDirectory
 		ARG 2 backupsDirectory
+		ARG 3 symlinkFinder
+		ARG 4 dataFixer
 	METHOD method_17926 createLevelDataParser (Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/class_7712;Lnet/minecraft/class_2378;Lcom/mojang/serialization/Lifecycle;)Ljava/util/function/BiFunction;
 		ARG 0 ops
 		ARG 1 dataConfiguration
@@ -27,7 +32,7 @@ CLASS net/minecraft/class_32 net/minecraft/world/level/storage/LevelStorage
 		ARG 2 levelDataParser
 	METHOD method_26999 create (Ljava/nio/file/Path;)Lnet/minecraft/class_32;
 		ARG 0 path
-	METHOD method_27002 createSession (Ljava/lang/String;)Lnet/minecraft/class_32$class_5143;
+	METHOD method_27002 createSessionWithoutSymlinkCheck (Ljava/lang/String;)Lnet/minecraft/class_32$class_5143;
 		ARG 1 directoryName
 	METHOD method_29010 readGeneratorProperties (Lcom/mojang/serialization/Dynamic;Lcom/mojang/datafixers/DataFixer;I)Lcom/mojang/serialization/DataResult;
 		ARG 0 levelData
@@ -67,6 +72,13 @@ CLASS net/minecraft/class_32 net/minecraft/world/level/storage/LevelStorage
 		ARG 0 levelData
 	METHOD method_45553 (Lcom/mojang/serialization/Dynamic;)Ljava/util/stream/Stream;
 		ARG 0 featureFlag
+	METHOD method_52235 createSymlinkFinder (Ljava/nio/file/Path;)Lnet/minecraft/class_8580;
+		ARG 0 allowedSymlinksFile
+	METHOD method_52236 createSession (Ljava/lang/String;)Lnet/minecraft/class_32$class_5143;
+		ARG 1 directoryName
+	METHOD method_52237 getSymlinkFinder ()Lnet/minecraft/class_8580;
+	METHOD method_52238 resolve (Ljava/lang/String;)Ljava/nio/file/Path;
+		ARG 1 name
 	CLASS class_5143 Session
 		FIELD field_23767 lock Lnet/minecraft/class_5125;
 		FIELD field_23768 directory Lnet/minecraft/class_32$class_7411;
@@ -74,6 +86,7 @@ CLASS net/minecraft/class_32 net/minecraft/world/level/storage/LevelStorage
 		FIELD field_24190 paths Ljava/util/Map;
 		METHOD <init> (Lnet/minecraft/class_32;Ljava/lang/String;Ljava/nio/file/Path;)V
 			ARG 2 directoryName
+			ARG 3 path
 		METHOD method_27005 getDirectoryName ()Ljava/lang/String;
 		METHOD method_27008 save (Ljava/lang/String;)V
 			ARG 1 name

--- a/mappings/net/minecraft/world/level/storage/LevelSummary.mapping
+++ b/mappings/net/minecraft/world/level/storage/LevelSummary.mapping
@@ -50,3 +50,9 @@ CLASS net/minecraft/class_34 net/minecraft/world/level/storage/LevelSummary
 		METHOD method_33406 promptsBackup ()Z
 		METHOD method_33407 needsBoldRedFormatting ()Z
 		METHOD method_33408 getTranslationKeySuffix ()Ljava/lang/String;
+	CLASS class_8578 SymlinkLevelSummary
+		METHOD <init> (Ljava/lang/String;Ljava/nio/file/Path;)V
+			ARG 1 name
+			ARG 2 iconPath
+		METHOD method_52239 (Lnet/minecraft/class_2583;)Lnet/minecraft/class_2583;
+			ARG 0 style


### PR DESCRIPTION
New package: `net.minecraft.util.path`. `PathUtil` and `ZipCompressor` will be repackaged in a next big update. Since the file it reads is `allowed_symlinks.txt`, I made it one word.