### PR TITLE
Rename the ServerPlayerEntity#setGameMode method to readGameModeNbt

### DIFF
--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -195,7 +195,7 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 		COMMENT
 		COMMENT @see MinecraftServer#getForcedGameMode
 		ARG 1 backupGameMode
-	METHOD method_32748 setGameMode (Lnet/minecraft/class_2487;)V
+	METHOD method_32748 readGameModeNbt (Lnet/minecraft/class_2487;)V
 		ARG 1 nbt
 	METHOD method_32749 writeGameModeNbt (Lnet/minecraft/class_2487;)V
 		ARG 1 nbt


### PR DESCRIPTION
The method changed by this pull request updates both the current and previous game mode from NBT, which matches the existing `ServerPlayerEntity#writeGameModeNbt` method.