### PR TITLE
Rename AbstractBlock.lootTableId -> lootTableKey

### DIFF
--- a/mappings/net/minecraft/block/AbstractBlock.mapping
+++ b/mappings/net/minecraft/block/AbstractBlock.mapping
@@ -225,10 +225,10 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		COMMENT @see Block#hasDynamicBounds
 	FIELD field_23155 settings Lnet/minecraft/class_4970$class_2251;
 		COMMENT The {@link AbstractBlock.Settings} to apply to this block.
-	FIELD field_23156 lootTableId Lnet/minecraft/class_5321;
-		COMMENT The {@link net.minecraft.util.Identifier} of the loot table that determines what this block drops.
+	FIELD field_23156 lootTableKey Lnet/minecraft/class_5321;
+		COMMENT The {@link RegistryKey} of the loot table that determines what this block drops.
 		COMMENT
-		COMMENT @see #getLootTableId
+		COMMENT @see #getLootTableKey
 		COMMENT @see #getDroppedStacks
 	FIELD field_23157 DIRECTIONS [Lnet/minecraft/class_2350;
 	FIELD field_23159 collidable Z
@@ -343,7 +343,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		COMMENT {@return the block as {@link Block}}
 		COMMENT
 		COMMENT <p>This is used for casting purposes.
-	METHOD method_26162 getLootTableId ()Lnet/minecraft/class_5321;
+	METHOD method_26162 getLootTableKey ()Lnet/minecraft/class_5321;
 	METHOD method_26403 getDefaultMapColor ()Lnet/minecraft/class_3620;
 	METHOD method_32913 getMaxHorizontalModelOffset ()F
 	METHOD method_36555 getHardness ()F
@@ -888,7 +888,7 @@ CLASS net/minecraft/class_4970 net/minecraft/block/AbstractBlock
 		FIELD field_10663 luminance Ljava/util/function/ToIntFunction;
 		FIELD field_10664 collidable Z
 		FIELD field_10665 soundGroup Lnet/minecraft/class_2498;
-		FIELD field_10666 lootTableId Lnet/minecraft/class_5321;
+		FIELD field_10666 lootTableKey Lnet/minecraft/class_5321;
 		FIELD field_10667 slipperiness F
 		FIELD field_10669 hardness F
 		FIELD field_10670 dynamicBounds Z


### PR DESCRIPTION
The field has been changed to a `RegistryKey<LootTable>`. (See also https://github.com/FabricMC/fabric/pull/3664#discussion_r1537932343 where some confusion came up about this :^) )