### PR TITLE
Let's not do that again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,26 +1,27 @@
-.gradle/
-*-merged.jar
-*-mapped.jar
-*-intermediary.jar
-*.DS_Store
-build/
-out/
-mappings_official/
-namedSrc/
+# Ignore everything
+/*
 
-# idea
-.idea/
-*.iml
-*.iws
-*.ipr
-*.jar
+# Folders
+!/.github
+!/filament
+!/gradle
+!/src
+!/unpick-definitions
 
-# eclipse
-.eclipse
-.classpath
-.project
-.settings/
+# Files
 
-# vscode
-.vscode/
-bin/
+!.editorconfig
+!.gitattributes
+!.gitignore
+!build.gradle
+!CONTRIBUTING.md
+!enigma_profile.json
+!gradle.properties
+!gradlew
+!gradlew.bat
+!HEADER
+!LICENSE
+!MAINTAINERS
+!README.md
+!settings.gradle
+!unpick-logging.properties

--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ tasks.register('downloadIntermediary', DownloadTask) {
 tasks.register('mapIntermediaryJar', MapJarTask) {
 	dependsOn downloadIntermediary, mergeMinecraftJars
 	group = mapJarGroup
-	output = file("${minecraft_version}-intermediary.jar")
+	output = layout.buildDirectory.file("${minecraft_version}-intermediary.jar")
 	input = mergeMinecraftJars.output
 	mappings = downloadIntermediary.output
 	classpath.from minecraftLibraries
@@ -135,7 +135,7 @@ tasks.register('mapIntermediaryJar', MapJarTask) {
 tasks.register('mapServerIntermediaryJar', MapJarTask) {
 	dependsOn downloadIntermediary, extractBundledServer
 	group = mapJarGroup
-	output = file("${minecraft_version}-server-intermediary.jar")
+	output = layout.buildDirectory.file("${minecraft_version}-server-intermediary.jar")
 	input = extractBundledServer.output
 	mappings = downloadIntermediary.output
 	classpath.from minecraftLibraries
@@ -338,7 +338,7 @@ remapUnpickDefinitionsIntermediary {
 tasks.register('unpickIntermediaryJar', UnpickJarTask) {
 	group = 'unpick'
 	input = mapIntermediaryJar.output
-	output = file("${minecraft_version}-intermediary-unpicked.jar")
+	output = layout.buildDirectory.file("${minecraft_version}-intermediary-unpicked.jar")
 	unpickDefinition = remapUnpickDefinitionsIntermediary.output
 	constantsJarFile = constantsJar.archiveFile
 	classpath.from minecraftLibraries
@@ -406,7 +406,7 @@ tasks.register('v2MergedYarnJar', Jar) {
 tasks.register('mapNamedJar', MapJarTask) {
 	dependsOn mergeV2, unpickIntermediaryJar
 	group = mapJarGroup
-	output = file("${minecraft_version}-named.jar")
+	output = layout.buildDirectory.file("${minecraft_version}-named.jar")
 	input = unpickIntermediaryJar.output
 	mappings = mergeV2.output
 	classpath.from minecraftLibraries
@@ -445,7 +445,7 @@ tasks.register('genFakeSource', JavaExec) {
 }
 
 tasks.register('decompileCFR', JavaExec) {
-	def outputDir = file("namedSrc")
+	def outputDir = layout.buildDirectory.file("namedSrc")
 
 	dependsOn mapNamedJar
 	mainClass = "org.benf.cfr.reader.Main"

--- a/filament/.gitignore
+++ b/filament/.gitignore
@@ -1,0 +1,12 @@
+# Ignore everything
+/*
+
+# Folders
+!/src
+# Files
+
+!.gitignore
+!build.gradle
+!checkstyle.xml
+!gradle.properties
+!settings.gradle


### PR DESCRIPTION
- Move to using a "git include", every file on the repo must be specified 
- No longer place jars or sources in the root of the project where its easy for them to get commited