### PR TITLE
Correctly name Raid-``ravager``-spawn methods

### DIFF
--- a/mappings/net/minecraft/village/raid/Raid.mapping
+++ b/mappings/net/minecraft/village/raid/Raid.mapping
@@ -21,7 +21,7 @@ CLASS net/minecraft/class_3765 net/minecraft/village/raid/Raid
 	FIELD field_19022 waveCount I
 	FIELD field_19023 status Lnet/minecraft/class_3765$class_4259;
 	FIELD field_19024 finishCooldown I
-	FIELD field_19172 preCalculatedRavagerSpawnLocation Ljava/util/Optional;
+	FIELD field_19172 preCalculatedRaidersSpawnLocation Ljava/util/Optional;
 	FIELD field_30670 MAX_DESPAWN_COUNTER I
 	FIELD field_30675 SQUARED_MAX_RAIDER_DISTANCE I
 	FIELD field_30683 OMINOUS_BANNER_TRANSLATION_KEY Lnet/minecraft/class_2561;
@@ -82,7 +82,7 @@ CLASS net/minecraft/class_3765 net/minecraft/village/raid/Raid
 		ARG 1 pos
 	METHOD method_16523 updateBar ()V
 	METHOD method_16524 hasStarted ()Z
-	METHOD method_16525 getRavagerSpawnLocation (II)Lnet/minecraft/class_2338;
+	METHOD method_16525 findRandomRaidersSpawnLocation (II)Lnet/minecraft/class_2338;
 		ARG 1 proximity
 		ARG 2 tries
 	METHOD method_16831 getWorld ()Lnet/minecraft/class_1937;
@@ -115,7 +115,7 @@ CLASS net/minecraft/class_3765 net/minecraft/village/raid/Raid
 	METHOD method_20023 hasWon ()Z
 	METHOD method_20024 hasLost ()Z
 	METHOD method_20025 getEnchantmentChance ()F
-	METHOD method_20267 preCalculateRavagerSpawnLocation (I)Ljava/util/Optional;
+	METHOD method_20267 getRaidersSpawnLocation (I)Ljava/util/Optional;
 		ARG 1 proximity
 	METHOD method_20509 setCenter (Lnet/minecraft/class_2338;)V
 		ARG 1 center


### PR DESCRIPTION
Fixes #3938 

These methods don't handle ravanger spawning but spawning of raiders in general