### PR TITLE
Fix a couple of inverted mapping semantics

### DIFF
--- a/mappings/net/minecraft/block/entity/ChiseledBookshelfBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/ChiseledBookshelfBlockEntity.mapping
@@ -8,7 +8,7 @@ CLASS net/minecraft/class_7716 net/minecraft/block/entity/ChiseledBookshelfBlock
 		ARG 2 state
 	METHOD method_47585 updateState (I)V
 		ARG 1 interactedSlot
-	METHOD method_47587 getOpenSlotCount ()I
+	METHOD method_47587 getFilledSlotCount ()I
 	METHOD method_47887 getLastInteractedSlot ()I
 	METHOD method_51356 (Lnet/minecraft/class_1799;Lnet/minecraft/class_1263;Lnet/minecraft/class_1799;)Z
 		ARG 2 stack2

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -166,13 +166,13 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 			COMMENT whether the new spawn point is {@linkplain #isSpawnForced() forced}
 		ARG 5 sendMessage
 			COMMENT if {@code true}, a game message about the spawn point change will be sent
-	METHOD method_26285 isBedTooFarAway (Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Z
+	METHOD method_26285 isBedWithinRange (Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Z
 		ARG 1 pos
 		ARG 2 direction
 	METHOD method_26286 isBedObstructed (Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Z
 		ARG 1 pos
 		ARG 2 direction
-	METHOD method_26287 isBedTooFarAway (Lnet/minecraft/class_2338;)Z
+	METHOD method_26287 isBedWithinRange (Lnet/minecraft/class_2338;)Z
 		ARG 1 pos
 	METHOD method_29205 (Lnet/minecraft/class_2487;Lnet/minecraft/class_2520;)V
 		ARG 1 encoded


### PR DESCRIPTION
Currently, `ChiseledBookshelfBlockEntity#getOpenSlotCount()` and `ServerPlayerEntity#isBedTooFarAway()` perform functions that are exact opposites of their mapping names; `getOpenSlotCount()` returns the number of slots that contain books and `isBedTooFarAway()` returns true if the player is close enough to sleep in the bed.

This pull request proposes the following changes:
```diff
- getOpenSlotCount()
+ getFilledSlotCount()
```
```diff
- isBedTooFarAway()
+ isBedWithinRange()
```