### PR TITLE
[1.20.1] Add mappings for AbstractNbtList.add/remove

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,9 +268,6 @@ combineUnpickDefinitions {
 java {
 	sourceCompatibility = JavaVersion.VERSION_17
 	targetCompatibility = JavaVersion.VERSION_17
-	toolchain {
-		languageVersion.set(JavaLanguageVersion.of(17))
-	}
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -268,6 +268,9 @@ combineUnpickDefinitions {
 java {
 	sourceCompatibility = JavaVersion.VERSION_17
 	targetCompatibility = JavaVersion.VERSION_17
+	toolchain {
+		languageVersion.set(JavaLanguageVersion.of(17))
+	}
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/mappings/net/minecraft/nbt/AbstractNbtList.mapping
+++ b/mappings/net/minecraft/nbt/AbstractNbtList.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_2483 net/minecraft/nbt/AbstractNbtList
 	COMMENT Represents an abstraction of a mutable NBT list which holds elements of the same type.
-	METHOD add (ILjava/lang/Object;)V
+	METHOD add add (ILjava/lang/Object;)V
 		ARG 1 index
 		ARG 2 value
 	METHOD method_10533 addElement (ILnet/minecraft/class_2520;)Z
@@ -21,7 +21,7 @@ CLASS net/minecraft/class_2483 net/minecraft/nbt/AbstractNbtList
 		COMMENT Gets the {@linkplain NbtElement#getType type} of element that this list holds.
 		COMMENT
 		COMMENT @return the type of element that this list holds
-	METHOD remove (I)Ljava/lang/Object;
+	METHOD remove remove (I)Ljava/lang/Object;
 		ARG 1 index
 	METHOD set (ILjava/lang/Object;)Ljava/lang/Object;
 		ARG 1 index

--- a/mappings/net/minecraft/nbt/AbstractNbtList.mapping
+++ b/mappings/net/minecraft/nbt/AbstractNbtList.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_2483 net/minecraft/nbt/AbstractNbtList
 	COMMENT Represents an abstraction of a mutable NBT list which holds elements of the same type.
-	METHOD add add (ILjava/lang/Object;)V
+	METHOD method_10531 add (ILjava/lang/Object;)V
 		ARG 1 index
 		ARG 2 value
 	METHOD method_10533 addElement (ILnet/minecraft/class_2520;)Z
@@ -21,7 +21,7 @@ CLASS net/minecraft/class_2483 net/minecraft/nbt/AbstractNbtList
 		COMMENT Gets the {@linkplain NbtElement#getType type} of element that this list holds.
 		COMMENT
 		COMMENT @return the type of element that this list holds
-	METHOD remove remove (I)Ljava/lang/Object;
+	METHOD method_10531 remove (I)Ljava/lang/Object;
 		ARG 1 index
 	METHOD set (ILjava/lang/Object;)Ljava/lang/Object;
 		ARG 1 index


### PR DESCRIPTION
Fixes NBT lists `add` and `remove` methods getting mixed up with their synthetic obfuscation.

Ensures Gradle to pick JVM 17 when the local default is set to another version (prevents Enigma from running properly)