### PR TITLE
Standardise WrapperLookup params and fields to "registries"

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -115,6 +115,16 @@ front of the coordinate (`velocityX`, not `xVelocity`).
 
 Name screen coordinates `x` and `y`, rather than `left` and `top`.
 
+### Special classes
+
+Unless a more descriptive name is better, these Minecraft classes should get specific names as fields and parameters:
+
+| Class                                                  | Name              |
+| ------------------------------------------------------ | ----------------- |
+| `net.minecraft.client.render.VertexConsumerProvider`   | `vertexConsumers` |
+| `net.minecraft.client.util.math.MatrixStack`           | `matrices`        |
+| `net.minecraft.registry.RegistryWrapper.WrapperLookup` | `registries`      |
+
 ## Javadocs
 
 Write sentences for class, method and field javadocs, starting with an uppercase and ending with a period. Start method docs with verbs, like `Gets` or `Called`. Use HTML tags such as `<p>` if the docs have several paragraphs, as line wraps are converted to spaces in the generated documentation. Feel free to start a new line whenever you feel the current line is too long. Note that some ending tags such as `</p>` are not mandatory for Javadocs to render correctly.

--- a/mappings/net/minecraft/block/entity/BlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntity.mapping
@@ -77,7 +77,7 @@ CLASS net/minecraft/class_2586 net/minecraft/block/entity/BlockEntity
 		ARG 0 pos
 		ARG 1 state
 		ARG 2 nbt
-		ARG 3 registryLookup
+		ARG 3 registries
 	METHOD method_11007 writeNbt (Lnet/minecraft/class_2487;Lnet/minecraft/class_7225$class_7874;)V
 		COMMENT Writes data to {@code nbt}. Subclasses should override this if they
 		COMMENT store a persistent data.
@@ -88,7 +88,7 @@ CLASS net/minecraft/class_2586 net/minecraft/block/entity/BlockEntity
 		COMMENT
 		COMMENT @see #readNbt
 		ARG 1 nbt
-		ARG 2 registryLookup
+		ARG 2 registries
 	METHOD method_11010 getCachedState ()Lnet/minecraft/class_2680;
 		COMMENT {@return the cached block state at the block entity's position}
 		COMMENT
@@ -117,7 +117,7 @@ CLASS net/minecraft/class_2586 net/minecraft/block/entity/BlockEntity
 		COMMENT
 		COMMENT @see #writeNbt
 		ARG 1 nbt
-		ARG 2 registryLookup
+		ARG 2 registries
 	METHOD method_11015 isRemoved ()Z
 	METHOD method_11016 getPos ()Lnet/minecraft/class_2338;
 		COMMENT {@return the block entity's position}
@@ -137,7 +137,7 @@ CLASS net/minecraft/class_2586 net/minecraft/block/entity/BlockEntity
 		COMMENT <p>To send all NBT data of this block entity saved to disk, return {@link #createNbt}.
 		COMMENT
 		COMMENT @see #toUpdatePacket
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_17897 (Lnet/minecraft/class_2487;Lnet/minecraft/class_7225$class_7874;Ljava/lang/String;Lnet/minecraft/class_2586;)Lnet/minecraft/class_2586;
 		ARG 3 blockEntity
 	METHOD method_17899 (Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Ljava/lang/String;Lnet/minecraft/class_2591;)Lnet/minecraft/class_2586;
@@ -203,7 +203,7 @@ CLASS net/minecraft/class_2586 net/minecraft/block/entity/BlockEntity
 		COMMENT
 		COMMENT @see #createNbt
 		COMMENT @see #createNbtWithId
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_38243 createNbtWithId (Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_2487;
 		COMMENT {@return the block entity's NBT data with block entity type ID}
 		COMMENT
@@ -212,7 +212,7 @@ CLASS net/minecraft/class_2586 net/minecraft/block/entity/BlockEntity
 		COMMENT
 		COMMENT @see #createNbt
 		COMMENT @see #createNbtWithIdentifyingData
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_38244 createNbt (Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_2487;
 		COMMENT {@return the block entity's NBT data}
 		COMMENT
@@ -222,7 +222,7 @@ CLASS net/minecraft/class_2586 net/minecraft/block/entity/BlockEntity
 		COMMENT @see #writeNbt
 		COMMENT @see #createNbtWithIdentifyingData
 		COMMENT @see #createNbtWithId
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_5431 markDirty ()V
 		COMMENT Marks this block entity as dirty and that it needs to be saved.
 		COMMENT This also triggers {@linkplain World#updateComparators comparator update}.
@@ -253,18 +253,18 @@ CLASS net/minecraft/class_2586 net/minecraft/block/entity/BlockEntity
 		ARG 0 error
 	METHOD method_58690 read (Lnet/minecraft/class_2487;Lnet/minecraft/class_7225$class_7874;)V
 		ARG 1 nbt
-		ARG 2 registryLookup
+		ARG 2 registries
 	METHOD method_58691 readComponentlessNbt (Lnet/minecraft/class_2487;Lnet/minecraft/class_7225$class_7874;)V
 		ARG 1 nbt
-		ARG 2 registryLookup
+		ARG 2 registries
 	METHOD method_58692 createComponentlessNbt (Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_2487;
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_58693 getComponents ()Lnet/minecraft/class_9323;
 	METHOD method_59535 createComponentlessNbtWithIdentifyingData (Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_2487;
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_59894 tryParseCustomName (Ljava/lang/String;Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_2561;
 		ARG 0 json
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_61175 validateSupports (Lnet/minecraft/class_2680;)V
 		ARG 1 state
 	METHOD method_61176 supports (Lnet/minecraft/class_2680;)Z

--- a/mappings/net/minecraft/block/jukebox/JukeboxSong.mapping
+++ b/mappings/net/minecraft/block/jukebox/JukeboxSong.mapping
@@ -10,5 +10,5 @@ CLASS net/minecraft/class_9793 net/minecraft/block/jukebox/JukeboxSong
 	METHOD method_60752 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 0 instance
 	METHOD method_60753 getSongEntryFromStack (Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_1799;)Ljava/util/Optional;
-		ARG 0 registryLookup
+		ARG 0 registries
 		ARG 1 stack

--- a/mappings/net/minecraft/client/gui/screen/ingame/CreativeInventoryScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/CreativeInventoryScreen.mapping
@@ -68,7 +68,7 @@ CLASS net/minecraft/class_481 net/minecraft/client/gui/screen/ingame/CreativeInv
 	METHOD method_47420 updateDisplayParameters (Lnet/minecraft/class_7699;ZLnet/minecraft/class_7225$class_7874;)V
 		ARG 1 enabledFeatures
 		ARG 2 showOperatorTab
-		ARG 3 registryLookup
+		ARG 3 registries
 	METHOD method_47421 refreshSelectedTab (Ljava/util/Collection;)V
 		ARG 1 displayStacks
 	METHOD method_47422 getTabX (Lnet/minecraft/class_1761;)I
@@ -82,7 +82,7 @@ CLASS net/minecraft/class_481 net/minecraft/client/gui/screen/ingame/CreativeInv
 		ARG 1 searchManager
 		ARG 2 enabledFeatures
 		ARG 3 showOperatorTab
-		ARG 4 registryLookup
+		ARG 4 registries
 	CLASS class_482 LockableSlot
 	CLASS class_483 CreativeScreenHandler
 		FIELD field_2897 itemList Lnet/minecraft/class_2371;

--- a/mappings/net/minecraft/client/option/HotbarStorageEntry.mapping
+++ b/mappings/net/minecraft/client/option/HotbarStorageEntry.mapping
@@ -16,7 +16,7 @@ CLASS net/minecraft/class_748 net/minecraft/client/option/HotbarStorageEntry
 	METHOD method_56838 (Lnet/minecraft/class_748;)Ljava/util/List;
 		ARG 0 entry
 	METHOD method_56839 deserialize (Lnet/minecraft/class_7225$class_7874;)Ljava/util/List;
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_56840 (Lnet/minecraft/class_7225$class_7874;Lcom/mojang/serialization/Dynamic;)Lnet/minecraft/class_1799;
 		ARG 1 stack
 	METHOD method_56841 (Ljava/lang/String;)V

--- a/mappings/net/minecraft/client/search/SearchManager.mapping
+++ b/mappings/net/minecraft/client/search/SearchManager.mapping
@@ -26,7 +26,7 @@ CLASS net/minecraft/class_1124 net/minecraft/client/search/SearchManager
 		ARG 1 context
 		ARG 2 type
 	METHOD method_60357 addItemTooltipReloader (Lnet/minecraft/class_7225$class_7874;Ljava/util/List;)V
-		ARG 1 registryLookup
+		ARG 1 registries
 		ARG 2 stacks
 	METHOD method_60358 (Lnet/minecraft/class_2378;Lnet/minecraft/class_5455$class_6890;Lnet/minecraft/class_8786;)Lnet/minecraft/class_2960;
 		ARG 2 recipe

--- a/mappings/net/minecraft/command/CommandRegistryAccess.mapping
+++ b/mappings/net/minecraft/command/CommandRegistryAccess.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/class_7157 net/minecraft/command/CommandRegistryAccess
 	COMMENT callbacks (such as {@link net.minecraft.server.command.CommandManager} constructor)
 	COMMENT provides an instance with proper configurations.
 	METHOD method_46722 of (Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_7699;)Lnet/minecraft/class_7157;
-		ARG 0 wrapperLookup
+		ARG 0 registries
 		ARG 1 enabledFeatures
 	CLASS 1
 		METHOD method_56810 (Lnet/minecraft/class_7699;Lnet/minecraft/class_7225$class_7226;)Lnet/minecraft/class_7225$class_7226;

--- a/mappings/net/minecraft/command/DataCommandStorage.mapping
+++ b/mappings/net/minecraft/command/DataCommandStorage.mapping
@@ -18,7 +18,7 @@ CLASS net/minecraft/class_4565 net/minecraft/command/DataCommandStorage
 		ARG 2 nbt
 	METHOD method_52613 (Ljava/lang/String;Lnet/minecraft/class_2487;Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_4565$class_4566;
 		ARG 2 nbt
-		ARG 3 registryLookup
+		ARG 3 registries
 	METHOD method_52614 getPersistentStateType (Ljava/lang/String;)Lnet/minecraft/class_18$class_8645;
 		ARG 1 namespace
 	CLASS class_4566 PersistentState

--- a/mappings/net/minecraft/command/argument/ItemPredicateArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/ItemPredicateArgumentType.mapping
@@ -68,7 +68,7 @@ CLASS net/minecraft/class_2293 net/minecraft/command/argument/ItemPredicateArgum
 		FIELD field_50068 itemSubPredicateTypeRegistryWrapper Lnet/minecraft/class_7225$class_7226;
 		FIELD field_50069 nbtOps Lnet/minecraft/class_6903;
 		METHOD <init> (Lnet/minecraft/class_7225$class_7874;)V
-			ARG 1 registryLookup
+			ARG 1 registries
 		METHOD method_58544 (Lnet/minecraft/class_6880$class_6883;)Lnet/minecraft/class_2960;
 			ARG 0 entry
 		METHOD method_58545 (Lnet/minecraft/class_6880$class_6883;Lnet/minecraft/class_1799;)Z

--- a/mappings/net/minecraft/command/argument/ItemStringReader.mapping
+++ b/mappings/net/minecraft/command/argument/ItemStringReader.mapping
@@ -14,7 +14,7 @@ CLASS net/minecraft/class_2291 net/minecraft/command/argument/ItemStringReader
 	FIELD field_51458 MALFORMED_ITEM_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD field_51831 EXCLAMATION_MARK C
 	METHOD <init> (Lnet/minecraft/class_7225$class_7874;)V
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_58517 consume (Lcom/mojang/brigadier/StringReader;Lnet/minecraft/class_2291$class_9219;)V
 		ARG 1 reader
 		ARG 2 callbacks

--- a/mappings/net/minecraft/command/argument/ParticleEffectArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/ParticleEffectArgumentType.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_2223 net/minecraft/command/argument/ParticleEffectArgumentType
-	FIELD field_48929 registryLookup Lnet/minecraft/class_7225$class_7874;
+	FIELD field_48929 registries Lnet/minecraft/class_7225$class_7874;
 	FIELD field_51438 INVALID_OPTIONS_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD field_9935 EXAMPLES Ljava/util/Collection;
 	FIELD field_9936 UNKNOWN_PARTICLE_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
@@ -17,13 +17,13 @@ CLASS net/minecraft/class_2223 net/minecraft/command/argument/ParticleEffectArgu
 		ARG 0 registryAccess
 	METHOD method_9418 readParameters (Lcom/mojang/brigadier/StringReader;Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_2394;
 		ARG 0 reader
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_9419 (Ljava/lang/Object;)Lcom/mojang/brigadier/Message;
 		ARG 0 id
 	METHOD method_9420 readParameters (Lcom/mojang/brigadier/StringReader;Lnet/minecraft/class_2396;Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_2394;
 		ARG 0 reader
 		ARG 1 type
-		ARG 2 registryLookup
+		ARG 2 registries
 	METHOD method_9421 getParticle (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lnet/minecraft/class_2394;
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/command/argument/RegistryEntryArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/RegistryEntryArgumentType.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_9433 net/minecraft/command/argument/RegistryEntryArgum
 	FIELD field_50037 FAILED_TO_PARSE_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD field_50038 EXAMPLES Ljava/util/Collection;
 	FIELD field_50039 INVALID_EXCEPTION Lcom/mojang/brigadier/exceptions/SimpleCommandExceptionType;
-	FIELD field_50040 registryLookup Lnet/minecraft/class_7225$class_7874;
+	FIELD field_50040 registries Lnet/minecraft/class_7225$class_7874;
 	FIELD field_50041 canLookupRegistry Z
 	FIELD field_50042 entryCodec Lcom/mojang/serialization/Codec;
 	METHOD <init> (Lnet/minecraft/class_7157;Lnet/minecraft/class_5321;Lcom/mojang/serialization/Codec;)V

--- a/mappings/net/minecraft/command/argument/StyleArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/StyleArgumentType.mapping
@@ -1,9 +1,9 @@
 CLASS net/minecraft/class_9019 net/minecraft/command/argument/StyleArgumentType
 	FIELD field_47553 INVALID_STYLE_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	FIELD field_47554 EXAMPLES Ljava/util/Collection;
-	FIELD field_48932 registryLookup Lnet/minecraft/class_7225$class_7874;
+	FIELD field_48932 registries Lnet/minecraft/class_7225$class_7874;
 	METHOD <init> (Lnet/minecraft/class_7225$class_7874;)V
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_55446 style (Lnet/minecraft/class_7157;)Lnet/minecraft/class_9019;
 		ARG 0 registryAccess
 	METHOD method_55448 getStyle (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lnet/minecraft/class_2583;

--- a/mappings/net/minecraft/command/argument/TextArgumentType.mapping
+++ b/mappings/net/minecraft/command/argument/TextArgumentType.mapping
@@ -1,9 +1,9 @@
 CLASS net/minecraft/class_2178 net/minecraft/command/argument/TextArgumentType
-	FIELD field_48917 registryLookup Lnet/minecraft/class_7225$class_7874;
+	FIELD field_48917 registries Lnet/minecraft/class_7225$class_7874;
 	FIELD field_9841 EXAMPLES Ljava/util/Collection;
 	FIELD field_9842 INVALID_COMPONENT_EXCEPTION Lcom/mojang/brigadier/exceptions/DynamicCommandExceptionType;
 	METHOD <init> (Lnet/minecraft/class_7225$class_7874;)V
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_9280 getTextArgument (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lnet/minecraft/class_2561;
 		ARG 0 context
 		ARG 1 name

--- a/mappings/net/minecraft/component/type/ItemEnchantmentsComponent.mapping
+++ b/mappings/net/minecraft/component/type/ItemEnchantmentsComponent.mapping
@@ -33,7 +33,7 @@ CLASS net/minecraft/class_9304 net/minecraft/component/type/ItemEnchantmentsComp
 	METHOD method_58449 withShowInTooltip (Z)Lnet/minecraft/class_9304;
 		ARG 1 showInTooltip
 	METHOD method_59716 getTooltipOrderList (Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_5321;Lnet/minecraft/class_6862;)Lnet/minecraft/class_6885;
-		ARG 0 registryLookup
+		ARG 0 registries
 		ARG 1 registryRef
 		ARG 2 tooltipOrderTag
 	CLASS class_9305 Builder

--- a/mappings/net/minecraft/component/type/NbtComponent.mapping
+++ b/mappings/net/minecraft/component/type/NbtComponent.mapping
@@ -22,7 +22,7 @@ CLASS net/minecraft/class_9279 net/minecraft/component/type/NbtComponent
 		ARG 0 component
 	METHOD method_57449 applyToBlockEntity (Lnet/minecraft/class_2586;Lnet/minecraft/class_7225$class_7874;)Z
 		ARG 1 blockEntity
-		ARG 2 registryLookup
+		ARG 2 registries
 	METHOD method_57450 contains (Ljava/lang/String;)Z
 		ARG 1 key
 	METHOD method_57451 apply (Ljava/util/function/Consumer;)Lnet/minecraft/class_9279;

--- a/mappings/net/minecraft/component/type/WrittenBookContentComponent.mapping
+++ b/mappings/net/minecraft/component/type/WrittenBookContentComponent.mapping
@@ -23,7 +23,7 @@ CLASS net/minecraft/class_9302 net/minecraft/component/type/WrittenBookContentCo
 		ARG 2 text
 	METHOD method_57524 exceedsSerializedLengthLimit (Lnet/minecraft/class_2561;Lnet/minecraft/class_7225$class_7874;)Z
 		ARG 0 text
-		ARG 1 lookup
+		ARG 1 registries
 	METHOD method_57525 getPages (Z)Ljava/util/List;
 		ARG 1 shouldFilter
 	METHOD method_57526 (ZLnet/minecraft/class_9262;)Lnet/minecraft/class_2561;

--- a/mappings/net/minecraft/data/DataProvider.mapping
+++ b/mappings/net/minecraft/data/DataProvider.mapping
@@ -15,7 +15,7 @@ CLASS net/minecraft/class_2405 net/minecraft/data/DataProvider
 		ARG 0 key
 	METHOD method_53496 writeCodecToPath (Lnet/minecraft/class_7403;Lnet/minecraft/class_7225$class_7874;Lcom/mojang/serialization/Codec;Ljava/lang/Object;Ljava/nio/file/Path;)Ljava/util/concurrent/CompletableFuture;
 		ARG 0 writer
-		ARG 1 registryLookup
+		ARG 1 registries
 		ARG 2 codec
 		ARG 3 value
 		ARG 4 path

--- a/mappings/net/minecraft/data/report/BiomeParametersProvider.mapping
+++ b/mappings/net/minecraft/data/report/BiomeParametersProvider.mapping
@@ -18,7 +18,7 @@ CLASS net/minecraft/class_7228 net/minecraft/data/report/BiomeParametersProvider
 	METHOD method_42032 resolvePath (Lnet/minecraft/class_2960;)Ljava/nio/file/Path;
 		ARG 1 id
 	METHOD method_46810 (Lnet/minecraft/class_7403;Lnet/minecraft/class_7225$class_7874;)Ljava/util/concurrent/CompletionStage;
-		ARG 2 lookup
+		ARG 2 registries
 	METHOD method_49648 (Ljava/util/List;Lnet/minecraft/class_7403;Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/class_8197$class_5305;Lnet/minecraft/class_6544$class_6547;)V
 		ARG 4 preset
 		ARG 5 entries

--- a/mappings/net/minecraft/data/report/BlockListProvider.mapping
+++ b/mappings/net/minecraft/data/report/BlockListProvider.mapping
@@ -7,4 +7,4 @@ CLASS net/minecraft/class_2422 net/minecraft/data/report/BlockListProvider
 	METHOD method_57952 (Lnet/minecraft/class_6903;Lcom/google/gson/JsonObject;Lnet/minecraft/class_6880$class_6883;)V
 		ARG 2 entry
 	METHOD method_57954 (Lnet/minecraft/class_7403;Ljava/nio/file/Path;Lnet/minecraft/class_7225$class_7874;)Ljava/util/concurrent/CompletionStage;
-		ARG 2 registryLookup
+		ARG 2 registries

--- a/mappings/net/minecraft/data/report/CommandSyntaxProvider.mapping
+++ b/mappings/net/minecraft/data/report/CommandSyntaxProvider.mapping
@@ -5,4 +5,4 @@ CLASS net/minecraft/class_2425 net/minecraft/data/report/CommandSyntaxProvider
 		ARG 1 output
 		ARG 2 registryLookupFuture
 	METHOD method_46811 (Lnet/minecraft/class_7403;Ljava/nio/file/Path;Lnet/minecraft/class_7225$class_7874;)Ljava/util/concurrent/CompletionStage;
-		ARG 2 lookup
+		ARG 2 registries

--- a/mappings/net/minecraft/data/report/ItemListProvider.mapping
+++ b/mappings/net/minecraft/data/report/ItemListProvider.mapping
@@ -7,6 +7,6 @@ CLASS net/minecraft/class_9338 net/minecraft/data/report/ItemListProvider
 	METHOD method_57955 (Lnet/minecraft/class_6903;Lcom/google/gson/JsonObject;Lnet/minecraft/class_6880$class_6883;)V
 		ARG 2 entry
 	METHOD method_57959 (Lnet/minecraft/class_7403;Ljava/nio/file/Path;Lnet/minecraft/class_7225$class_7874;)Ljava/util/concurrent/CompletionStage;
-		ARG 2 registryLookup
+		ARG 2 registries
 	METHOD method_60581 (Ljava/lang/String;)Ljava/lang/IllegalStateException;
 		ARG 0 components

--- a/mappings/net/minecraft/data/server/DynamicRegistriesProvider.mapping
+++ b/mappings/net/minecraft/data/server/DynamicRegistriesProvider.mapping
@@ -20,6 +20,6 @@ CLASS net/minecraft/class_5475 net/minecraft/data/server/DynamicRegistriesProvid
 	METHOD method_46813 (Lnet/minecraft/class_5321;Lnet/minecraft/class_7403;Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/class_7655$class_7657;Lnet/minecraft/class_7225$class_7226;)Ljava/util/concurrent/CompletableFuture;
 		ARG 5 wrapper
 	METHOD method_46814 (Lnet/minecraft/class_7403;Lnet/minecraft/class_7225$class_7874;)Ljava/util/concurrent/CompletionStage;
-		ARG 2 lookup
+		ARG 2 registries
 	METHOD method_46816 (Lnet/minecraft/class_7403;Lnet/minecraft/class_7225$class_7874;Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/class_7655$class_7657;)Ljava/util/stream/Stream;
 		ARG 4 entry

--- a/mappings/net/minecraft/data/server/DynamicRegistriesProvider.mapping
+++ b/mappings/net/minecraft/data/server/DynamicRegistriesProvider.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/class_5475 net/minecraft/data/server/DynamicRegistriesProvid
 		ARG 2 registryLookupFuture
 	METHOD method_39678 writeRegistryEntries (Lnet/minecraft/class_7403;Lnet/minecraft/class_7225$class_7874;Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/class_7655$class_7657;)Ljava/util/Optional;
 		ARG 1 writer
-		ARG 2 lookup
+		ARG 2 registries
 		ARG 3 ops
 		ARG 4 registry
 	METHOD method_39680 writeToPath (Ljava/nio/file/Path;Lnet/minecraft/class_7403;Lcom/mojang/serialization/DynamicOps;Lcom/mojang/serialization/Encoder;Ljava/lang/Object;)Ljava/util/concurrent/CompletableFuture;

--- a/mappings/net/minecraft/data/server/advancement/AdvancementProvider.mapping
+++ b/mappings/net/minecraft/data/server/advancement/AdvancementProvider.mapping
@@ -9,4 +9,4 @@ CLASS net/minecraft/class_2409 net/minecraft/data/server/advancement/Advancement
 	METHOD method_10333 (Ljava/util/Set;Ljava/util/List;Lnet/minecraft/class_7403;Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_8779;)V
 		ARG 5 advancement
 	METHOD method_46809 (Lnet/minecraft/class_7403;Lnet/minecraft/class_7225$class_7874;)Ljava/util/concurrent/CompletionStage;
-		ARG 2 lookup
+		ARG 2 registries

--- a/mappings/net/minecraft/data/server/advancement/AdvancementTabGenerator.mapping
+++ b/mappings/net/minecraft/data/server/advancement/AdvancementTabGenerator.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_7785 net/minecraft/data/server/advancement/AdvancementTabGenerator
 	METHOD method_10335 accept (Lnet/minecraft/class_7225$class_7874;Ljava/util/function/Consumer;)V
-		ARG 1 lookup
+		ARG 1 registries
 		ARG 2 exporter
 	METHOD method_55578 reference (Ljava/lang/String;)Lnet/minecraft/class_8779;
 		COMMENT {@return an advancement to use as a reference in {@link

--- a/mappings/net/minecraft/data/server/advancement/vanilla/VanillaAdventureTabAdvancementGenerator.mapping
+++ b/mappings/net/minecraft/data/server/advancement/vanilla/VanillaAdventureTabAdvancementGenerator.mapping
@@ -8,7 +8,7 @@ CLASS net/minecraft/class_2412 net/minecraft/data/server/advancement/vanilla/Van
 		ARG 0 builder
 	METHOD method_10337 requireListedBiomesVisited (Lnet/minecraft/class_161$class_162;Lnet/minecraft/class_7225$class_7874;Ljava/util/List;)Lnet/minecraft/class_161$class_162;
 		ARG 0 builder
-		ARG 1 registryLookup
+		ARG 1 registries
 		ARG 2 biomes
 	METHOD method_37315 createLookingAtEntityUsing (Lnet/minecraft/class_2048$class_2049;Lnet/minecraft/class_2073$class_2074;)Lnet/minecraft/class_175;
 		ARG 0 lookingAt
@@ -17,7 +17,7 @@ CLASS net/minecraft/class_2412 net/minecraft/data/server/advancement/vanilla/Van
 		ARG 0 range
 		ARG 1 entity
 	METHOD method_49356 buildAdventuringTime (Lnet/minecraft/class_7225$class_7874;Ljava/util/function/Consumer;Lnet/minecraft/class_8779;Lnet/minecraft/class_8197$class_5305;)V
-		ARG 0 registryLookup
+		ARG 0 registries
 		ARG 1 exporter
 		ARG 2 parent
 		ARG 3 biomeSourceListPreset

--- a/mappings/net/minecraft/data/server/advancement/vanilla/VanillaHusbandryTabAdvancementGenerator.mapping
+++ b/mappings/net/minecraft/data/server/advancement/vanilla/VanillaHusbandryTabAdvancementGenerator.mapping
@@ -26,6 +26,6 @@ CLASS net/minecraft/class_2414 net/minecraft/data/server/advancement/vanilla/Van
 		ARG 0 entry
 	METHOD method_59775 requireAllWolvesTamed (Lnet/minecraft/class_161$class_162;Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_161$class_162;
 		ARG 0 builder
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_59776 (Lnet/minecraft/class_7225$class_7226;Lnet/minecraft/class_161$class_162;Lnet/minecraft/class_5321;)V
 		ARG 2 key

--- a/mappings/net/minecraft/data/server/loottable/BlockLootTableGenerator.mapping
+++ b/mappings/net/minecraft/data/server/loottable/BlockLootTableGenerator.mapping
@@ -4,16 +4,16 @@ CLASS net/minecraft/class_7788 net/minecraft/data/server/loottable/BlockLootTabl
 	FIELD field_40609 requiredFeatures Lnet/minecraft/class_7699;
 	FIELD field_40610 lootTables Ljava/util/Map;
 	FIELD field_40611 LEAVES_STICK_DROP_CHANCE [F
-	FIELD field_51845 registryLookup Lnet/minecraft/class_7225$class_7874;
+	FIELD field_51845 registries Lnet/minecraft/class_7225$class_7874;
 	METHOD <init> (Ljava/util/Set;Lnet/minecraft/class_7699;Ljava/util/Map;Lnet/minecraft/class_7225$class_7874;)V
 		ARG 1 explosionImmuneItems
 		ARG 2 requiredFeatures
 		ARG 3 lootTables
-		ARG 4 registryLookup
+		ARG 4 registries
 	METHOD <init> (Ljava/util/Set;Lnet/minecraft/class_7699;Lnet/minecraft/class_7225$class_7874;)V
 		ARG 1 explosionImmuneItems
 		ARG 2 requiredFeatures
-		ARG 3 registryLookup
+		ARG 3 registries
 	METHOD method_10379 generate ()V
 	METHOD method_45975 dropsNothing ()Lnet/minecraft/class_52$class_53;
 	METHOD method_45976 drops (Lnet/minecraft/class_1935;)Lnet/minecraft/class_52$class_53;

--- a/mappings/net/minecraft/data/server/loottable/EntityLootTableGenerator.mapping
+++ b/mappings/net/minecraft/data/server/loottable/EntityLootTableGenerator.mapping
@@ -3,14 +3,14 @@ CLASS net/minecraft/class_7789 net/minecraft/data/server/loottable/EntityLootTab
 	FIELD field_40615 lootTables Ljava/util/Map;
 	FIELD field_42084 requiredFeatures Lnet/minecraft/class_7699;
 	FIELD field_42085 featureSet Lnet/minecraft/class_7699;
-	FIELD field_51846 registryLookup Lnet/minecraft/class_7225$class_7874;
+	FIELD field_51846 registries Lnet/minecraft/class_7225$class_7874;
 	METHOD <init> (Lnet/minecraft/class_7699;Lnet/minecraft/class_7225$class_7874;)V
 		ARG 1 requiredFeatures
-		ARG 2 registryLookup
+		ARG 2 registries
 	METHOD <init> (Lnet/minecraft/class_7699;Lnet/minecraft/class_7699;Lnet/minecraft/class_7225$class_7874;)V
 		ARG 1 requiredFeatures
 		ARG 2 featureSet
-		ARG 3 registryLookup
+		ARG 3 registries
 	METHOD method_10400 generate ()V
 	METHOD method_46027 shouldCheck (Lnet/minecraft/class_1299;)Z
 		ARG 0 entityType

--- a/mappings/net/minecraft/data/server/loottable/LootTableProvider.mapping
+++ b/mappings/net/minecraft/data/server/loottable/LootTableProvider.mapping
@@ -23,7 +23,7 @@ CLASS net/minecraft/class_2438 net/minecraft/data/server/loottable/LootTableProv
 		ARG 4 builder
 	METHOD method_56883 run (Lnet/minecraft/class_7403;Lnet/minecraft/class_7225$class_7874;)Ljava/util/concurrent/CompletableFuture;
 		ARG 1 writer
-		ARG 2 registryLookup
+		ARG 2 registries
 	METHOD method_56884 (Lnet/minecraft/class_7403;Lnet/minecraft/class_7225$class_7874;)Ljava/util/concurrent/CompletionStage;
 		ARG 2 registryLookup
 	METHOD method_58574 getId (Lnet/minecraft/class_5321;)Lnet/minecraft/class_2960;

--- a/mappings/net/minecraft/data/server/loottable/LootTableProvider.mapping
+++ b/mappings/net/minecraft/data/server/loottable/LootTableProvider.mapping
@@ -25,7 +25,7 @@ CLASS net/minecraft/class_2438 net/minecraft/data/server/loottable/LootTableProv
 		ARG 1 writer
 		ARG 2 registries
 	METHOD method_56884 (Lnet/minecraft/class_7403;Lnet/minecraft/class_7225$class_7874;)Ljava/util/concurrent/CompletionStage;
-		ARG 2 registryLookup
+		ARG 2 registries
 	METHOD method_58574 getId (Lnet/minecraft/class_5321;)Lnet/minecraft/class_2960;
 		ARG 0 lootTableKey
 	CLASS class_7790 LootTypeGenerator

--- a/mappings/net/minecraft/data/server/loottable/vanilla/VanillaBlockLootTableGenerator.mapping
+++ b/mappings/net/minecraft/data/server/loottable/vanilla/VanillaBlockLootTableGenerator.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_2430 net/minecraft/data/server/loottable/vanilla/Vanil
 	FIELD field_11338 JUNGLE_SAPLING_DROP_CHANCE [F
 	FIELD field_11340 EXPLOSION_IMMUNE Ljava/util/Set;
 	METHOD <init> (Lnet/minecraft/class_7225$class_7874;)V
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_16232 (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;
 		ARG 1 block
 	METHOD method_16233 (Lnet/minecraft/class_2248;)Lnet/minecraft/class_52$class_53;

--- a/mappings/net/minecraft/data/server/loottable/vanilla/VanillaEntityLootTableGenerator.mapping
+++ b/mappings/net/minecraft/data/server/loottable/vanilla/VanillaEntityLootTableGenerator.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_2434 net/minecraft/data/server/loottable/vanilla/VanillaEntityLootTableGenerator
 	METHOD <init> (Lnet/minecraft/class_7225$class_7874;)V
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_48515 createElderGuardianTableBuilder ()Lnet/minecraft/class_52$class_53;
 	METHOD method_62736 (Lnet/minecraft/class_1767;Lnet/minecraft/class_1935;)V
 		ARG 1 color

--- a/mappings/net/minecraft/data/server/recipe/RecipeGenerator.mapping
+++ b/mappings/net/minecraft/data/server/recipe/RecipeGenerator.mapping
@@ -1,10 +1,10 @@
 CLASS net/minecraft/class_2446 net/minecraft/data/server/recipe/RecipeGenerator
 	FIELD field_28555 VARIANT_FACTORIES Ljava/util/Map;
-	FIELD field_48981 registryLookupWrapper Lnet/minecraft/class_7225$class_7874;
+	FIELD field_48981 registries Lnet/minecraft/class_7225$class_7874;
 	FIELD field_53721 exporter Lnet/minecraft/class_8790;
 	FIELD field_53722 registryLookup Lnet/minecraft/class_7871;
 	METHOD <init> (Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_8790;)V
-		ARG 1 registryLookup
+		ARG 1 registries
 		ARG 2 exporter
 	METHOD method_10419 generate ()V
 	METHOD method_10420 conditionsFromTag (Lnet/minecraft/class_6862;)Lnet/minecraft/class_175;
@@ -407,10 +407,10 @@ CLASS net/minecraft/class_2446 net/minecraft/data/server/recipe/RecipeGenerator
 			ARG 1 output
 			ARG 2 registryLookupFuture
 		METHOD method_62766 getRecipeGenerator (Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_8790;)Lnet/minecraft/class_2446;
-			ARG 1 registryLookup
+			ARG 1 registries
 			ARG 2 exporter
 		CLASS 1
-			FIELD field_53728 registryLookup Lnet/minecraft/class_7225$class_7874;
+			FIELD field_53728 registries Lnet/minecraft/class_7225$class_7874;
 			FIELD field_53729 recipePathResolver Lnet/minecraft/class_7784$class_7489;
 			FIELD field_53730 recipeAdvancementPathResolver Lnet/minecraft/class_7784$class_7489;
 			METHOD method_62768 addRecipeAdvancement (Lnet/minecraft/class_8779;)V

--- a/mappings/net/minecraft/data/server/tag/EnchantmentTagProvider.mapping
+++ b/mappings/net/minecraft/data/server/tag/EnchantmentTagProvider.mapping
@@ -5,5 +5,5 @@ CLASS net/minecraft/class_9674 net/minecraft/data/server/tag/EnchantmentTagProvi
 	METHOD method_59779 (Ljava/util/Set;Lnet/minecraft/class_6880$class_6883;)Z
 		ARG 1 entry
 	METHOD method_59781 createTooltipOrderTag (Lnet/minecraft/class_7225$class_7874;[Lnet/minecraft/class_5321;)V
-		ARG 1 registryLookup
+		ARG 1 registries
 		ARG 2 enchantments

--- a/mappings/net/minecraft/data/server/tag/ItemTagProvider.mapping
+++ b/mappings/net/minecraft/data/server/tag/ItemTagProvider.mapping
@@ -16,7 +16,7 @@ CLASS net/minecraft/class_7805 net/minecraft/data/server/tag/ItemTagProvider
 	METHOD method_46831 (Lnet/minecraft/class_1792;)Lnet/minecraft/class_5321;
 		ARG 0 item
 	METHOD method_49649 (Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_2474$class_8211;)Lnet/minecraft/class_7225$class_7874;
-		ARG 1 lookup
+		ARG 1 registries
 		ARG 2 blockTags
 	METHOD method_49650 (Lnet/minecraft/class_2474$class_8211;Lnet/minecraft/class_6862;Lnet/minecraft/class_6862;)V
 		ARG 2 blockTag

--- a/mappings/net/minecraft/data/server/tag/TagProvider.mapping
+++ b/mappings/net/minecraft/data/server/tag/TagProvider.mapping
@@ -17,7 +17,7 @@ CLASS net/minecraft/class_2474 net/minecraft/data/server/tag/TagProvider
 	METHOD method_10512 getOrCreateTagBuilder (Lnet/minecraft/class_6862;)Lnet/minecraft/class_2474$class_5124;
 		ARG 1 tag
 	METHOD method_10514 configure (Lnet/minecraft/class_7225$class_7874;)V
-		ARG 1 lookup
+		ARG 1 registries
 	METHOD method_27169 getTagBuilder (Lnet/minecraft/class_6862;)Lnet/minecraft/class_3495;
 		ARG 1 tag
 	METHOD method_27170 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_3495;

--- a/mappings/net/minecraft/data/server/tag/TagProvider.mapping
+++ b/mappings/net/minecraft/data/server/tag/TagProvider.mapping
@@ -28,7 +28,7 @@ CLASS net/minecraft/class_2474 net/minecraft/data/server/tag/TagProvider
 	METHOD method_49656 (Lnet/minecraft/class_6862;)Ljava/util/Optional;
 		ARG 1 tag
 	METHOD method_49657 (Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_2474$class_8211;)Lnet/minecraft/class_2474$class_8210;
-		ARG 0 lookup
+		ARG 0 registries
 		ARG 1 parent
 	METHOD method_49658 (Ljava/util/function/Predicate;Ljava/util/function/Predicate;Lnet/minecraft/class_3497;)Z
 		ARG 2 tagEntry
@@ -40,7 +40,7 @@ CLASS net/minecraft/class_2474 net/minecraft/data/server/tag/TagProvider
 		ARG 1 void_
 	METHOD method_49662 getTagLookupFuture ()Ljava/util/concurrent/CompletableFuture;
 	METHOD method_49706 (Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_7225$class_7874;
-		ARG 1 lookup
+		ARG 1 registries
 	METHOD method_49707 (Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_7225$class_7874;
 		ARG 1 registryLookupFuture
 	CLASS class_5124 ProvidedTagBuilder

--- a/mappings/net/minecraft/entity/InventoryOwner.mapping
+++ b/mappings/net/minecraft/entity/InventoryOwner.mapping
@@ -7,5 +7,7 @@ CLASS net/minecraft/class_6067 net/minecraft/entity/InventoryOwner
 		ARG 2 item
 	METHOD method_46399 writeInventory (Lnet/minecraft/class_2487;Lnet/minecraft/class_7225$class_7874;)V
 		ARG 1 nbt
+		ARG 2 registries
 	METHOD method_46400 readInventory (Lnet/minecraft/class_2487;Lnet/minecraft/class_7225$class_7874;)V
 		ARG 1 nbt
+		ARG 2 registries

--- a/mappings/net/minecraft/entity/boss/BossBarManager.mapping
+++ b/mappings/net/minecraft/entity/boss/BossBarManager.mapping
@@ -9,9 +9,11 @@ CLASS net/minecraft/class_3004 net/minecraft/entity/boss/BossBarManager
 		ARG 1 id
 	METHOD method_12972 readNbt (Lnet/minecraft/class_2487;Lnet/minecraft/class_7225$class_7874;)V
 		ARG 1 nbt
+		ARG 2 registries
 	METHOD method_12973 remove (Lnet/minecraft/class_3002;)V
 		ARG 1 bossBar
 	METHOD method_12974 toNbt (Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_2487;
+		ARG 1 registries
 	METHOD method_12975 onPlayerConnect (Lnet/minecraft/class_3222;)V
 		ARG 1 player
 	METHOD method_12976 onPlayerDisconnect (Lnet/minecraft/class_3222;)V

--- a/mappings/net/minecraft/entity/boss/CommandBossBar.mapping
+++ b/mappings/net/minecraft/entity/boss/CommandBossBar.mapping
@@ -22,9 +22,11 @@ CLASS net/minecraft/class_3002 net/minecraft/entity/boss/CommandBossBar
 	METHOD method_12962 addPlayers (Ljava/util/Collection;)Z
 		ARG 1 players
 	METHOD method_12963 toNbt (Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_2487;
+		ARG 1 registries
 	METHOD method_12964 addPlayer (Ljava/util/UUID;)V
 		ARG 1 uuid
 	METHOD method_12965 toHoverableText ()Lnet/minecraft/class_2561;
 	METHOD method_12966 fromNbt (Lnet/minecraft/class_2487;Lnet/minecraft/class_2960;Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_3002;
 		ARG 0 nbt
 		ARG 1 id
+		ARG 2 registries

--- a/mappings/net/minecraft/entity/vehicle/VehicleInventory.mapping
+++ b/mappings/net/minecraft/entity/vehicle/VehicleInventory.mapping
@@ -18,7 +18,7 @@ CLASS net/minecraft/class_7265 net/minecraft/entity/vehicle/VehicleInventory
 		ARG 1 player
 	METHOD method_42285 readInventoryFromNbt (Lnet/minecraft/class_2487;Lnet/minecraft/class_7225$class_7874;)V
 		ARG 1 nbt
-		ARG 2 registriesLookup
+		ARG 2 registries
 	METHOD method_42286 removeInventoryStack (II)Lnet/minecraft/class_1799;
 		ARG 1 slot
 		ARG 2 amount
@@ -27,7 +27,7 @@ CLASS net/minecraft/class_7265 net/minecraft/entity/vehicle/VehicleInventory
 		ARG 2 stack
 	METHOD method_42288 writeInventoryToNbt (Lnet/minecraft/class_2487;Lnet/minecraft/class_7225$class_7874;)V
 		ARG 1 nbt
-		ARG 2 registriesLookup
+		ARG 2 registries
 	METHOD method_42289 removeInventoryStack (I)Lnet/minecraft/class_1799;
 		ARG 1 slot
 	METHOD method_42290 getInventoryStack (I)Lnet/minecraft/class_1799;

--- a/mappings/net/minecraft/item/FuelRegistry.mapping
+++ b/mappings/net/minecraft/item/FuelRegistry.mapping
@@ -6,10 +6,10 @@ CLASS net/minecraft/class_9895 net/minecraft/item/FuelRegistry
 	METHOD method_61752 isFuel (Lnet/minecraft/class_1799;)Z
 		ARG 1 item
 	METHOD method_61753 createDefault (Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_7699;)Lnet/minecraft/class_9895;
-		ARG 0 lookup
+		ARG 0 registries
 		ARG 1 featureSet
 	METHOD method_61754 createDefault (Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_7699;I)Lnet/minecraft/class_9895;
-		ARG 0 lookup
+		ARG 0 registries
 		ARG 1 featureSet
 		ARG 2 itemSmeltTime
 	METHOD method_61755 getFuelTicks (Lnet/minecraft/class_1799;)I
@@ -19,7 +19,7 @@ CLASS net/minecraft/class_9895 net/minecraft/item/FuelRegistry
 		FIELD field_52637 featureSet Lnet/minecraft/class_7699;
 		FIELD field_52638 fuelValues Lit/unimi/dsi/fastutil/objects/Object2IntSortedMap;
 		METHOD <init> (Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_7699;)V
-			ARG 1 lookup
+			ARG 1 registries
 			ARG 2 featureSet
 		METHOD method_61756 build ()Lnet/minecraft/class_9895;
 		METHOD method_61757 add (ILnet/minecraft/class_1792;)V

--- a/mappings/net/minecraft/item/GoatHornItem.mapping
+++ b/mappings/net/minecraft/item/GoatHornItem.mapping
@@ -12,6 +12,6 @@ CLASS net/minecraft/class_7430 net/minecraft/item/GoatHornItem
 		ARG 2 instrument
 	METHOD method_43711 getInstrument (Lnet/minecraft/class_1799;Lnet/minecraft/class_7225$class_7874;)Ljava/util/Optional;
 		ARG 1 stack
-		ARG 2 registryLookup
+		ARG 2 registries
 	METHOD method_45432 (Lnet/minecraft/class_6880;)Ljava/lang/Integer;
 		ARG 0 instrument

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -433,5 +433,5 @@ CLASS net/minecraft/class_1792 net/minecraft/item/Item
 		METHOD method_59529 getMapState (Lnet/minecraft/class_9209;)Lnet/minecraft/class_22;
 			ARG 1 mapIdComponent
 		METHOD method_59530 create (Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_1792$class_9635;
-			ARG 0 registryLookup
+			ARG 0 registries
 		METHOD method_59531 getUpdateTickRate ()F

--- a/mappings/net/minecraft/item/ItemGroup.mapping
+++ b/mappings/net/minecraft/item/ItemGroup.mapping
@@ -116,4 +116,4 @@ CLASS net/minecraft/class_1761 net/minecraft/item/ItemGroup
 		METHOD method_48932 doesNotMatch (Lnet/minecraft/class_7699;ZLnet/minecraft/class_7225$class_7874;)Z
 			ARG 1 enabledFeatures
 			ARG 2 hasPermissions
-			ARG 3 lookup
+			ARG 3 registries

--- a/mappings/net/minecraft/item/ItemGroups.mapping
+++ b/mappings/net/minecraft/item/ItemGroups.mapping
@@ -41,7 +41,7 @@ CLASS net/minecraft/class_7706 net/minecraft/item/ItemGroups
 	METHOD method_47330 updateDisplayContext (Lnet/minecraft/class_7699;ZLnet/minecraft/class_7225$class_7874;)Z
 		ARG 0 enabledFeatures
 		ARG 1 operatorEnabled
-		ARG 2 lookup
+		ARG 2 registries
 	METHOD method_47331 (Lnet/minecraft/class_1761$class_8128;Lnet/minecraft/class_1761;)V
 		ARG 1 group
 	METHOD method_47332 addSuspiciousStews (Lnet/minecraft/class_1761$class_7704;Lnet/minecraft/class_1761$class_7705;)V
@@ -68,7 +68,7 @@ CLASS net/minecraft/class_7706 net/minecraft/item/ItemGroups
 		ARG 3 paintingVariantEntry
 	METHOD method_48937 addPaintings (Lnet/minecraft/class_1761$class_7704;Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_7225$class_7226;Ljava/util/function/Predicate;Lnet/minecraft/class_1761$class_7705;)V
 		ARG 0 entries
-		ARG 1 registryLookup
+		ARG 1 registries
 		ARG 2 registryWrapper
 		ARG 3 filter
 		ARG 4 stackVisibility

--- a/mappings/net/minecraft/item/map/MapState.mapping
+++ b/mappings/net/minecraft/item/map/MapState.mapping
@@ -113,7 +113,7 @@ CLASS net/minecraft/class_22 net/minecraft/item/map/MapState
 		ARG 3 color
 	METHOD method_32371 fromNbt (Lnet/minecraft/class_2487;Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_22;
 		ARG 0 nbt
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_32372 hasExplorationMapDecoration ()Z
 	METHOD method_32373 getDecorations ()Ljava/lang/Iterable;
 	METHOD method_32374 markDecorationsDirty ()V

--- a/mappings/net/minecraft/item/trim/ArmorTrimMaterials.mapping
+++ b/mappings/net/minecraft/item/trim/ArmorTrimMaterials.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_8055 net/minecraft/item/trim/ArmorTrimMaterials
 	METHOD method_48439 (Lnet/minecraft/class_1799;Lnet/minecraft/class_6880$class_6883;)Z
 		ARG 1 recipe
 	METHOD method_48440 get (Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_1799;)Ljava/util/Optional;
-		ARG 0 registriesLookup
+		ARG 0 registries
 		ARG 1 stack
 	METHOD method_48441 of (Ljava/lang/String;)Lnet/minecraft/class_5321;
 		ARG 0 id

--- a/mappings/net/minecraft/item/trim/ArmorTrimPatterns.mapping
+++ b/mappings/net/minecraft/item/trim/ArmorTrimPatterns.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_8057 net/minecraft/item/trim/ArmorTrimPatterns
 	METHOD method_48447 (Lnet/minecraft/class_1799;Lnet/minecraft/class_6880$class_6883;)Z
 		ARG 1 pattern
 	METHOD method_48448 get (Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_1799;)Ljava/util/Optional;
-		ARG 0 registriesLookup
+		ARG 0 registries
 		ARG 1 stack
 	METHOD method_48449 of (Ljava/lang/String;)Lnet/minecraft/class_5321;
 		ARG 0 id

--- a/mappings/net/minecraft/loot/condition/RandomChanceWithEnchantedBonusLootCondition.mapping
+++ b/mappings/net/minecraft/loot/condition/RandomChanceWithEnchantedBonusLootCondition.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_225 net/minecraft/loot/condition/RandomChanceWithEncha
 	METHOD method_53425 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 0 instance
 	METHOD method_953 builder (Lnet/minecraft/class_7225$class_7874;FF)Lnet/minecraft/class_5341$class_210;
-		ARG 0 registryLookup
+		ARG 0 registries
 		ARG 1 base
 		ARG 2 perLevelAboveFirst
 	METHOD test (Ljava/lang/Object;)Z

--- a/mappings/net/minecraft/loot/function/EnchantRandomlyLootFunction.mapping
+++ b/mappings/net/minecraft/loot/function/EnchantRandomlyLootFunction.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/class_109 net/minecraft/loot/function/EnchantRandomlyLootFun
 		ARG 2 random
 	METHOD method_35520 create ()Lnet/minecraft/class_109$class_4954;
 	METHOD method_489 builder (Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_109$class_4954;
-		ARG 0 registryLookup
+		ARG 0 registries
 	METHOD method_53324 (Lnet/minecraft/class_109;)Ljava/util/Optional;
 		ARG 0 function
 	METHOD method_60290 (Lnet/minecraft/class_109;)Ljava/lang/Boolean;

--- a/mappings/net/minecraft/loot/function/EnchantWithLevelsLootFunction.mapping
+++ b/mappings/net/minecraft/loot/function/EnchantWithLevelsLootFunction.mapping
@@ -7,7 +7,7 @@ CLASS net/minecraft/class_106 net/minecraft/loot/function/EnchantWithLevelsLootF
 		ARG 2 levels
 		ARG 3 options
 	METHOD method_481 builder (Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_5658;)Lnet/minecraft/class_106$class_107;
-		ARG 0 registryLookup
+		ARG 0 registries
 		ARG 1 levels
 	METHOD method_53329 (Lnet/minecraft/class_106;)Ljava/util/Optional;
 		ARG 0 function

--- a/mappings/net/minecraft/loot/function/EnchantedCountIncreaseLootFunction.mapping
+++ b/mappings/net/minecraft/loot/function/EnchantedCountIncreaseLootFunction.mapping
@@ -16,7 +16,7 @@ CLASS net/minecraft/class_125 net/minecraft/loot/function/EnchantedCountIncrease
 	METHOD method_53350 (Lnet/minecraft/class_125;)Lnet/minecraft/class_5658;
 		ARG 0 function
 	METHOD method_547 builder (Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_5658;)Lnet/minecraft/class_125$class_126;
-		ARG 0 registryLookup
+		ARG 0 registries
 		ARG 1 count
 	METHOD method_549 hasLimit ()Z
 	METHOD method_60296 (Lnet/minecraft/class_125;)Lnet/minecraft/class_6880;

--- a/mappings/net/minecraft/recipe/Recipe.mapping
+++ b/mappings/net/minecraft/recipe/Recipe.mapping
@@ -28,7 +28,7 @@ CLASS net/minecraft/class_1860 net/minecraft/recipe/Recipe
 		COMMENT
 		COMMENT <p>The returned stack should not be modified. To obtain the actual output,
 		COMMENT call {@link #craft(Inventory, DynamicRegistryManager)}.
-		ARG 1 registriesLookup
+		ARG 1 registries
 	METHOD method_8111 getRemainder (Lnet/minecraft/class_9695;)Lnet/minecraft/class_2371;
 		COMMENT {@return the remaining stacks to be left in the {@code inventory} after the recipe is used}
 		COMMENT At each index, the remainder item stack in the list should correspond to the original
@@ -73,7 +73,7 @@ CLASS net/minecraft/class_1860 net/minecraft/recipe/Recipe
 		COMMENT
 		COMMENT @return the resulting item stack
 		ARG 1 input
-		ARG 2 lookup
+		ARG 2 registries
 	METHOD method_8118 isIgnoredInRecipeBook ()Z
 		COMMENT {@return whether this recipe is ignored by the recipe book} If a recipe
 		COMMENT is ignored by the recipe book, it will be never displayed. In addition,

--- a/mappings/net/minecraft/recipe/RecipeManager.mapping
+++ b/mappings/net/minecraft/recipe/RecipeManager.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_1863 net/minecraft/recipe/RecipeManager
 	COMMENT from data packs' JSON files.
 	FIELD field_19359 GSON Lcom/google/gson/Gson;
 	FIELD field_36308 recipesById Ljava/util/Map;
-	FIELD field_48848 registryLookup Lnet/minecraft/class_7225$class_7874;
+	FIELD field_48848 registries Lnet/minecraft/class_7225$class_7874;
 	FIELD field_51481 recipesByType Lcom/google/common/collect/Multimap;
 	FIELD field_52600 usableValues Ljava/util/List;
 	FIELD field_9024 errored Z
@@ -12,7 +12,7 @@ CLASS net/minecraft/class_1863 net/minecraft/recipe/RecipeManager
 		COMMENT {@code false} and is never {@code true}, and isn't used anywhere.
 	FIELD field_9027 LOGGER Lorg/slf4j/Logger;
 	METHOD <init> (Lnet/minecraft/class_7225$class_7874;)V
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_17717 getAllOfType (Lnet/minecraft/class_3956;)Ljava/util/Collection;
 		ARG 1 type
 	METHOD method_17720 deserialize (Lnet/minecraft/class_2960;Lcom/google/gson/JsonObject;Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_8786;
@@ -28,7 +28,7 @@ CLASS net/minecraft/class_1863 net/minecraft/recipe/RecipeManager
 		ARG 0 id
 			COMMENT the recipe's ID
 		ARG 1 json
-		ARG 2 registryLookup
+		ARG 2 registries
 	METHOD method_17876 (Lnet/minecraft/class_1937;Lnet/minecraft/class_8786;)Ljava/lang/String;
 		ARG 1 entry
 	METHOD method_17877 getAllMatches (Lnet/minecraft/class_3956;Lnet/minecraft/class_9695;Lnet/minecraft/class_1937;)Ljava/util/List;

--- a/mappings/net/minecraft/registry/BuiltinRegistries.mapping
+++ b/mappings/net/minecraft/registry/BuiltinRegistries.mapping
@@ -12,7 +12,7 @@ CLASS net/minecraft/class_7887 net/minecraft/registry/BuiltinRegistries
 	METHOD method_46822 (Lnet/minecraft/class_7871;Lnet/minecraft/class_6880$class_6883;)V
 		ARG 1 biome
 	METHOD method_46823 validate (Lnet/minecraft/class_7225$class_7874;)V
-		ARG 0 wrapperLookup
+		ARG 0 registries
 	METHOD method_49382 validate (Lnet/minecraft/class_7871;Lnet/minecraft/class_7225;)V
 		ARG 0 placedFeatureLookup
 		ARG 1 biomeLookup

--- a/mappings/net/minecraft/registry/ExperimentalRegistriesValidator.mapping
+++ b/mappings/net/minecraft/registry/ExperimentalRegistriesValidator.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_8931 net/minecraft/registry/ExperimentalRegistriesValidator
 	METHOD method_54839 (Lnet/minecraft/class_7877;Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_7877$class_8993;
-		ARG 1 lookup
+		ARG 1 registries
 	METHOD method_54840 validate (Ljava/util/concurrent/CompletableFuture;Lnet/minecraft/class_7877;)Ljava/util/concurrent/CompletableFuture;
 		ARG 0 registriesFuture
 		ARG 1 builder

--- a/mappings/net/minecraft/registry/RegistryBuilder.mapping
+++ b/mappings/net/minecraft/registry/RegistryBuilder.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/class_7877 net/minecraft/registry/RegistryBuilder
 		ARG 1 registryManager
 	METHOD method_46781 createWrapperLookup (Lnet/minecraft/class_5455;Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_8990$class_8991;)Lnet/minecraft/class_7877$class_8993;
 		ARG 1 baseRegistryManager
-		ARG 2 wrapperLookup
+		ARG 2 registries
 		ARG 3 cloneableRegistries
 	METHOD method_46782 (Lnet/minecraft/class_7877$class_7878;Lnet/minecraft/class_7877$class_7884;)Lnet/minecraft/class_7877$class_7883;
 		ARG 1 info

--- a/mappings/net/minecraft/registry/RegistryOps.mapping
+++ b/mappings/net/minecraft/registry/RegistryOps.mapping
@@ -20,7 +20,7 @@ CLASS net/minecraft/class_6903 net/minecraft/registry/RegistryOps
 		ARG 1 ops
 	METHOD method_46632 of (Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_6903;
 		ARG 0 delegate
-		ARG 1 wrapperLookup
+		ARG 1 registries
 	METHOD method_46633 (Ljava/lang/Object;)Lnet/minecraft/class_6880$class_6883;
 		ARG 0 object
 	METHOD method_46634 getEntryLookup (Lnet/minecraft/class_5321;)Ljava/util/Optional;
@@ -33,7 +33,7 @@ CLASS net/minecraft/class_6903 net/minecraft/registry/RegistryOps
 		ARG 0 key
 	METHOD method_56622 withRegistry (Lcom/mojang/serialization/Dynamic;Lnet/minecraft/class_7225$class_7874;)Lcom/mojang/serialization/Dynamic;
 		ARG 0 dynamic
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_57110 withDelegate (Lcom/mojang/serialization/DynamicOps;)Lnet/minecraft/class_6903;
 		ARG 1 delegate
 	CLASS class_7862 RegistryInfo
@@ -45,10 +45,10 @@ CLASS net/minecraft/class_6903 net/minecraft/registry/RegistryOps
 		METHOD method_46623 getRegistryInfo (Lnet/minecraft/class_5321;)Ljava/util/Optional;
 			ARG 1 registryRef
 	CLASS class_9683 CachedRegistryInfoGetter
-		FIELD field_51501 registriesLookup Lnet/minecraft/class_7225$class_7874;
+		FIELD field_51501 registries Lnet/minecraft/class_7225$class_7874;
 		FIELD field_51502 cache Ljava/util/Map;
 		METHOD <init> (Lnet/minecraft/class_7225$class_7874;)V
-			ARG 1 registriesLookup
+			ARG 1 registries
 		METHOD equals (Ljava/lang/Object;)Z
 			ARG 1 o
 		METHOD method_59855 compute (Lnet/minecraft/class_5321;)Ljava/util/Optional;

--- a/mappings/net/minecraft/registry/RegistryPair.mapping
+++ b/mappings/net/minecraft/registry/RegistryPair.mapping
@@ -15,6 +15,6 @@ CLASS net/minecraft/class_9791 net/minecraft/registry/RegistryPair
 	METHOD method_60738 create (Lcom/mojang/datafixers/util/Either;)Lnet/minecraft/class_9791;
 		ARG 0 entryOrKey
 	METHOD method_60739 getEntry (Lnet/minecraft/class_7225$class_7874;)Ljava/util/Optional;
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_60740 getValue (Lnet/minecraft/class_2378;)Ljava/util/Optional;
 		ARG 1 registry

--- a/mappings/net/minecraft/registry/ReloadableRegistries.mapping
+++ b/mappings/net/minecraft/registry/ReloadableRegistries.mapping
@@ -45,9 +45,9 @@ CLASS net/minecraft/class_9383 net/minecraft/registry/ReloadableRegistries
 	METHOD method_61247 (Lnet/minecraft/class_7780;Lnet/minecraft/class_7225$class_7874;Ljava/util/List;)Lnet/minecraft/class_9383$class_9842;
 		ARG 2 registries
 	CLASS class_9385 Lookup
-		FIELD field_49920 registriesLookup Lnet/minecraft/class_7225$class_7874;
+		FIELD field_49920 registries Lnet/minecraft/class_7225$class_7874;
 		METHOD <init> (Lnet/minecraft/class_7225$class_7874;)V
-			ARG 1 registriesLookup
+			ARG 1 registries
 		METHOD method_58290 getIds (Lnet/minecraft/class_5321;)Ljava/util/Collection;
 			ARG 1 registryRef
 		METHOD method_58291 (Lnet/minecraft/class_5321;Lnet/minecraft/class_7225$class_7226;)Ljava/util/Optional;

--- a/mappings/net/minecraft/scoreboard/ServerScoreboard.mapping
+++ b/mappings/net/minecraft/scoreboard/ServerScoreboard.mapping
@@ -19,7 +19,7 @@ CLASS net/minecraft/class_2995 net/minecraft/scoreboard/ServerScoreboard
 	METHOD method_12941 runUpdateListeners ()V
 	METHOD method_32704 stateFromNbt (Lnet/minecraft/class_2487;Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_273;
 		ARG 1 nbt
-		ARG 2 registryLookup
+		ARG 2 registries
 	METHOD method_32705 createState ()Lnet/minecraft/class_273;
 	METHOD method_52297 getPersistentStateType ()Lnet/minecraft/class_18$class_8645;
 	CLASS class_2996 UpdateMode

--- a/mappings/net/minecraft/server/DataPackContents.mapping
+++ b/mappings/net/minecraft/server/DataPackContents.mapping
@@ -14,7 +14,7 @@ CLASS net/minecraft/class_5350 net/minecraft/server/DataPackContents
 	FIELD field_52345 pendingTagLoads Ljava/util/List;
 	METHOD <init> (Lnet/minecraft/class_7780;Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_7699;Lnet/minecraft/class_2170$class_5364;Ljava/util/List;I)V
 		ARG 1 dynamicRegistries
-		ARG 2 registryLookup
+		ARG 2 registries
 		ARG 3 enabledFeatures
 		ARG 4 environment
 		ARG 5 pendingTagLoads

--- a/mappings/net/minecraft/server/ServerAdvancementLoader.mapping
+++ b/mappings/net/minecraft/server/ServerAdvancementLoader.mapping
@@ -3,9 +3,9 @@ CLASS net/minecraft/class_2989 net/minecraft/server/ServerAdvancementLoader
 	FIELD field_13405 GSON Lcom/google/gson/Gson;
 	FIELD field_13406 LOGGER Lorg/slf4j/Logger;
 	FIELD field_46076 manager Lnet/minecraft/class_163;
-	FIELD field_48787 registryLookup Lnet/minecraft/class_7225$class_7874;
+	FIELD field_48787 registries Lnet/minecraft/class_7225$class_7874;
 	METHOD <init> (Lnet/minecraft/class_7225$class_7874;)V
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_12893 getAdvancements ()Ljava/util/Collection;
 	METHOD method_12896 get (Lnet/minecraft/class_2960;)Lnet/minecraft/class_8779;
 		ARG 1 id

--- a/mappings/net/minecraft/server/command/CommandManager.mapping
+++ b/mappings/net/minecraft/server/command/CommandManager.mapping
@@ -28,7 +28,7 @@ CLASS net/minecraft/class_2170 net/minecraft/server/command/CommandManager
 		ARG 0 parseResults
 		ARG 1 sourceMapper
 	METHOD method_46732 createRegistryAccess (Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_7157;
-		ARG 0 registryLookup
+		ARG 0 registries
 	METHOD method_54312 throwException (Lcom/mojang/brigadier/ParseResults;)V
 		ARG 0 parse
 	METHOD method_54313 callWithContext (Lnet/minecraft/class_2168;Ljava/util/function/Consumer;)V

--- a/mappings/net/minecraft/server/dedicated/ServerPropertiesHandler.mapping
+++ b/mappings/net/minecraft/server/dedicated/ServerPropertiesHandler.mapping
@@ -77,13 +77,13 @@ CLASS net/minecraft/class_3806 net/minecraft/server/dedicated/ServerPropertiesHa
 	METHOD method_43661 parseResourcePackPrompt (Ljava/lang/String;)Lnet/minecraft/class_2561;
 		ARG 0 prompt
 	METHOD method_45157 createDimensionsRegistryHolder (Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_7723;
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_45159 parseDataPackSettings (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/class_5359;
 		ARG 0 enabled
 		ARG 1 disabled
 	CLASS class_7044 WorldGenProperties
 		FIELD field_37277 LEVEL_TYPE_TO_PRESET_KEY Ljava/util/Map;
 		METHOD method_41242 createDimensionsRegistryHolder (Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_7723;
-			ARG 1 registryLookup
+			ARG 1 registries
 		METHOD method_41244 (Lnet/minecraft/class_2960;)Lnet/minecraft/class_5321;
 			ARG 0 levelTypeId

--- a/mappings/net/minecraft/util/JsonReaderUtils.mapping
+++ b/mappings/net/minecraft/util/JsonReaderUtils.mapping
@@ -4,7 +4,7 @@ CLASS net/minecraft/class_9010 net/minecraft/util/JsonReaderUtils
 	METHOD method_55376 getPos (Lcom/google/gson/stream/JsonReader;)I
 		ARG 0 jsonReader
 	METHOD method_55377 parse (Lnet/minecraft/class_7225$class_7874;Lcom/mojang/brigadier/StringReader;Lcom/mojang/serialization/Codec;)Ljava/lang/Object;
-		ARG 0 registryLookup
+		ARG 0 registries
 		ARG 1 stringReader
 		ARG 2 codec
 	METHOD method_58128 readWhileMatching (Lcom/mojang/brigadier/StringReader;Lnet/minecraft/class_5462;)Ljava/lang/String;

--- a/mappings/net/minecraft/util/math/random/RandomSequencesState.mapping
+++ b/mappings/net/minecraft/util/math/random/RandomSequencesState.mapping
@@ -35,7 +35,7 @@ CLASS net/minecraft/class_8565 net/minecraft/util/math/random/RandomSequencesSta
 		ARG 2 fallback
 	METHOD method_52516 (JLnet/minecraft/class_2487;Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_8565;
 		ARG 2 nbt
-		ARG 3 registryLookup
+		ARG 3 registries
 	METHOD method_52517 reset (Lnet/minecraft/class_2960;)V
 		ARG 1 id
 	METHOD method_52518 createSequence (Lnet/minecraft/class_2960;IZZ)Lnet/minecraft/class_8564;

--- a/mappings/net/minecraft/village/raid/RaidManager.mapping
+++ b/mappings/net/minecraft/village/raid/RaidManager.mapping
@@ -30,7 +30,7 @@ CLASS net/minecraft/class_3767 net/minecraft/village/raid/RaidManager
 		ARG 0 world
 	METHOD method_52561 (Lnet/minecraft/class_3218;Lnet/minecraft/class_2487;Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_3767;
 		ARG 1 nbt
-		ARG 2 registryLookup
+		ARG 2 registries
 	METHOD method_77 fromNbt (Lnet/minecraft/class_3218;Lnet/minecraft/class_2487;)Lnet/minecraft/class_3767;
 		ARG 0 world
 		ARG 1 nbt

--- a/mappings/net/minecraft/world/ChunkUpdateState.mapping
+++ b/mappings/net/minecraft/world/ChunkUpdateState.mapping
@@ -17,5 +17,5 @@ CLASS net/minecraft/class_3440 net/minecraft/world/ChunkUpdateState
 	METHOD method_14898 getAll ()Lit/unimi/dsi/fastutil/longs/LongSet;
 	METHOD method_32358 fromNbt (Lnet/minecraft/class_2487;Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_3440;
 		ARG 0 nbt
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_52601 getPersistentStateType ()Lnet/minecraft/class_18$class_8645;

--- a/mappings/net/minecraft/world/ForcedChunkState.mapping
+++ b/mappings/net/minecraft/world/ForcedChunkState.mapping
@@ -6,6 +6,6 @@ CLASS net/minecraft/class_1932 net/minecraft/world/ForcedChunkState
 		ARG 1 chunks
 	METHOD method_32350 fromNbt (Lnet/minecraft/class_2487;Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_1932;
 		ARG 0 nbt
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_52570 getPersistentStateType ()Lnet/minecraft/class_18$class_8645;
 	METHOD method_8375 getChunks ()Lit/unimi/dsi/fastutil/longs/LongSet;

--- a/mappings/net/minecraft/world/IdCountsState.mapping
+++ b/mappings/net/minecraft/world/IdCountsState.mapping
@@ -4,5 +4,5 @@ CLASS net/minecraft/class_3978 net/minecraft/world/IdCountsState
 	METHOD method_17920 increaseAndGetMapId ()Lnet/minecraft/class_9209;
 	METHOD method_32360 fromNbt (Lnet/minecraft/class_2487;Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_3978;
 		ARG 0 nbt
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_52610 getPersistentStateType ()Lnet/minecraft/class_18$class_8645;

--- a/mappings/net/minecraft/world/PersistentState.mapping
+++ b/mappings/net/minecraft/world/PersistentState.mapping
@@ -1,10 +1,10 @@
 CLASS net/minecraft/class_18 net/minecraft/world/PersistentState
 	FIELD field_72 dirty Z
 	METHOD method_17919 toNbt (Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_2487;
-		ARG 1 registryLookup
+		ARG 1 registries
 	METHOD method_75 writeNbt (Lnet/minecraft/class_2487;Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_2487;
 		ARG 1 nbt
-		ARG 2 registryLookup
+		ARG 2 registries
 	METHOD method_78 setDirty (Z)V
 		ARG 1 dirty
 	METHOD method_79 isDirty ()Z

--- a/mappings/net/minecraft/world/PersistentStateManager.mapping
+++ b/mappings/net/minecraft/world/PersistentStateManager.mapping
@@ -3,12 +3,12 @@ CLASS net/minecraft/class_26 net/minecraft/world/PersistentStateManager
 	FIELD field_136 LOGGER Lorg/slf4j/Logger;
 	FIELD field_17663 dataFixer Lcom/mojang/datafixers/DataFixer;
 	FIELD field_17664 directory Ljava/nio/file/Path;
-	FIELD field_48926 registryLookup Lnet/minecraft/class_7225$class_7874;
+	FIELD field_48926 registries Lnet/minecraft/class_7225$class_7874;
 	FIELD field_52688 savingFuture Ljava/util/concurrent/CompletableFuture;
 	METHOD <init> (Ljava/nio/file/Path;Lcom/mojang/datafixers/DataFixer;Lnet/minecraft/class_7225$class_7874;)V
 		ARG 1 directory
 		ARG 2 dataFixer
-		ARG 3 registryLookup
+		ARG 3 registries
 	METHOD method_120 readFromFile (Ljava/util/function/BiFunction;Lnet/minecraft/class_4284;Ljava/lang/String;)Lnet/minecraft/class_18;
 		ARG 1 readFunction
 		ARG 2 dataFixTypes

--- a/mappings/net/minecraft/world/chunk/Chunk.mapping
+++ b/mappings/net/minecraft/world/chunk/Chunk.mapping
@@ -87,7 +87,7 @@ CLASS net/minecraft/class_2791 net/minecraft/world/chunk/Chunk
 		ARG 2 upperHeight
 	METHOD method_20598 getPackedBlockEntityNbt (Lnet/minecraft/class_2338;Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_2487;
 		ARG 1 pos
-		ARG 2 registryLookup
+		ARG 2 registries
 	METHOD method_32914 getGameEventDispatcher (I)Lnet/minecraft/class_5713;
 		ARG 1 ySectionCoord
 	METHOD method_38255 getOrCreateChunkNoiseSampler (Ljava/util/function/Function;)Lnet/minecraft/class_6568;

--- a/mappings/net/minecraft/world/dimension/DimensionOptionsRegistryHolder.mapping
+++ b/mappings/net/minecraft/world/dimension/DimensionOptionsRegistryHolder.mapping
@@ -27,7 +27,7 @@ CLASS net/minecraft/class_7723 net/minecraft/world/dimension/DimensionOptionsReg
 	METHOD method_45521 (Lnet/minecraft/class_2378;Ljava/util/List;Lnet/minecraft/class_5321;)V
 		ARG 3 key
 	METHOD method_45522 with (Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_2794;)Lnet/minecraft/class_7723;
-		ARG 1 registryLookup
+		ARG 1 registries
 		ARG 2 chunkGenerator
 	METHOD method_45523 (Lnet/minecraft/class_2385;Lnet/minecraft/class_7723$class_7724;)V
 		ARG 1 entry

--- a/mappings/net/minecraft/world/gen/WorldPresets.mapping
+++ b/mappings/net/minecraft/world/gen/WorldPresets.mapping
@@ -12,9 +12,9 @@ CLASS net/minecraft/class_5317 net/minecraft/world/gen/WorldPresets
 	METHOD method_41597 of (Ljava/lang/String;)Lnet/minecraft/class_5321;
 		ARG 0 id
 	METHOD method_41598 createDemoOptions (Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_7723;
-		ARG 0 registryLookup
+		ARG 0 registries
 	METHOD method_41599 getDefaultOverworldOptions (Lnet/minecraft/class_7225$class_7874;)Lnet/minecraft/class_5363;
-		ARG 0 registryLookup
+		ARG 0 registries
 	METHOD method_45547 (Lnet/minecraft/class_5363;)Ljava/util/Optional;
 		ARG 0 overworld
 	CLASS class_7146 Registrar

--- a/mappings/net/minecraft/world/level/storage/LevelStorage.mapping
+++ b/mappings/net/minecraft/world/level/storage/LevelStorage.mapping
@@ -66,7 +66,7 @@ CLASS net/minecraft/class_32 net/minecraft/world/level/storage/LevelStorage
 		ARG 0 dynamic
 		ARG 1 dataConfiguration
 		ARG 2 dimensionsRegistry
-		ARG 3 registryLookup
+		ARG 3 registries
 	METHOD method_54524 parseSummary (Lcom/mojang/serialization/Dynamic;Lnet/minecraft/class_32$class_7411;Z)Lnet/minecraft/class_34;
 		ARG 1 dynamic
 		ARG 2 save


### PR DESCRIPTION
- Some old more descriptive names like `nonReloadables`, `first`/`second`, `fullRegistry` and `base`/`patches` were retained.
- I also added this class as well as a few similar cases to CONVENTIONS.md.
  - Another option is a general rule for these "providers" (and `MatrixStack` is sort of already covered under the collection rules). It would just lead to refactors like `registry, blockRegistry -> blocks`, which are out of scope here. 😅 