### PR TITLE
Update method names in DefaultSkinHelper to reflect new return type

### DIFF
--- a/mappings/net/minecraft/client/util/DefaultSkinHelper.mapping
+++ b/mappings/net/minecraft/client/util/DefaultSkinHelper.mapping
@@ -1,9 +1,9 @@
 CLASS net/minecraft/class_1068 net/minecraft/client/util/DefaultSkinHelper
 	FIELD field_41121 SKINS [Lnet/minecraft/class_8685;
-	METHOD method_4648 getTexture (Ljava/util/UUID;)Lnet/minecraft/class_8685;
+	METHOD method_4648 getSkinTextures (Ljava/util/UUID;)Lnet/minecraft/class_8685;
 		ARG 0 uuid
 	METHOD method_4649 getTexture ()Lnet/minecraft/class_2960;
-	METHOD method_52854 getTexture (Lcom/mojang/authlib/GameProfile;)Lnet/minecraft/class_8685;
+	METHOD method_52854 getSkinTextures (Lcom/mojang/authlib/GameProfile;)Lnet/minecraft/class_8685;
 		ARG 0 profile
 	METHOD method_52855 createSkinTextures (Ljava/lang/String;Lnet/minecraft/class_8685$class_7920;)Lnet/minecraft/class_8685;
 		ARG 0 texture


### PR DESCRIPTION
I noticed that, as of 1.20.2, the names of two of the `getTexture` methods in `DefaultSkinHelper` no longer make sense given the changed return type of those methods. They now return an instance of `SkinTextures`, instead of an `Identifier`, so naming them `getSkinTextures` seems more appropriate.