### PR TITLE
Fix flow distance

### DIFF
--- a/mappings/net/minecraft/fluid/FlowableFluid.mapping
+++ b/mappings/net/minecraft/fluid/FlowableFluid.mapping
@@ -31,7 +31,7 @@ CLASS net/minecraft/class_3609 net/minecraft/fluid/FlowableFluid
 		ARG 4 state
 		ARG 5 fromPos
 		ARG 6 fromState
-	METHOD method_15733 getFlowSpeed (Lnet/minecraft/class_4538;)I
+	METHOD method_15733 getMaxFlowDistance (Lnet/minecraft/class_4538;)I
 		ARG 1 world
 	METHOD method_15736 canFlowDownTo (Lnet/minecraft/class_1922;Lnet/minecraft/class_3611;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)Z
 		ARG 1 world
@@ -58,7 +58,7 @@ CLASS net/minecraft/class_3609 net/minecraft/fluid/FlowableFluid
 		ARG 2 pos
 	METHOD method_15741 getBlockStateLevel (Lnet/minecraft/class_3610;)I
 		ARG 0 state
-	METHOD method_15742 getFlowSpeedBetween (Lnet/minecraft/class_4538;Lnet/minecraft/class_2338;ILnet/minecraft/class_2350;Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;Lit/unimi/dsi/fastutil/shorts/Short2ObjectMap;Lit/unimi/dsi/fastutil/shorts/Short2BooleanMap;)I
+	METHOD method_15742 getMinFlowDownDistance (Lnet/minecraft/class_4538;Lnet/minecraft/class_2338;ILnet/minecraft/class_2350;Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;Lit/unimi/dsi/fastutil/shorts/Short2ObjectMap;Lit/unimi/dsi/fastutil/shorts/Short2BooleanMap;)I
 		ARG 1 world
 		ARG 2 pos
 		ARG 4 direction

--- a/mappings/net/minecraft/fluid/FlowableFluid.mapping
+++ b/mappings/net/minecraft/fluid/FlowableFluid.mapping
@@ -32,6 +32,7 @@ CLASS net/minecraft/class_3609 net/minecraft/fluid/FlowableFluid
 		ARG 5 fromPos
 		ARG 6 fromState
 	METHOD method_15733 getMaxFlowDistance (Lnet/minecraft/class_4538;)I
+		COMMENT {@return the maximum horizontal distance to check for holes the fluid can flow down into}
 		ARG 1 world
 	METHOD method_15736 canFlowDownTo (Lnet/minecraft/class_1922;Lnet/minecraft/class_3611;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)Z
 		ARG 1 world
@@ -59,6 +60,7 @@ CLASS net/minecraft/class_3609 net/minecraft/fluid/FlowableFluid
 	METHOD method_15741 getBlockStateLevel (Lnet/minecraft/class_3610;)I
 		ARG 0 state
 	METHOD method_15742 getMinFlowDownDistance (Lnet/minecraft/class_4538;Lnet/minecraft/class_2338;ILnet/minecraft/class_2350;Lnet/minecraft/class_2680;Lnet/minecraft/class_2338;Lit/unimi/dsi/fastutil/shorts/Short2ObjectMap;Lit/unimi/dsi/fastutil/shorts/Short2BooleanMap;)I
+		COMMENT Finds the distance to the closest hole the fluid can flow down into starting with the direction specified.
 		ARG 1 world
 		ARG 2 pos
 		ARG 4 direction


### PR DESCRIPTION
Fix the flow distance methods incorrectly named flow speed. This has been an issue for a while now, see [this discord message](https://discord.com/channels/507304429255393322/521545796882006027/1189164947377238087).

If you look at the source code, it's clear that `getFlowSpeedBetween -> getMinFlowDownDistance` is a dfs algorithm searching for whether to flow in the direction, and has nothing to do with how fast the fluid is flowing. `getFlowSpeed -> getMaxFlowDistance` is only used in the previously mentioned method and it is the limit for the distance for the dfs algorithm.

Alternate names `getMaxHorizontalFlowDistance` or `getMaxFlowDownDistance` for the second method.