### PR TITLE
Rename `originalHealth` to `damage` in `DamageTracker#onDamage`

### DIFF
--- a/mappings/net/minecraft/entity/damage/DamageTracker.mapping
+++ b/mappings/net/minecraft/entity/damage/DamageTracker.mapping
@@ -28,5 +28,5 @@ CLASS net/minecraft/class_1283 net/minecraft/entity/damage/DamageTracker
 	METHOD method_5546 getTimeSinceLastAttack ()I
 	METHOD method_5547 onDamage (Lnet/minecraft/class_1282;F)V
 		ARG 1 damageSource
-		ARG 2 originalHealth
+		ARG 2 damage
 	METHOD method_5548 getDeathMessage ()Lnet/minecraft/class_2561;


### PR DESCRIPTION
In [this commit](https://github.com/FabricMC/yarn/commit/e0f6764c4d0509eb5e193a3a9750f9704b7c22d9#diff-d72bb65d3fa74dcf087d338f4253d609d6e4027d49fbe2025d90bdceb3dab843L30-L33) the `damage` argument was removed instead of `originalHealth`