### PR TITLE
Fix glint argument being named solid in ItemRenderer#getArmorGlintConsumer

### DIFF
--- a/mappings/net/minecraft/client/render/item/ItemRenderer.mapping
+++ b/mappings/net/minecraft/client/render/item/ItemRenderer.mapping
@@ -70,7 +70,7 @@ CLASS net/minecraft/class_918 net/minecraft/client/render/item/ItemRenderer
 	METHOD method_27952 getArmorGlintConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;Z)Lnet/minecraft/class_4588;
 		ARG 0 provider
 		ARG 1 layer
-		ARG 2 solid
+		ARG 2 glint
 	METHOD method_29711 getDirectItemGlintConsumer (Lnet/minecraft/class_4597;Lnet/minecraft/class_1921;ZZ)Lnet/minecraft/class_4588;
 		ARG 0 provider
 		ARG 1 layer


### PR DESCRIPTION
Somewhere between 1.20.4 and 1.21 the solid argument was removed, but it was thought that the glint argument was removed. This PR fixes that.