### PR TITLE
Fix FoodComponent constructor having outdated names

### DIFF
--- a/mappings/net/minecraft/component/type/FoodComponent.mapping
+++ b/mappings/net/minecraft/component/type/FoodComponent.mapping
@@ -4,9 +4,12 @@ CLASS net/minecraft/class_4174 net/minecraft/component/type/FoodComponent
 	FIELD field_49993 PACKET_CODEC Lnet/minecraft/class_9139;
 	FIELD field_49994 DEFAULT_EAT_SECONDS F
 	METHOD <init> (IFZFLjava/util/Optional;Ljava/util/List;)V
-		ARG 1 hunger
-		ARG 2 saturationModifier
-		ARG 3 meat
+		ARG 1 nutrition
+		ARG 2 saturation
+		ARG 3 canAlwaysEat
+		ARG 4 eatSeconds
+		ARG 5 usingConvertsTo
+		ARG 6 effects
 	METHOD method_58399 getEatTicks ()I
 	METHOD method_58400 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 0 instance


### PR DESCRIPTION
For some reason, likely due to its use of generics in its record components, the FoodComponent record still uses a separate constructor which is visible using some decompilers, and had wrong and outdated mappings for its arguments which weren't visible in enigma. This manually fixes the arguments to match the exposed record component names.