### PR TITLE
Use NON_NEGATIVE spelling convention

### DIFF
--- a/mappings/net/minecraft/util/dynamic/Codecs.mapping
+++ b/mappings/net/minecraft/util/dynamic/Codecs.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_5699 net/minecraft/util/dynamic/Codecs
 	COMMENT <p>It has a few methods to create checkers for {@code Codec.flatXmap} to add
 	COMMENT extra value validation to encoding and decoding. See the implementation of
 	COMMENT {@link #nonEmptyList(Codec)}.
-	FIELD field_33441 NONNEGATIVE_INT Lcom/mojang/serialization/Codec;
+	FIELD field_33441 NON_NEGATIVE_INT Lcom/mojang/serialization/Codec;
 	FIELD field_33442 POSITIVE_INT Lcom/mojang/serialization/Codec;
 	FIELD field_34387 POSITIVE_FLOAT Lcom/mojang/serialization/Codec;
 	FIELD field_37408 REGULAR_EXPRESSION Lcom/mojang/serialization/Codec;

--- a/mappings/net/minecraft/util/math/intprovider/IntProvider.mapping
+++ b/mappings/net/minecraft/util/math/intprovider/IntProvider.mapping
@@ -23,3 +23,7 @@ CLASS net/minecraft/class_6017 net/minecraft/util/math/intprovider/IntProvider
 		ARG 0 min
 		ARG 1 max
 		ARG 2 providerCodec
+	METHOD method_58612 validateProvider (IILnet/minecraft/class_6017;)Lcom/mojang/serialization/DataResult;
+		ARG 0 min
+		ARG 1 max
+		ARG 2 provider


### PR DESCRIPTION
Fixes #3647 (Constant strings say "non-negative" so I chose that) and maps a method in IntProvider that validates that the provider's range is within the provided (by the method arguments) range