### PR TITLE
Fix incorrect method name in EnchantmentHelper

### DIFF
--- a/mappings/net/minecraft/enchantment/EnchantmentHelper.mapping
+++ b/mappings/net/minecraft/enchantment/EnchantmentHelper.mapping
@@ -303,8 +303,8 @@ CLASS net/minecraft/class_1890 net/minecraft/enchantment/EnchantmentHelper
 		ARG 3 enchantment
 		ARG 4 level
 		ARG 5 context
-	METHOD method_61711 getBookWithEnchantment (Lnet/minecraft/class_1889;)Lnet/minecraft/class_1799;
-		ARG 0 enchantmentEntry
+	METHOD method_61711 getEnchantedBookWith (Lnet/minecraft/class_1889;)Lnet/minecraft/class_1799;
+		ARG 0 entry
 	METHOD method_8201 isCompatible (Ljava/util/Collection;Lnet/minecraft/class_6880;)Z
 		COMMENT {@return whether the {@code candidate} enchantment is compatible with the
 		COMMENT {@code existing} enchantments}

--- a/mappings/net/minecraft/enchantment/EnchantmentHelper.mapping
+++ b/mappings/net/minecraft/enchantment/EnchantmentHelper.mapping
@@ -254,7 +254,7 @@ CLASS net/minecraft/class_1890 net/minecraft/enchantment/EnchantmentHelper
 	METHOD method_60173 (Lnet/minecraft/class_3218;Lnet/minecraft/class_1799;Lorg/apache/commons/lang3/mutable/MutableFloat;Lnet/minecraft/class_6880;I)V
 		ARG 3 enchantment
 		ARG 4 level
-	METHOD method_60174 getEffectListAndLevel (Lnet/minecraft/class_1799;Lnet/minecraft/class_9331;)Lcom/mojang/datafixers/util/Pair;
+	METHOD method_60174 getHighestLevelEffect (Lnet/minecraft/class_1799;Lnet/minecraft/class_9331;)Lcom/mojang/datafixers/util/Pair;
 		ARG 0 stack
 		ARG 1 componentType
 	METHOD method_60175 modifyKnockback (Lnet/minecraft/class_3218;Lnet/minecraft/class_1799;Lnet/minecraft/class_1297;Lnet/minecraft/class_1282;F)F
@@ -303,6 +303,8 @@ CLASS net/minecraft/class_1890 net/minecraft/enchantment/EnchantmentHelper
 		ARG 3 enchantment
 		ARG 4 level
 		ARG 5 context
+	METHOD method_61711 getBookWithEnchantment (Lnet/minecraft/class_1889;)Lnet/minecraft/class_1799;
+		ARG 0 enchantmentEntry
 	METHOD method_8201 isCompatible (Ljava/util/Collection;Lnet/minecraft/class_6880;)Z
 		COMMENT {@return whether the {@code candidate} enchantment is compatible with the
 		COMMENT {@code existing} enchantments}


### PR DESCRIPTION
Fixes #3913 and maps a method that gets a new enchantment book with a specified enchantment entry