### PR TITLE
Rename `StringIdentifiable.Codec` to `StringIdentifiable.EnumCodec`

### DIFF
--- a/mappings/net/minecraft/util/StringIdentifiable.mapping
+++ b/mappings/net/minecraft/util/StringIdentifiable.mapping
@@ -5,6 +5,7 @@ CLASS net/minecraft/class_3542 net/minecraft/util/StringIdentifiable
 	COMMENT @apiNote To make an enum serializable with codecs, implement this on the enum class,
 	COMMENT implement {@link #asString} to return a unique ID, and add a {@code static final}
 	COMMENT field that holds {@linkplain #createCodec the codec for the enum}.
+	FIELD field_38377 CACHED_MAP_THRESHOLD I
 	METHOD method_15434 asString ()Ljava/lang/String;
 		COMMENT {@return the unique string representation of the enum, used for serialization}
 	METHOD method_28140 createCodec (Ljava/util/function/Supplier;)Lnet/minecraft/class_3542$class_7292;
@@ -31,7 +32,7 @@ CLASS net/minecraft/class_3542 net/minecraft/util/StringIdentifiable
 	CLASS 1
 		METHOD keys (Lcom/mojang/serialization/DynamicOps;)Ljava/util/stream/Stream;
 			ARG 1 ops
-	CLASS class_7292 Codec
+	CLASS class_7292 EnumCodec
 		FIELD field_38378 base Lcom/mojang/serialization/Codec;
 		FIELD field_38379 idToIdentifiable Ljava/util/function/Function;
 		METHOD <init> ([Ljava/lang/Enum;Ljava/util/function/Function;)V


### PR DESCRIPTION
This pull request changes the name of the inner class of `StringIdentifiable` from `Codec` to `EnumCodec`. That way we don't have to fully specify `com.mojang.serialization.Codec<...>` when using such an instance in an enum that implements `StringIdentifiable`, as it by default selects `net.minecraft.util.StringIdentifiable.Codec`. (It would also prevent the fully specified name in the class itself when viewing the source, though that's really just an implementation detail.) On top of that, the codec is only really used for enums as per the `StringIdentifiable::createCodec` method, so this change would also reflect its usage better.
It also maps the one field present in `StringIdentifiable`.