### PR TITLE
Rename id in entity-related packets to entityId

### DIFF
--- a/mappings/net/minecraft/network/packet/s2c/play/EntityAnimationS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/EntityAnimationS2CPacket.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_2616 net/minecraft/network/packet/s2c/play/EntityAnimationS2CPacket
 	FIELD field_12028 animationId I
-	FIELD field_12029 id I
+	FIELD field_12029 entityId I
 	FIELD field_33295 SWING_MAIN_HAND I
 	FIELD field_33297 WAKE_UP I
 	FIELD field_33298 SWING_OFF_HAND I
@@ -13,6 +13,6 @@ CLASS net/minecraft/class_2616 net/minecraft/network/packet/s2c/play/EntityAnima
 	METHOD <init> (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD method_11267 getAnimationId ()I
-	METHOD method_11269 getId ()I
+	METHOD method_11269 getEntityId ()I
 	METHOD method_55857 write (Lnet/minecraft/class_2540;)V
 		ARG 1 buf

--- a/mappings/net/minecraft/network/packet/s2c/play/EntityEquipmentUpdateS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/EntityEquipmentUpdateS2CPacket.mapping
@@ -1,13 +1,13 @@
 CLASS net/minecraft/class_2744 net/minecraft/network/packet/s2c/play/EntityEquipmentUpdateS2CPacket
-	FIELD field_12565 id I
+	FIELD field_12565 entityId I
 	FIELD field_25721 equipmentList Ljava/util/List;
 	FIELD field_47982 CODEC Lnet/minecraft/class_9139;
 	METHOD <init> (ILjava/util/List;)V
-		ARG 1 id
+		ARG 1 entityId
 		ARG 2 equipmentList
 	METHOD <init> (Lnet/minecraft/class_9129;)V
 		ARG 1 buf
-	METHOD method_11820 getId ()I
+	METHOD method_11820 getEntityId ()I
 	METHOD method_30145 getEquipmentList ()Ljava/util/List;
 	METHOD method_55929 write (Lnet/minecraft/class_9129;)V
 		ARG 1 buf

--- a/mappings/net/minecraft/network/packet/s2c/play/EntityPassengersSetS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/EntityPassengersSetS2CPacket.mapping
@@ -1,12 +1,12 @@
 CLASS net/minecraft/class_2752 net/minecraft/network/packet/s2c/play/EntityPassengersSetS2CPacket
 	FIELD field_12593 passengerIds [I
-	FIELD field_12594 id I
+	FIELD field_12594 entityId I
 	FIELD field_47986 CODEC Lnet/minecraft/class_9139;
 	METHOD <init> (Lnet/minecraft/class_1297;)V
 		ARG 1 entity
 	METHOD <init> (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD method_11840 getPassengerIds ()[I
-	METHOD method_11841 getId ()I
+	METHOD method_11841 getEntityId ()I
 	METHOD method_55933 write (Lnet/minecraft/class_2540;)V
 		ARG 1 buf

--- a/mappings/net/minecraft/network/packet/s2c/play/EntityPositionS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/EntityPositionS2CPacket.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_2777 net/minecraft/network/packet/s2c/play/EntityPosit
 	FIELD field_12702 y D
 	FIELD field_12703 x D
 	FIELD field_12704 onGround Z
-	FIELD field_12705 id I
+	FIELD field_12705 entityId I
 	FIELD field_12706 pitch B
 	FIELD field_12707 yaw B
 	FIELD field_48004 CODEC Lnet/minecraft/class_9139;
@@ -11,7 +11,7 @@ CLASS net/minecraft/class_2777 net/minecraft/network/packet/s2c/play/EntityPosit
 		ARG 1 entity
 	METHOD <init> (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
-	METHOD method_11916 getId ()I
+	METHOD method_11916 getEntityId ()I
 	METHOD method_11917 getX ()D
 	METHOD method_11918 getZ ()D
 	METHOD method_11919 getY ()D

--- a/mappings/net/minecraft/network/packet/s2c/play/EntitySetHeadYawS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/EntitySetHeadYawS2CPacket.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_2726 net/minecraft/network/packet/s2c/play/EntitySetHeadYawS2CPacket
 	FIELD field_12436 headYaw B
-	FIELD field_12437 entity I
+	FIELD field_12437 entityId I
 	FIELD field_47963 CODEC Lnet/minecraft/class_9139;
 	METHOD <init> (Lnet/minecraft/class_1297;B)V
 		ARG 1 entity

--- a/mappings/net/minecraft/network/packet/s2c/play/EntitySpawnS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/EntitySpawnS2CPacket.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/class_2604 net/minecraft/network/packet/s2c/play/EntitySpawn
 	FIELD field_11950 velocityY I
 	FIELD field_11951 velocityX I
 	FIELD field_11952 uuid Ljava/util/UUID;
-	FIELD field_11953 id I
+	FIELD field_11953 entityId I
 	FIELD field_11954 entityData I
 	FIELD field_11955 entityType Lnet/minecraft/class_1299;
 	FIELD field_11956 z D
@@ -18,7 +18,7 @@ CLASS net/minecraft/class_2604 net/minecraft/network/packet/s2c/play/EntitySpawn
 	FIELD field_38817 headYaw B
 	FIELD field_47896 CODEC Lnet/minecraft/class_9139;
 	METHOD <init> (ILjava/util/UUID;DDDFFLnet/minecraft/class_1299;ILnet/minecraft/class_243;D)V
-		ARG 1 id
+		ARG 1 entityId
 		ARG 2 uuid
 		ARG 3 x
 		ARG 5 y
@@ -44,7 +44,7 @@ CLASS net/minecraft/class_2604 net/minecraft/network/packet/s2c/play/EntitySpawn
 		ARG 1 buf
 	METHOD method_11164 getUuid ()Ljava/util/UUID;
 	METHOD method_11166 getEntityData ()I
-	METHOD method_11167 getId ()I
+	METHOD method_11167 getEntityId ()I
 	METHOD method_11168 getYaw ()F
 	METHOD method_11169 getEntityType ()Lnet/minecraft/class_1299;
 	METHOD method_11170 getVelocityX ()D

--- a/mappings/net/minecraft/network/packet/s2c/play/EntityStatusS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/EntityStatusS2CPacket.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_2663 net/minecraft/network/packet/s2c/play/EntityStatusS2CPacket
 	FIELD field_12174 status B
-	FIELD field_12175 id I
+	FIELD field_12175 entityId I
 	FIELD field_47924 CODEC Lnet/minecraft/class_9139;
 	METHOD <init> (Lnet/minecraft/class_1297;B)V
 		ARG 1 entity

--- a/mappings/net/minecraft/network/packet/s2c/play/EntityVelocityUpdateS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/EntityVelocityUpdateS2CPacket.mapping
@@ -7,10 +7,10 @@ CLASS net/minecraft/class_2743 net/minecraft/network/packet/s2c/play/EntityVeloc
 	FIELD field_12561 velocityZ I
 	FIELD field_12562 velocityY I
 	FIELD field_12563 velocityX I
-	FIELD field_12564 id I
+	FIELD field_12564 entityId I
 	FIELD field_47981 CODEC Lnet/minecraft/class_9139;
 	METHOD <init> (ILnet/minecraft/class_243;)V
-		ARG 1 id
+		ARG 1 entityId
 		ARG 2 velocity
 	METHOD <init> (Lnet/minecraft/class_1297;)V
 		ARG 1 entity
@@ -18,7 +18,7 @@ CLASS net/minecraft/class_2743 net/minecraft/network/packet/s2c/play/EntityVeloc
 		ARG 1 buf
 	METHOD method_11815 getVelocityX ()D
 	METHOD method_11816 getVelocityY ()D
-	METHOD method_11818 getId ()I
+	METHOD method_11818 getEntityId ()I
 	METHOD method_11819 getVelocityZ ()D
 	METHOD method_55928 write (Lnet/minecraft/class_2540;)V
 		ARG 1 buf

--- a/mappings/net/minecraft/network/packet/s2c/play/ExperienceOrbSpawnS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/ExperienceOrbSpawnS2CPacket.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_2606 net/minecraft/network/packet/s2c/play/ExperienceO
 	FIELD field_11971 y D
 	FIELD field_11972 x D
 	FIELD field_11973 experience I
-	FIELD field_11974 id I
+	FIELD field_11974 entityId I
 	FIELD field_47897 CODEC Lnet/minecraft/class_9139;
 	METHOD <init> (Lnet/minecraft/class_1303;Lnet/minecraft/class_3231;)V
 		ARG 1 orb
@@ -12,7 +12,7 @@ CLASS net/minecraft/class_2606 net/minecraft/network/packet/s2c/play/ExperienceO
 		ARG 1 buf
 	METHOD method_11180 getZ ()D
 	METHOD method_11181 getY ()D
-	METHOD method_11183 getId ()I
+	METHOD method_11183 getEntityId ()I
 	METHOD method_11184 getExperience ()I
 	METHOD method_11185 getX ()D
 	METHOD method_55856 write (Lnet/minecraft/class_2540;)V


### PR DESCRIPTION
In some places it's already entityId, including some places where it's in record components. There were unfortunately also a few instances of `id` in records, which I couldn't remap.
This improves consistency and clarity.