### PR TITLE
fix: ChunkGenerator#getDebugHudText -> ChunkGenerator#appendDebugHudText

### DIFF
--- a/mappings/net/minecraft/world/gen/chunk/ChunkGenerator.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/ChunkGenerator.mapping
@@ -141,7 +141,7 @@ CLASS net/minecraft/class_2794 net/minecraft/world/gen/chunk/ChunkGenerator
 		ARG 4 center
 		ARG 5 skipReferencedStructures
 		ARG 6 placement
-	METHOD method_40450 getDebugHudText (Ljava/util/List;Lnet/minecraft/class_7138;Lnet/minecraft/class_2338;)V
+	METHOD method_40450 appendDebugHudText (Ljava/util/List;Lnet/minecraft/class_7138;Lnet/minecraft/class_2338;)V
 		ARG 1 text
 		ARG 2 noiseConfig
 		ARG 3 pos


### PR DESCRIPTION
Fixes #3996

The List<String> parameter may be worth renaming to `output` or just `list` maybe? I'm not sure so I'll leave it as-is
