### PR TITLE
Rename PistonBlock#move boolean argument to 'extend'

### DIFF
--- a/mappings/net/minecraft/block/PistonBlock.mapping
+++ b/mappings/net/minecraft/block/PistonBlock.mapping
@@ -15,7 +15,7 @@ CLASS net/minecraft/class_2665 net/minecraft/block/PistonBlock
 		ARG 1 world
 		ARG 2 pos
 		ARG 3 dir
-		ARG 4 retract
+		ARG 4 extend
 	METHOD method_11482 shouldExtend (Lnet/minecraft/class_8235;Lnet/minecraft/class_2338;Lnet/minecraft/class_2350;)Z
 		ARG 1 world
 		ARG 2 pos


### PR DESCRIPTION
Fixes #3914 

Easy to confirm that this should be `extend` by looking at the head of the method
![image](https://github.com/user-attachments/assets/3c5b027b-edcf-48aa-b902-206c42612763)
In English, this means "if not extending (so, retracting) and there's a piston head present in the provider direction, set that piston head to air". This lines up with what actually happens in the game

If "retract" was the correct name, this wouldn't make sense.