### PR TITLE
Rename overloaded methods in the WorldRenderer class that build buffers

### DIFF
--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -219,7 +219,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	METHOD method_29365 loadTransparencyPostProcessor ()V
 	METHOD method_29701 resetTransparencyPostProcessor ()V
 	METHOD method_32133 setupFrustum (Lnet/minecraft/class_243;Lorg/joml/Matrix4f;Lorg/joml/Matrix4f;)V
-	METHOD method_3239 renderClouds (Lnet/minecraft/class_289;DDDLnet/minecraft/class_243;)Lnet/minecraft/class_9801;
+	METHOD method_3239 buildCloudsBuffer (Lnet/minecraft/class_289;DDDLnet/minecraft/class_243;)Lnet/minecraft/class_9801;
 		ARG 2 x
 		ARG 4 y
 		ARG 6 z
@@ -249,7 +249,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 		ARG 9 positionMatrix
 	METHOD method_3252 tick ()V
 	METHOD method_3254 drawEntityOutlinesFramebuffer ()V
-	METHOD method_3255 renderStars (Lnet/minecraft/class_289;)Lnet/minecraft/class_9801;
+	METHOD method_3255 buildStarsBuffer (Lnet/minecraft/class_289;)Lnet/minecraft/class_9801;
 	METHOD method_3257 renderSky (Lorg/joml/Matrix4f;Lorg/joml/Matrix4f;FLnet/minecraft/class_4184;ZLjava/lang/Runnable;)V
 		ARG 2 projectionMatrix
 		ARG 3 tickDelta
@@ -352,7 +352,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 		ARG 3 z
 		ARG 4 important
 	METHOD method_3296 loadEntityOutlinePostProcessor ()V
-	METHOD method_34550 renderSky (Lnet/minecraft/class_289;F)Lnet/minecraft/class_9801;
+	METHOD method_34550 buildSkyBuffer (Lnet/minecraft/class_289;F)Lnet/minecraft/class_9801;
 	METHOD method_34810 getChunkBuilder ()Lnet/minecraft/class_846;
 	METHOD method_34811 getChunkCount ()D
 	METHOD method_34812 getViewDistance ()D


### PR DESCRIPTION
A few methods in the `WorldRenderer` class have a pattern involving an overloaded `renderX` method:

```java
private void renderX() {
	this.x = new VertexBuffer(VertexBuffer.Usage.STATIC);
	this.x.bind();
	this.x.upload(this.renderX(Tessellator.getInstance()));
	VertexBuffer.unbind();
}
```

Since the `renderX` called within this method returns a built buffer, it can be renamed to reduce overlap and confusion between the two names.