### PR TITLE
Util: Rename and document error methods that pause the game

### DIFF
--- a/mappings/net/minecraft/util/Util.mapping
+++ b/mappings/net/minecraft/util/Util.mapping
@@ -40,8 +40,19 @@ CLASS net/minecraft/class_156 net/minecraft/util/Util
 		COMMENT
 		COMMENT @throws IndexOutOfBoundsException if {@code list} is empty
 		ARG 0 list
-	METHOD method_22320 throwOrPause (Ljava/lang/Throwable;)Ljava/lang/Throwable;
+	METHOD method_22320 getFatalOrPause (Ljava/lang/Throwable;)Ljava/lang/Throwable;
+		COMMENT Returns the provided fatal throwable, or pauses the game if
+		COMMENT {@link net.minecraft.SharedConstants#isDevelopment SharedConstants.isDevelopment}
+		COMMENT is {@code true}.
+		COMMENT
+		COMMENT <p>This method is usually chained with a {@code throw} statement:
+		COMMENT {@snippet :
+		COMMENT throw Util.getFatalOrPause(theFatalException);
+		COMMENT }
+		COMMENT
+		COMMENT @return the provided throwable
 		ARG 0 t
+			COMMENT the throwable
 	METHOD method_22321 getInnermostMessage (Ljava/lang/Throwable;)Ljava/lang/String;
 		ARG 0 t
 	METHOD method_24155 throwUnchecked (Ljava/lang/Throwable;)V
@@ -144,8 +155,12 @@ CLASS net/minecraft/class_156 net/minecraft/util/Util
 	METHOD method_33141 decodeFixedLengthList (Ljava/util/List;I)Lcom/mojang/serialization/DataResult;
 		ARG 0 list
 		ARG 1 length
-	METHOD method_33559 error (Ljava/lang/String;)V
+	METHOD method_33559 logErrorOrPause (Ljava/lang/String;)V
+		COMMENT Logs an error-level message and pauses the game if
+		COMMENT {@link net.minecraft.SharedConstants#isDevelopment SharedConstants.isDevelopment}
+		COMMENT is {@code true}.
 		ARG 0 message
+			COMMENT the log message
 	METHOD method_33560 pause (Ljava/lang/String;)V
 		ARG 0 message
 	METHOD method_33787 debugRunnable (Ljava/lang/String;Ljava/lang/Runnable;)Ljava/lang/Runnable;
@@ -176,9 +191,14 @@ CLASS net/minecraft/class_156 net/minecraft/util/Util
 	METHOD method_38647 (Ljava/lang/String;)V
 		ARG 0 message
 	METHOD method_38648 getMaxBackgroundThreads ()I
-	METHOD method_39977 error (Ljava/lang/String;Ljava/lang/Throwable;)V
+	METHOD method_39977 logErrorOrPause (Ljava/lang/String;Ljava/lang/Throwable;)V
+		COMMENT Logs an error-level message and pauses the game if
+		COMMENT {@link net.minecraft.SharedConstants#isDevelopment SharedConstants.isDevelopment}
+		COMMENT is {@code true}.
 		ARG 0 message
+			COMMENT the log message
 		ARG 1 throwable
+			COMMENT a throwable related to the log message
 	METHOD method_40082 (Ljava/util/List;Ljava/lang/Void;)Ljava/util/List;
 		ARG 1 void_
 	METHOD method_40083 getRandomOrEmpty (Ljava/util/List;Lnet/minecraft/class_5819;)Ljava/util/Optional;


### PR DESCRIPTION
- throwOrPause -> getFatalOrPause (based on "fatal" in the log message)
- error -> logErrorOrPause (more descriptive)