### PR TITLE
Add Javadoc descriptions to the fields of AbstractBlock

### DIFF
--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -230,10 +230,10 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 	FIELD field_23163 slipperiness F
 	FIELD field_23164 velocityMultiplier F
 	FIELD field_23165 jumpVelocityMultiplier F
-		COMMENT The multiplier applied to a {@link net.minecraft.entity.LivingEntity} when jumping off this block.
+		COMMENT The multiplier applied to the velocity of a {@link net.minecraft.entity.LivingEntity} when it jumps off this block.
 		COMMENT
 		COMMENT @see Block#getJumpVelocityMultiplier
-		COMMENT @see net.minecraft.entity.LivingEntity#getJumpVelocityMultiplier
+		COMMENT @see net.minecraft.entity.Entity#getJumpVelocityMultiplier
 	FIELD field_40337 requiredFeatures Lnet/minecraft/class_7699;
 	METHOD <init> (Lnet/minecraft/class_4970$class_2251;)V
 		ARG 1 settings

--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -220,21 +220,53 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 	COMMENT <li>Called before {@link #getDroppedStacks getDroppedStacks} in this case.</li>
 	COMMENT </ol>
 	FIELD field_23154 dynamicBounds Z
+		COMMENT Whether this block's collision shape can change.
+		COMMENT
+		COMMENT @see #hasDynamicBounds
 	FIELD field_23155 settings Lnet/minecraft/class_4970$class_2251;
+		COMMENT The {@link AbstractBlock.Settings} to apply to this block.
 	FIELD field_23156 lootTableId Lnet/minecraft/class_2960;
+		COMMENT The {@link net.minecraft.util.Identifier} of the loot table that determines what this block drops.
+		COMMENT
+		COMMENT @see #getLootTableId
+		COMMENT @see #getDroppedStacks
 	FIELD field_23157 DIRECTIONS [Lnet/minecraft/class_2350;
 	FIELD field_23159 collidable Z
+		COMMENT Whether this block can be walked on or through.
+		COMMENT
+		COMMENT @see #getCollisionShape
 	FIELD field_23160 resistance F
+		COMMENT The blast resistance of the block.
+		COMMENT
+		COMMENT @see Block#getBlastResistance
 	FIELD field_23161 randomTicks Z
+		COMMENT Whether this block should tick when randomly selected when ticking the world. An example of this ticking is crop growth.
+		COMMENT
+		COMMENT @see Block#hasRandomTicks
+		COMMENT @see net.minecraft.server.world.ServerWorld#tickChunk
 	FIELD field_23162 soundGroup Lnet/minecraft/class_2498;
+		COMMENT The collection of sounds played when breaking, stepping on, placing, hitting (with a projectile), or falling on this block.
+		COMMENT
+		COMMENT @see #getSoundGroup
 	FIELD field_23163 slipperiness F
+		COMMENT A speed reduction applied to a {@link net.minecraft.entity.LivingEntity} that tries to move across this block.
+		COMMENT
+		COMMENT @see Block#getSlipperiness
+		COMMENT @see net.minecraft.entity.LivingEntity#travel
 	FIELD field_23164 velocityMultiplier F
+		COMMENT The multiplier applied to the velocity of an {@link net.minecraft.entity.Entity} when it walks on this block.
+		COMMENT
+		COMMENT @see Block#getVelocityMultiplier
+		COMMENT @see net.minecraft.entity.Entity#getVelocityMultiplier
 	FIELD field_23165 jumpVelocityMultiplier F
 		COMMENT The multiplier applied to the velocity of a {@link net.minecraft.entity.LivingEntity} when it jumps off this block.
 		COMMENT
 		COMMENT @see Block#getJumpVelocityMultiplier
 		COMMENT @see net.minecraft.entity.Entity#getJumpVelocityMultiplier
 	FIELD field_40337 requiredFeatures Lnet/minecraft/class_7699;
+		COMMENT The set of {@link net.minecraft.resource.featuretoggle.FeatureFlag FeatureFlags} that are required for this block to work correctly.
+		COMMENT
+		COMMENT @see net.minecraft.resource.featuretoggle.FeatureFlags
 	METHOD <init> (Lnet/minecraft/class_4970$class_2251;)V
 		ARG 1 settings
 	METHOD method_17454 createScreenHandlerFactory (Lnet/minecraft/class_2680;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)Lnet/minecraft/class_3908;

--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -230,6 +230,10 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 	FIELD field_23163 slipperiness F
 	FIELD field_23164 velocityMultiplier F
 	FIELD field_23165 jumpVelocityMultiplier F
+		COMMENT The multiplier applied to a {@link net.minecraft.entity.LivingEntity} when jumping off this block.
+		COMMENT
+		COMMENT @see Block#getJumpVelocityMultiplier
+		COMMENT @see net.minecraft.entity.LivingEntity#getJumpVelocityMultiplier
 	FIELD field_40337 requiredFeatures Lnet/minecraft/class_7699;
 	METHOD <init> (Lnet/minecraft/class_4970$class_2251;)V
 		ARG 1 settings


### PR DESCRIPTION
As in the title.

```java
    /**
     * Whether this block can be walked on or through.
     * 
     * @see #getCollisionShape
     */
    protected final boolean collidable;
    /**
     * The blast resistance of the block.
     * 
     * @see Block#getBlastResistance
     */
    protected final float resistance;
    /**
     * Whether this block should tick when randomly selected when ticking the world. An example of this ticking is crop growth.
     * 
     * @see Block#hasRandomTicks
     * @see net.minecraft.server.world.ServerWorld#tickChunk
     */
    protected final boolean randomTicks;
    /**
     * The collection of sounds played when breaking, stepping on, placing, hitting (with a projectile), or falling on this block.
     * 
     * @see #getSoundGroup
     */
    protected final BlockSoundGroup soundGroup;
    /**
     * A speed reduction applied to a {@link net.minecraft.entity.LivingEntity} that tries to move across this block.
     * 
     * @see Block#getSlipperiness
     * @see net.minecraft.entity.LivingEntity#travel
     */
    protected final float slipperiness;
    /**
     * The multiplier applied to the velocity of an {@link net.minecraft.entity.Entity} when it walks on this block.
     * 
     * @see Block#getVelocityMultiplier
     * @see net.minecraft.entity.Entity#getVelocityMultiplier
     */
    protected final float velocityMultiplier;
    /**
     * The multiplier applied to the velocity of a {@link net.minecraft.entity.LivingEntity} when it jumps off this block.
     * 
     * @see Block#getJumpVelocityMultiplier
     * @see net.minecraft.entity.Entity#getJumpVelocityMultiplier
     */
    protected final float jumpVelocityMultiplier;
    /**
     * Whether this block's collision shape can change.
     * 
     * @see #hasDynamicBounds
     */
    protected final boolean dynamicBounds;
    /**
     * The set of {@link net.minecraft.resource.featuretoggle.FeatureFlag FeatureFlags} that are required for this block to work correctly.
     * 
     * @see net.minecraft.resource.featuretoggle.FeatureFlags
     */
    protected final FeatureSet requiredFeatures;
    /**
     * The {@link AbstractBlock.Settings} to apply to this block.
     */
    protected final AbstractBlock.Settings settings;
    /**
     * The {@link net.minecraft.util.Identifier} of the loot table that determines what this block drops.
     * 
     * @see #getLootTableId
     * @see #getDroppedStacks
     */
    @Nullable
    protected Identifier lootTableId;
```
