### PR TITLE
Fix minor capitalisation error on field name

### DIFF
--- a/mappings/net/minecraft/client/render/entity/feature/SaddleFeatureRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/SaddleFeatureRenderer.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_992 net/minecraft/client/render/entity/feature/SaddleFeatureRenderer
 	FIELD field_4887 model Lnet/minecraft/class_583;
-	FIELD field_4888 TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_4888 texture Lnet/minecraft/class_2960;
 	METHOD <init> (Lnet/minecraft/class_3883;Lnet/minecraft/class_583;Lnet/minecraft/class_2960;)V
 		ARG 1 context
 		ARG 2 model


### PR DESCRIPTION
This fixes an all-caps name I noticed on a non-static field.