### PR TITLE
Rename `unlockCraftedRecipe` to `onRecipeCrafted` in `PlayerEntity`

### DIFF
--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -122,7 +122,7 @@ CLASS net/minecraft/class_1657 net/minecraft/entity/player/PlayerEntity
 		ARG 1 lastDeathPos
 	METHOD method_43122 getLastDeathPos ()Ljava/util/Optional;
 	METHOD method_45015 shouldCloseHandledScreenOnRespawn ()Z
-	METHOD method_51283 unlockCraftedRecipe (Lnet/minecraft/class_1860;Ljava/util/List;)V
+	METHOD method_51283 onRecipeCrafted (Lnet/minecraft/class_1860;Ljava/util/List;)V
 		ARG 1 recipe
 		ARG 2 ingredients
 	METHOD method_7254 unlockRecipes (Ljava/util/Collection;)I


### PR DESCRIPTION
This method doesn't unlock any recipes, it triggers the `recipe_crafted` advancement criteria in `ServerPlayerEntity`

```java
@Override
public void unlockCraftedRecipe(Recipe<?> recipe, List<ItemStack> ingredients) {
	Criteria.RECIPE_CRAFTED.trigger(this, recipe.getId(), ingredients);
}
```