### PR TITLE
Rename `getEnchantmentsMap` to `getEnchantmentEntries`

### DIFF
--- a/mappings/net/minecraft/component/type/ItemEnchantmentsComponent.mapping
+++ b/mappings/net/minecraft/component/type/ItemEnchantmentsComponent.mapping
@@ -19,7 +19,7 @@ CLASS net/minecraft/class_9304 net/minecraft/component/type/ItemEnchantmentsComp
 		ARG 1 enchantment
 	METHOD method_57537 (Lnet/minecraft/class_9304;)Ljava/lang/Boolean;
 		ARG 0 component
-	METHOD method_57539 getEnchantmentsMap ()Ljava/util/Set;
+	METHOD method_57539 getEnchantmentEntries ()Ljava/util/Set;
 	METHOD method_57540 (Lnet/minecraft/class_9304;)Lit/unimi/dsi/fastutil/objects/Object2IntOpenHashMap;
 		ARG 0 component
 	METHOD method_57541 getSize ()I


### PR DESCRIPTION
The returned value is a `Set` of entires that is then iterated over at it's call sites so it doesn't make much sense to continue calling it a map.