### PR TITLE
Rename and document the SimpleParticleType class

### DIFF
--- a/mappings/net/minecraft/particle/SimpleParticleType.mapping
+++ b/mappings/net/minecraft/particle/SimpleParticleType.mapping
@@ -1,4 +1,9 @@
 CLASS net/minecraft/class_2400 net/minecraft/particle/SimpleParticleType
+	COMMENT A particle type representing a particle with no additional parameters.
+	COMMENT
+	COMMENT <p>Because no additional parameters can be provided, this particle type
+	COMMENT itself implements {@link ParticleEffect} and can be passed to methods
+	COMMENT which accept particle parameters.
 	FIELD field_11259 PARAMETER_FACTORY Lnet/minecraft/class_2394$class_2395;
 	FIELD field_25127 codec Lcom/mojang/serialization/MapCodec;
 	FIELD field_48460 PACKET_CODEC Lnet/minecraft/class_9139;

--- a/mappings/net/minecraft/particle/SimpleParticleType.mapping
+++ b/mappings/net/minecraft/particle/SimpleParticleType.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2400 net/minecraft/particle/DefaultParticleType
+CLASS net/minecraft/class_2400 net/minecraft/particle/SimpleParticleType
 	FIELD field_11259 PARAMETER_FACTORY Lnet/minecraft/class_2394$class_2395;
 	FIELD field_25127 codec Lcom/mojang/serialization/MapCodec;
 	FIELD field_48460 PACKET_CODEC Lnet/minecraft/class_9139;


### PR DESCRIPTION
This pull request implements one of three proposed changes in https://github.com/FabricMC/yarn/issues/3836#issuecomment-2041285454 while introducing documentation to clarify the use of the `SimpleParticleType` class.

The changed name should better reflect that the particle type is simple (having one variant) rather than default (having multiple variants but currently representing a default one). The documentation clears up cases such as the following code:

```java
ParticleEffect effect = ParticleTypes.SNOWFLAKE;
```