### PR TITLE
Rename deceptively named `roll` field in `LivingEntity`

### DIFF
--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -47,7 +47,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	FIELD field_6235 hurtTime I
 	FIELD field_6236 attacking Lnet/minecraft/class_1309;
 	FIELD field_6238 playerHitTimer I
-	FIELD field_6239 roll I
+	FIELD field_6239 fallFlyingTicks I
 	FIELD field_6240 POTION_SWIRLS_COLOR Lnet/minecraft/class_2940;
 	FIELD field_6241 headYaw F
 	FIELD field_6243 leaningPitch F
@@ -381,7 +381,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_5999 isUndead ()Z
 	METHOD method_6000 enterCombat ()V
 	METHOD method_6002 getDeathSound ()Lnet/minecraft/class_3414;
-	METHOD method_6003 getRoll ()I
+	METHOD method_6003 getFallFlyingTicks ()I
 	METHOD method_6005 takeKnockback (DDD)V
 		ARG 1 strength
 		ARG 3 x


### PR DESCRIPTION
As the title suggests, this field in `LivingEntity` seems very deceptively named, and managed to get me quite confused in the process. Turns out it has nothing to do with the entity's roll, whatever that may be, but instead seems to count the amount of ticks since the entity started fall flying. This PR proposes it to be renamed to `fallFlyingTicks`.