### PR TITLE
Rename parameter lastSlotId to slotCount

### DIFF
--- a/mappings/net/minecraft/inventory/SlotRanges.mapping
+++ b/mappings/net/minecraft/inventory/SlotRanges.mapping
@@ -26,7 +26,7 @@ CLASS net/minecraft/class_9349 net/minecraft/inventory/SlotRanges
 		ARG 0 list
 		ARG 1 baseName
 		ARG 2 firstSlotId
-		ARG 3 lastSlotId
+		ARG 3 slotCount
 	METHOD method_58087 createAndAdd (Ljava/util/List;Ljava/lang/String;[I)V
 		ARG 0 list
 		ARG 1 name


### PR DESCRIPTION
Changed `lastSlotId` to `slotCount` in the `createAndAdd` method of `SlotRanges`

The mapping made sense up until the enderchest where the method looked like this
```java
createAndAdd(list, "enderchest.", 200, 27);
```
with `200` in `firstSlotId` and `27` in `lastSlotId`, which doesn't really make sense (unless you count integer overflows but I don't think that's the intended thing).
The code does a `fori` loop from 0 to `lastSlotId` and does `firstSlotId + i`. So I think `slotCount` is a pretty good name, `size` could work too.