### PR TITLE
Map CommandBlockExecutor name getters more accurately

### DIFF
--- a/mappings/net/minecraft/world/CommandBlockExecutor.mapping
+++ b/mappings/net/minecraft/world/CommandBlockExecutor.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/class_1918 net/minecraft/world/CommandBlockExecutor
 	FIELD field_9168 command Ljava/lang/String;
 	FIELD field_9169 DATE_FORMAT Ljava/text/SimpleDateFormat;
 	METHOD method_52175 isEditable ()Z
-	METHOD method_57558 getCustomNameNullable ()Lnet/minecraft/class_2561;
+	METHOD method_57558 getCustomName ()Lnet/minecraft/class_2561;
 	METHOD method_8286 setCommand (Ljava/lang/String;)V
 		ARG 1 command
 	METHOD method_8287 setTrackOutput (Z)V
@@ -37,7 +37,7 @@ CLASS net/minecraft/class_1918 net/minecraft/world/CommandBlockExecutor
 		ARG 2 registries
 	METHOD method_8298 setSuccessCount (I)V
 		ARG 1 successCount
-	METHOD method_8299 getCustomName ()Lnet/minecraft/class_2561;
+	METHOD method_8299 getName ()Lnet/minecraft/class_2561;
 	METHOD method_8300 getPos ()Lnet/minecraft/class_243;
 	METHOD method_8301 execute (Lnet/minecraft/class_1937;)Z
 		ARG 1 world


### PR DESCRIPTION
Fixes #3906
