### PR TITLE
Remove invalid mappings

### DIFF
--- a/mappings/net/minecraft/block/entity/MobSpawnerBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/MobSpawnerBlockEntity.mapping
@@ -14,6 +14,3 @@ CLASS net/minecraft/class_2636 net/minecraft/block/entity/MobSpawnerBlockEntity
 		ARG 1 pos
 		ARG 2 state
 		ARG 3 blockEntity
-	METHOD method_46408 (Lnet/minecraft/class_1299;Lnet/minecraft/class_5819;)V
-		ARG 1 entityType
-		ARG 2 random

--- a/mappings/net/minecraft/client/gui/widget/ClickableWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ClickableWidget.mapping
@@ -45,18 +45,12 @@ CLASS net/minecraft/class_339 net/minecraft/client/gui/widget/ClickableWidget
 	METHOD method_25361 clicked (DD)Z
 		ARG 1 mouseX
 		ARG 3 mouseY
-	METHOD method_25365 (Z)V
-		ARG 1 focused
 	METHOD method_25367 isSelected ()Z
 	METHOD method_25369 getMessage ()Lnet/minecraft/class_2561;
 	METHOD method_32602 getNarrationMessage (Lnet/minecraft/class_2561;)Lnet/minecraft/class_5250;
 		ARG 0 message
 	METHOD method_37021 appendDefaultNarrations (Lnet/minecraft/class_6382;)V
 		ARG 1 builder
-	METHOD method_46419 (I)V
-		ARG 1 y
-	METHOD method_46421 (I)V
-		ARG 1 x
 	METHOD method_47399 appendClickableNarrations (Lnet/minecraft/class_6382;)V
 		ARG 1 builder
 	METHOD method_47400 setTooltip (Lnet/minecraft/class_7919;)V

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -882,8 +882,6 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		ARG 9 yaw
 		ARG 10 pitch
 	METHOD method_48155 canSprintAsVehicle ()Z
-	METHOD method_48850 (Ljava/util/List;)V
-		ARG 1 dataEntries
 	METHOD method_48921 couldAcceptPassenger ()Z
 		COMMENT {@return {@code true} if this entity supports passengers in general}
 	METHOD method_48922 onDamaged (Lnet/minecraft/class_1282;)V
@@ -1228,12 +1226,6 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_5671 getCommandSource ()Lnet/minecraft/class_2168;
 		COMMENT {@return a command source which represents this entity}
 	METHOD method_5672 getHighSpeedSplashSound ()Lnet/minecraft/class_3414;
-	METHOD method_5674 (Lnet/minecraft/class_2940;)V
-		COMMENT Called on the client when the tracked data is set.
-		COMMENT
-		COMMENT <p>This can be overridden to refresh other fields when the tracked data
-		COMMENT is set or changed.
-		ARG 1 data
 	METHOD method_5675 isPushedByFluids ()Z
 		COMMENT {@return whether the entity is pushed by fluids}
 		COMMENT

--- a/mappings/net/minecraft/entity/ai/brain/task/MultiTickTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/MultiTickTask.mapping
@@ -23,19 +23,7 @@ CLASS net/minecraft/class_4097 net/minecraft/entity/ai/brain/task/MultiTickTask
 		ARG 1 world
 		ARG 2 entity
 		ARG 3 time
-	METHOD method_18922 (Lnet/minecraft/class_3218;Lnet/minecraft/class_1309;J)Z
-		ARG 1 world
-		ARG 2 entity
-		ARG 3 time
-	METHOD method_18923 (Lnet/minecraft/class_3218;Lnet/minecraft/class_1309;J)V
-		ARG 1 world
-		ARG 2 entity
-		ARG 3 time
 	METHOD method_18924 keepRunning (Lnet/minecraft/class_3218;Lnet/minecraft/class_1309;J)V
-		ARG 1 world
-		ARG 2 entity
-		ARG 3 time
-	METHOD method_18925 (Lnet/minecraft/class_3218;Lnet/minecraft/class_1309;J)V
 		ARG 1 world
 		ARG 2 entity
 		ARG 3 time

--- a/mappings/net/minecraft/entity/ai/pathing/BirdPathNodeMaker.mapping
+++ b/mappings/net/minecraft/entity/ai/pathing/BirdPathNodeMaker.mapping
@@ -4,10 +4,6 @@ CLASS net/minecraft/class_6 net/minecraft/entity/ai/pathing/BirdPathNodeMaker
 		ARG 1 node
 	METHOD method_22878 unvisited (Lnet/minecraft/class_9;)Z
 		ARG 1 node
-	METHOD method_31932 (III)Lnet/minecraft/class_7;
-		ARG 1 x
-		ARG 2 y
-		ARG 3 z
 	METHOD method_47933 getPassableNode (III)Lnet/minecraft/class_9;
 		ARG 1 x
 		ARG 2 y

--- a/mappings/net/minecraft/entity/data/DataTracked.mapping
+++ b/mappings/net/minecraft/entity/data/DataTracked.mapping
@@ -2,4 +2,8 @@ CLASS net/minecraft/class_9221 net/minecraft/entity/data/DataTracked
 	METHOD method_48850 onDataTrackerUpdate (Ljava/util/List;)V
 		ARG 1 entries
 	METHOD method_5674 onTrackedDataSet (Lnet/minecraft/class_2940;)V
+		COMMENT Called on the client when the tracked data is set.
+		COMMENT
+		COMMENT <p>This can be overridden to refresh other fields when the tracked data
+		COMMENT is set or changed.
 		ARG 1 data

--- a/mappings/net/minecraft/entity/mob/MobEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/MobEntity.mapping
@@ -196,9 +196,6 @@ CLASS net/minecraft/class_1308 net/minecraft/entity/mob/MobEntity
 	METHOD method_5944 getPathfindingPenalty (Lnet/minecraft/class_7;)F
 		ARG 1 nodeType
 	METHOD method_5945 getLimitPerChunk ()I
-	METHOD method_5946 (Lnet/minecraft/class_1304;F)V
-		ARG 1 slot
-		ARG 2 chance
 	METHOD method_5947 isPersistent ()Z
 	METHOD method_5948 getEquipmentForSlot (Lnet/minecraft/class_1304;I)Lnet/minecraft/class_1792;
 		ARG 0 equipmentSlot

--- a/mappings/net/minecraft/entity/passive/AbstractHorseEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/AbstractHorseEntity.mapping
@@ -79,8 +79,6 @@ CLASS net/minecraft/class_1496 net/minecraft/entity/passive/AbstractHorseEntity
 	METHOD method_6001 initAttributes (Lnet/minecraft/class_5819;)V
 		ARG 1 random
 	METHOD method_6721 onChestedStatusChanged ()V
-	METHOD method_6722 (Lnet/minecraft/class_1657;)V
-		ARG 1 player
 	METHOD method_6723 playJumpSound ()V
 	METHOD method_6724 isEatingGrass ()Z
 	METHOD method_6726 putPlayerOnBack (Lnet/minecraft/class_1657;)V

--- a/mappings/net/minecraft/predicate/entity/PlayerPredicate.mapping
+++ b/mappings/net/minecraft/predicate/entity/PlayerPredicate.mapping
@@ -9,8 +9,6 @@ CLASS net/minecraft/class_4553 net/minecraft/predicate/entity/PlayerPredicate
 		ARG 5 advancements
 	METHOD comp_1817 experienceLevel ()Lnet/minecraft/class_2096$class_2100;
 	METHOD comp_1818 gameMode ()Lnet/minecraft/class_9789;
-	METHOD method_22497 (Lnet/minecraft/class_1297;Lnet/minecraft/class_3218;Lnet/minecraft/class_243;)Z
-		ARG 1 entity
 	METHOD method_37250 (Lnet/minecraft/class_1297;)Z
 		ARG 0 hitEntity
 	METHOD method_53219 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;

--- a/mappings/net/minecraft/util/math/random/ChunkRandom.mapping
+++ b/mappings/net/minecraft/util/math/random/ChunkRandom.mapping
@@ -60,8 +60,6 @@ CLASS net/minecraft/class_2919 net/minecraft/util/math/random/ChunkRandom
 		ARG 4 regionZ
 		ARG 5 salt
 	METHOD method_35335 getSampleCount ()I
-	METHOD method_43156 (I)I
-		ARG 1 count
 	CLASS class_6675 RandomProvider
 		FIELD field_35144 provider Ljava/util/function/LongFunction;
 		METHOD <init> (Ljava/lang/String;ILjava/util/function/LongFunction;)V


### PR DESCRIPTION
This fixes all the methods found a couple of days ago in [Discord](https://discord.com/channels/507304429255393322/521545796882006027/1242119118841446431). It should also 110% get backported to 1.20.6 lol
These are all the fixed methods:
- `method_5674`
- `method_5946`
- `method_6722`
- `method_18922`
- `method_18923`
- `method_18925`
- `method_22497`
- `method_25365`
- `method_31932`
- `method_43156`
- `method_46408`
- `method_46419`
- `method_46421`
- `method_48850`

I also moved the javadoc where applicable.
