### PR TITLE
Rename `Uuids#INT_STREAM_LIST_CODEC`

### DIFF
--- a/mappings/net/minecraft/util/Uuids.mapping
+++ b/mappings/net/minecraft/util/Uuids.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/class_4844 net/minecraft/util/Uuids
 	FIELD field_40825 CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_41525 STRING_CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_46588 STRICT_CODEC Lcom/mojang/serialization/Codec;
-	FIELD field_47491 INT_STREAM_LIST_CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_47491 SET_CODEC Lcom/mojang/serialization/Codec;
 	METHOD method_26274 toIntArray (JJ)[I
 		ARG 0 uuidMost
 		ARG 2 uuidLeast


### PR DESCRIPTION
This is a codec for a set of UUIDs. (Because 4-int representation is the standard I just omitted that part.)