### PR TITLE
Rename messageHistorySize to messageHistoryIndex

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/ChatScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ChatScreen.mapping
@@ -8,7 +8,7 @@ CLASS net/minecraft/class_408 net/minecraft/client/gui/screen/ChatScreen
 	FIELD field_18973 originalChatText Ljava/lang/String;
 	FIELD field_21616 chatInputSuggestor Lnet/minecraft/class_4717;
 	FIELD field_2382 chatField Lnet/minecraft/class_342;
-	FIELD field_2387 messageHistorySize I
+	FIELD field_2387 messageHistoryIndex I
 	FIELD field_2389 chatLastMessage Ljava/lang/String;
 	FIELD field_32237 SHIFT_SCROLL_AMOUNT D
 	FIELD field_33953 USAGE_TEXT Lnet/minecraft/class_2561;


### PR DESCRIPTION
This variable is only used in method `setChatFromHistory` and points to some past message when the player uses up/down key to navigate through history.
It should be renamed to avoid confusion.