### PR TITLE
Map a method and field related to components

### DIFF
--- a/mappings/net/minecraft/block/entity/DecoratedPotBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/DecoratedPotBlockEntity.mapping
@@ -10,7 +10,7 @@ CLASS net/minecraft/class_8172 net/minecraft/block/entity/DecoratedPotBlockEntit
 	METHOD <init> (Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)V
 		ARG 1 pos
 		ARG 2 state
-	METHOD method_49196 readNbtFromStack (Lnet/minecraft/class_1799;)V
+	METHOD method_49196 readFrom (Lnet/minecraft/class_1799;)V
 		ARG 1 stack
 	METHOD method_49204 getHorizontalFacing ()Lnet/minecraft/class_2350;
 	METHOD method_51511 getSherds ()Lnet/minecraft/class_8526;

--- a/mappings/net/minecraft/component/type/DyedColorComponent.mapping
+++ b/mappings/net/minecraft/component/type/DyedColorComponent.mapping
@@ -1,6 +1,7 @@
 CLASS net/minecraft/class_9282 net/minecraft/component/type/DyedColorComponent
 	FIELD field_49312 CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_49313 PACKET_CODEC Lnet/minecraft/class_9139;
+	FIELD field_49314 DEFAULT_COLOR I
 	FIELD field_49750 BASE_CODEC Lcom/mojang/serialization/Codec;
 	METHOD method_57469 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 0 instance


### PR DESCRIPTION
`field_49314` matches the one originally from `DyeItem.DEFAULT_COLOR` and `readFrom` (previously `readNbtFromStack`) matches the other method in `BannerBlockEntity`, as it also copies the components.