### PR TITLE
Rename BackgroundRenderer#setFogBlack, map constants

### DIFF
--- a/mappings/net/minecraft/client/render/BackgroundRenderer.mapping
+++ b/mappings/net/minecraft/client/render/BackgroundRenderer.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_758 net/minecraft/client/render/BackgroundRenderer
+	FIELD field_32684 WATER_FOG_CHANGE_DURATION F
+	FIELD field_32685 WATER_FOG_LENGTH I
 	FIELD field_38338 FOG_MODIFIERS Ljava/util/List;
 	FIELD field_4031 waterFogColor I
 	FIELD field_4032 blue F
@@ -23,7 +25,7 @@ CLASS net/minecraft/class_758 net/minecraft/client/render/BackgroundRenderer
 		ARG 2 viewDistance
 		ARG 3 thickFog
 		ARG 4 tickDelta
-	METHOD method_3212 setFogBlack ()V
+	METHOD method_3212 applyFogColor ()V
 	METHOD method_42588 getFogModifier (Lnet/minecraft/class_1297;F)Lnet/minecraft/class_758$class_7286;
 		ARG 0 entity
 		ARG 1 tickDelta


### PR DESCRIPTION
Resolves #3603. Renames `BackgroundRenderer#setFogBlack` to `BackgroundRenderer#applyFogColor`. Also maps the two remaining constants;
- WATER_FOG_LENGTH seems to be used in the calculation for how long fog in water should appear for (around like 230).
- WATER_FOG_CHANGE_DURATION is more of a guess but it seems to only be used with lastWaterFogColorUpdateTime, so this seems like a reasonable guess