### PR TITLE
Name methods and locals in PacketCodecs.BYTE_ARRAY

### DIFF
--- a/mappings/net/minecraft/network/codec/PacketCodecs.mapping
+++ b/mappings/net/minecraft/network/codec/PacketCodecs.mapping
@@ -329,6 +329,11 @@ CLASS net/minecraft/class_9135 net/minecraft/network/codec/PacketCodecs
 		METHOD method_56403 decode (Lio/netty/buffer/ByteBuf;)[B
 			ARG 1 buf
 		METHOD method_56404 encode (Lio/netty/buffer/ByteBuf;[B)V
+	CLASS 3
+		METHOD method_59799 decode (Lio/netty/buffer/ByteBuf;)[B
+			ARG 1 buf
+		METHOD method_59800 encode (Lio/netty/buffer/ByteBuf;[B)V
+			ARG 1 buf
 	CLASS 6
 		METHOD method_56899 (Ljava/lang/Object;Ljava/lang/String;)Lio/netty/handler/codec/EncoderException;
 			ARG 1 error


### PR DESCRIPTION
Ensures consistency with the other members of PacketCodecs and, in the case of naming the functions, is actually out of a concern with code correctness (encode and decode need to be overridden).