### PR TITLE
Rename registerPressurePlate to registerWeightedPressurePlate 

### DIFF
--- a/mappings/net/minecraft/data/client/BlockStateModelGenerator.mapping
+++ b/mappings/net/minecraft/data/client/BlockStateModelGenerator.mapping
@@ -281,8 +281,8 @@ CLASS net/minecraft/class_4910 net/minecraft/data/client/BlockStateModelGenerato
 	METHOD method_25664 registerTallSeagrass ()V
 	METHOD method_25665 registerOrientableTrapdoor (Lnet/minecraft/class_2248;)V
 		ARG 1 trapdoorBlock
-	METHOD method_25666 registerPressurePlate (Lnet/minecraft/class_2248;Lnet/minecraft/class_2248;)V
-		ARG 1 pressurePlate
+	METHOD method_25666 registerWeightedPressurePlate (Lnet/minecraft/class_2248;Lnet/minecraft/class_2248;)V
+		ARG 1 weightedPressurePlate
 		ARG 2 textureSource
 	METHOD method_25667 createAxisRotatedBlockState (Lnet/minecraft/class_2248;Lnet/minecraft/class_2960;Lnet/minecraft/class_2960;)Lnet/minecraft/class_4917;
 		ARG 0 block


### PR DESCRIPTION
This method in `BlockStateModelGenerator` uses the `POWERED` property, which is not present in `PressurePlateBlock`, only `WeightedPressurePlateBlock`.
Normal pressure plates are instead handled by `BlockTexturePool#pressurePlate`.
A case of confusion caused by the previous name can be seen [here](https://discord.com/channels/507304429255393322/507982478276034570/1131634487512543382).