### PR TITLE
Rename WanderAroundTask to MoveToTargetTask

### DIFF
--- a/mappings/net/minecraft/entity/ai/brain/task/MoveToTargetTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/MoveToTargetTask.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_4112 net/minecraft/entity/ai/brain/task/WanderAroundTask
+CLASS net/minecraft/class_4112 net/minecraft/entity/ai/brain/task/MoveToTargetTask
 	FIELD field_18369 path Lnet/minecraft/class_11;
 	FIELD field_18370 lookTargetPos Lnet/minecraft/class_2338;
 	FIELD field_18371 speed F


### PR DESCRIPTION
# Motivation
WanderAroundTask does not accurately describe what the class does, which lead to much confusion for me and potentially confusion for others learning the Brain System. MoveToTargetTask much more accurately describes that this task causes the entity to move towards their walk target.