### PR TITLE
Add distinct names to `Sprite` classes

### DIFF
--- a/mappings/net/minecraft/client/gui/tooltip/BundleTooltipComponent.mapping
+++ b/mappings/net/minecraft/client/gui/tooltip/BundleTooltipComponent.mapping
@@ -22,7 +22,7 @@ CLASS net/minecraft/class_5682 net/minecraft/client/gui/tooltip/BundleTooltipCom
 	METHOD method_33290 getRows ()I
 	METHOD method_52755 getColumnsWidth ()I
 	METHOD method_52756 getRowsHeight ()I
-	CLASS class_5771 Sprite
+	CLASS class_5771 SlotSprite
 		FIELD field_28370 width I
 		FIELD field_28371 height I
 		FIELD field_45507 texture Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/client/texture/atlas/AtlasSprite.mapping
+++ b/mappings/net/minecraft/client/texture/atlas/AtlasSprite.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_7958 net/minecraft/client/texture/atlas/Sprite
+CLASS net/minecraft/class_7958 net/minecraft/client/texture/atlas/AtlasSprite
 	FIELD field_41416 id Lnet/minecraft/class_2960;
 	FIELD field_41417 resource Lnet/minecraft/class_3298;
 	FIELD field_41418 image Ljava/util/concurrent/atomic/AtomicReference;


### PR DESCRIPTION
Classes `net.minecraft.client.gui.tooltip.BundleTooltipComponent.Sprite`, `net.minecraft.client.texture.atlas.Sprite`, `net.minecraft.client.texture.Sprite` share the same name. In my experience 2 last ones caused import issues most frequently. 
This PR renames the first two to `SlotSprite` and `AtlasSprite` respectively.