### PR TITLE
Map ByteArray codecs in PacketCodecs

### DIFF
--- a/mappings/net/minecraft/network/codec/PacketCodecs.mapping
+++ b/mappings/net/minecraft/network/codec/PacketCodecs.mapping
@@ -77,6 +77,7 @@ CLASS net/minecraft/class_9135 net/minecraft/network/codec/PacketCodecs
 		COMMENT
 		COMMENT @see net.minecraft.network.PacketByteBuf#readByteArray()
 		COMMENT @see net.minecraft.network.PacketByteBuf#writeByteArray(byte[])
+	FIELD field_49674 MAX_INITIAL_COLLECTION_SIZE I
 	FIELD field_49675 INTEGER Lnet/minecraft/class_9139;
 		COMMENT A codec for an integer value.
 		COMMENT
@@ -319,6 +320,8 @@ CLASS net/minecraft/class_9135 net/minecraft/network/codec/PacketCodecs
 		METHOD method_56403 decode (Lio/netty/buffer/ByteBuf;)[B
 			ARG 1 buf
 		METHOD method_56404 encode (Lio/netty/buffer/ByteBuf;[B)V
+			ARG 1 buf
+			ARG 2 value
 	CLASS 20
 		FIELD field_49691 NAME_MAX_LENGTH I
 		FIELD field_49692 VALUE_MAX_LENGTH I
@@ -329,6 +332,12 @@ CLASS net/minecraft/class_9135 net/minecraft/network/codec/PacketCodecs
 			ARG 1 signature
 		METHOD method_58017 (Lio/netty/buffer/ByteBuf;)Ljava/lang/String;
 			ARG 0 buf2
+	CLASS 3
+		METHOD method_59799 decode (Lio/netty/buffer/ByteBuf;)[B
+			ARG 1 buf
+		METHOD method_59800 encode (Lio/netty/buffer/ByteBuf;[B)V
+			ARG 1 buf
+			ARG 2 value
 	CLASS 6
 		METHOD method_56899 (Ljava/lang/Object;Ljava/lang/String;)Lio/netty/handler/codec/EncoderException;
 			ARG 1 error


### PR DESCRIPTION
Fixes #3917 

This issue was very weird to me. Other codecs had `encode` and `decode` as their method names, but were marked obfuscated and there were no mappings for these methods except for the PacketCodec returned by the `byteArray` method. I'm not sure why `BYTE_ARRAY` field and `byteArray` method require manual mapping.

Also I mapped a constant that defines the maximum size a collection can be initialized with when reading collections. I think it needs to be unpicked to work properly, but I don't know how.