### PR TITLE
Rename the Blocks.createStairs method to createStairsBlock

### DIFF
--- a/mappings/net/minecraft/block/Blocks.mapping
+++ b/mappings/net/minecraft/block/Blocks.mapping
@@ -186,7 +186,7 @@ CLASS net/minecraft/class_2246 net/minecraft/block/Blocks
 	METHOD method_52571 register (Lnet/minecraft/class_5321;Lnet/minecraft/class_2248;)Lnet/minecraft/class_2248;
 		ARG 0 key
 		ARG 1 block
-	METHOD method_53980 createStairs (Lnet/minecraft/class_2248;)Lnet/minecraft/class_2248;
+	METHOD method_53980 createStairsBlock (Lnet/minecraft/class_2248;)Lnet/minecraft/class_2248;
 		ARG 0 base
 	METHOD method_53981 (Lnet/minecraft/class_2680;Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z
 		ARG 0 state


### PR DESCRIPTION
This pull request fixes an inconsistency regarding factory methods in the `Blocks` class, as all other factory methods within the `Blocks` class that return a `Block` instance are suffixed.