### PR TITLE
Update `ClickableWidget#renderButton` to `ClickableWidget#renderWidget`

### DIFF
--- a/mappings/net/minecraft/client/gui/widget/ClickableWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ClickableWidget.mapping
@@ -63,7 +63,7 @@ CLASS net/minecraft/class_339 net/minecraft/client/gui/widget/ClickableWidget
 		ARG 1 tooltip
 	METHOD method_47402 setTooltipDelay (I)V
 		ARG 1 delay
-	METHOD method_48579 renderButton (Lnet/minecraft/class_332;IIF)V
+	METHOD method_48579 renderWidget (Lnet/minecraft/class_332;IIF)V
 		ARG 1 context
 		ARG 2 mouseX
 		ARG 3 mouseY


### PR DESCRIPTION
Since the `EntryListWidget` now extends `ClickableWidget`, `ClickableWidget`'s `renderButton` is updated  to have more generic name; `renderWidget`.