### PR TITLE
Renamed shouldTickLeash to beforeLeashTick

### DIFF
--- a/mappings/net/minecraft/entity/Leashable.mapping
+++ b/mappings/net/minecraft/entity/Leashable.mapping
@@ -10,7 +10,13 @@ CLASS net/minecraft/class_9817 net/minecraft/entity/Leashable
 	METHOD method_60953 isLeashed ()Z
 	METHOD method_60954 mightBeLeashed ()Z
 	METHOD method_60955 getLeashData ()Lnet/minecraft/class_9817$class_9818;
-	METHOD method_60956 shouldTickLeash (Lnet/minecraft/class_1297;F)Z
+	METHOD method_60956 beforeLeashTick (Lnet/minecraft/class_1297;F)Z
+		COMMENT Called before the default leash-ticking logic.
+		COMMENT Subclasses can override this to add their own logic to it.
+		COMMENT <p>
+		COMMENT {@return whether the default logic should run after this.}
+		COMMENT
+		COMMENT @see Leashable#tickLeash
 		ARG 1 leashHolder
 		ARG 2 distance
 	METHOD method_60957 attachLeash (Lnet/minecraft/class_1297;Lnet/minecraft/class_1297;Z)V


### PR DESCRIPTION
Renamed `Leashable::shouldTickLeash` to better represent how this method is used in the vanilla classes, and gave it some javadoc.

The current name suggests a function with no side-effect, other than its returned value. In reality, all of its overrides exist to give additional leash-ticking logic to entities; the return value is almost never changed.

So far I settled for `beforeLeashTick`.