### PR TITLE
Document missing properties & improve a few names

### DIFF
--- a/mappings/net/minecraft/block/BlockWithEntity.mapping
+++ b/mappings/net/minecraft/block/BlockWithEntity.mapping
@@ -11,7 +11,7 @@ CLASS net/minecraft/class_2237 net/minecraft/block/BlockWithEntity
 	COMMENT
 	COMMENT @see net.minecraft.block.entity.BlockEntity
 	COMMENT @see BlockEntityProvider
-	METHOD method_31618 checkType (Lnet/minecraft/class_2591;Lnet/minecraft/class_2591;Lnet/minecraft/class_5558;)Lnet/minecraft/class_5558;
+	METHOD method_31618 validateTicker (Lnet/minecraft/class_2591;Lnet/minecraft/class_2591;Lnet/minecraft/class_5558;)Lnet/minecraft/class_5558;
 		COMMENT {@return the ticker if the given type and expected type are the same, or {@code null} if they are different}
 		ARG 0 givenType
 		ARG 1 expectedType

--- a/mappings/net/minecraft/block/ConnectingBlock.mapping
+++ b/mappings/net/minecraft/block/ConnectingBlock.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/class_2429 net/minecraft/block/ConnectingBlock
 	FIELD field_11330 DOWN Lnet/minecraft/class_2746;
 	FIELD field_11331 SOUTH Lnet/minecraft/class_2746;
 	FIELD field_11332 NORTH Lnet/minecraft/class_2746;
-	FIELD field_11333 connectionsToShape [Lnet/minecraft/class_265;
+	FIELD field_11333 facingsToShape [Lnet/minecraft/class_265;
 	FIELD field_11334 FACINGS [Lnet/minecraft/class_2350;
 	FIELD field_11335 EAST Lnet/minecraft/class_2746;
 	METHOD <init> (FLnet/minecraft/class_4970$class_2251;)V

--- a/mappings/net/minecraft/block/enums/BlockFace.mapping
+++ b/mappings/net/minecraft/block/enums/BlockFace.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2738 net/minecraft/block/enums/WallMountLocation
+CLASS net/minecraft/class_2738 net/minecraft/block/enums/BlockFace
 	FIELD field_12472 name Ljava/lang/String;
 	METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
 		ARG 3 name

--- a/mappings/net/minecraft/state/property/Properties.mapping
+++ b/mappings/net/minecraft/state/property/Properties.mapping
@@ -129,6 +129,7 @@ CLASS net/minecraft/class_2741 net/minecraft/state/property/Properties
 		COMMENT
 		COMMENT <p>This property is normally used for doors, trapdoors and fence gates but is also used by barrels.
 	FIELD field_12538 LEVEL_15 Lnet/minecraft/class_2758;
+		COMMENT A property that specifies the level of a light block or a fluid block on a scale of 0 to 15.
 	FIELD field_12539 UNSTABLE Lnet/minecraft/class_2746;
 		COMMENT  A property that specifies if TNT is unstable.
 		COMMENT
@@ -167,8 +168,8 @@ CLASS net/minecraft/class_2741 net/minecraft/state/property/Properties
 		COMMENT A property that specifies if a tripwire has been disarmed.
 	FIELD field_12554 HAS_BOTTLE_0 Lnet/minecraft/class_2746;
 		COMMENT A property that specifies if a brewing stand has a bottle in slot 0.
-	FIELD field_12555 WALL_MOUNT_LOCATION Lnet/minecraft/class_2754;
-		COMMENT A property that specifies the type of wall a block is attached to.
+	FIELD field_12555 BLOCK_FACE Lnet/minecraft/class_2754;
+		COMMENT A property that specifies the block face a block is attached to.
 	FIELD field_12556 AGE_2 Lnet/minecraft/class_2758;
 		COMMENT A property that specifies the age of a block on a scale of 0 to 2.
 	FIELD field_16503 DISTANCE_0_7 Lnet/minecraft/class_2758;
@@ -204,10 +205,17 @@ CLASS net/minecraft/class_2741 net/minecraft/state/property/Properties
 	FIELD field_27220 CANDLES Lnet/minecraft/class_2758;
 		COMMENT A property that specifies the amount of candles in a candle block.
 	FIELD field_28062 VERTICAL_DIRECTION Lnet/minecraft/class_2753;
+		COMMENT A property that specifies the direction a pointed dripstone is facing.
+		COMMENT
+		COMMENT <p>This property allows a block to face either down or up.
 	FIELD field_28063 THICKNESS Lnet/minecraft/class_2754;
+		COMMENT A property that specifies the thickness of a pointed dripstone.
 	FIELD field_28120 SCULK_SENSOR_PHASE Lnet/minecraft/class_2754;
+		COMMENT A property that specifies the current phase of a sculk sensor.
 	FIELD field_28716 BERRIES Lnet/minecraft/class_2746;
+		COMMENT A property that specifies the amount of berries in a cave vines block.
 	FIELD field_28717 TILT Lnet/minecraft/class_2754;
+		COMMENT A property that specifies how a big dripleaf is tilted down.
 	FIELD field_31387 LEVEL_3_MIN I
 	FIELD field_31388 LEVEL_1_8_MIN I
 	FIELD field_31389 LEVEL_3_MAX I
@@ -225,19 +233,32 @@ CLASS net/minecraft/class_2741 net/minecraft/state/property/Properties
 	FIELD field_31402 DISTANCE_1_7_MAX I
 	FIELD field_33723 LEVEL_15_MAX I
 	FIELD field_37651 BLOOM Lnet/minecraft/class_2746;
+		COMMENT A property that specifies if a sculk catalyst is blooming.
 	FIELD field_37652 SHRIEKING Lnet/minecraft/class_2746;
+		COMMENT A property that specifies if a sculk shrieker is shrieking.
 	FIELD field_37653 AGE_4_MAX I
 	FIELD field_37654 AGE_4 Lnet/minecraft/class_2758;
+		COMMENT A property that specifies the age of a block on a scale of 0 to 4.
 	FIELD field_38423 CAN_SUMMON Lnet/minecraft/class_2746;
+		COMMENT A property that specifies if a sculk shrieker can summon a warden.
 	FIELD field_41317 SLOT_0_OCCUPIED Lnet/minecraft/class_2746;
+		COMMENT A property that specifies if a chiseled bookshelf has a book in slot 0.
 	FIELD field_41318 SLOT_1_OCCUPIED Lnet/minecraft/class_2746;
+		COMMENT A property that specifies if a chiseled bookshelf has a book in slot 1.
 	FIELD field_41319 SLOT_2_OCCUPIED Lnet/minecraft/class_2746;
+		COMMENT A property that specifies if a chiseled bookshelf has a book in slot 2.
 	FIELD field_41320 SLOT_3_OCCUPIED Lnet/minecraft/class_2746;
+		COMMENT A property that specifies if a chiseled bookshelf has a book in slot 3.
 	FIELD field_41321 SLOT_4_OCCUPIED Lnet/minecraft/class_2746;
+		COMMENT A property that specifies if a chiseled bookshelf has a book in slot 4.
 	FIELD field_41322 SLOT_5_OCCUPIED Lnet/minecraft/class_2746;
+		COMMENT A property that specifies if a chiseled bookshelf has a book in slot 5.
 	FIELD field_42835 FLOWER_AMOUNT Lnet/minecraft/class_2758;
+		COMMENT A property that specifies the amount of flowers in a pink petals block.
 	FIELD field_42836 DUSTED Lnet/minecraft/class_2758;
+		COMMENT A property that specifies how much a brushable block is dusted on a scale of 0 to 3.
 	FIELD field_43307 CRACKED Lnet/minecraft/class_2746;
+		COMMENT A property that specifies if a decorated pot is cracked.
 	METHOD method_11813 (Lnet/minecraft/class_2768;)Z
 		ARG 0 shape
 	METHOD method_11814 (Lnet/minecraft/class_2350;)Z


### PR DESCRIPTION
- Document missing state properties
- Closes #2828 by renaming `WallMountLocation`  to `BlockFace`
- Closes #2593 by renaming `connectionsToShape` to `facingsToShape`
- Closes #2046 by renaming `checkType` to `validateTicker`