### PR TITLE
Fix renderFood parameter (left -> right)

### DIFF
--- a/mappings/net/minecraft/client/gui/hud/InGameHud.mapping
+++ b/mappings/net/minecraft/client/gui/hud/InGameHud.mapping
@@ -245,7 +245,7 @@ CLASS net/minecraft/class_329 net/minecraft/client/gui/hud/InGameHud
 		ARG 1 context
 		ARG 2 player
 		ARG 3 top
-		ARG 4 left
+		ARG 4 right
 	METHOD method_58478 renderArmor (Lnet/minecraft/class_332;Lnet/minecraft/class_1657;IIII)V
 		ARG 0 context
 		ARG 1 player


### PR DESCRIPTION
Can be verified by seeing that the value is subtracted from in `renderFood` (i.e. it renders the icons from right-to-left)