### PR TITLE
Rename `SculkShriekerWarningManager#canIncreaseWarningLevel` to `isWardenNearby`

### DIFF
--- a/mappings/net/minecraft/block/entity/SculkShriekerWarningManager.mapping
+++ b/mappings/net/minecraft/block/entity/SculkShriekerWarningManager.mapping
@@ -26,7 +26,7 @@ CLASS net/minecraft/class_7262 net/minecraft/block/entity/SculkShriekerWarningMa
 	METHOD method_42255 (Lnet/minecraft/class_243;Lnet/minecraft/class_3222;)Z
 		ARG 1 player
 	METHOD method_42258 reset ()V
-	METHOD method_42259 canIncreaseWarningLevel (Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;)Z
+	METHOD method_42259 isWardenNearby (Lnet/minecraft/class_3218;Lnet/minecraft/class_2338;)Z
 		ARG 0 world
 		ARG 1 pos
 	METHOD method_42261 increaseWarningLevel ()V


### PR DESCRIPTION
The name of the `canIncreaseWarningLevel()` method of `SculkShriekerWarningManager` suggests the opposite of what it is actually used for, and is overbroad. 

This method is used in `warnNearbyPlayers()` to prevent shriekers from spawning multiple wardens if other wardens are nearby. It returns `true` if there are any Wardens within a 48x48x48 box around the given position in the world, and false if there are none. When it returns `true`, then `warnNearbyPlayers()` will fail. However, the current name suggests that `warnNearbyPlayers()` should only fail if `canIncreaseWarningLevel()` returns false.

It is also a bit overbroad, as there are other conditions that are checked to see if a sculk shrieker will warn a player or not, so this PR fixes these issues by renaming the method to `isWardenNearby` to better reflect both what the method actually does and is used for.