### PR TITLE
Various mappings, renames, and fixes

### DIFF
--- a/mappings/net/minecraft/advancement/AdvancementPositioner.mapping
+++ b/mappings/net/minecraft/advancement/AdvancementPositioner.mapping
@@ -15,6 +15,8 @@ CLASS net/minecraft/class_194 net/minecraft/advancement/AdvancementPositioner
 		ARG 3 previousSibling
 		ARG 4 childrenSize
 		ARG 5 depth
+	METHOD method_53710 (Lnet/minecraft/class_185;)V
+		ARG 1 display
 	METHOD method_841 onFinishCalculation (Lnet/minecraft/class_194;)Lnet/minecraft/class_194;
 		ARG 1 last
 	METHOD method_842 findMinRowRecursively (FIF)F

--- a/mappings/net/minecraft/advancement/criterion/BredAnimalsCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/BredAnimalsCriterion.mapping
@@ -19,9 +19,15 @@ CLASS net/minecraft/class_196 net/minecraft/advancement/criterion/BredAnimalsCri
 			ARG 0 parent
 			ARG 1 partner
 			ARG 2 child
+		METHOD method_53074 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_5258;)V
+			ARG 1 child
 		METHOD method_53075 parentMatches (Ljava/util/Optional;Lnet/minecraft/class_47;)Z
 			ARG 0 parent
 			ARG 1 parentContext
+		METHOD method_53076 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_5258;)V
+			ARG 1 partner
+		METHOD method_53077 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_5258;)V
+			ARG 1 parent
 		METHOD method_860 any ()Lnet/minecraft/class_175;
 		METHOD method_861 create (Lnet/minecraft/class_2048$class_2049;)Lnet/minecraft/class_175;
 			ARG 0 child

--- a/mappings/net/minecraft/advancement/criterion/ConsumeItemCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/ConsumeItemCriterion.mapping
@@ -10,6 +10,8 @@ CLASS net/minecraft/class_2010 net/minecraft/advancement/criterion/ConsumeItemCr
 			ARG 1 playerPredicate
 			ARG 2 item
 		METHOD method_35112 predicate (Lnet/minecraft/class_2073$class_2074;)Lnet/minecraft/class_175;
+		METHOD method_53109 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2073;)V
+			ARG 1 item
 		METHOD method_8826 matches (Lnet/minecraft/class_1799;)Z
 			ARG 1 stack
 		METHOD method_8827 any ()Lnet/minecraft/class_175;

--- a/mappings/net/minecraft/advancement/criterion/CriterionProgress.mapping
+++ b/mappings/net/minecraft/advancement/criterion/CriterionProgress.mapping
@@ -1,9 +1,11 @@
 CLASS net/minecraft/class_178 net/minecraft/advancement/criterion/CriterionProgress
-	FIELD field_1219 obtainedDate Ljava/time/Instant;
+	FIELD field_1219 obtainedTime Ljava/time/Instant;
+	METHOD <init> (Ljava/time/Instant;)V
+		ARG 1 obtainedTime
 	METHOD method_784 isObtained ()Z
 	METHOD method_785 fromPacket (Lnet/minecraft/class_2540;)Lnet/minecraft/class_178;
 		ARG 0 buf
-	METHOD method_786 getObtainedDate ()Ljava/time/Instant;
+	METHOD method_786 getObtainedTime ()Ljava/time/Instant;
 	METHOD method_787 toPacket (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD method_789 obtain ()V

--- a/mappings/net/minecraft/advancement/criterion/CuredZombieVillagerCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/CuredZombieVillagerCriterion.mapping
@@ -12,6 +12,10 @@ CLASS net/minecraft/class_2014 net/minecraft/advancement/criterion/CuredZombieVi
 			ARG 1 playerPredicate
 			ARG 2 zombie
 			ARG 3 villager
+		METHOD method_53110 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_5258;)V
+			ARG 1 villager
+		METHOD method_53111 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_5258;)V
+			ARG 1 zombie
 		METHOD method_8836 any ()Lnet/minecraft/class_175;
 		METHOD method_8837 matches (Lnet/minecraft/class_47;Lnet/minecraft/class_47;)Z
 			ARG 1 zombie

--- a/mappings/net/minecraft/advancement/criterion/EffectsChangedCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/EffectsChangedCriterion.mapping
@@ -12,6 +12,11 @@ CLASS net/minecraft/class_2027 net/minecraft/advancement/criterion/EffectsChange
 			ARG 2 effects
 			ARG 3 source
 		METHOD method_37224 create (Lnet/minecraft/class_2048$class_2049;)Lnet/minecraft/class_175;
+			ARG 0 source
+		METHOD method_53121 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_5258;)V
+			ARG 1 source
+		METHOD method_53122 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2102;)V
+			ARG 1 effects
 		METHOD method_8868 matches (Lnet/minecraft/class_3222;Lnet/minecraft/class_47;)Z
 			ARG 1 player
 			ARG 2 context

--- a/mappings/net/minecraft/advancement/criterion/EnchantedItemCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/EnchantedItemCriterion.mapping
@@ -12,6 +12,8 @@ CLASS net/minecraft/class_2030 net/minecraft/advancement/criterion/EnchantedItem
 			ARG 1 playerPredicate
 			ARG 2 item
 			ARG 3 levels
+		METHOD method_53124 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2073;)V
+			ARG 1 item
 		METHOD method_8877 any ()Lnet/minecraft/class_175;
 		METHOD method_8878 matches (Lnet/minecraft/class_1799;I)Z
 			ARG 1 stack

--- a/mappings/net/minecraft/advancement/criterion/EnterBlockCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/EnterBlockCriterion.mapping
@@ -5,6 +5,8 @@ CLASS net/minecraft/class_2037 net/minecraft/advancement/criterion/EnterBlockCri
 		ARG 1 conditions
 	METHOD method_22466 getBlock (Lcom/google/gson/JsonObject;)Lnet/minecraft/class_2248;
 		ARG 0 obj
+	METHOD method_53127 (Lnet/minecraft/class_2248;Lnet/minecraft/class_4559;)V
+		ARG 1 statePredicate
 	METHOD method_8885 trigger (Lnet/minecraft/class_3222;Lnet/minecraft/class_2680;)V
 		ARG 1 player
 		ARG 2 state
@@ -15,6 +17,8 @@ CLASS net/minecraft/class_2037 net/minecraft/advancement/criterion/EnterBlockCri
 			ARG 1 playerPredicate
 			ARG 2 block
 			ARG 3 state
+		METHOD method_53128 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_4559;)V
+			ARG 1 state
 		METHOD method_8890 block (Lnet/minecraft/class_2248;)Lnet/minecraft/class_175;
 			ARG 0 block
 		METHOD method_8891 matches (Lnet/minecraft/class_2680;)Z

--- a/mappings/net/minecraft/advancement/criterion/EntityHurtPlayerCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/EntityHurtPlayerCriterion.mapping
@@ -15,6 +15,8 @@ CLASS net/minecraft/class_2044 net/minecraft/advancement/criterion/EntityHurtPla
 		METHOD method_35209 create (Lnet/minecraft/class_2019;)Lnet/minecraft/class_175;
 			ARG 0 predicate
 		METHOD method_35210 create ()Lnet/minecraft/class_175;
+		METHOD method_53133 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2019;)V
+			ARG 1 damage
 		METHOD method_8907 matches (Lnet/minecraft/class_3222;Lnet/minecraft/class_1282;FFZ)Z
 			ARG 1 player
 			ARG 2 damageSource

--- a/mappings/net/minecraft/advancement/criterion/FilledBucketCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/FilledBucketCriterion.mapping
@@ -9,6 +9,9 @@ CLASS net/minecraft/class_2054 net/minecraft/advancement/criterion/FilledBucketC
 		METHOD <init> (Ljava/util/Optional;Ljava/util/Optional;)V
 			ARG 1 playerPredicate
 			ARG 2 item
+		METHOD method_53149 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2073;)V
+			ARG 1 item
 		METHOD method_8937 create (Lnet/minecraft/class_2073$class_2074;)Lnet/minecraft/class_175;
+			ARG 0 item
 		METHOD method_8938 matches (Lnet/minecraft/class_1799;)Z
 			ARG 1 stack

--- a/mappings/net/minecraft/advancement/criterion/FishingRodHookedCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/FishingRodHookedCriterion.mapping
@@ -19,6 +19,12 @@ CLASS net/minecraft/class_2058 net/minecraft/advancement/criterion/FishingRodHoo
 			ARG 1 rodStack
 			ARG 2 hookedEntity
 			ARG 3 fishingLoots
+		METHOD method_53151 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_5258;)V
+			ARG 1 hookedEntity
+		METHOD method_53152 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2073;)V
+			ARG 1 caughtItem
+		METHOD method_53153 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2073;)V
+			ARG 1 rod
 		METHOD method_8947 create (Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)Lnet/minecraft/class_175;
 			ARG 0 rod
 			ARG 1 hookedEntity

--- a/mappings/net/minecraft/advancement/criterion/ItemCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/ItemCriterion.mapping
@@ -8,7 +8,8 @@ CLASS net/minecraft/class_4711 net/minecraft/advancement/criterion/ItemCriterion
 	CLASS class_4712 Conditions
 		FIELD field_24495 location Ljava/util/Optional;
 		METHOD <init> (Ljava/util/Optional;Ljava/util/Optional;)V
-			ARG 2 playerPredicate
+			ARG 1 playerPredicate
+			ARG 2 location
 		METHOD method_27981 createItemUsedOnBlock (Lnet/minecraft/class_2090$class_2091;Lnet/minecraft/class_2073$class_2074;)Lnet/minecraft/class_175;
 			ARG 0 location
 			ARG 1 item
@@ -24,3 +25,5 @@ CLASS net/minecraft/class_4711 net/minecraft/advancement/criterion/ItemCriterion
 			ARG 1 location
 		METHOD method_51712 createPlacedBlock ([Lnet/minecraft/class_5341$class_210;)Lnet/minecraft/class_175;
 			ARG 0 locationConditions
+		METHOD method_53167 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_5258;)V
+			ARG 1 location

--- a/mappings/net/minecraft/advancement/criterion/ItemDurabilityChangedCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/ItemDurabilityChangedCriterion.mapping
@@ -17,6 +17,8 @@ CLASS net/minecraft/class_2069 net/minecraft/advancement/criterion/ItemDurabilit
 		METHOD method_35229 create (Ljava/util/Optional;Lnet/minecraft/class_2096$class_2100;)Lnet/minecraft/class_175;
 			ARG 0 item
 			ARG 1 durability
+		METHOD method_53161 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2073;)V
+			ARG 1 item
 		METHOD method_8967 create (Ljava/util/Optional;Ljava/util/Optional;Lnet/minecraft/class_2096$class_2100;)Lnet/minecraft/class_175;
 			ARG 0 playerPredicate
 			ARG 1 item

--- a/mappings/net/minecraft/advancement/criterion/LevitationCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/LevitationCriterion.mapping
@@ -12,6 +12,8 @@ CLASS net/minecraft/class_2085 net/minecraft/advancement/criterion/LevitationCri
 			ARG 1 playerPredicate
 			ARG 2 distance
 			ARG 3 duration
+		METHOD method_53170 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2025;)V
+			ARG 1 distance
 		METHOD method_9013 create (Lnet/minecraft/class_2025;)Lnet/minecraft/class_175;
 			ARG 0 distance
 		METHOD method_9014 matches (Lnet/minecraft/class_3222;Lnet/minecraft/class_243;I)Z

--- a/mappings/net/minecraft/advancement/criterion/LightningStrikeCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/LightningStrikeCriterion.mapping
@@ -20,3 +20,7 @@ CLASS net/minecraft/class_6405 net/minecraft/advancement/criterion/LightningStri
 		METHOD method_37244 test (Lnet/minecraft/class_47;Ljava/util/List;)Z
 			ARG 1 lightning
 			ARG 2 bystanders
+		METHOD method_53176 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_5258;)V
+			ARG 1 bystander
+		METHOD method_53177 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_5258;)V
+			ARG 1 lightning

--- a/mappings/net/minecraft/advancement/criterion/OnKilledCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/OnKilledCriterion.mapping
@@ -9,8 +9,9 @@ CLASS net/minecraft/class_2080 net/minecraft/advancement/criterion/OnKilledCrite
 		FIELD field_9667 killingBlow Ljava/util/Optional;
 		FIELD field_9668 entity Ljava/util/Optional;
 		METHOD <init> (Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V
-			ARG 2 playerPredicate
-			ARG 3 entity
+			ARG 1 playerPredicate
+			ARG 2 entity
+			ARG 3 killingBlow
 		METHOD method_35247 createPlayerKilledEntity (Lnet/minecraft/class_2048$class_2049;Ljava/util/Optional;)Lnet/minecraft/class_175;
 			ARG 0 killedEntityPredicateBuilder
 			ARG 1 killingBlow
@@ -39,6 +40,10 @@ CLASS net/minecraft/class_2080 net/minecraft/advancement/criterion/OnKilledCrite
 			ARG 0 entity
 			ARG 1 killingBlow
 		METHOD method_42671 createKillMobNearSculkCatalyst ()Lnet/minecraft/class_175;
+		METHOD method_53168 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_5258;)V
+			ARG 1 entity
+		METHOD method_53169 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2022;)V
+			ARG 1 killingBlow
 		METHOD method_8997 createPlayerKilledEntity (Lnet/minecraft/class_2048$class_2049;)Lnet/minecraft/class_175;
 			ARG 0 killedEntityPredicateBuilder
 		METHOD method_8998 createEntityKilledPlayer ()Lnet/minecraft/class_175;

--- a/mappings/net/minecraft/advancement/criterion/PlayerHurtEntityCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/PlayerHurtEntityCriterion.mapping
@@ -23,6 +23,10 @@ CLASS net/minecraft/class_2115 net/minecraft/advancement/criterion/PlayerHurtEnt
 		METHOD method_35297 create (Lnet/minecraft/class_2019$class_2020;)Lnet/minecraft/class_175;
 			ARG 0 damage
 		METHOD method_35298 create ()Lnet/minecraft/class_175;
+		METHOD method_53214 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_5258;)V
+			ARG 1 entity
+		METHOD method_53215 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2019;)V
+			ARG 1 damage
 		METHOD method_9103 create (Lnet/minecraft/class_2019$class_2020;Ljava/util/Optional;)Lnet/minecraft/class_175;
 			ARG 0 damage
 			ARG 1 entity

--- a/mappings/net/minecraft/advancement/criterion/PlayerInteractedWithEntityCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/PlayerInteractedWithEntityCriterion.mapping
@@ -22,3 +22,7 @@ CLASS net/minecraft/class_5409 net/minecraft/advancement/criterion/PlayerInterac
 		METHOD method_43278 create (Lnet/minecraft/class_2073$class_2074;Ljava/util/Optional;)Lnet/minecraft/class_175;
 			ARG 0 item
 			ARG 1 entity
+		METHOD method_53217 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_5258;)V
+			ARG 1 entity
+		METHOD method_53218 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2073;)V
+			ARG 1 item

--- a/mappings/net/minecraft/advancement/criterion/RecipeUnlockedCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/RecipeUnlockedCriterion.mapping
@@ -5,9 +5,11 @@ CLASS net/minecraft/class_2119 net/minecraft/advancement/criterion/RecipeUnlocke
 		ARG 0 id
 	METHOD method_9107 trigger (Lnet/minecraft/class_3222;Lnet/minecraft/class_8786;)V
 		ARG 1 player
+		ARG 2 recipe
 	CLASS class_2121 Conditions
 		FIELD field_9742 recipe Lnet/minecraft/class_2960;
 		METHOD <init> (Ljava/util/Optional;Lnet/minecraft/class_2960;)V
 			ARG 1 playerPredicate
 			ARG 2 recipe
 		METHOD method_9112 matches (Lnet/minecraft/class_8786;)Z
+			ARG 1 recipe

--- a/mappings/net/minecraft/advancement/criterion/ShotCrossbowCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/ShotCrossbowCriterion.mapping
@@ -11,6 +11,8 @@ CLASS net/minecraft/class_2123 net/minecraft/advancement/criterion/ShotCrossbowC
 			ARG 2 item
 		METHOD method_35323 create (Ljava/util/Optional;)Lnet/minecraft/class_175;
 			ARG 0 item
+		METHOD method_53230 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2073;)V
+			ARG 1 item
 		METHOD method_9120 create (Lnet/minecraft/class_1935;)Lnet/minecraft/class_175;
 			ARG 0 item
 		METHOD method_9121 matches (Lnet/minecraft/class_1799;)Z

--- a/mappings/net/minecraft/advancement/criterion/SlideDownBlockCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/SlideDownBlockCriterion.mapping
@@ -8,6 +8,8 @@ CLASS net/minecraft/class_4713 net/minecraft/advancement/criterion/SlideDownBloc
 	METHOD method_23909 trigger (Lnet/minecraft/class_3222;Lnet/minecraft/class_2680;)V
 		ARG 1 player
 		ARG 2 state
+	METHOD method_53231 (Lnet/minecraft/class_2248;Lnet/minecraft/class_4559;)V
+		ARG 1 statePredicate
 	CLASS class_4714 Conditions
 		FIELD field_21587 block Lnet/minecraft/class_2248;
 		FIELD field_21588 state Ljava/util/Optional;
@@ -18,4 +20,6 @@ CLASS net/minecraft/class_4713 net/minecraft/advancement/criterion/SlideDownBloc
 		METHOD method_23912 create (Lnet/minecraft/class_2248;)Lnet/minecraft/class_175;
 			ARG 0 block
 		METHOD method_23913 test (Lnet/minecraft/class_2680;)Z
+			ARG 1 state
+		METHOD method_53232 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_4559;)V
 			ARG 1 state

--- a/mappings/net/minecraft/advancement/criterion/SummonedEntityCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/SummonedEntityCriterion.mapping
@@ -9,6 +9,8 @@ CLASS net/minecraft/class_2128 net/minecraft/advancement/criterion/SummonedEntit
 		METHOD <init> (Ljava/util/Optional;Ljava/util/Optional;)V
 			ARG 1 playerPredicate
 			ARG 2 entity
+		METHOD method_53244 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_5258;)V
+			ARG 1 entity
 		METHOD method_9129 create (Lnet/minecraft/class_2048$class_2049;)Lnet/minecraft/class_175;
 			ARG 0 summonedEntityPredicateBuilder
 		METHOD method_9130 matches (Lnet/minecraft/class_47;)Z

--- a/mappings/net/minecraft/advancement/criterion/TameAnimalCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/TameAnimalCriterion.mapping
@@ -10,6 +10,9 @@ CLASS net/minecraft/class_2131 net/minecraft/advancement/criterion/TameAnimalCri
 			ARG 1 playerPredicate
 			ARG 2 entity
 		METHOD method_16114 create (Lnet/minecraft/class_2048$class_2049;)Lnet/minecraft/class_175;
+			ARG 0 entity
+		METHOD method_53249 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_5258;)V
+			ARG 1 entity
 		METHOD method_9138 any ()Lnet/minecraft/class_175;
 		METHOD method_9139 matches (Lnet/minecraft/class_47;)Z
 			ARG 1 entity

--- a/mappings/net/minecraft/advancement/criterion/TargetHitCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/TargetHitCriterion.mapping
@@ -20,3 +20,5 @@ CLASS net/minecraft/class_4851 net/minecraft/advancement/criterion/TargetHitCrit
 			ARG 1 projectile
 			ARG 2 hitPos
 			ARG 3 signalStrength
+		METHOD method_53250 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_5258;)V
+			ARG 1 projectile

--- a/mappings/net/minecraft/advancement/criterion/ThrownItemPickedUpByEntityCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/ThrownItemPickedUpByEntityCriterion.mapping
@@ -9,8 +9,9 @@ CLASS net/minecraft/class_5279 net/minecraft/advancement/criterion/ThrownItemPic
 		FIELD field_24493 item Ljava/util/Optional;
 		FIELD field_24494 entity Ljava/util/Optional;
 		METHOD <init> (Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V
-			ARG 2 playerPredicate
-			ARG 3 item
+			ARG 1 playerPredicate
+			ARG 2 item
+			ARG 3 entity
 		METHOD method_27978 createThrownItemPickedUpByEntity (Lnet/minecraft/class_5258;Ljava/util/Optional;Ljava/util/Optional;)Lnet/minecraft/class_175;
 			ARG 0 player
 			ARG 1 item
@@ -23,3 +24,7 @@ CLASS net/minecraft/class_5279 net/minecraft/advancement/criterion/ThrownItemPic
 			ARG 0 playerPredicate
 			ARG 1 item
 			ARG 2 entity
+		METHOD method_53212 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_5258;)V
+			ARG 1 entity
+		METHOD method_53213 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2073;)V
+			ARG 1 item

--- a/mappings/net/minecraft/advancement/criterion/TickCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/TickCriterion.mapping
@@ -15,3 +15,5 @@ CLASS net/minecraft/class_2135 net/minecraft/advancement/criterion/TickCriterion
 		METHOD method_43139 createHeroOfTheVillage ()Lnet/minecraft/class_175;
 		METHOD method_43279 createAvoidVibration ()Lnet/minecraft/class_175;
 		METHOD method_49195 createTick ()Lnet/minecraft/class_175;
+		METHOD method_53788 createLocation (Lnet/minecraft/class_2048$class_2049;)Lnet/minecraft/class_175;
+			ARG 0 entity

--- a/mappings/net/minecraft/advancement/criterion/TravelCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/TravelCriterion.mapping
@@ -8,14 +8,20 @@ CLASS net/minecraft/class_2108 net/minecraft/advancement/criterion/TravelCriteri
 		FIELD field_35040 startPos Ljava/util/Optional;
 		FIELD field_9723 distance Ljava/util/Optional;
 		METHOD <init> (Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V
-			ARG 2 playerPredicate
-			ARG 3 startPos
+			ARG 1 playerPredicate
+			ARG 2 startPos
+			ARG 3 distance
 		METHOD method_38850 rideEntityInLava (Lnet/minecraft/class_2048$class_2049;Lnet/minecraft/class_2025;)Lnet/minecraft/class_175;
 			ARG 0 entity
 			ARG 1 distance
 		METHOD method_38851 fallFromHeight (Lnet/minecraft/class_2048$class_2049;Lnet/minecraft/class_2025;Lnet/minecraft/class_2090$class_2091;)Lnet/minecraft/class_175;
 			ARG 0 entity
 			ARG 1 distance
+			ARG 2 startPos
+		METHOD method_53119 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2025;)V
+			ARG 1 distance
+		METHOD method_53120 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2090;)V
+			ARG 1 startPos
 		METHOD method_9085 netherTravel (Lnet/minecraft/class_2025;)Lnet/minecraft/class_175;
 			ARG 0 distance
 		METHOD method_9086 matches (Lnet/minecraft/class_3218;Lnet/minecraft/class_243;Lnet/minecraft/class_243;)Z

--- a/mappings/net/minecraft/advancement/criterion/UsedTotemCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/UsedTotemCriterion.mapping
@@ -11,6 +11,8 @@ CLASS net/minecraft/class_2148 net/minecraft/advancement/criterion/UsedTotemCrit
 			ARG 2 item
 		METHOD method_35399 create (Lnet/minecraft/class_2073;)Lnet/minecraft/class_175;
 			ARG 0 itemPredicate
+		METHOD method_53258 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2073;)V
+			ARG 1 item
 		METHOD method_9170 create (Lnet/minecraft/class_1935;)Lnet/minecraft/class_175;
 			ARG 0 item
 		METHOD method_9171 matches (Lnet/minecraft/class_1799;)Z

--- a/mappings/net/minecraft/advancement/criterion/UsingItemCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/UsingItemCriterion.mapping
@@ -14,3 +14,5 @@ CLASS net/minecraft/class_6409 net/minecraft/advancement/criterion/UsingItemCrit
 			ARG 1 item
 		METHOD method_37266 test (Lnet/minecraft/class_1799;)Z
 			ARG 1 stack
+		METHOD method_53259 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2073;)V
+			ARG 1 item

--- a/mappings/net/minecraft/advancement/criterion/VillagerTradeCriterion.mapping
+++ b/mappings/net/minecraft/advancement/criterion/VillagerTradeCriterion.mapping
@@ -14,6 +14,10 @@ CLASS net/minecraft/class_2140 net/minecraft/advancement/criterion/VillagerTrade
 			ARG 3 item
 		METHOD method_38914 create (Lnet/minecraft/class_2048$class_2049;)Lnet/minecraft/class_175;
 			ARG 0 playerPredicate
+		METHOD method_53255 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_5258;)V
+			ARG 1 villager
+		METHOD method_53256 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2073;)V
+			ARG 1 item
 		METHOD method_9153 any ()Lnet/minecraft/class_175;
 		METHOD method_9154 matches (Lnet/minecraft/class_47;Lnet/minecraft/class_1799;)Z
 			ARG 1 villager

--- a/mappings/net/minecraft/block/AbstractCauldronBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractCauldronBlock.mapping
@@ -16,6 +16,7 @@ CLASS net/minecraft/class_2275 net/minecraft/block/AbstractCauldronBlock
 		COMMENT <p>The behavior map must match {@link CauldronBehavior#createMap} by providing
 		COMMENT a nonnull value for <em>all</em> items.
 		ARG 1 settings
+		ARG 2 behaviorMap
 	METHOD method_31615 getFluidHeight (Lnet/minecraft/class_2680;)D
 		ARG 1 state
 	METHOD method_31616 isEntityTouchingFluid (Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;Lnet/minecraft/class_1297;)Z

--- a/mappings/net/minecraft/block/BambooShootBlock.mapping
+++ b/mappings/net/minecraft/block/BambooShootBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2202 net/minecraft/block/BambooSaplingBlock
+CLASS net/minecraft/class_2202 net/minecraft/block/BambooShootBlock
 	FIELD field_46262 CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD field_9897 SHAPE Lnet/minecraft/class_265;
 	METHOD method_9351 grow (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)V

--- a/mappings/net/minecraft/block/Blocks.mapping
+++ b/mappings/net/minecraft/block/Blocks.mapping
@@ -173,7 +173,7 @@ CLASS net/minecraft/class_2246 net/minecraft/block/Blocks
 	METHOD method_45451 createWoodenButtonBlock (Lnet/minecraft/class_8177;)Lnet/minecraft/class_2248;
 		ARG 0 blockSetType
 	METHOD method_45453 createStoneButtonBlock ()Lnet/minecraft/class_2248;
-	METHOD method_47375 createBambooBlock (Lnet/minecraft/class_3620;Lnet/minecraft/class_3620;Lnet/minecraft/class_2498;)Lnet/minecraft/class_2248;
+	METHOD method_47375 createLogBlock (Lnet/minecraft/class_3620;Lnet/minecraft/class_3620;Lnet/minecraft/class_2498;)Lnet/minecraft/class_2248;
 		ARG 0 topMapColor
 		ARG 1 sideMapColor
 		ARG 2 soundGroup

--- a/mappings/net/minecraft/block/BulbBlock.mapping
+++ b/mappings/net/minecraft/block/BulbBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_8922 net/minecraft/block/CopperBulbBlock
+CLASS net/minecraft/class_8922 net/minecraft/block/BulbBlock
 	FIELD field_47080 CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD field_47081 POWERED Lnet/minecraft/class_2746;
 	FIELD field_47082 LIT Lnet/minecraft/class_2746;

--- a/mappings/net/minecraft/block/CropBlock.mapping
+++ b/mappings/net/minecraft/block/CropBlock.mapping
@@ -8,6 +8,7 @@ CLASS net/minecraft/class_2302 net/minecraft/block/CropBlock
 		ARG 1 pos
 	METHOD method_9824 getAgeProperty ()Lnet/minecraft/class_2758;
 	METHOD method_9825 isMature (Lnet/minecraft/class_2680;)Z
+		ARG 1 state
 	METHOD method_9826 applyGrowth (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)V
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/block/DoubleBlockProperties.mapping
+++ b/mappings/net/minecraft/block/DoubleBlockProperties.mapping
@@ -2,6 +2,8 @@ CLASS net/minecraft/class_4732 net/minecraft/block/DoubleBlockProperties
 	METHOD method_24173 toPropertySource (Lnet/minecraft/class_2591;Ljava/util/function/Function;Ljava/util/function/Function;Lnet/minecraft/class_2753;Lnet/minecraft/class_2680;Lnet/minecraft/class_1936;Lnet/minecraft/class_2338;Ljava/util/function/BiPredicate;)Lnet/minecraft/class_4732$class_4734;
 		ARG 0 blockEntityType
 		ARG 1 typeMapper
+		ARG 2 directionMapper
+		ARG 3 directionProperty
 		ARG 4 state
 		ARG 5 world
 		ARG 6 pos

--- a/mappings/net/minecraft/block/EntityShapeContext.mapping
+++ b/mappings/net/minecraft/block/EntityShapeContext.mapping
@@ -13,4 +13,6 @@ CLASS net/minecraft/class_3727 net/minecraft/block/EntityShapeContext
 		ARG 4 heldItem
 		ARG 5 walkOnFluidPredicate
 		ARG 6 entity
+	METHOD method_27868 (Lnet/minecraft/class_3610;)Z
+		ARG 0 fluidState
 	METHOD method_32480 getEntity ()Lnet/minecraft/class_1297;

--- a/mappings/net/minecraft/block/MossBlock.mapping
+++ b/mappings/net/minecraft/block/MossBlock.mapping
@@ -1,2 +1,6 @@
 CLASS net/minecraft/class_5807 net/minecraft/block/MossBlock
 	FIELD field_46397 CODEC Lcom/mojang/serialization/MapCodec;
+	METHOD method_46684 (Lnet/minecraft/class_3218;Lnet/minecraft/class_5819;Lnet/minecraft/class_2338;Lnet/minecraft/class_6880$class_6883;)V
+		ARG 3 entry
+	METHOD method_46685 (Lnet/minecraft/class_2378;)Ljava/util/Optional;
+		ARG 0 key

--- a/mappings/net/minecraft/block/OxidizableBulbBlock.mapping
+++ b/mappings/net/minecraft/block/OxidizableBulbBlock.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_8924 net/minecraft/block/OxidizableCopperBulbBlock
+CLASS net/minecraft/class_8924 net/minecraft/block/OxidizableBulbBlock
 	FIELD field_47088 CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD field_47089 oxidationLevel Lnet/minecraft/class_5955$class_5811;
 	METHOD <init> (Lnet/minecraft/class_5955$class_5811;Lnet/minecraft/class_4970$class_2251;)V

--- a/mappings/net/minecraft/block/SculkShriekerBlock.mapping
+++ b/mappings/net/minecraft/block/SculkShriekerBlock.mapping
@@ -6,8 +6,10 @@ CLASS net/minecraft/class_7268 net/minecraft/block/SculkShriekerBlock
 	FIELD field_38422 CAN_SUMMON Lnet/minecraft/class_2746;
 	FIELD field_46436 CODEC Lcom/mojang/serialization/MapCodec;
 	METHOD method_42317 (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_7133;)V
+		ARG 0 worldx
 		ARG 1 pos
 		ARG 2 statex
+		ARG 3 blockEntity
 	METHOD method_43132 (Lnet/minecraft/class_3218;Lnet/minecraft/class_7133;)V
 		ARG 1 blockEntity
 	METHOD method_43133 (Lnet/minecraft/class_3218;Lnet/minecraft/class_7133;)V

--- a/mappings/net/minecraft/block/SpongeBlock.mapping
+++ b/mappings/net/minecraft/block/SpongeBlock.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/class_2502 net/minecraft/block/SpongeBlock
+	FIELD field_31250 ABSORB_RADIUS I
+	FIELD field_31251 ABSORB_LIMIT I
+	FIELD field_43257 DIRECTIONS [Lnet/minecraft/class_2350;
 	FIELD field_46456 CODEC Lcom/mojang/serialization/MapCodec;
 	METHOD method_10619 absorbWater (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)Z
 		ARG 1 world

--- a/mappings/net/minecraft/block/StructureVoidBlock.mapping
+++ b/mappings/net/minecraft/block/StructureVoidBlock.mapping
@@ -1,3 +1,4 @@
 CLASS net/minecraft/class_2518 net/minecraft/block/StructureVoidBlock
 	FIELD field_11589 SHAPE Lnet/minecraft/class_265;
+	FIELD field_31257 SHAPE_MARGIN D
 	FIELD field_46466 CODEC Lcom/mojang/serialization/MapCodec;

--- a/mappings/net/minecraft/block/SweetBerryBushBlock.mapping
+++ b/mappings/net/minecraft/block/SweetBerryBushBlock.mapping
@@ -3,4 +3,5 @@ CLASS net/minecraft/class_3830 net/minecraft/block/SweetBerryBushBlock
 	FIELD field_17001 SMALL_SHAPE Lnet/minecraft/class_265;
 	FIELD field_17002 LARGE_SHAPE Lnet/minecraft/class_265;
 	FIELD field_31259 MAX_AGE I
+	FIELD field_31260 MIN_MOVEMENT_FOR_DAMAGE F
 	FIELD field_46468 CODEC Lcom/mojang/serialization/MapCodec;

--- a/mappings/net/minecraft/block/dispenser/DispenserBehavior.mapping
+++ b/mappings/net/minecraft/block/dispenser/DispenserBehavior.mapping
@@ -12,6 +12,9 @@ CLASS net/minecraft/class_2357 net/minecraft/block/dispenser/DispenserBehavior
 		ARG 0 pointer
 		ARG 1 entityType
 		ARG 2 direction
+	CLASS 2
+		METHOD method_48306 (Lnet/minecraft/class_2350;Lnet/minecraft/class_1531;)V
+			ARG 1 entity
 	CLASS 3
 		METHOD method_27159 (Lnet/minecraft/class_1309;)Z
 			ARG 0 entity

--- a/mappings/net/minecraft/block/entity/BeehiveBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BeehiveBlockEntity.mapping
@@ -50,6 +50,8 @@ CLASS net/minecraft/class_4482 net/minecraft/block/entity/BeehiveBlockEntity
 	METHOD method_21859 getBees ()Lnet/minecraft/class_2499;
 	METHOD method_22400 hasNoBees ()Z
 	METHOD method_23280 isNearFire ()Z
+	METHOD method_23901 (Lnet/minecraft/class_1297;)Lnet/minecraft/class_1297;
+		ARG 0 entity
 	METHOD method_23902 getHoneyLevel (Lnet/minecraft/class_2680;)I
 		ARG 0 state
 	METHOD method_23903 getBeeCount ()I

--- a/mappings/net/minecraft/block/entity/BrushableBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BrushableBlockEntity.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_8174 net/minecraft/block/entity/BrushableBlockEntity
+	FIELD field_42801 LOGGER Lorg/slf4j/Logger;
 	FIELD field_42802 LOOT_TABLE_NBT_KEY Ljava/lang/String;
 	FIELD field_42803 LOOT_TABLE_SEED_NBT_KEY Ljava/lang/String;
 	FIELD field_42804 HIT_DIRECTION_NBT_KEY Ljava/lang/String;

--- a/mappings/net/minecraft/block/entity/CampfireBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/CampfireBlockEntity.mapping
@@ -12,6 +12,8 @@ CLASS net/minecraft/class_3924 net/minecraft/block/entity/CampfireBlockEntity
 		ARG 1 user
 		ARG 2 stack
 		ARG 3 cookTime
+	METHOD method_17504 (Lnet/minecraft/class_1263;Lnet/minecraft/class_1937;Lnet/minecraft/class_8786;)Lnet/minecraft/class_1799;
+		ARG 2 recipe
 	METHOD method_17505 getItemsBeingCooked ()Lnet/minecraft/class_2371;
 	METHOD method_17506 spawnItemsBeingCooked ()V
 	METHOD method_17510 updateListeners ()V

--- a/mappings/net/minecraft/block/entity/ChiseledBookshelfBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/ChiseledBookshelfBlockEntity.mapping
@@ -10,3 +10,5 @@ CLASS net/minecraft/class_7716 net/minecraft/block/entity/ChiseledBookshelfBlock
 		ARG 1 interactedSlot
 	METHOD method_47587 getOpenSlotCount ()I
 	METHOD method_47887 getLastInteractedSlot ()I
+	METHOD method_51356 (Lnet/minecraft/class_1799;Lnet/minecraft/class_1263;Lnet/minecraft/class_1799;)Z
+		ARG 2 stack2

--- a/mappings/net/minecraft/block/entity/SculkSpreadManager.mapping
+++ b/mappings/net/minecraft/block/entity/SculkSpreadManager.mapping
@@ -94,6 +94,8 @@ CLASS net/minecraft/class_7128 net/minecraft/block/entity/SculkSpreadManager
 			ARG 0 state
 		METHOD method_41504 (Lnet/minecraft/class_2338;)Z
 			ARG 0 pos
+		METHOD method_41505 (Lit/unimi/dsi/fastutil/objects/ObjectArrayList;)V
+			ARG 0 list
 		METHOD method_41506 (Ljava/util/List;)Ljava/util/Set;
 			ARG 0 directions
 		METHOD method_41507 shuffleOffsets (Lnet/minecraft/class_5819;)Ljava/util/List;

--- a/mappings/net/minecraft/block/enums/Orientation.mapping
+++ b/mappings/net/minecraft/block/enums/Orientation.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_5000 net/minecraft/block/enums/JigsawOrientation
+CLASS net/minecraft/class_5000 net/minecraft/block/enums/Orientation
 	FIELD field_23393 BY_INDEX Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
 	FIELD field_23394 name Ljava/lang/String;
 	FIELD field_23395 rotation Lnet/minecraft/class_2350;

--- a/mappings/net/minecraft/data/client/BlockStateModelGenerator.mapping
+++ b/mappings/net/minecraft/data/client/BlockStateModelGenerator.mapping
@@ -523,6 +523,8 @@ CLASS net/minecraft/class_4910 net/minecraft/data/client/BlockStateModelGenerato
 		ARG 2 tintType
 		ARG 3 stageProperty
 		ARG 4 stages
+	METHOD method_49375 ([ILnet/minecraft/class_2248;Lnet/minecraft/class_4910$class_4913;Ljava/lang/Integer;)Lnet/minecraft/class_4935;
+		ARG 4 stage
 	METHOD method_49376 (Lnet/minecraft/class_2248;Ljava/lang/Integer;)Lnet/minecraft/class_4935;
 		ARG 2 dusted
 	METHOD method_49377 registerBrushableBlock (Lnet/minecraft/class_2248;)V

--- a/mappings/net/minecraft/data/client/Model.mapping
+++ b/mappings/net/minecraft/data/client/Model.mapping
@@ -34,6 +34,8 @@ CLASS net/minecraft/class_4942 net/minecraft/data/client/Model
 		ARG 2 textures
 		ARG 3 modelCollector
 		ARG 4 jsonFactory
+	METHOD method_48526 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_2960;)V
+		ARG 1 parent
 	METHOD method_48527 (Lcom/google/gson/JsonObject;Lnet/minecraft/class_4945;Lnet/minecraft/class_2960;)V
 		ARG 1 textureKey
 		ARG 2 texture

--- a/mappings/net/minecraft/state/property/DirectionProperty.mapping
+++ b/mappings/net/minecraft/state/property/DirectionProperty.mapping
@@ -40,3 +40,5 @@ CLASS net/minecraft/class_2753 net/minecraft/state/property/DirectionProperty
 		ARG 0 name
 			COMMENT the name of the property; see {@linkplain Property#name the note on the
 			COMMENT name}
+	METHOD method_38862 (Lnet/minecraft/class_2350;)Z
+		ARG 0 direction

--- a/mappings/net/minecraft/state/property/Properties.mapping
+++ b/mappings/net/minecraft/state/property/Properties.mapping
@@ -201,7 +201,7 @@ CLASS net/minecraft/class_2741 net/minecraft/state/property/Properties
 	FIELD field_23187 CHARGES Lnet/minecraft/class_2758;
 		COMMENT A property that specifies the amount of charges a respawn anchor has.
 	FIELD field_23333 ORIENTATION Lnet/minecraft/class_2754;
-		COMMENT A property that specifies the orientation of a jigsaw.
+		COMMENT A property that specifies the orientation of a jigsaw or crafter.
 	FIELD field_27220 CANDLES Lnet/minecraft/class_2758;
 		COMMENT A property that specifies the amount of candles in a candle block.
 	FIELD field_28062 VERTICAL_DIRECTION Lnet/minecraft/class_2753;


### PR DESCRIPTION
It's that time again, I went through some packages and mapped a few things, and fixed some issues I found along the way.
Maybe should be split up, but most of the classes are just one line changes so eh it's manageable I think
Only a few packages done, any further ones I do (if I do them) will be a separate PR

Notable renames include:
- `JigsawOrientation` -> `Orientation` : it's used by Crafters too now!
- `CopperBulbBlock` and `OxidizableCopperBulbBlock` -> `BulbBlock` and `OxidizableBulbBlock` : more consistent with how other copper related block classes are named in Yarn, and feels less constricting on how mods could use them
- `BambooSaplingBlock` -> `BambooShootBlock` : Matches its in-game name rather than its ID. It doesn't extend the sapling class anyway!
- `Blocks#createBambooBlock` -> `Blocks#createLogBlock` : It's used by Cherry Logs too now! Plus the previous name could confuse as to if it made Bamboo blocks, or Bamboo Block blocks. It was the latter. It just makes a log with a custom sound group.

Most other things are just mapping lambda params and a couple fields and method params.