### PR TITLE
Document ButtonTextures and fix constructor parameters

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/ButtonTextures.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ButtonTextures.mapping
@@ -4,8 +4,8 @@ CLASS net/minecraft/class_8666 net/minecraft/client/gui/screen/ButtonTextures
 		ARG 2 focused
 	METHOD <init> (Lnet/minecraft/class_2960;Lnet/minecraft/class_2960;Lnet/minecraft/class_2960;)V
 		ARG 1 enabled
-		ARG 2 focused
-		ARG 3 disabled
+		ARG 2 disabled
+		ARG 3 focused
 	METHOD method_52729 get (ZZ)Lnet/minecraft/class_2960;
 		ARG 1 enabled
 		ARG 2 focused

--- a/mappings/net/minecraft/client/gui/screen/ButtonTextures.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ButtonTextures.mapping
@@ -1,11 +1,34 @@
 CLASS net/minecraft/class_8666 net/minecraft/client/gui/screen/ButtonTextures
+	COMMENT A set of button textures. It contains four texture choices, one of each of the cases
+	COMMENT where a button is enabled/disabled and focused/not focused.
+	FIELD comp_1604 Lnet/minecraft/class_2960;
+		COMMENT the texture for when the widget is enabled, but not focused
+	FIELD comp_1605 Lnet/minecraft/class_2960;
+		COMMENT the texture for when the widget is disabled, but not focused
+	FIELD comp_1606 Lnet/minecraft/class_2960;
+		COMMENT the texture for when the widget is enabled and focused
+	FIELD comp_1607 Lnet/minecraft/class_2960;
+		COMMENT the texture for when the widget is disabled and focused
 	METHOD <init> (Lnet/minecraft/class_2960;Lnet/minecraft/class_2960;)V
+		COMMENT Constructs a set of button textures where only focusing the widget affects
+		COMMENT the textures.
 		ARG 1 unfocused
+			COMMENT the texture for when the widget is not focused
 		ARG 2 focused
+			COMMENT the texture for when the widget is focused
 	METHOD <init> (Lnet/minecraft/class_2960;Lnet/minecraft/class_2960;Lnet/minecraft/class_2960;)V
+		COMMENT Constructs a set of button textures where both disabled cases use the same texture.
 		ARG 1 enabled
+			COMMENT the texture for when the widget is enabled, but not focused
 		ARG 2 disabled
+			COMMENT the texture for when the widget is disabled
 		ARG 3 focused
+			COMMENT the texture for when the widget is enabled and focused
 	METHOD method_52729 get (ZZ)Lnet/minecraft/class_2960;
+		COMMENT Gets a specific texture option from this texture set.
+		COMMENT
+		COMMENT @return the texture identifier matching the widget state
 		ARG 1 enabled
+			COMMENT {@code true} if the widget is enabled, {@code false} otherwise
 		ARG 2 focused
+			COMMENT {@code true} if the widget is focused, {@code false} otherwise


### PR DESCRIPTION
Adds javadoc to the class and fixes the param order in `<init>(Identifier, Identifier, Identifier)`