### PR TITLE
GameMenuScreen constants

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/GameMenuScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/GameMenuScreen.mapping
@@ -6,6 +6,11 @@ CLASS net/minecraft/class_433 net/minecraft/client/gui/screen/GameMenuScreen
 	FIELD field_41613 SAVING_LEVEL_TEXT Lnet/minecraft/class_2561;
 	FIELD field_41614 GAME_TEXT Lnet/minecraft/class_2561;
 	FIELD field_41615 PAUSED_TEXT Lnet/minecraft/class_2561;
+	FIELD field_41616 GRID_COLUMNS I
+	FIELD field_41617 BUTTONS_TOP_MARGIN I
+	FIELD field_41618 GRID_MARGIN I
+	FIELD field_41619 WIDE_BUTTON_WIDTH I
+	FIELD field_41620 NORMAL_BUTTON_WIDTH I
 	FIELD field_41621 RETURN_TO_GAME_TEXT Lnet/minecraft/class_2561;
 	FIELD field_41622 ADVANCEMENTS_TEXT Lnet/minecraft/class_2561;
 	FIELD field_41623 STATS_TEXT Lnet/minecraft/class_2561;


### PR DESCRIPTION
Maps the unnamed constants in `GameMenuScreen`. 
Not really sure about `BUTTONS_TOP_MARGIN`, that name might not be the clearest, I'm open for suggestions.