### PR TITLE
Rename the FuelRegistry.Builder#featureSet field to enabledFeatures

### DIFF
--- a/mappings/net/minecraft/item/FuelRegistry.mapping
+++ b/mappings/net/minecraft/item/FuelRegistry.mapping
@@ -7,20 +7,20 @@ CLASS net/minecraft/class_9895 net/minecraft/item/FuelRegistry
 		ARG 1 item
 	METHOD method_61753 createDefault (Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_7699;)Lnet/minecraft/class_9895;
 		ARG 0 lookup
-		ARG 1 featureSet
+		ARG 1 enabledFeatures
 	METHOD method_61754 createDefault (Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_7699;I)Lnet/minecraft/class_9895;
 		ARG 0 lookup
-		ARG 1 featureSet
+		ARG 1 enabledFeatures
 		ARG 2 itemSmeltTime
 	METHOD method_61755 getFuelTicks (Lnet/minecraft/class_1799;)I
 		ARG 1 item
 	CLASS class_9896 Builder
 		FIELD field_52636 itemLookup Lnet/minecraft/class_7225;
-		FIELD field_52637 featureSet Lnet/minecraft/class_7699;
+		FIELD field_52637 enabledFeatures Lnet/minecraft/class_7699;
 		FIELD field_52638 fuelValues Lit/unimi/dsi/fastutil/objects/Object2IntSortedMap;
 		METHOD <init> (Lnet/minecraft/class_7225$class_7874;Lnet/minecraft/class_7699;)V
 			ARG 1 lookup
-			ARG 2 featureSet
+			ARG 2 enabledFeatures
 		METHOD method_61756 build ()Lnet/minecraft/class_9895;
 		METHOD method_61757 add (ILnet/minecraft/class_1792;)V
 			ARG 1 value


### PR DESCRIPTION
This field contains currently enabled features as opposed to being a more generic feature set, so the more specific terminology already used within Yarn should be used. The arguments indirectly passed into the builder's constructor already use the terminology:

```java
// In the ClientPlayNetworkHandler constructor
this.fuelRegistry = FuelRegistry.createDefault(connectionState.receivedRegistries(), this.enabledFeatures);

// In the ClientPlayNetworkHandler#onSynchronizeTags method
this.fuelRegistry = FuelRegistry.createDefault(this.combinedDynamicRegistries, this.enabledFeatures);

// In the MinecraftServer constructor and MinecraftServer#reloadResources method
this.fuelRegistry = FuelRegistry.createDefault(this.combinedDynamicRegistries.getCombinedRegistryManager(), this.saveProperties.getEnabledFeatures());
```

The names of intermediate parameters have been changed as well.