### PR TITLE
Rename the NbtTagSizeTracker class to NbtSizeTracker

### DIFF
--- a/mappings/net/minecraft/nbt/NbtIo.mapping
+++ b/mappings/net/minecraft/nbt/NbtIo.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_2507 net/minecraft/nbt/NbtIo
 	COMMENT A set of utility functions for reading, writing, and scanning NBT files.
-	COMMENT Methods that do not require {@link NbtTagSizeTracker} accept any bytes of data,
-	COMMENT provided that its depth does not exceed {@value NbtTagSizeTracker#DEFAULT_MAX_DEPTH}.
+	COMMENT Methods that do not require {@link NbtSizeTracker} accept any bytes of data,
+	COMMENT provided that its depth does not exceed {@value NbtSizeTracker#DEFAULT_MAX_DEPTH}.
 	COMMENT
 	COMMENT <p>When {@linkplain DataOutput#writeUTF writing an invalid string}, methods in
 	COMMENT this class will write an empty string instead of crashing, with the exception of
@@ -41,7 +41,7 @@ CLASS net/minecraft/class_2507 net/minecraft/nbt/NbtIo
 		COMMENT @throws IOException if the IO operation fails or if the root NBT element is
 		COMMENT not a compound
 		COMMENT @throws NbtSizeValidationException if the NBT is too deep
-		COMMENT @see #readCompressed(Path, NbtTagSizeTracker)
+		COMMENT @see #readCompressed(Path, NbtSizeTracker)
 		ARG 0 stream
 		ARG 1 tagSizeTracker
 	METHOD method_10630 write (Lnet/minecraft/class_2487;Ljava/nio/file/Path;)V
@@ -60,7 +60,7 @@ CLASS net/minecraft/class_2507 net/minecraft/nbt/NbtIo
 		COMMENT method will <strong>throw an error</strong>, unlike other methods.
 		COMMENT
 		COMMENT @throws IOException if the IO operation fails
-		COMMENT @see #read(DataInput, NbtTagSizeTracker)
+		COMMENT @see #read(DataInput, NbtSizeTracker)
 		COMMENT @see #writeForPacket(NbtElement, DataOutput)
 		COMMENT @see #write(NbtElement, DataOutput)
 		ARG 0 nbt
@@ -87,7 +87,7 @@ CLASS net/minecraft/class_2507 net/minecraft/nbt/NbtIo
 		COMMENT @throws IOException if the IO operation fails or if the root NBT element is
 		COMMENT not a compound
 		COMMENT @throws NbtSizeValidationException if the NBT is too deep
-		COMMENT @see #readCompressed(InputStream, NbtTagSizeTracker)
+		COMMENT @see #readCompressed(InputStream, NbtSizeTracker)
 		ARG 0 path
 		ARG 1 tagSizeTracker
 	METHOD method_30614 writeCompressed (Lnet/minecraft/class_2487;Ljava/nio/file/Path;)V
@@ -118,7 +118,7 @@ CLASS net/minecraft/class_2507 net/minecraft/nbt/NbtIo
 		COMMENT
 		COMMENT @throws IOException if the IO operation fails
 		COMMENT @throws NbtSizeValidationException if the {@code tracker}'s validation fails
-		COMMENT @see #scanCompressed(InputStream, NbtScanner, NbtTagSizeTracker)
+		COMMENT @see #scanCompressed(InputStream, NbtScanner, NbtSizeTracker)
 		ARG 0 path
 		ARG 1 scanner
 		ARG 2 tracker
@@ -131,7 +131,7 @@ CLASS net/minecraft/class_2507 net/minecraft/nbt/NbtIo
 		COMMENT
 		COMMENT @throws IOException if the IO operation fails
 		COMMENT @throws NbtSizeValidationException if the {@code tracker}'s validation fails
-		COMMENT @see #scanCompressed(Path, NbtScanner, NbtTagSizeTracker)
+		COMMENT @see #scanCompressed(Path, NbtScanner, NbtSizeTracker)
 		ARG 0 stream
 		ARG 1 scanner
 		ARG 2 tracker
@@ -148,13 +148,13 @@ CLASS net/minecraft/class_2507 net/minecraft/nbt/NbtIo
 		COMMENT
 		COMMENT @apiNote In vanilla, this is used exclusively in networking.
 		COMMENT @throws IOException if the IO operation fails
-		COMMENT @see #read(DataInput, NbtTagSizeTracker)
+		COMMENT @see #read(DataInput, NbtSizeTracker)
 		COMMENT @see #write(NbtElement, DataOutput)
 		ARG 0 nbt
 		ARG 1 output
 	METHOD method_52894 read (Ljava/io/DataInput;Lnet/minecraft/class_2505;)Lnet/minecraft/class_2520;
 		COMMENT Reads an NBT element from {@code input}. Unlike {@link
-		COMMENT #readCompound(DataInput, NbtTagSizeTracker)}, the element does not have to
+		COMMENT #readCompound(DataInput, NbtSizeTracker)}, the element does not have to
 		COMMENT be a compound.
 		COMMENT
 		COMMENT @return the NBT element from the input
@@ -174,7 +174,7 @@ CLASS net/minecraft/class_2507 net/minecraft/nbt/NbtIo
 		COMMENT method will write an empty string instead of crashing.
 		COMMENT
 		COMMENT @throws IOException if the IO operation fails
-		COMMENT @see #read(DataInput, NbtTagSizeTracker)
+		COMMENT @see #read(DataInput, NbtSizeTracker)
 		COMMENT @see #writeForPacket(NbtElement, DataOutput)
 		COMMENT @see #writeUnsafe(NbtElement, DataOutput)
 		ARG 0 nbt

--- a/mappings/net/minecraft/nbt/NbtSizeTracker.mapping
+++ b/mappings/net/minecraft/nbt/NbtSizeTracker.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2505 net/minecraft/nbt/NbtTagSizeTracker
+CLASS net/minecraft/class_2505 net/minecraft/nbt/NbtSizeTracker
 	COMMENT Tracks the size of NBT elements in bytes and in depth. Throws {@link
 	COMMENT NbtSizeValidationException} if the tracked element becomes larger than {@link
 	COMMENT #maxBytes} or if the depth exceeds {@link #maxDepth} during addition.

--- a/mappings/net/minecraft/network/PacketByteBuf.mapping
+++ b/mappings/net/minecraft/network/PacketByteBuf.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 	COMMENT  <th><b>Object Type</b></th> <th><b>read method</b></th> <th><b>write method</b></th>
 	COMMENT </tr>
 	COMMENT <tr>
-	COMMENT  <td>Codec-based (NBT)</td><td>{@link #decode(DynamicOps, Codec, NbtTagSizeTracker)}</td><td>{@link #encode(DynamicOps, Codec, Object)}</td>
+	COMMENT  <td>Codec-based (NBT)</td><td>{@link #decode(DynamicOps, Codec, NbtSizeTracker)}</td><td>{@link #encode(DynamicOps, Codec, Object)}</td>
 	COMMENT </tr>
 	COMMENT <tr>
 	COMMENT  <td>Codec-based (JSON)</td><td>{@link #decodeAsJson(Codec)}</td><td>{@link #encodeAsJson(Codec, Object)}</td>
@@ -351,7 +351,7 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 		COMMENT @throws io.netty.handler.codec.EncoderException if the NBT cannot be
 		COMMENT written
 		COMMENT @see #readNbt()
-		COMMENT @see #readNbt(NbtTagSizeTracker)
+		COMMENT @see #readNbt(NbtSizeTracker)
 		ARG 1 nbt
 	METHOD method_10795 readByteArray ()[B
 		COMMENT Reads an array of primitive bytes from this buf. The array first has a
@@ -383,14 +383,14 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 		COMMENT this method returns {@code null}. The compound can have a maximum size of
 		COMMENT {@value #MAX_READ_NBT_SIZE} bytes.
 		COMMENT
-		COMMENT <p>Note that unlike {@link #readNbt(NbtTagSizeTracker)}, this can only
+		COMMENT <p>Note that unlike {@link #readNbt(NbtSizeTracker)}, this can only
 		COMMENT read compounds.
 		COMMENT
 		COMMENT @return the read compound, may be {@code null}
 		COMMENT @throws io.netty.handler.codec.EncoderException if the NBT cannot be read
 		COMMENT @throws net.minecraft.nbt.NbtSizeValidationException if the compound exceeds the allowed maximum size
 		COMMENT @see #writeNbt(NbtCompound)
-		COMMENT @see #readNbt(NbtTagSizeTracker)
+		COMMENT @see #readNbt(NbtSizeTracker)
 		COMMENT @see #MAX_READ_NBT_SIZE
 	METHOD method_10799 readIntArray (I)[I
 		COMMENT Reads an array of primitive ints from this buf. The array first has a
@@ -494,7 +494,7 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 			COMMENT the pos to write
 	METHOD method_10808 readText ()Lnet/minecraft/class_2561;
 		COMMENT Reads a text from this buf. A text is represented as an NBT-encoded data
-		COMMENT with {@linkplain NbtTagSizeTracker the maximum size} as {@value #MAX_READ_NBT_SIZE}.
+		COMMENT with {@linkplain NbtSizeTracker the maximum size} as {@value #MAX_READ_NBT_SIZE}.
 		COMMENT
 		COMMENT @return the read text
 		COMMENT @throws io.netty.handler.codec.EncoderException if the NBT cannot be read
@@ -647,7 +647,7 @@ CLASS net/minecraft/class_2540 net/minecraft/network/PacketByteBuf
 		COMMENT @param <T> the encoded object's type
 		COMMENT @throws io.netty.handler.codec.EncoderException if the {@code codec} fails
 		COMMENT to encode the compound NBT
-		COMMENT @see #decode(DynamicOps, Codec, NbtTagSizeTracker)
+		COMMENT @see #decode(DynamicOps, Codec, NbtSizeTracker)
 		ARG 1 ops
 		ARG 2 codec
 		ARG 3 value

--- a/unpick-definitions/network.unpick
+++ b/unpick-definitions/network.unpick
@@ -12,7 +12,7 @@ target_method net/minecraft/network/PacketByteBuf readString (I)Ljava/lang/Strin
 target_method net/minecraft/network/PacketByteBuf writeString (Ljava/lang/String;I)Lnet/minecraft/network/PacketByteBuf;
 	param 1 max_string_length
 # somehow does not work
-#target_method net/minecraft/nbt/NbtTagSizeTracker <init> (J)V
+#target_method net/minecraft/nbt/NbtSizeTracker <init> (J)V
 #	param 0 max_nbt_size
 target_method net/minecraft/network/encoding/VarInts getSizeInBytes (I)I
 	return max_var_int_length


### PR DESCRIPTION
Yarn has historically avoided redundant naming with regards to NBT, so renaming the `NbtTagSizeTracker` class (effectively 'named binary tag tag size tracker') seems like a logical step.