### PR TITLE
Leashable constant mappings

### DIFF
--- a/mappings/net/minecraft/entity/Leashable.mapping
+++ b/mappings/net/minecraft/entity/Leashable.mapping
@@ -1,5 +1,7 @@
 CLASS net/minecraft/class_9817 net/minecraft/entity/Leashable
 	FIELD field_52216 LEASH_NBT_KEY Ljava/lang/String;
+	FIELD field_52314 MAX_LEASH_LENGTH D
+	FIELD field_52315 SHORT_LEASH_LENGTH D
 	METHOD method_5931 canBeLeashed ()Z
 	METHOD method_5932 detachLeash (ZZ)V
 		ARG 1 sendPacket


### PR DESCRIPTION
Adds mappings for the constants in 1.21's new Leashable interface.

`MAX_LEASH_LENGTH` is the length past which a leash will break.  
`SHORT_LEASH_LENGTH` is the distance within which mobs will not be pulled toward their leader. This name is meant to mirror the mapping for the method `onShortLeashTick`.