### PR TITLE
Correct very incorrect names in ServerScoreboard

### DIFF
--- a/mappings/net/minecraft/scoreboard/ServerScoreboard.mapping
+++ b/mappings/net/minecraft/scoreboard/ServerScoreboard.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_2995 net/minecraft/scoreboard/ServerScoreboard
 	FIELD field_13426 updateListeners Ljava/util/List;
-	FIELD field_13427 visibleObjectives Ljava/util/Set;
+	FIELD field_13427 syncableObjectives Ljava/util/Set;
 	FIELD field_13428 server Lnet/minecraft/server/MinecraftServer;
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;)V
 		ARG 1 server

--- a/mappings/net/minecraft/scoreboard/ServerScoreboard.mapping
+++ b/mappings/net/minecraft/scoreboard/ServerScoreboard.mapping
@@ -1,18 +1,18 @@
 CLASS net/minecraft/class_2995 net/minecraft/scoreboard/ServerScoreboard
 	FIELD field_13426 updateListeners Ljava/util/List;
-	FIELD field_13427 objectives Ljava/util/Set;
+	FIELD field_13427 visibleObjectives Ljava/util/Set;
 	FIELD field_13428 server Lnet/minecraft/server/MinecraftServer;
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;)V
 		ARG 1 server
 	METHOD method_12935 addUpdateListener (Ljava/lang/Runnable;)V
 		ARG 1 listener
-	METHOD method_12936 getSlot (Lnet/minecraft/class_266;)I
+	METHOD method_12936 countDisplaySlots (Lnet/minecraft/class_266;)I
 		ARG 1 objective
 	METHOD method_12937 createChangePackets (Lnet/minecraft/class_266;)Ljava/util/List;
 		ARG 1 objective
-	METHOD method_12938 removeScoreboardObjective (Lnet/minecraft/class_266;)V
+	METHOD method_12938 stopSyncing (Lnet/minecraft/class_266;)V
 		ARG 1 objective
-	METHOD method_12939 addScoreboardObjective (Lnet/minecraft/class_266;)V
+	METHOD method_12939 startSyncing (Lnet/minecraft/class_266;)V
 		ARG 1 objective
 	METHOD method_12940 createRemovePackets (Lnet/minecraft/class_266;)Ljava/util/List;
 		ARG 1 objective


### PR DESCRIPTION
Fixes #3850 

The proposed names may bring up some concerns, so I'm gonna explain them here:

`objectives` -> `syncableObjectives`: The original issue proposed `syncedObjectives` and `visibleObjectives`. `syncedObjectives` can sound like "objectives that are [already] synced", which is wrong (the field stores objectives whose changes will be synced with all clients)
I discarded `visibleObjectives` because the main purpose of ServerScoreboard is to synchronize objectives with clients (what it does). How it chooses which objectives to synchronize is an implementation detail

As such, the methods were named `startSyncing` and `stopSyncing` accordingly, instead of, for example, `markVisible` and `unmarkVisible` (which wouldn't mean anything)



