### PR TITLE
Javadoc fixes for net.minecraft.nbt.NbtIo

### DIFF
--- a/mappings/net/minecraft/nbt/NbtIo.mapping
+++ b/mappings/net/minecraft/nbt/NbtIo.mapping
@@ -136,7 +136,7 @@ CLASS net/minecraft/class_2507 net/minecraft/nbt/NbtIo
 		ARG 1 scanner
 		ARG 2 tracker
 	METHOD method_40059 decompress (Ljava/io/InputStream;)Ljava/io/DataInputStream;
-		COMMENT @return a new input stream that decompresses the input {@code stream}
+		COMMENT {@return a new input stream that decompresses the input {@code stream}}
 		ARG 0 stream
 	METHOD method_52892 readElement (Ljava/io/DataInput;Lnet/minecraft/class_2505;B)Lnet/minecraft/class_2520;
 		ARG 0 input
@@ -163,7 +163,7 @@ CLASS net/minecraft/class_2507 net/minecraft/nbt/NbtIo
 		ARG 0 input
 		ARG 1 tracker
 	METHOD method_54906 compress (Ljava/io/OutputStream;)Ljava/io/DataOutputStream;
-		COMMENT @return a new output stream that compresses the input {@code stream}
+		COMMENT {@return a new output stream that compresses the input {@code stream}}
 		ARG 0 stream
 	METHOD method_55324 write (Lnet/minecraft/class_2520;Ljava/io/DataOutput;)V
 		COMMENT Writes the {@code nbt} to {@code output}. The output is the byte indicating

--- a/mappings/net/minecraft/nbt/NbtIo.mapping
+++ b/mappings/net/minecraft/nbt/NbtIo.mapping
@@ -136,7 +136,7 @@ CLASS net/minecraft/class_2507 net/minecraft/nbt/NbtIo
 		ARG 1 scanner
 		ARG 2 tracker
 	METHOD method_40059 decompress (Ljava/io/InputStream;)Ljava/io/DataInputStream;
-		COMMENT {@return a new input stream that decompresses the input {@code stream}}
+		COMMENT @return a new input stream that decompresses the input {@code stream}
 		ARG 0 stream
 	METHOD method_52892 readElement (Ljava/io/DataInput;Lnet/minecraft/class_2505;B)Lnet/minecraft/class_2520;
 		ARG 0 input
@@ -163,7 +163,7 @@ CLASS net/minecraft/class_2507 net/minecraft/nbt/NbtIo
 		ARG 0 input
 		ARG 1 tracker
 	METHOD method_54906 compress (Ljava/io/OutputStream;)Ljava/io/DataOutputStream;
-		COMMENT {@return a new output stream that compresses the input {@code stream}}
+		COMMENT @return a new output stream that compresses the input {@code stream}
 		ARG 0 stream
 	METHOD method_55324 write (Lnet/minecraft/class_2520;Ljava/io/DataOutput;)V
 		COMMENT Writes the {@code nbt} to {@code output}. The output is the byte indicating

--- a/mappings/net/minecraft/nbt/NbtIo.mapping
+++ b/mappings/net/minecraft/nbt/NbtIo.mapping
@@ -48,7 +48,7 @@ CLASS net/minecraft/class_2507 net/minecraft/nbt/NbtIo
 		COMMENT Writes the {@code nbt} to the file at {@code path}.
 		COMMENT
 		COMMENT @throws IOException if the IO operation fails
-		COMMENT @see #write(NbtCompound, DataOutput)
+		COMMENT @see #writeCompound(NbtCompound, DataOutput)
 		ARG 0 nbt
 		ARG 1 path
 	METHOD method_10631 writeUnsafe (Lnet/minecraft/class_2520;Ljava/io/DataOutput;)V


### PR DESCRIPTION
This PR fixes ~~two issues~~ one issue I found when reading the Javadocs in NbtIo:

~~1) `compress` and `decompress` had their `@return` comments wrapped with `{}`~~
![image](https://github.com/FabricMC/yarn/assets/61277953/f59ac383-1b78-49bc-b5da-30870e8bc1fe)

2) The wrong method name was used when referring to `writeCompound(NbtCompound, DataOutput)`
![image](https://github.com/FabricMC/yarn/assets/61277953/1c51cbd6-14e7-419a-8834-3034c519ad83)
