### PR TITLE
Repackage GUI classes

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/multiplayer/AddServerScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/multiplayer/AddServerScreen.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_422 net/minecraft/client/gui/screen/AddServerScreen
+CLASS net/minecraft/class_422 net/minecraft/client/gui/screen/multiplayer/AddServerScreen
 	FIELD field_19236 callback Lit/unimi/dsi/fastutil/booleans/BooleanConsumer;
 	FIELD field_21791 parent Lnet/minecraft/class_437;
 	FIELD field_2469 server Lnet/minecraft/class_642;

--- a/mappings/net/minecraft/client/gui/screen/multiplayer/ConnectScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/multiplayer/ConnectScreen.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_412 net/minecraft/client/gui/screen/ConnectScreen
+CLASS net/minecraft/class_412 net/minecraft/client/gui/screen/multiplayer/ConnectScreen
 	COMMENT The connection screen is used to initiate a connection to a remote server.
 	COMMENT This is only used when connecting over LAN or to a remote dedicated server.
 	FIELD field_19097 lastNarrationTime J

--- a/mappings/net/minecraft/client/gui/screen/multiplayer/DirectConnectScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/multiplayer/DirectConnectScreen.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_420 net/minecraft/client/gui/screen/DirectConnectScreen
+CLASS net/minecraft/class_420 net/minecraft/client/gui/screen/multiplayer/DirectConnectScreen
 	FIELD field_19235 callback Lit/unimi/dsi/fastutil/booleans/BooleanConsumer;
 	FIELD field_21790 parent Lnet/minecraft/class_437;
 	FIELD field_2460 serverEntry Lnet/minecraft/class_642;

--- a/mappings/net/minecraft/client/gui/screen/world/BackupPromptScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/world/BackupPromptScreen.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_405 net/minecraft/client/gui/screen/BackupPromptScreen
+CLASS net/minecraft/class_405 net/minecraft/client/gui/screen/world/BackupPromptScreen
 	FIELD field_19232 showEraseCacheCheckbox Z
 	FIELD field_19234 eraseCacheCheckbox Lnet/minecraft/class_4286;
 	FIELD field_2364 subtitle Lnet/minecraft/class_2561;

--- a/mappings/net/minecraft/client/gui/screen/world/CustomizeBuffetLevelScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/world/CustomizeBuffetLevelScreen.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_415 net/minecraft/client/gui/screen/CustomizeBuffetLevelScreen
+CLASS net/minecraft/class_415 net/minecraft/client/gui/screen/world/CustomizeBuffetLevelScreen
 	FIELD field_2438 confirmButton Lnet/minecraft/class_4185;
 	FIELD field_2441 biomeSelectionList Lnet/minecraft/class_415$class_4190;
 	FIELD field_24562 parent Lnet/minecraft/class_437;

--- a/mappings/net/minecraft/client/gui/screen/world/CustomizeFlatLevelScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/world/CustomizeFlatLevelScreen.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_413 net/minecraft/client/gui/screen/CustomizeFlatLevelScreen
+CLASS net/minecraft/class_413 net/minecraft/client/gui/screen/world/CustomizeFlatLevelScreen
 	FIELD field_2418 tileText Lnet/minecraft/class_2561;
 	FIELD field_2419 config Lnet/minecraft/class_3232;
 	FIELD field_2421 widgetButtonRemoveLayer Lnet/minecraft/class_4185;

--- a/mappings/net/minecraft/client/gui/screen/world/DataPackFailureScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/world/DataPackFailureScreen.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_5346 net/minecraft/client/gui/screen/DatapackFailureScreen
+CLASS net/minecraft/class_5346 net/minecraft/client/gui/screen/world/DataPackFailureScreen
 	FIELD field_25265 wrappedText Lnet/minecraft/class_5489;
 	FIELD field_46859 goBack Ljava/lang/Runnable;
 	FIELD field_46860 runServerInSafeMode Ljava/lang/Runnable;

--- a/mappings/net/minecraft/client/gui/screen/world/LevelLoadingScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/world/LevelLoadingScreen.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3928 net/minecraft/client/gui/screen/LevelLoadingScreen
+CLASS net/minecraft/class_3928 net/minecraft/client/gui/screen/world/LevelLoadingScreen
 	FIELD field_17406 progressProvider Lnet/minecraft/class_3953;
 	FIELD field_17407 STATUS_TO_COLOR Lit/unimi/dsi/fastutil/objects/Object2IntMap;
 	FIELD field_19101 lastNarrationTime J

--- a/mappings/net/minecraft/client/gui/screen/world/PresetsScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/world/PresetsScreen.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_430 net/minecraft/client/gui/screen/PresetsScreen
+CLASS net/minecraft/class_430 net/minecraft/client/gui/screen/world/PresetsScreen
 	FIELD field_25043 LOGGER Lorg/slf4j/Logger;
 	FIELD field_25044 config Lnet/minecraft/class_3232;
 	FIELD field_2519 parent Lnet/minecraft/class_413;

--- a/mappings/net/minecraft/server/WorldGenerationProgressTracker.mapping
+++ b/mappings/net/minecraft/server/WorldGenerationProgressTracker.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3953 net/minecraft/client/gui/WorldGenerationProgressTracker
+CLASS net/minecraft/class_3953 net/minecraft/server/WorldGenerationProgressTracker
 	FIELD field_17474 progressLogger Lnet/minecraft/class_3951;
 	FIELD field_17475 chunkStatuses Lit/unimi/dsi/fastutil/longs/Long2ObjectOpenHashMap;
 	FIELD field_17476 spawnPos Lnet/minecraft/class_1923;


### PR DESCRIPTION
Reduces the clutter in the `gui.screen` package. Also moves a class that's incorrectly classified as client-only, and fixes the caps on "data pack" (two words in Yarn).