### PR TITLE
Swapped parameters in DrawContext#fill to be the right way around

### DIFF
--- a/mappings/net/minecraft/client/gui/DrawContext.mapping
+++ b/mappings/net/minecraft/client/gui/DrawContext.mapping
@@ -183,8 +183,8 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawContext
 	METHOD method_48196 fill (Lnet/minecraft/class_1921;IIIIII)V
 		ARG 1 layer
 		ARG 2 x1
-		ARG 3 x2
-		ARG 4 y1
+		ARG 3 y1
+		ARG 4 x2
 		ARG 5 y2
 		ARG 6 z
 		ARG 7 color
@@ -422,8 +422,8 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawContext
 	METHOD method_51739 fill (Lnet/minecraft/class_1921;IIIII)V
 		ARG 1 layer
 		ARG 2 x1
-		ARG 3 x2
-		ARG 4 y1
+		ARG 3 y1
+		ARG 4 x2
 		ARG 5 y2
 		ARG 6 color
 	METHOD method_51740 fillGradient (Lnet/minecraft/class_1921;IIIIIII)V


### PR DESCRIPTION
The `x2` and `y1` parameters in two instances of `net.minecraft.client.gui.DrawContext#fill` were swapped around the wrong way. The correct way is `x1, y1, x2, y2`.