### PR TITLE
Change Sherds#stream() to Sherds#toList()

### DIFF
--- a/mappings/net/minecraft/block/entity/Sherds.mapping
+++ b/mappings/net/minecraft/block/entity/Sherds.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_8526 net/minecraft/block/entity/Sherds
 		ARG 2 left
 		ARG 3 right
 		ARG 4 front
-	METHOD method_51512 stream ()Ljava/util/List;
+	METHOD method_51512 toList ()Ljava/util/List;
 	METHOD method_51513 toNbt (Lnet/minecraft/class_2487;)Lnet/minecraft/class_2487;
 		ARG 1 nbt
 	METHOD method_51514 getSherd (Ljava/util/List;I)Ljava/util/Optional;


### PR DESCRIPTION
`Sherds#stream()` has a return value of `List<Item>`, which means if someone wanted to convert the list to a stream of type `Item`, they would have to write `sherds.stream().stream()` which is confusing and counterintuitive.

This pull request just changes `stream()` to `toList()`, making it very obvious what it's doing.