### PR TITLE
Make remove and add tag method names more consistent

### DIFF
--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -1595,7 +1595,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT @see #streamSelfAndPassengers
 		COMMENT @see #streamPassengersAndSelf
 	METHOD method_5737 getSwimSound ()Lnet/minecraft/class_3414;
-	METHOD method_5738 removeScoreboardTag (Ljava/lang/String;)Z
+	METHOD method_5738 removeCommandTag (Ljava/lang/String;)Z
 		COMMENT Removes a command tag from this entity.
 		COMMENT
 		COMMENT <p>Command tags are set using the {@linkplain net.minecraft.server.command.TagCommand


### PR DESCRIPTION
Changes `removeScoreboardTag` in `Entity` to be consistent with its `addCommandTag` method.