### PR TITLE
Change misleading method name `getNextMapId` in `ServerWorld` and `IdCountsState`

### DIFF
--- a/mappings/net/minecraft/world/IdCountsState.mapping
+++ b/mappings/net/minecraft/world/IdCountsState.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_3978 net/minecraft/world/IdCountsState
 	FIELD field_17662 idCounts Lit/unimi/dsi/fastutil/objects/Object2IntMap;
 	FIELD field_31830 IDCOUNTS_KEY Ljava/lang/String;
-	METHOD method_17920 getNextMapId ()Lnet/minecraft/class_9209;
+	METHOD method_17920 increaseAndGetMapId ()Lnet/minecraft/class_9209;
 	METHOD method_32360 fromNbt (Lnet/minecraft/class_2487;Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_3978;
 		ARG 0 nbt
 		ARG 1 registryLookup

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -56,7 +56,7 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 9 velocityX
 		ARG 11 velocityY
 		ARG 13 velocityZ
-	METHOD method_17889 getNextMapId ()Lnet/minecraft/class_9209;
+	METHOD method_17889 increaseAndGetMapId ()Lnet/minecraft/class_9209;
 	METHOD method_17890 putMapState (Lnet/minecraft/class_9209;Lnet/minecraft/class_22;)V
 		ARG 1 id
 		ARG 2 state


### PR DESCRIPTION
Although named as `getNextMapId`, these methods also increase the id count of maps, which is very misleading.

Following is the implementation of `IdCountsState.getNextMapId()` in the Minecraft 1.20.6:

````
    public MapIdComponent increaseAndGetMapId() {
        int i = this.idCounts.getInt((Object)"map") + 1;
        this.idCounts.put((Object)"map", i);
        this.markDirty();
        return new MapIdComponent(i);
    }
````