### PR TITLE
Suppress some warnings from name proposal

### DIFF
--- a/filament/src/main/java/net/fabricmc/filament/nameproposal/RecordComponentNameFinder.java
+++ b/filament/src/main/java/net/fabricmc/filament/nameproposal/RecordComponentNameFinder.java
@@ -100,6 +100,11 @@ public final class RecordComponentNameFinder extends ClassVisitor {
 
 			for (int i = 2; i < bootstrapMethodArguments.length; i++) {
 				if (bootstrapMethodArguments[i] instanceof Handle handle) {
+					if (!handle.getName().startsWith("comp_")) {
+						// Valid record bytecode, but doesn't have an intermediary name, making it impossible to match up with the record field or method
+						continue;
+					}
+
 					if (handle.getTag() == Opcodes.H_GETFIELD && handle.getOwner().equals(recordClassName)) {
 						var argName = names[i - 2];
 						put(recordNames, handle.getName(), argName);

--- a/mappings/net/minecraft/component/type/BookContent.mapping
+++ b/mappings/net/minecraft/component/type/BookContent.mapping
@@ -1,4 +1,3 @@
 CLASS net/minecraft/class_9364 net/minecraft/component/type/BookContent
-	METHOD comp_2422 pages ()Ljava/util/List;
 	METHOD method_58186 withPages (Ljava/util/List;)Ljava/lang/Object;
 		ARG 1 pages

--- a/mappings/net/minecraft/component/type/WrittenBookContentComponent.mapping
+++ b/mappings/net/minecraft/component/type/WrittenBookContentComponent.mapping
@@ -1,5 +1,4 @@
 CLASS net/minecraft/class_9302 net/minecraft/component/type/WrittenBookContentComponent
-	FIELD comp_2422 pages Ljava/util/List;
 	FIELD field_49375 MAX_SERIALIZED_PAGE_LENGTH I
 	FIELD field_49378 MAX_TITLE_LENGTH I
 	FIELD field_49379 MAX_GENERATION I


### PR DESCRIPTION
WritableBookContentComponent.comp_2418 needs renaming to comp_2422 in intermedairy to fix the final warning

The removal of the mappings for comp_2422 makes no difference to the output as they are automatically named to this via name propsoal.