### PR TITLE
24w40a recipe and client

### DIFF
--- a/mappings/net/minecraft/client/font/FontStorage.mapping
+++ b/mappings/net/minecraft/client/font/FontStorage.mapping
@@ -11,7 +11,10 @@ CLASS net/minecraft/class_377 net/minecraft/client/font/FontStorage
 	FIELD field_39934 MAX_ADVANCE F
 	FIELD field_49120 allFonts Ljava/util/List;
 	FIELD field_49121 availableFonts Ljava/util/List;
+	FIELD field_54819 glyphFinder Ljava/util/function/IntFunction;
+	FIELD field_54820 glyphRendererFinder Ljava/util/function/IntFunction;
 	METHOD <init> (Lnet/minecraft/class_1060;Lnet/minecraft/class_2960;)V
+		ARG 1 textureManager
 		ARG 2 id
 	METHOD method_2004 setFonts (Ljava/util/List;Ljava/util/Set;)V
 		ARG 1 allFonts

--- a/mappings/net/minecraft/client/font/GlyphRenderer.mapping
+++ b/mappings/net/minecraft/client/font/GlyphRenderer.mapping
@@ -24,6 +24,8 @@ CLASS net/minecraft/class_382 net/minecraft/client/font/GlyphRenderer
 		ARG 3 y
 		ARG 4 matrix
 		ARG 5 vertexConsumer
+		ARG 6 color
+		ARG 7 light
 	METHOD method_22944 drawRectangle (Lnet/minecraft/class_382$class_328;Lorg/joml/Matrix4f;Lnet/minecraft/class_4588;I)V
 		ARG 1 rectangle
 		ARG 2 matrix
@@ -37,9 +39,11 @@ CLASS net/minecraft/class_382 net/minecraft/client/font/GlyphRenderer
 		FIELD field_2007 minY F
 		FIELD field_2008 minX F
 		FIELD field_20911 zIndex F
+		FIELD field_54821 color I
 		METHOD <init> (FFFFFI)V
 			ARG 1 minX
 			ARG 2 minY
 			ARG 3 maxX
 			ARG 4 maxY
 			ARG 5 zIndex
+			ARG 6 color

--- a/mappings/net/minecraft/client/font/TextRenderer.mapping
+++ b/mappings/net/minecraft/client/font/TextRenderer.mapping
@@ -26,6 +26,8 @@ CLASS net/minecraft/class_327 net/minecraft/client/font/TextRenderer
 		ARG 6 y
 		ARG 7 matrix
 		ARG 8 vertexConsumer
+		ARG 9 color
+		ARG 10 light
 	METHOD method_1713 getWrappedLinesHeight (Ljava/lang/String;I)I
 		COMMENT Gets the height of the text when it has been wrapped.
 		COMMENT
@@ -63,7 +65,7 @@ CLASS net/minecraft/class_327 net/minecraft/client/font/TextRenderer
 		ARG 6 matrix
 		ARG 7 vertexConsumerProvider
 		ARG 8 layerType
-		ARG 9 underlineColor
+		ARG 9 backgroundColor
 		ARG 10 light
 	METHOD method_1726 isRightToLeft ()Z
 		COMMENT Checks if the currently set language uses right to left writing.
@@ -161,7 +163,7 @@ CLASS net/minecraft/class_327 net/minecraft/client/font/TextRenderer
 		ARG 6 matrix
 		ARG 7 vertexConsumerProvider
 		ARG 8 layerType
-		ARG 9 underlineColor
+		ARG 9 backgroundColor
 		ARG 10 light
 	METHOD method_30880 getWidth (Lnet/minecraft/class_5481;)I
 		COMMENT Gets the width of some text when rendered.
@@ -209,10 +211,27 @@ CLASS net/minecraft/class_327 net/minecraft/client/font/TextRenderer
 		FIELD field_24251 y F
 		FIELD field_24252 rectangles Ljava/util/List;
 		FIELD field_33997 layerType Lnet/minecraft/class_327$class_6415;
+		FIELD field_54817 color I
+		FIELD field_54818 backgroundColor I
 		METHOD <init> (Lnet/minecraft/class_327;Lnet/minecraft/class_4597;FFIIZLorg/joml/Matrix4f;Lnet/minecraft/class_327$class_6415;I)V
 			ARG 2 vertexConsumers
 			ARG 3 x
 			ARG 4 y
+			ARG 5 color
+			ARG 6 backgroundColor
+			ARG 7 shadow
+			ARG 8 matrix
+			ARG 9 layerType
+			ARG 10 light
+		METHOD <init> (Lnet/minecraft/class_327;Lnet/minecraft/class_4597;FFIZLorg/joml/Matrix4f;Lnet/minecraft/class_327$class_6415;I)V
+			ARG 2 vertexConsumers
+			ARG 3 x
+			ARG 4 y
+			ARG 5 color
+			ARG 6 shadow
+			ARG 7 matrix
+			ARG 8 layerType
+			ARG 9 light
 		METHOD method_27531 drawLayer ()F
 		METHOD method_27532 addRectangle (Lnet/minecraft/class_382$class_328;)V
 			ARG 1 rectangle

--- a/mappings/net/minecraft/client/gui/DrawContext.mapping
+++ b/mappings/net/minecraft/client/gui/DrawContext.mapping
@@ -230,13 +230,17 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawContext
 		ARG 4 y
 		ARG 5 color
 		ARG 6 shadow
-	METHOD method_51431 drawItemInSlot (Lnet/minecraft/class_327;Lnet/minecraft/class_1799;II)V
+	METHOD method_51431 drawStackOverlay (Lnet/minecraft/class_327;Lnet/minecraft/class_1799;II)V
 		ARG 1 textRenderer
 		ARG 2 stack
 		ARG 3 x
 		ARG 4 y
-	METHOD method_51432 drawItemInSlot (Lnet/minecraft/class_327;Lnet/minecraft/class_1799;IILjava/lang/String;)V
+	METHOD method_51432 drawStackOverlay (Lnet/minecraft/class_327;Lnet/minecraft/class_1799;IILjava/lang/String;)V
 		ARG 1 textRenderer
+		ARG 2 stack
+		ARG 3 x
+		ARG 4 y
+		ARG 5 stackCountText
 	METHOD method_51433 drawText (Lnet/minecraft/class_327;Ljava/lang/String;IIIZ)I
 		ARG 1 textRenderer
 		ARG 2 text
@@ -486,6 +490,20 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawContext
 		ARG 3 x
 		ARG 4 y
 		ARG 5 texture
+	METHOD method_64859 drawStackCount (Lnet/minecraft/class_327;Lnet/minecraft/class_1799;IILjava/lang/String;)V
+		ARG 1 textRenderer
+		ARG 2 stack
+		ARG 3 x
+		ARG 4 y
+		ARG 5 stackCountText
+	METHOD method_64860 drawItemBar (Lnet/minecraft/class_1799;II)V
+		ARG 1 stack
+		ARG 2 x
+		ARG 3 y
+	METHOD method_64861 drawCooldownProgress (Lnet/minecraft/class_1799;II)V
+		ARG 1 stack
+		ARG 2 x
+		ARG 3 y
 	CLASS class_8214 ScissorStack
 		FIELD field_43099 stack Ljava/util/Deque;
 		METHOD method_49699 pop ()Lnet/minecraft/class_8030;

--- a/mappings/net/minecraft/client/gui/screen/ingame/AbstractFurnaceScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/AbstractFurnaceScreen.mapping
@@ -10,3 +10,4 @@ CLASS net/minecraft/class_489 net/minecraft/client/gui/screen/ingame/AbstractFur
 		ARG 5 background
 		ARG 6 litProgressTexture
 		ARG 7 burnProgressTexture
+		ARG 8 recipeBookTabs

--- a/mappings/net/minecraft/client/gui/screen/ingame/BlastFurnaceScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/BlastFurnaceScreen.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/class_3871 net/minecraft/client/gui/screen/ingame/BlastFurna
 	FIELD field_45446 LIT_PROGRESS_TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_45447 BURN_PROGRESS_TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_52804 TOGGLE_BLASTABLE_TEXT Lnet/minecraft/class_2561;
+	FIELD field_54822 TABS Ljava/util/List;
 	METHOD <init> (Lnet/minecraft/class_3705;Lnet/minecraft/class_1661;Lnet/minecraft/class_2561;)V
 		ARG 1 container
 		ARG 2 inventory

--- a/mappings/net/minecraft/client/gui/screen/ingame/FurnaceScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/FurnaceScreen.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/class_3873 net/minecraft/client/gui/screen/ingame/FurnaceScr
 	FIELD field_45469 LIT_PROGRESS_TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_45470 BURN_PROGRESS_TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_52810 TOGGLE_SMELTABLE_TEXT Lnet/minecraft/class_2561;
+	FIELD field_54823 TABS Ljava/util/List;
 	METHOD <init> (Lnet/minecraft/class_3858;Lnet/minecraft/class_1661;Lnet/minecraft/class_2561;)V
 		ARG 1 handler
 		ARG 2 inventory

--- a/mappings/net/minecraft/client/gui/screen/ingame/SmokerScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/SmokerScreen.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/class_3874 net/minecraft/client/gui/screen/ingame/SmokerScre
 	FIELD field_45499 LIT_PROGRESS_TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_45500 BURN_PROGRESS_TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_52811 TOGGLE_SMOKABLE_TEXT Lnet/minecraft/class_2561;
+	FIELD field_54824 TABS Ljava/util/List;
 	METHOD <init> (Lnet/minecraft/class_3706;Lnet/minecraft/class_1661;Lnet/minecraft/class_2561;)V
 		ARG 1 handler
 		ARG 2 inventory

--- a/mappings/net/minecraft/client/gui/screen/recipebook/AbstractCraftingRecipeBookWidget.mapping
+++ b/mappings/net/minecraft/client/gui/screen/recipebook/AbstractCraftingRecipeBookWidget.mapping
@@ -1,5 +1,13 @@
 CLASS net/minecraft/class_9933 net/minecraft/client/gui/screen/recipebook/AbstractCraftingRecipeBookWidget
 	FIELD field_52824 TEXTURES Lnet/minecraft/class_8666;
 	FIELD field_52825 TOGGLE_CRAFTABLE_TEXT Lnet/minecraft/class_2561;
+	FIELD field_54827 TABS Ljava/util/List;
 	METHOD <init> (Lnet/minecraft/class_9884;)V
 		ARG 1 screenHandler
+	METHOD method_64869 (Ljava/util/List;Lnet/minecraft/class_9934;Lnet/minecraft/class_10302$class_10308;Lnet/minecraft/class_10302;III)V
+		ARG 3 slot
+		ARG 4 index
+		ARG 5 x
+		ARG 6 y
+	METHOD method_64870 canDisplay (Lnet/minecraft/class_10295;)Z
+		ARG 1 display

--- a/mappings/net/minecraft/client/gui/screen/recipebook/AbstractFurnaceRecipeBookWidget.mapping
+++ b/mappings/net/minecraft/client/gui/screen/recipebook/AbstractFurnaceRecipeBookWidget.mapping
@@ -4,3 +4,6 @@ CLASS net/minecraft/class_517 net/minecraft/client/gui/screen/recipebook/Abstrac
 	METHOD <init> (Lnet/minecraft/class_1720;Lnet/minecraft/class_2561;Ljava/util/List;)V
 		ARG 1 screenHandler
 		ARG 2 toggleCraftableButtonText
+		ARG 3 tabs
+	METHOD method_64871 (Lnet/minecraft/class_10295;)Z
+		ARG 0 display

--- a/mappings/net/minecraft/client/gui/screen/recipebook/AnimatedResultButton.mapping
+++ b/mappings/net/minecraft/client/gui/screen/recipebook/AnimatedResultButton.mapping
@@ -7,13 +7,23 @@ CLASS net/minecraft/class_514 net/minecraft/client/gui/screen/recipebook/Animate
 	FIELD field_45557 SLOT_MANY_UNCRAFTABLE_TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_45558 SLOT_UNCRAFTABLE_TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_52846 currentIndexProvider Lnet/minecraft/class_9938;
+	FIELD field_54834 results Ljava/util/List;
 	METHOD <init> (Lnet/minecraft/class_9938;)V
 		ARG 1 currentIndexProvider
 	METHOD method_2640 showResultCollection (Lnet/minecraft/class_516;ZLnet/minecraft/class_513;Lnet/minecraft/class_10302$class_10308;)V
 		ARG 1 resultCollection
 		ARG 2 filteringCraftable
 		ARG 3 results
+		ARG 4 context
 	METHOD method_2642 hasSingleResult ()Z
 	METHOD method_2644 getTooltip (Lnet/minecraft/class_1799;)Ljava/util/List;
+		ARG 1 stack
 	METHOD method_2645 getResultCollection ()Lnet/minecraft/class_516;
 	METHOD method_62048 hasMultipleResults ()Z
+	METHOD method_64880 (Lnet/minecraft/class_10302$class_10308;Lnet/minecraft/class_10297;)Lnet/minecraft/class_514$class_10330;
+		ARG 1 entry
+	METHOD method_64881 getCurrentId ()Lnet/minecraft/class_10298;
+	METHOD method_64882 getDisplayStack ()Lnet/minecraft/class_1799;
+	CLASS class_10330 Result
+		METHOD method_64883 getDisplayStack (I)Lnet/minecraft/class_1799;
+			ARG 1 currentIndex

--- a/mappings/net/minecraft/client/gui/screen/recipebook/GhostRecipe.mapping
+++ b/mappings/net/minecraft/client/gui/screen/recipebook/GhostRecipe.mapping
@@ -17,6 +17,19 @@ CLASS net/minecraft/class_9934 net/minecraft/client/gui/screen/recipebook/GhostR
 		ARG 1 context
 		ARG 2 client
 		ARG 3 resultHasPadding
+	METHOD method_64872 addInputs (Lnet/minecraft/class_1735;Lnet/minecraft/class_10302$class_10308;Lnet/minecraft/class_10302;)V
+		ARG 1 slot
+		ARG 2 context
+		ARG 3 display
+	METHOD method_64873 addItems (Lnet/minecraft/class_1735;Lnet/minecraft/class_10302$class_10308;Lnet/minecraft/class_10302;Z)V
+		ARG 1 slot
+		ARG 2 context
+		ARG 3 display
+		ARG 4 resultSlot
+	METHOD method_64874 addResults (Lnet/minecraft/class_1735;Lnet/minecraft/class_10302$class_10308;Lnet/minecraft/class_10302;)V
+		ARG 1 slot
+		ARG 2 context
+		ARG 3 display
 	CLASS class_9935 CyclingItem
 		METHOD method_62035 get (I)Lnet/minecraft/class_1799;
 			ARG 1 index

--- a/mappings/net/minecraft/client/gui/screen/recipebook/RecipeAlternativesWidget.mapping
+++ b/mappings/net/minecraft/client/gui/screen/recipebook/RecipeAlternativesWidget.mapping
@@ -18,13 +18,21 @@ CLASS net/minecraft/class_508 net/minecraft/client/gui/screen/recipebook/RecipeA
 	METHOD method_2616 isVisible ()Z
 	METHOD method_2617 showAlternativesForResult (Lnet/minecraft/class_516;Lnet/minecraft/class_10302$class_10308;ZIIIIF)V
 		ARG 1 resultCollection
+		ARG 2 context
+		ARG 3 filteringCraftable
+		ARG 4 buttonX
+		ARG 5 buttonY
+		ARG 6 areaCenterX
+		ARG 7 areaCenterY
+		ARG 8 delta
 	CLASS class_509 AlternativeButtonWidget
-		FIELD field_3114 recipe Lnet/minecraft/class_10298;
+		FIELD field_3114 recipeId Lnet/minecraft/class_10298;
 		FIELD field_3115 craftable Z
 		FIELD field_52834 inputSlots Ljava/util/List;
 		METHOD <init> (Lnet/minecraft/class_508;IILnet/minecraft/class_10298;ZLjava/util/List;)V
 			ARG 2 x
 			ARG 3 y
+			ARG 4 recipeId
 			ARG 5 craftable
 			ARG 6 inputSlots
 		METHOD method_62039 getOverlayTexture (Z)Lnet/minecraft/class_2960;
@@ -52,7 +60,13 @@ CLASS net/minecraft/class_508 net/minecraft/client/gui/screen/recipebook/RecipeA
 		METHOD <init> (Lnet/minecraft/class_508;IILnet/minecraft/class_10298;Lnet/minecraft/class_10295;Lnet/minecraft/class_10302$class_10308;Z)V
 			ARG 2 x
 			ARG 3 y
+			ARG 4 recipeId
+			ARG 5 display
+			ARG 6 context
+			ARG 7 craftable
 		METHOD method_2619 alignRecipe (Lnet/minecraft/class_10295;Lnet/minecraft/class_10302$class_10308;)Ljava/util/List;
+			ARG 0 display
+			ARG 1 context
 	CLASS class_9936 CraftingAlternativeButtonWidget
 		FIELD field_52830 CRAFTING_OVERLAY Lnet/minecraft/class_2960;
 		FIELD field_52831 CRAFTING_OVERLAY_HIGHLIGHTED Lnet/minecraft/class_2960;
@@ -61,4 +75,15 @@ CLASS net/minecraft/class_508 net/minecraft/client/gui/screen/recipebook/RecipeA
 		METHOD <init> (Lnet/minecraft/class_508;IILnet/minecraft/class_10298;Lnet/minecraft/class_10295;Lnet/minecraft/class_10302$class_10308;Z)V
 			ARG 2 x
 			ARG 3 y
+			ARG 4 recipeId
+			ARG 5 display
+			ARG 6 context
+			ARG 7 craftable
 		METHOD method_62036 collectInputSlots (Lnet/minecraft/class_10295;Lnet/minecraft/class_10302$class_10308;)Ljava/util/List;
+			ARG 0 display
+			ARG 1 context
+		METHOD method_62037 (Lnet/minecraft/class_10302$class_10308;Ljava/util/List;Lnet/minecraft/class_10302;III)V
+			ARG 2 slot
+			ARG 3 index
+			ARG 4 x
+			ARG 5 y

--- a/mappings/net/minecraft/client/gui/screen/recipebook/RecipeBookProvider.mapping
+++ b/mappings/net/minecraft/client/gui/screen/recipebook/RecipeBookProvider.mapping
@@ -1,2 +1,4 @@
 CLASS net/minecraft/class_518 net/minecraft/client/gui/screen/recipebook/RecipeBookProvider
 	METHOD method_16891 refreshRecipeBook ()V
+	METHOD method_64862 onCraftFailed (Lnet/minecraft/class_10295;)V
+		ARG 1 display

--- a/mappings/net/minecraft/client/gui/screen/recipebook/RecipeBookResults.mapping
+++ b/mappings/net/minecraft/client/gui/screen/recipebook/RecipeBookResults.mapping
@@ -14,6 +14,11 @@ CLASS net/minecraft/class_513 net/minecraft/client/gui/screen/recipebook/RecipeB
 	FIELD field_45552 PAGE_FORWARD_TEXTURES Lnet/minecraft/class_8666;
 	FIELD field_45553 PAGE_BACKWARD_TEXTURES Lnet/minecraft/class_8666;
 	FIELD field_52844 filteringCraftable Z
+	FIELD field_54832 recipeBookWidget Lnet/minecraft/class_507;
+	METHOD <init> (Lnet/minecraft/class_507;Lnet/minecraft/class_9938;Z)V
+		ARG 1 recipeBookWidget
+		ARG 2 currentIndexProvider
+		ARG 3 furnace
 	METHOD method_2625 refreshResultButtons ()V
 	METHOD method_2626 hideShowPageButtons ()V
 	METHOD method_2627 setResults (Ljava/util/List;ZZ)V
@@ -48,3 +53,6 @@ CLASS net/minecraft/class_513 net/minecraft/client/gui/screen/recipebook/RecipeB
 	METHOD method_2638 hideAlternates ()V
 	METHOD method_37083 forEachButton (Ljava/util/function/Consumer;)V
 		ARG 1 consumer
+	METHOD method_64878 getLastClickedRecipe ()Lnet/minecraft/class_10298;
+	METHOD method_64879 onRecipeDisplayed (Lnet/minecraft/class_10298;)V
+		ARG 1 recipeId

--- a/mappings/net/minecraft/client/gui/screen/recipebook/RecipeBookWidget.mapping
+++ b/mappings/net/minecraft/client/gui/screen/recipebook/RecipeBookWidget.mapping
@@ -25,8 +25,11 @@ CLASS net/minecraft/class_507 net/minecraft/client/gui/screen/recipebook/RecipeB
 	FIELD field_53832 selectedRecipe Lnet/minecraft/class_10298;
 	FIELD field_53833 selectedRecipeResults Lnet/minecraft/class_516;
 	FIELD field_54388 searchFieldRect Lnet/minecraft/class_8030;
+	FIELD field_54830 selectedRecipeId Lnet/minecraft/class_10298;
+	FIELD field_54831 tabs Ljava/util/List;
 	METHOD <init> (Lnet/minecraft/class_1729;Ljava/util/List;)V
 		ARG 1 craftingScreenHandler
+		ARG 2 tabs
 	METHOD method_17064 getToggleCraftableButtonText ()Lnet/minecraft/class_2561;
 	METHOD method_2576 triggerPirateSpeakEasterEgg (Ljava/lang/String;)V
 		ARG 1 search
@@ -94,5 +97,26 @@ CLASS net/minecraft/class_507 net/minecraft/client/gui/screen/recipebook/RecipeB
 	METHOD method_62045 isFilteringCraftable ()Z
 	METHOD method_62889 select (Lnet/minecraft/class_516;Lnet/minecraft/class_10298;)Z
 		ARG 1 results
+		ARG 2 recipeId
 	METHOD method_64366 getTop ()I
 	METHOD method_64367 getLeft ()I
+	METHOD method_64868 showGhostRecipe (Lnet/minecraft/class_9934;Lnet/minecraft/class_10295;Lnet/minecraft/class_10302$class_10308;)V
+		ARG 1 ghostRecipe
+		ARG 2 display
+		ARG 3 context
+	METHOD method_64875 onCraftFailed (Lnet/minecraft/class_10295;)V
+		ARG 1 display
+	METHOD method_64876 onRecipeDisplayed (Lnet/minecraft/class_10298;)V
+		ARG 1 recipeId
+	METHOD method_64877 (Lnet/minecraft/class_516;)Z
+		ARG 0 resultCollection
+	CLASS class_10329 Tab
+		METHOD <init> (Lnet/minecraft/class_10331;)V
+			ARG 1 type
+		METHOD <init> (Lnet/minecraft/class_1792;Lnet/minecraft/class_1792;Lnet/minecraft/class_314;)V
+			ARG 1 primaryIcon
+			ARG 2 secondaryIcon
+			ARG 3 group
+		METHOD <init> (Lnet/minecraft/class_1792;Lnet/minecraft/class_314;)V
+			ARG 1 primaryIcon
+			ARG 2 group

--- a/mappings/net/minecraft/client/gui/screen/recipebook/RecipeGroupButtonWidget.mapping
+++ b/mappings/net/minecraft/client/gui/screen/recipebook/RecipeGroupButtonWidget.mapping
@@ -1,8 +1,9 @@
 CLASS net/minecraft/class_512 net/minecraft/client/gui/screen/recipebook/RecipeGroupButtonWidget
 	FIELD field_3122 bounce F
 	FIELD field_45554 TEXTURES Lnet/minecraft/class_8666;
+	FIELD field_54833 tab Lnet/minecraft/class_507$class_10329;
 	METHOD <init> (Lnet/minecraft/class_507$class_10329;)V
-		ARG 1 category
+		ARG 1 tab
 	METHOD method_2621 renderIcons (Lnet/minecraft/class_332;)V
 		ARG 1 context
 	METHOD method_2622 checkForNewRecipes (Lnet/minecraft/class_299;Z)V

--- a/mappings/net/minecraft/client/gui/screen/recipebook/RecipeResultCollection.mapping
+++ b/mappings/net/minecraft/client/gui/screen/recipebook/RecipeResultCollection.mapping
@@ -1,9 +1,23 @@
 CLASS net/minecraft/class_516 net/minecraft/client/gui/screen/recipebook/RecipeResultCollection
 	FIELD field_3146 craftableRecipes Ljava/util/Set;
 	FIELD field_3148 singleOutput Z
+	FIELD field_54835 entries Ljava/util/List;
+	FIELD field_54836 displayableRecipes Ljava/util/Set;
+	METHOD <init> (Ljava/util/List;)V
+		ARG 1 entries
 	METHOD method_2650 getAllRecipes ()Ljava/util/List;
 	METHOD method_2653 isCraftable (Lnet/minecraft/class_10298;)Z
+		ARG 1 recipeId
 	METHOD method_2655 hasCraftableRecipes ()Z
 	METHOD method_2656 hasSingleOutput ()Z
 	METHOD method_30295 shouldHaveSingleOutput (Ljava/util/List;)Z
+		ARG 0 recipes
+	METHOD method_64884 populateRecipes (Lnet/minecraft/class_9875;Ljava/util/function/Predicate;)V
+		ARG 1 finder
+		ARG 2 displayablePredicate
+	METHOD method_64885 filter (Lnet/minecraft/class_516$class_9937;)Ljava/util/List;
+		ARG 1 filterMode
+	METHOD method_64886 hasDisplayableRecipes ()Z
+	METHOD method_64887 (Lnet/minecraft/class_10298;)Z
+		ARG 1 recipeId
 	CLASS class_9937 RecipeFilterMode

--- a/mappings/net/minecraft/client/gui/widget/EntryListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/EntryListWidget.mapping
@@ -149,6 +149,8 @@ CLASS net/minecraft/class_350 net/minecraft/client/gui/widget/EntryListWidget
 		COMMENT this has no side effects (like loading more entries).
 		ARG 1 amount
 	METHOD method_60322 refreshScroll ()V
+	METHOD method_64847 setSelected (I)V
+		ARG 1 index
 	CLASS class_351 Entry
 		FIELD field_22752 parentList Lnet/minecraft/class_350;
 		METHOD method_25343 render (Lnet/minecraft/class_332;IIIIIIIZF)V

--- a/mappings/net/minecraft/client/gui/widget/LoadingWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/LoadingWidget.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_8661 net/minecraft/client/realms/gui/RealmsLoadingWidget
+CLASS net/minecraft/class_8661 net/minecraft/client/gui/widget/LoadingWidget
 	FIELD field_45361 textRenderer Lnet/minecraft/class_327;
 	METHOD <init> (Lnet/minecraft/class_327;Lnet/minecraft/class_2561;)V
 		ARG 1 textRenderer

--- a/mappings/net/minecraft/client/network/ClientPlayNetworkHandler.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayNetworkHandler.mapping
@@ -38,7 +38,8 @@ CLASS net/minecraft/class_634 net/minecraft/client/network/ClientPlayNetworkHand
 	FIELD field_53030 fuelRegistry Lnet/minecraft/class_9895;
 	FIELD field_53031 profileKeyPairFuture Ljava/util/concurrent/CompletableFuture;
 	FIELD field_53032 syncedOptions Lnet/minecraft/class_8791;
-	FIELD field_54850 stonecuttingRecipes Lnet/minecraft/class_10333;
+	FIELD field_54850 recipeManager Lnet/minecraft/class_10333;
+	FIELD field_54851 removedPlayerVehicleId Ljava/util/OptionalInt;
 	METHOD <init> (Lnet/minecraft/class_310;Lnet/minecraft/class_2535;Lnet/minecraft/class_8675;)V
 		ARG 1 client
 	METHOD method_16690 getSessionId ()Ljava/util/UUID;
@@ -150,3 +151,12 @@ CLASS net/minecraft/class_634 net/minecraft/client/network/ClientPlayNetworkHand
 		ARG 3 registryRef
 		ARG 4 serialized
 	METHOD method_62151 fetchProfileKey ()V
+	METHOD method_64896 (I)V
+		ARG 1 id
+	METHOD method_64897 setPosition (Lnet/minecraft/class_10182;Ljava/util/Set;Lnet/minecraft/class_1297;Z)Z
+		ARG 0 pos
+		ARG 1 flags
+		ARG 2 entity
+	METHOD method_64898 refreshRecipeBook (Lnet/minecraft/class_299;)V
+		ARG 1 recipeBook
+	METHOD method_64899 getRecipeManager ()Lnet/minecraft/class_10286;

--- a/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerEntity.mapping
@@ -78,6 +78,7 @@ CLASS net/minecraft/class_746 net/minecraft/client/network/ClientPlayerEntity
 		COMMENT {@return the color multiplier of vision in water} Visibility in
 		COMMENT water is reduced when the player just entered water.
 	METHOD method_3141 onRecipeDisplayed (Lnet/minecraft/class_10298;)V
+		ARG 1 recipeId
 	METHOD method_3143 getStatHandler ()Lnet/minecraft/class_3469;
 	METHOD method_3144 isRiding ()Z
 	METHOD method_3145 setExperience (FII)V

--- a/mappings/net/minecraft/client/network/ClientPlayerInteractionManager.mapping
+++ b/mappings/net/minecraft/client/network/ClientPlayerInteractionManager.mapping
@@ -61,6 +61,7 @@ CLASS net/minecraft/class_636 net/minecraft/client/network/ClientPlayerInteracti
 	METHOD method_2911 syncSelectedSlot ()V
 	METHOD method_2912 clickRecipe (ILnet/minecraft/class_10298;Z)V
 		ARG 1 syncId
+		ARG 2 recipeId
 		ARG 3 craftAll
 	METHOD method_2913 hasExperienceBar ()Z
 	METHOD method_2914 hasCreativeInventory ()Z

--- a/mappings/net/minecraft/client/network/ClientRegistries.mapping
+++ b/mappings/net/minecraft/client/network/ClientRegistries.mapping
@@ -5,9 +5,47 @@ CLASS net/minecraft/class_9173 net/minecraft/client/network/ClientRegistries
 		ARG 1 registryRef
 		ARG 2 entries
 	METHOD method_56585 createRegistryManager (Lnet/minecraft/class_5912;Lnet/minecraft/class_5455$class_6890;Z)Lnet/minecraft/class_5455$class_6890;
+		ARG 1 resourceFactory
+		ARG 2 registryManager
 		ARG 3 local
 	METHOD method_56586 putTags (Ljava/util/Map;)V
 		ARG 1 tags
+	METHOD method_62155 createRegistryManager (Lnet/minecraft/class_5912;Lnet/minecraft/class_9173$class_9174;Z)Lnet/minecraft/class_5455;
+		ARG 1 resourceFactory
+		ARG 2 dynamicRegistries
+		ARG 3 local
+	METHOD method_62156 (Lnet/minecraft/class_6864$class_5748;Lnet/minecraft/class_5321;Lnet/minecraft/class_7655$class_9841;)Lnet/minecraft/class_7655$class_9841;
+		ARG 1 key
+		ARG 2 value
+	METHOD method_62157 loadTags (Lnet/minecraft/class_9173$class_9954;Lnet/minecraft/class_5455$class_6890;Z)V
+		ARG 1 tags
+		ARG 2 registryManager
+		ARG 3 local
+	METHOD method_62158 (Ljava/util/Map;Lnet/minecraft/class_5321;Ljava/util/List;)V
+		ARG 1 registryRef
+		ARG 2 entries
+	METHOD method_62159 (Ljava/util/Map;ZLjava/util/List;Lnet/minecraft/class_5455$class_6890;Lnet/minecraft/class_5321;Lnet/minecraft/class_6864$class_5748;)V
+		ARG 4 registryRef
+		ARG 5 tags
+	METHOD method_62160 startTagReload (Lnet/minecraft/class_5455$class_6890;Lnet/minecraft/class_5321;Lnet/minecraft/class_6864$class_5748;)Lnet/minecraft/class_2378$class_10106;
+		ARG 0 registryManager
+		ARG 1 registryRef
+		ARG 2 tags
+	METHOD method_62161 (ZLnet/minecraft/class_5455$class_6890;Lnet/minecraft/class_5321;Lnet/minecraft/class_6864$class_5748;)V
+		ARG 2 registryRef
+		ARG 3 serialized
+	METHOD method_64901 (Ljava/util/Map$Entry;)Ljava/lang/String;
+		ARG 0 entry
+	METHOD method_64902 (Lnet/minecraft/class_2378$class_10106;)Ljava/lang/String;
+		ARG 0 tag
+	METHOD method_64903 addCrashReportSection (Lnet/minecraft/class_128;Ljava/util/Map;Ljava/util/List;)V
+		ARG 0 crashReport
+		ARG 1 data
+		ARG 2 tags
+	METHOD method_64904 (Ljava/util/Map$Entry;)Lnet/minecraft/class_2960;
+		ARG 0 entry
+	METHOD method_64906 (Lnet/minecraft/class_2378$class_10106;)Lnet/minecraft/class_2960;
+		ARG 0 tag
 	CLASS class_9174 DynamicRegistries
 		FIELD field_48769 dynamicRegistries Ljava/util/Map;
 		METHOD method_56587 (Lnet/minecraft/class_5321;)Ljava/util/List;

--- a/mappings/net/minecraft/client/particle/BlockDustParticle.mapping
+++ b/mappings/net/minecraft/client/particle/BlockDustParticle.mapping
@@ -30,5 +30,6 @@ CLASS net/minecraft/class_727 net/minecraft/client/particle/BlockDustParticle
 		ARG 8 velocityX
 		ARG 10 velocityY
 		ARG 12 velocityZ
+	CLASS class_10334 CrumbleFactory
 	CLASS class_728 Factory
 	CLASS class_9482 DustPillarFactory

--- a/mappings/net/minecraft/client/realms/dto/RealmsServer.mapping
+++ b/mappings/net/minecraft/client/realms/dto/RealmsServer.mapping
@@ -22,6 +22,8 @@ CLASS net/minecraft/class_4877 net/minecraft/client/realms/dto/RealmsServer
 	FIELD field_46694 activeVersion Ljava/lang/String;
 	FIELD field_46695 compatibility Lnet/minecraft/class_4877$class_8842;
 	FIELD field_46696 NO_PARENT I
+	FIELD field_54807 hardcore Z
+	FIELD field_54808 gameMode I
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o
 	METHOD method_25053 getDescription ()Ljava/lang/String;
@@ -62,6 +64,12 @@ CLASS net/minecraft/class_4877 net/minecraft/client/realms/dto/RealmsServer
 		ARG 0 compatibility
 	METHOD method_54367 isPrerelease ()Z
 	METHOD method_60315 isMinigame ()Z
+	METHOD method_64843 parseSettings (Lcom/google/gson/JsonElement;)Lnet/minecraft/class_10327;
+		ARG 0 json
+	METHOD method_64844 isSet (Lcom/google/gson/JsonObject;Ljava/lang/String;Z)Z
+		ARG 0 json
+		ARG 1 name
+		ARG 2 defaultValue
 	CLASS class_4319 McoServerComparator
 		FIELD field_19432 refOwner Ljava/lang/String;
 		METHOD <init> (Ljava/lang/String;)V

--- a/mappings/net/minecraft/client/realms/dto/RealmsWorldOptions.mapping
+++ b/mappings/net/minecraft/client/realms/dto/RealmsWorldOptions.mapping
@@ -34,6 +34,8 @@ CLASS net/minecraft/class_4883 net/minecraft/client/realms/dto/RealmsWorldOption
 	METHOD method_25077 getSlotName (I)Ljava/lang/String;
 		ARG 1 index
 	METHOD method_25078 parse (Lcom/google/gson/JsonObject;Lnet/minecraft/class_10327;)Lnet/minecraft/class_4883;
+		ARG 0 json
+		ARG 1 settings
 	METHOD method_25079 setEmpty (Z)V
 		ARG 1 empty
 	METHOD method_25080 getEmptyDefaults ()Lnet/minecraft/class_4883;

--- a/mappings/net/minecraft/client/realms/dto/RealmsWorldSettings.mapping
+++ b/mappings/net/minecraft/client/realms/dto/RealmsWorldSettings.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_10327 net/minecraft/client/realms/dto/RealmsWorldSettings

--- a/mappings/net/minecraft/client/realms/gui/RealmsWorldSlotButton.mapping
+++ b/mappings/net/minecraft/client/realms/gui/RealmsWorldSlotButton.mapping
@@ -46,6 +46,7 @@ CLASS net/minecraft/class_4367 net/minecraft/client/realms/gui/RealmsWorldSlotBu
 		FIELD field_19688 action Lnet/minecraft/class_4367$class_4368;
 		FIELD field_46848 version Ljava/lang/String;
 		FIELD field_46849 compatibility Lnet/minecraft/class_4877$class_8842;
+		FIELD field_54809 hardcore Z
 		METHOD <init> (Lnet/minecraft/class_4877;I)V
 			ARG 1 server
 			ARG 2 slot

--- a/mappings/net/minecraft/client/realms/gui/screen/RealmsAcceptRejectButton.mapping
+++ b/mappings/net/minecraft/client/realms/gui/screen/RealmsAcceptRejectButton.mapping
@@ -25,11 +25,13 @@ CLASS net/minecraft/class_4371 net/minecraft/client/realms/gui/screen/RealmsAcce
 	METHOD method_21113 render (Lnet/minecraft/class_332;Ljava/util/List;Lnet/minecraft/class_350;IIII)V
 		ARG 0 context
 		ARG 1 buttons
+		ARG 2 selectionList
 		ARG 3 x
 		ARG 4 y
 		ARG 5 mouseX
 		ARG 6 mouseY
 	METHOD method_21114 handleClick (Lnet/minecraft/class_350;Lnet/minecraft/class_4280$class_4281;Ljava/util/List;IDD)V
+		ARG 0 selectionList
 		ARG 1 entry
 		ARG 2 buttons
 		ARG 3 button

--- a/mappings/net/minecraft/client/realms/gui/screen/RealmsBackupScreen.mapping
+++ b/mappings/net/minecraft/client/realms/gui/screen/RealmsBackupScreen.mapping
@@ -21,9 +21,14 @@ CLASS net/minecraft/class_4381 net/minecraft/client/realms/gui/screen/RealmsBack
 	METHOD method_21166 downloadClicked ()V
 	METHOD method_25110 (Lnet/minecraft/class_4185;)V
 		ARG 1 button
+	METHOD method_25111 (Lnet/minecraft/class_8816;)V
+		ARG 1 button
 	METHOD method_25113 (Lnet/minecraft/class_4185;)V
 		ARG 1 button
 	METHOD method_57661 startBackupFetcher ()V
+	CLASS 1
+		METHOD method_64845 (Lnet/minecraft/class_4867;)Lnet/minecraft/class_4381$class_4383;
+			ARG 1 backup
 	CLASS class_4382 BackupObjectSelectionList
 	CLASS class_4383 BackupObjectSelectionListEntry
 		FIELD field_19761 mBackup Lnet/minecraft/class_4867;

--- a/mappings/net/minecraft/client/realms/gui/screen/RealmsMainScreen.mapping
+++ b/mappings/net/minecraft/client/realms/gui/screen/RealmsMainScreen.mapping
@@ -56,6 +56,7 @@ CLASS net/minecraft/class_4325 net/minecraft/client/realms/gui/screen/RealmsMain
 	FIELD field_51815 INCOMPATIBLE_POPUP_TITLE Lnet/minecraft/class_2561;
 	FIELD field_51816 INCOMPATIBLE_RELEASE_TYPE_MESSAGE Lnet/minecraft/class_2561;
 	FIELD field_52116 onlinePlayers Lnet/minecraft/class_4881;
+	FIELD field_54806 HARDCORE_ICON_TEXTURE Lnet/minecraft/class_2960;
 	METHOD <init> (Lnet/minecraft/class_437;)V
 		ARG 1 parent
 	METHOD method_20853 play (Lnet/minecraft/class_4877;Lnet/minecraft/class_437;)V
@@ -79,7 +80,7 @@ CLASS net/minecraft/class_4325 net/minecraft/client/realms/gui/screen/RealmsMain
 		ARG 1 server
 	METHOD method_25001 isOwnedNotExpired (Lnet/minecraft/class_4877;)Z
 		ARG 1 serverData
-	METHOD method_38503 findServer ()Lnet/minecraft/class_4877;
+	METHOD method_38503 getSelectedServer ()Lnet/minecraft/class_4877;
 	METHOD method_38504 (Lnet/minecraft/class_4877;Lnet/minecraft/class_8816;)V
 		ARG 2 popup
 	METHOD method_38505 removeSelection ()V
@@ -186,7 +187,18 @@ CLASS net/minecraft/class_4325 net/minecraft/client/realms/gui/screen/RealmsMain
 	METHOD method_60861 showNeedsUpgradeScreen (Lnet/minecraft/class_4877;Lnet/minecraft/class_437;)V
 		ARG 0 serverData
 		ARG 1 parent
+	METHOD method_64834 getGameModeText (IZ)Lnet/minecraft/class_2561;
+		ARG 0 id
+		ARG 1 hardcore
 	CLASS class_4329 RealmSelectionList
+		METHOD method_64840 refresh (Lnet/minecraft/class_4325;Lnet/minecraft/class_4877;)V
+			ARG 1 mainScreen
+			ARG 2 selectedServer
+		METHOD method_64841 addVisitEntries (Lnet/minecraft/class_8204$class_8205;Lnet/minecraft/class_4325;)V
+			ARG 1 url
+			ARG 2 mainScreen
+		METHOD method_64842 addServerEntries (Lnet/minecraft/class_4877;)V
+			ARG 1 selectedServer
 	CLASS class_4330 RealmSelectionListEntry
 		FIELD field_19518 server Lnet/minecraft/class_4877;
 		FIELD field_46686 tooltip Lnet/minecraft/class_9110;
@@ -200,6 +212,7 @@ CLASS net/minecraft/class_4325 net/minecraft/client/realms/gui/screen/RealmsMain
 			ARG 1 context
 			ARG 2 y
 			ARG 3 x
+			ARG 4 entryWidth
 		METHOD method_54567 drawServerNameAndVersion (Lnet/minecraft/class_332;III)V
 			ARG 1 context
 			ARG 2 y
@@ -254,6 +267,16 @@ CLASS net/minecraft/class_4325 net/minecraft/client/realms/gui/screen/RealmsMain
 			ARG 2 y
 			ARG 3 x
 			ARG 4 server
+		METHOD method_64838 drawGameMode (Lnet/minecraft/class_4877;Lnet/minecraft/class_332;III)V
+			ARG 1 server
+			ARG 2 context
+			ARG 3 x
+			ARG 4 entryWidth
+			ARG 5 y
+		METHOD method_64839 getGameModeRight (IILnet/minecraft/class_2561;)I
+			ARG 1 x
+			ARG 2 width
+			ARG 3 gameMode
 	CLASS class_8200 VisitButtonEntry
 		FIELD field_42999 button Lnet/minecraft/class_4185;
 		METHOD <init> (Lnet/minecraft/class_4325;Lnet/minecraft/class_4185;)V

--- a/mappings/net/minecraft/client/realms/gui/screen/RealmsPendingInvitesScreen.mapping
+++ b/mappings/net/minecraft/client/realms/gui/screen/RealmsPendingInvitesScreen.mapping
@@ -40,6 +40,7 @@ CLASS net/minecraft/class_4401 net/minecraft/client/realms/gui/screen/RealmsPend
 			ARG 1 index
 		METHOD method_21322 selectInviteListItem (I)V
 			ARG 1 item
+		METHOD method_64846 isEmpty ()Z
 	CLASS class_4403 PendingInvitationSelectionListEntry
 		FIELD field_19953 mPendingInvite Lnet/minecraft/class_4871;
 		FIELD field_19955 buttons Ljava/util/List;

--- a/mappings/net/minecraft/client/recipebook/ClientRecipeBook.mapping
+++ b/mappings/net/minecraft/client/recipebook/ClientRecipeBook.mapping
@@ -1,7 +1,30 @@
 CLASS net/minecraft/class_299 net/minecraft/client/recipebook/ClientRecipeBook
-	FIELD field_1638 resultsByGroup Ljava/util/Map;
+	FIELD field_1638 resultsByCategory Ljava/util/Map;
 	FIELD field_25778 orderedResults Ljava/util/List;
+	FIELD field_54810 recipes Ljava/util/Map;
+	FIELD field_54811 highlightedRecipes Ljava/util/Set;
 	METHOD method_1393 getOrderedResults ()Ljava/util/List;
-	METHOD method_1396 getResultsForGroup (Lnet/minecraft/class_10287;)Ljava/util/List;
+	METHOD method_1396 getResultsForCategory (Lnet/minecraft/class_10287;)Ljava/util/List;
+		ARG 1 category
 	METHOD method_30283 toGroupedMap (Ljava/lang/Iterable;)Ljava/util/Map;
 		ARG 0 recipes
+	METHOD method_64848 (Lnet/minecraft/class_314;)Ljava/util/List;
+		ARG 0 group
+	METHOD method_64849 add (Lnet/minecraft/class_10297;)V
+		ARG 1 entry
+	METHOD method_64850 remove (Lnet/minecraft/class_10298;)V
+		ARG 1 recipeId
+	METHOD method_64851 (Ljava/util/Map;Lcom/google/common/collect/ImmutableList$Builder;Lnet/minecraft/class_314;Ljava/util/List;)V
+		ARG 2 group
+		ARG 3 resultCollections
+	METHOD method_64852 (Ljava/util/Map;Lnet/minecraft/class_314;)Ljava/util/stream/Stream;
+		ARG 1 group
+	METHOD method_64853 refresh ()V
+	METHOD method_64854 (Lnet/minecraft/class_314;)Ljava/util/List;
+		ARG 0 group
+	METHOD method_64855 isHighlighted (Lnet/minecraft/class_10298;)Z
+		ARG 1 recipeId
+	METHOD method_64856 unmarkHighlighted (Lnet/minecraft/class_10298;)V
+		ARG 1 recipeId
+	METHOD method_64857 markHighlighted (Lnet/minecraft/class_10298;)V
+		ARG 1 recipeId

--- a/mappings/net/minecraft/client/render/ChunkRenderingDataPreparer.mapping
+++ b/mappings/net/minecraft/client/render/ChunkRenderingDataPreparer.mapping
@@ -40,7 +40,7 @@ CLASS net/minecraft/class_8679 net/minecraft/client/render/ChunkRenderingDataPre
 		ARG 2 camera
 		ARG 3 cameraPos
 		ARG 4 activeSections
-	METHOD method_52834 updateSectionOcculusionGraph (ZLnet/minecraft/class_4184;Lnet/minecraft/class_4604;Ljava/util/List;Lit/unimi/dsi/fastutil/longs/LongOpenHashSet;)V
+	METHOD method_52834 updateSectionOcclusionGraph (ZLnet/minecraft/class_4184;Lnet/minecraft/class_4604;Ljava/util/List;Lit/unimi/dsi/fastutil/longs/LongOpenHashSet;)V
 		ARG 1 cullChunks
 		ARG 2 camera
 		ARG 3 frustum

--- a/mappings/net/minecraft/client/render/VertexRendering.mapping
+++ b/mappings/net/minecraft/client/render/VertexRendering.mapping
@@ -56,6 +56,7 @@ CLASS net/minecraft/class_9974 net/minecraft/client/render/VertexRendering
 		ARG 3 offsetX
 		ARG 5 offsetY
 		ARG 7 offsetZ
+		ARG 9 color
 	METHOD method_62297 drawSide (Lnet/minecraft/class_4587;Lnet/minecraft/class_4588;Lnet/minecraft/class_2350;FFFFFFFFFF)V
 		ARG 0 matrices
 		ARG 1 vertexConsumers
@@ -76,6 +77,13 @@ CLASS net/minecraft/class_9974 net/minecraft/client/render/VertexRendering
 		ARG 2 offset
 		ARG 3 vec
 		ARG 4 argb
+	METHOD method_62299 (Lnet/minecraft/class_4588;Lnet/minecraft/class_4587$class_4665;DDDIDDDDDD)V
+		ARG 9 x1
+		ARG 11 y1
+		ARG 13 z1
+		ARG 15 x2
+		ARG 17 y2
+		ARG 19 z2
 	METHOD method_62300 drawFilledBox (Lnet/minecraft/class_4587;Lnet/minecraft/class_4588;DDDDDDFFFF)V
 		ARG 0 matrices
 		ARG 1 vertexConsumers

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -78,6 +78,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 		ARG 8 cameraZ
 		ARG 10 pos
 		ARG 11 state
+		ARG 12 color
 	METHOD method_22977 renderEntity (Lnet/minecraft/class_1297;DDDFLnet/minecraft/class_4587;Lnet/minecraft/class_4597;)V
 		ARG 1 entity
 		ARG 2 cameraX
@@ -239,6 +240,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	METHOD method_62206 renderBlockDamage (Lnet/minecraft/class_4587;Lnet/minecraft/class_4184;Lnet/minecraft/class_4597$class_4598;)V
 		ARG 1 matrices
 		ARG 2 camera
+		ARG 3 vertexConsumers
 	METHOD method_62207 renderEntities (Lnet/minecraft/class_4587;Lnet/minecraft/class_4597$class_4598;Lnet/minecraft/class_4184;Lnet/minecraft/class_9779;Ljava/util/List;)V
 		ARG 1 matrices
 		ARG 3 camera
@@ -252,7 +254,9 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 		ARG 1 camera
 	METHOD method_62210 renderTargetBlockOutline (Lnet/minecraft/class_4184;Lnet/minecraft/class_4597$class_4598;Lnet/minecraft/class_4587;Z)V
 		ARG 1 camera
+		ARG 2 vertexConsumers
 		ARG 3 matrices
+		ARG 4 translucent
 	METHOD method_62211 getEntitiesToRender (Lnet/minecraft/class_4184;Lnet/minecraft/class_4604;Ljava/util/List;)Z
 		ARG 1 camera
 		ARG 2 frustum

--- a/mappings/net/minecraft/client/render/debug/DebugRenderer.mapping
+++ b/mappings/net/minecraft/client/render/debug/DebugRenderer.mapping
@@ -137,6 +137,10 @@ CLASS net/minecraft/class_863 net/minecraft/client/render/debug/DebugRenderer
 		ARG 3 offsetX
 		ARG 5 offsetY
 		ARG 7 offsetZ
+		ARG 9 red
+		ARG 10 green
+		ARG 11 blue
+		ARG 12 alpha
 	METHOD method_62351 renderLate (Lnet/minecraft/class_4587;Lnet/minecraft/class_4597$class_4598;DDD)V
 		ARG 1 matrices
 		ARG 2 vertexConsumers

--- a/mappings/net/minecraft/client/render/entity/EntityRenderers.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderers.mapping
@@ -98,3 +98,7 @@ CLASS net/minecraft/class_5619 net/minecraft/client/render/entity/EntityRenderer
 		ARG 0 context
 	METHOD method_64539 (Lnet/minecraft/class_5617$class_5618;)Lnet/minecraft/class_897;
 		ARG 0 context
+	METHOD method_64919 (Lnet/minecraft/class_5617$class_5618;)Lnet/minecraft/class_897;
+		ARG 0 context
+	METHOD method_64920 (Lnet/minecraft/class_5617$class_5618;)Lnet/minecraft/class_897;
+		ARG 0 context

--- a/mappings/net/minecraft/client/render/entity/model/WardenEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/WardenEntityModel.mapping
@@ -21,12 +21,17 @@ CLASS net/minecraft/class_7280 net/minecraft/client/render/entity/model/WardenEn
 		ARG 1 yaw
 		ARG 2 pitch
 	METHOD method_42736 setTendrilPitches (Lnet/minecraft/class_10081;F)V
+		ARG 1 state
 		ARG 2 animationProgress
 	METHOD method_42737 setLimbAngles (FF)V
 		ARG 1 angle
 		ARG 2 distance
 	METHOD method_42738 getTendrils (Lnet/minecraft/class_10081;)Ljava/util/List;
+		ARG 1 state
 	METHOD method_42739 getBody (Lnet/minecraft/class_10081;)Ljava/util/List;
+		ARG 1 state
 	METHOD method_42740 getHeadAndLimbs (Lnet/minecraft/class_10081;)Ljava/util/List;
+		ARG 1 state
 	METHOD method_42741 getBodyHeadAndLimbs (Lnet/minecraft/class_10081;)Ljava/util/List;
+		ARG 1 state
 	METHOD method_42742 setArmPivots ()V

--- a/mappings/net/minecraft/client/render/model/json/JsonUnbakedModel.mapping
+++ b/mappings/net/minecraft/client/render/model/json/JsonUnbakedModel.mapping
@@ -15,6 +15,7 @@ CLASS net/minecraft/class_793 net/minecraft/client/render/model/json/JsonUnbaked
 	FIELD field_4253 parent Lnet/minecraft/class_793;
 	FIELD field_4254 GSON Lcom/google/gson/Gson;
 	FIELD field_4255 overrides Ljava/util/List;
+	FIELD field_54858 MISSING_SPRITE Lnet/minecraft/class_4730;
 	METHOD <init> (Lnet/minecraft/class_2960;Ljava/util/List;Ljava/util/Map;Ljava/lang/Boolean;Lnet/minecraft/class_793$class_4751;Lnet/minecraft/class_809;Ljava/util/List;)V
 		ARG 1 parentId
 		ARG 2 elements

--- a/mappings/net/minecraft/client/search/SearchManager.mapping
+++ b/mappings/net/minecraft/client/search/SearchManager.mapping
@@ -13,6 +13,7 @@ CLASS net/minecraft/class_1124 net/minecraft/client/search/SearchManager
 		ARG 0 stack
 	METHOD method_60352 addRecipeOutputReloader (Lnet/minecraft/class_299;Lnet/minecraft/class_1937;)V
 		ARG 1 recipeBook
+		ARG 2 world
 	METHOD method_60353 addReloader (Lnet/minecraft/class_1124$class_1125;Ljava/lang/Runnable;)V
 		ARG 1 key
 		ARG 2 reloader
@@ -38,4 +39,12 @@ CLASS net/minecraft/class_1124 net/minecraft/client/search/SearchManager
 		ARG 0 stack
 	METHOD method_60370 getItemTagReloadFuture ()Lnet/minecraft/class_1129;
 	METHOD method_60372 getItemTooltipReloadFuture ()Lnet/minecraft/class_1129;
+	METHOD method_64907 (Lnet/minecraft/class_10302$class_10308;Lnet/minecraft/class_10297;)Ljava/util/stream/Stream;
+		ARG 1 display
+	METHOD method_64908 (Lnet/minecraft/class_10302$class_10308;Lnet/minecraft/class_2378;Lnet/minecraft/class_516;)Ljava/util/stream/Stream;
+		ARG 2 resultCollection
+	METHOD method_64909 (Lnet/minecraft/class_2378;Lnet/minecraft/class_1799;)Lnet/minecraft/class_2960;
+		ARG 1 stack
+	METHOD method_64910 (Lnet/minecraft/class_10302$class_10308;Lnet/minecraft/class_10297;)Ljava/util/stream/Stream;
+		ARG 1 display
 	CLASS class_1125 Key

--- a/mappings/net/minecraft/client/toast/RecipeToast.mapping
+++ b/mappings/net/minecraft/client/toast/RecipeToast.mapping
@@ -12,4 +12,6 @@ CLASS net/minecraft/class_366 net/minecraft/client/toast/RecipeToast
 		ARG 1 categoryItem
 		ARG 2 unlockedItem
 	METHOD method_1985 show (Lnet/minecraft/class_374;Lnet/minecraft/class_10295;)V
+		ARG 0 toastManager
+		ARG 1 display
 	CLASS class_9932 DisplayItems

--- a/mappings/net/minecraft/entity/ModelTransformationMode.mapping
+++ b/mappings/net/minecraft/entity/ModelTransformationMode.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_811 net/minecraft/client/render/model/json/ModelTransformationMode
+CLASS net/minecraft/class_811 net/minecraft/entity/ModelTransformationMode
 	FIELD field_42468 CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_42469 FROM_INDEX Ljava/util/function/IntFunction;
 	FIELD field_42470 index B

--- a/mappings/net/minecraft/item/ModelTransformationMode.mapping
+++ b/mappings/net/minecraft/item/ModelTransformationMode.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_811 net/minecraft/entity/ModelTransformationMode
+CLASS net/minecraft/class_811 net/minecraft/item/ModelTransformationMode
 	FIELD field_42468 CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_42469 FROM_INDEX Ljava/util/function/IntFunction;
 	FIELD field_42470 index B

--- a/mappings/net/minecraft/network/packet/s2c/play/RecipeBookAddS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/RecipeBookAddS2CPacket.mapping
@@ -3,13 +3,13 @@ CLASS net/minecraft/class_10266 net/minecraft/network/packet/s2c/play/RecipeBook
 	CLASS class_10267 Entry
 		FIELD field_54518 SHOW_NOTIFICATION B
 			COMMENT If set, shows a toast for the unlocked recipe. Has value {@value}.
-		FIELD field_54519 TO_BE_DISPLAYED B
+		FIELD field_54519 HIGHLIGHTED B
 			COMMENT If set, plays an animation when the recipe is first viewed on the
 			COMMENT recipe book. Has value {@value}.
 		FIELD field_54520 PACKET_CODEC Lnet/minecraft/class_9139;
 		METHOD <init> (Lnet/minecraft/class_10297;ZZ)V
 			ARG 1 display
 			ARG 2 showNotification
-			ARG 3 toBeDisplayed
+			ARG 3 highlighted
 		METHOD method_64561 shouldShowNotification ()Z
-		METHOD method_64562 isToBeDisplayed ()Z
+		METHOD method_64562 isHighlighted ()Z

--- a/mappings/net/minecraft/network/packet/s2c/play/RecipeBookAddS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/RecipeBookAddS2CPacket.mapping
@@ -1,4 +1,15 @@
 CLASS net/minecraft/class_10266 net/minecraft/network/packet/s2c/play/RecipeBookAddS2CPacket
 	FIELD field_54517 CODEC Lnet/minecraft/class_9139;
 	CLASS class_10267 Entry
+		FIELD field_54518 SHOW_NOTIFICATION B
+			COMMENT If set, shows a toast for the unlocked recipe. Has value {@value}.
+		FIELD field_54519 TO_BE_DISPLAYED B
+			COMMENT If set, plays an animation when the recipe is first viewed on the
+			COMMENT recipe book. Has value {@value}.
 		FIELD field_54520 PACKET_CODEC Lnet/minecraft/class_9139;
+		METHOD <init> (Lnet/minecraft/class_10297;ZZ)V
+			ARG 1 display
+			ARG 2 showNotification
+			ARG 3 toBeDisplayed
+		METHOD method_64561 shouldShowNotification ()Z
+		METHOD method_64562 isToBeDisplayed ()Z

--- a/mappings/net/minecraft/recipe/AbstractCookingRecipe.mapping
+++ b/mappings/net/minecraft/recipe/AbstractCookingRecipe.mapping
@@ -2,9 +2,25 @@ CLASS net/minecraft/class_1874 net/minecraft/recipe/AbstractCookingRecipe
 	FIELD field_40241 category Lnet/minecraft/class_7709;
 	FIELD field_9057 experience F
 	FIELD field_9058 cookingTime I
+	METHOD <init> (Ljava/lang/String;Lnet/minecraft/class_7709;Lnet/minecraft/class_1856;Lnet/minecraft/class_1799;FI)V
+		ARG 1 group
+		ARG 2 category
+		ARG 3 ingredient
+		ARG 4 result
+		ARG 5 experience
+		ARG 6 cookingTime
 	METHOD method_45438 getCategory ()Lnet/minecraft/class_7709;
+	METHOD method_64663 getCookerItem ()Lnet/minecraft/class_1792;
 	METHOD method_8167 getCookingTime ()I
 	METHOD method_8171 getExperience ()F
+	CLASS class_10285 Serializer
+		FIELD field_54625 codec Lcom/mojang/serialization/MapCodec;
+		FIELD field_54626 packetCodec Lnet/minecraft/class_9139;
+		METHOD <init> (Lnet/minecraft/class_1874$class_3958;I)V
+			ARG 1 factory
+			ARG 2 defaultCookingTime
+		METHOD method_64665 (ILnet/minecraft/class_1874$class_3958;Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+			ARG 2 instance
 	CLASS class_3958 RecipeFactory
 		METHOD create (Ljava/lang/String;Lnet/minecraft/class_7709;Lnet/minecraft/class_1856;Lnet/minecraft/class_1799;FI)Lnet/minecraft/class_1874;
 			ARG 1 group

--- a/mappings/net/minecraft/recipe/Ingredient.mapping
+++ b/mappings/net/minecraft/recipe/Ingredient.mapping
@@ -30,6 +30,8 @@ CLASS net/minecraft/class_1856 net/minecraft/recipe/Ingredient
 		ARG 0 entries
 	METHOD method_61680 (Lnet/minecraft/class_1856;)Lnet/minecraft/class_6885;
 		ARG 0 ingredient
+	METHOD method_64672 (Ljava/util/List;)Ljava/lang/Record;
+		ARG 0 displays
 	METHOD method_64673 toDisplay ()Lnet/minecraft/class_10302;
 	METHOD method_8091 ofItems ([Lnet/minecraft/class_1935;)Lnet/minecraft/class_1856;
 		ARG 0 items

--- a/mappings/net/minecraft/recipe/IngredientPlacement.mapping
+++ b/mappings/net/minecraft/recipe/IngredientPlacement.mapping
@@ -1,9 +1,12 @@
 CLASS net/minecraft/class_9887 net/minecraft/recipe/IngredientPlacement
 	FIELD field_52597 NONE Lnet/minecraft/class_9887;
 	FIELD field_52599 placementSlots Ljava/util/List;
+	FIELD field_54635 ingredients Ljava/util/List;
+	FIELD field_54636 rawIngredients Ljava/util/List;
 	METHOD <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
-		ARG 1 rawIngredients
-		ARG 2 placementSlots
+		ARG 1 ingredients
+		ARG 2 rawIngredients
+		ARG 3 placementSlots
 	METHOD method_61681 getPlacementSlots ()Ljava/util/List;
 	METHOD method_61682 forSingleSlot (Lnet/minecraft/class_1856;)Lnet/minecraft/class_9887;
 		ARG 0 ingredient
@@ -14,4 +17,6 @@ CLASS net/minecraft/class_9887 net/minecraft/recipe/IngredientPlacement
 	METHOD method_61687 hasNoPlacement ()Z
 	METHOD method_64674 sort (Lnet/minecraft/class_1856;)Lnet/minecraft/class_1662$class_9873;
 		ARG 0 ingredient
+	METHOD method_64675 getIngredients ()Ljava/util/List;
+	METHOD method_64676 getRawIngredients ()Ljava/util/List;
 	CLASS class_9888 PlacementSlot

--- a/mappings/net/minecraft/recipe/RecipeCache.mapping
+++ b/mappings/net/minecraft/recipe/RecipeCache.mapping
@@ -7,8 +7,11 @@ CLASS net/minecraft/class_8884 net/minecraft/recipe/RecipeCache
 		ARG 1 index
 	METHOD method_54468 getAndCacheRecipe (Lnet/minecraft/class_9694;Lnet/minecraft/class_3218;)Ljava/util/Optional;
 		ARG 1 input
+		ARG 2 world
 	METHOD method_54469 validateRecipeManager (Lnet/minecraft/class_3218;)V
+		ARG 1 world
 	METHOD method_54470 getRecipe (Lnet/minecraft/class_3218;Lnet/minecraft/class_9694;)Ljava/util/Optional;
+		ARG 1 world
 		ARG 2 input
 	METHOD method_54471 cache (Lnet/minecraft/class_9694;Lnet/minecraft/class_8786;)V
 		ARG 1 input

--- a/mappings/net/minecraft/recipe/RecipeDisplayEntry.mapping
+++ b/mappings/net/minecraft/recipe/RecipeDisplayEntry.mapping
@@ -1,8 +1,8 @@
-CLASS net/minecraft/class_10297 net/minecraft/recipe/RecipeContents
+CLASS net/minecraft/class_10297 net/minecraft/recipe/RecipeDisplayEntry
 	COMMENT A recipe that is synced to the clients. Note that this does not include
 	COMMENT the recipe's registry key.
 	FIELD field_54663 PACKET_CODEC Lnet/minecraft/class_9139;
-	METHOD method_64729 (Lnet/minecraft/class_9875;)Z
+	METHOD method_64729 isCraftable (Lnet/minecraft/class_9875;)Z
 		ARG 1 finder
 	METHOD method_64730 getStacks (Lnet/minecraft/class_10302$class_10308;)Ljava/util/List;
 		ARG 1 context

--- a/mappings/net/minecraft/recipe/RecipeFinder.mapping
+++ b/mappings/net/minecraft/recipe/RecipeFinder.mapping
@@ -26,3 +26,10 @@ CLASS net/minecraft/class_9875 net/minecraft/recipe/RecipeFinder
 	METHOD method_61543 countCrafts (Lnet/minecraft/class_1860;Lnet/minecraft/class_1662$class_9874;)I
 		ARG 1 recipe
 		ARG 2 itemCallback
+	METHOD method_64644 isCraftable (Ljava/util/List;ILnet/minecraft/class_1662$class_9874;)Z
+		ARG 1 rawIngredients
+		ARG 2 quantity
+		ARG 3 itemCallback
+	METHOD method_64645 isCraftable (Ljava/util/List;Lnet/minecraft/class_1662$class_9874;)Z
+		ARG 1 rawIngredients
+		ARG 2 itemCallback

--- a/mappings/net/minecraft/recipe/RecipeGridAligner.mapping
+++ b/mappings/net/minecraft/recipe/RecipeGridAligner.mapping
@@ -2,6 +2,16 @@ CLASS net/minecraft/class_9838 net/minecraft/recipe/RecipeGridAligner
 	METHOD method_61229 alignRecipeToGrid (IIIILjava/lang/Iterable;Lnet/minecraft/class_9838$class_9839;)V
 		ARG 0 width
 		ARG 1 height
+		ARG 2 recipeWidth
+		ARG 3 recipeHeight
+		ARG 4 slots
+		ARG 5 filter
+	METHOD method_64566 alignRecipeToGrid (IILnet/minecraft/class_1860;Ljava/lang/Iterable;Lnet/minecraft/class_9838$class_9839;)V
+		ARG 0 width
+		ARG 1 height
+		ARG 2 recipe
+		ARG 3 slots
+		ARG 4 filter
 	CLASS class_9839 Filler
 		METHOD addItemToSlot (Ljava/lang/Object;III)V
 			ARG 1 slot

--- a/mappings/net/minecraft/recipe/ServerRecipeManager.mapping
+++ b/mappings/net/minecraft/recipe/ServerRecipeManager.mapping
@@ -43,8 +43,9 @@ CLASS net/minecraft/class_1863 net/minecraft/recipe/ServerRecipeManager
 		ARG 2 input
 		ARG 3 world
 		ARG 4 recipe
-	METHOD method_64679 (Lnet/minecraft/class_5321;Ljava/util/function/Consumer;)V
+	METHOD method_64679 forEachRecipeDisplay (Lnet/minecraft/class_5321;Ljava/util/function/Consumer;)V
 		ARG 1 key
+		ARG 2 action
 	METHOD method_64681 intitialize (Lnet/minecraft/class_7699;)V
 		ARG 1 features
 	METHOD method_64682 isEnabled (Lnet/minecraft/class_7699;Lnet/minecraft/class_1856;)Z
@@ -55,14 +56,24 @@ CLASS net/minecraft/class_1863 net/minecraft/recipe/ServerRecipeManager
 		ARG 1 ingredients
 	METHOD method_64684 (Lnet/minecraft/class_7699;Lnet/minecraft/class_6880;)Z
 		ARG 1 entry
-	METHOD method_64688 (Ljava/lang/Iterable;Lnet/minecraft/class_7699;)Ljava/util/List;
+	METHOD method_64685 (Lnet/minecraft/class_1863$class_10288;)Lnet/minecraft/class_5321;
+		ARG 0 recipe
+	METHOD method_64686 get (Lnet/minecraft/class_10298;)Lnet/minecraft/class_1863$class_10288;
+		ARG 1 id
+	METHOD method_64687 (Lit/unimi/dsi/fastutil/objects/Object2IntMap;Ljava/lang/Object;)I
+		ARG 1 group
+	METHOD method_64688 collectServerRecipes (Ljava/lang/Iterable;Lnet/minecraft/class_7699;)Ljava/util/List;
+		COMMENT Filters recipes by {@code enabledFeatures} and assigns an integer
+		COMMENT ID to each recipe and recipe group.
 		ARG 0 recipes
-		ARG 1 features
+		ARG 1 enabledFeatures
 	METHOD method_64689 (Ljava/util/List;Lnet/minecraft/class_2960;Lnet/minecraft/class_1860;)V
 		ARG 1 id
 		ARG 2 recipe
 	METHOD method_64690 (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lnet/minecraft/class_7699;Ljava/util/List;Lnet/minecraft/class_8786;)V
 		ARG 9 entry
+	METHOD method_64691 (Ljava/util/function/Consumer;Lnet/minecraft/class_1863$class_10288;)V
+		ARG 1 recipe
 	METHOD method_64692 getPropertySets ()Ljava/util/Map;
 	METHOD method_64693 (Lnet/minecraft/class_7699;Lnet/minecraft/class_1856;)Z
 		ARG 1 ingredient

--- a/mappings/net/minecraft/recipe/ServerRecipeManager.mapping
+++ b/mappings/net/minecraft/recipe/ServerRecipeManager.mapping
@@ -46,7 +46,7 @@ CLASS net/minecraft/class_1863 net/minecraft/recipe/ServerRecipeManager
 	METHOD method_64679 forEachRecipeDisplay (Lnet/minecraft/class_5321;Ljava/util/function/Consumer;)V
 		ARG 1 key
 		ARG 2 action
-	METHOD method_64681 intitialize (Lnet/minecraft/class_7699;)V
+	METHOD method_64681 initialize (Lnet/minecraft/class_7699;)V
 		ARG 1 features
 	METHOD method_64682 isEnabled (Lnet/minecraft/class_7699;Lnet/minecraft/class_1856;)Z
 		ARG 0 features

--- a/mappings/net/minecraft/recipe/ShapedRecipe.mapping
+++ b/mappings/net/minecraft/recipe/ShapedRecipe.mapping
@@ -17,6 +17,8 @@ CLASS net/minecraft/class_1869 net/minecraft/recipe/ShapedRecipe
 		ARG 4 result
 		ARG 5 showNotification
 	METHOD method_61693 getIngredients ()Ljava/util/List;
+	METHOD method_64718 (Ljava/util/Optional;)Lnet/minecraft/class_10302;
+		ARG 0 ingredient
 	METHOD method_8150 getWidth ()I
 	METHOD method_8158 getHeight ()I
 	CLASS class_1870 Serializer

--- a/mappings/net/minecraft/recipe/SingleStackRecipe.mapping
+++ b/mappings/net/minecraft/recipe/SingleStackRecipe.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_3972 net/minecraft/recipe/CuttingRecipe
+CLASS net/minecraft/class_3972 net/minecraft/recipe/SingleStackRecipe
 	COMMENT A recipe that has only one input ingredient. It can be used by any type
 	COMMENT of recipe as long as its subclass implements the proper interface.
 	FIELD field_17642 ingredient Lnet/minecraft/class_1856;

--- a/mappings/net/minecraft/recipe/book/CookingRecipeCategory.mapping
+++ b/mappings/net/minecraft/recipe/book/CookingRecipeCategory.mapping
@@ -1,3 +1,13 @@
 CLASS net/minecraft/class_7709 net/minecraft/recipe/book/CookingRecipeCategory
 	FIELD field_40245 CODEC Lcom/mojang/serialization/Codec;
-	FIELD field_40246 id Ljava/lang/String;
+	FIELD field_40246 name Ljava/lang/String;
+	FIELD field_54631 PACKET_CODEC Lnet/minecraft/class_9139;
+	FIELD field_54632 BY_ID Ljava/util/function/IntFunction;
+	FIELD field_54633 id I
+	METHOD <init> (Ljava/lang/String;IILjava/lang/String;)V
+		ARG 3 id
+		ARG 4 name
+	METHOD method_64669 (Lnet/minecraft/class_7709;)I
+		ARG 0 category
+	METHOD method_64670 (Lnet/minecraft/class_7709;)I
+		ARG 0 category

--- a/mappings/net/minecraft/recipe/book/RecipeBookCategory.mapping
+++ b/mappings/net/minecraft/recipe/book/RecipeBookCategory.mapping
@@ -1,1 +1,1 @@
-CLASS net/minecraft/class_5421 net/minecraft/recipe/book/RecipeBookCategory
+CLASS net/minecraft/class_10287 net/minecraft/recipe/book/RecipeBookCategory

--- a/mappings/net/minecraft/recipe/book/RecipeBookGroup.mapping
+++ b/mappings/net/minecraft/recipe/book/RecipeBookGroup.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_314 net/minecraft/client/recipebook/RecipeBookGroup
+CLASS net/minecraft/class_314 net/minecraft/recipe/book/RecipeBookGroup
 	FIELD field_54627 ID_TO_VALUE Ljava/util/function/IntFunction;
 	FIELD field_54628 PACKET_CODEC Lnet/minecraft/class_9139;
 	FIELD field_54629 id I

--- a/mappings/net/minecraft/recipe/book/RecipeBookOptions.mapping
+++ b/mappings/net/minecraft/recipe/book/RecipeBookOptions.mapping
@@ -33,9 +33,22 @@ CLASS net/minecraft/class_5411 net/minecraft/recipe/book/RecipeBookOptions
 		ARG 1 nbt
 	METHOD method_30190 toPacket (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
+	METHOD method_64581 apply (Lnet/minecraft/class_5421;Ljava/util/function/UnaryOperator;)V
+		ARG 1 category
+		ARG 2 modifier
+	METHOD method_64582 (Ljava/util/function/UnaryOperator;Lnet/minecraft/class_5421;Lnet/minecraft/class_5411$class_5412;)Lnet/minecraft/class_5411$class_5412;
+		ARG 1 key
+		ARG 2 value
+	METHOD method_64583 (ZLnet/minecraft/class_5411$class_5412;)Lnet/minecraft/class_5411$class_5412;
+		ARG 1 option
+	METHOD method_64584 (ZLnet/minecraft/class_5411$class_5412;)Lnet/minecraft/class_5411$class_5412;
+		ARG 1 option
+	METHOD method_64585 getOption (Lnet/minecraft/class_5421;)Lnet/minecraft/class_5411$class_5412;
+		ARG 1 category
 	CLASS class_5412 CategoryOption
 		FIELD comp_3247 guiOpen Z
 		FIELD comp_3248 filteringCraftable Z
+		FIELD field_54549 DEFAULT Lnet/minecraft/class_5411$class_5412;
 		METHOD <init> (ZZ)V
 			ARG 1 guiOpen
 			ARG 2 filteringCraftable
@@ -43,3 +56,7 @@ CLASS net/minecraft/class_5411 net/minecraft/recipe/book/RecipeBookOptions
 		METHOD comp_3248 filteringCraftable ()Z
 		METHOD equals (Ljava/lang/Object;)Z
 			ARG 1 o
+		METHOD method_64586 withGuiOpen (Z)Lnet/minecraft/class_5411$class_5412;
+			ARG 1 guiOpen
+		METHOD method_64587 withFilteringCraftable (Z)Lnet/minecraft/class_5411$class_5412;
+			ARG 1 filteringCraftable

--- a/mappings/net/minecraft/recipe/book/RecipeBookType.mapping
+++ b/mappings/net/minecraft/recipe/book/RecipeBookType.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_5421 net/minecraft/recipe/book/RecipeBookType

--- a/mappings/net/minecraft/recipe/display/RecipeDisplayBootstrap.mapping
+++ b/mappings/net/minecraft/recipe/display/RecipeDisplayBootstrap.mapping
@@ -1,3 +1,3 @@
-CLASS net/minecraft/class_10299 net/minecraft/recipe/display/RecipeDisplayBootstreap
+CLASS net/minecraft/class_10299 net/minecraft/recipe/display/RecipeDisplayBootstrap
 	METHOD method_64731 registerAndGetDefault (Lnet/minecraft/class_2378;)Lnet/minecraft/class_10295$class_10296;
 		ARG 0 registry

--- a/mappings/net/minecraft/recipe/display/SlotDisplay.mapping
+++ b/mappings/net/minecraft/recipe/display/SlotDisplay.mapping
@@ -48,6 +48,8 @@ CLASS net/minecraft/class_10302 net/minecraft/recipe/display/SlotDisplay
 		FIELD field_54688 CODEC Lcom/mojang/serialization/MapCodec;
 		FIELD field_54689 PACKET_CODEC Lnet/minecraft/class_9139;
 		FIELD field_54690 SERIALIZER Lnet/minecraft/class_10302$class_10312;
+		METHOD equals (Ljava/lang/Object;)Z
+			ARG 1 o
 		METHOD method_64750 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 			ARG 0 instance
 	CLASS class_10308 Context

--- a/mappings/net/minecraft/recipe/display/StoneCutterRecipeDisplay.mapping
+++ b/mappings/net/minecraft/recipe/display/StoneCutterRecipeDisplay.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_10315 net/minecraft/recipe/display/StoneCutterRecipeDisplay
+CLASS net/minecraft/class_10315 net/minecraft/recipe/display/StonecutterRecipeDisplay
 	FIELD field_54702 CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD field_54703 PACKET_CODEC Lnet/minecraft/class_9139;
 	FIELD field_54704 SERIALIZER Lnet/minecraft/class_10295$class_10296;

--- a/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
+++ b/mappings/net/minecraft/server/network/ServerPlayerEntity.mapping
@@ -328,6 +328,9 @@ CLASS net/minecraft/class_3222 net/minecraft/server/network/ServerPlayerEntity
 	METHOD method_64398 sendMessage (Lnet/minecraft/class_2561;)V
 		ARG 1 message
 	METHOD method_64401 getCommandOutput ()Lnet/minecraft/class_2165;
+	METHOD method_64579 (Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/class_5321;Ljava/util/function/Consumer;)V
+		ARG 1 key
+		ARG 2 adder
 	METHOD method_64580 (Lnet/minecraft/class_5321;)Z
 		ARG 1 recipeKey
 	METHOD method_7336 changeGameMode (Lnet/minecraft/class_1934;)Z

--- a/mappings/net/minecraft/server/network/ServerRecipeBook.mapping
+++ b/mappings/net/minecraft/server/network/ServerRecipeBook.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_3441 net/minecraft/server/network/ServerRecipeBook
 	FIELD field_15303 LOGGER Lorg/slf4j/Logger;
 	FIELD field_29820 RECIPE_BOOK_KEY Ljava/lang/String;
 	FIELD field_54550 unlocked Ljava/util/Set;
-	FIELD field_54551 toBeDisplayed Ljava/util/Set;
+	FIELD field_54551 highlighted Ljava/util/Set;
 		COMMENT Contains recipes that play an animation when first viewed on the recipe book.
 		COMMENT
 		COMMENT <p>This is saved under {@code toBeDisplayed} key in the player NBT data.
@@ -39,9 +39,9 @@ CLASS net/minecraft/class_3441 net/minecraft/server/network/ServerRecipeBook
 		ARG 1 recipeKey
 	METHOD method_64594 lock (Lnet/minecraft/class_5321;)V
 		ARG 1 recipeKey
-	METHOD method_64595 unmarkToBeDisplayed (Lnet/minecraft/class_5321;)V
+	METHOD method_64595 unmarkHighlighted (Lnet/minecraft/class_5321;)V
 		ARG 1 recipeKey
-	METHOD method_64596 markToBeDisplayed (Lnet/minecraft/class_5321;)V
+	METHOD method_64596 markHighlighted (Lnet/minecraft/class_5321;)V
 		ARG 1 recipeKey
 	CLASS class_10271 DisplayCollector
 		METHOD displaysForRecipe (Lnet/minecraft/class_5321;Ljava/util/function/Consumer;)V

--- a/mappings/net/minecraft/server/network/ServerRecipeBook.mapping
+++ b/mappings/net/minecraft/server/network/ServerRecipeBook.mapping
@@ -1,11 +1,20 @@
 CLASS net/minecraft/class_3441 net/minecraft/server/network/ServerRecipeBook
 	FIELD field_15303 LOGGER Lorg/slf4j/Logger;
 	FIELD field_29820 RECIPE_BOOK_KEY Ljava/lang/String;
+	FIELD field_54550 unlocked Ljava/util/Set;
+	FIELD field_54551 toBeDisplayed Ljava/util/Set;
+		COMMENT Contains recipes that play an animation when first viewed on the recipe book.
+		COMMENT
+		COMMENT <p>This is saved under {@code toBeDisplayed} key in the player NBT data.
+	FIELD field_54552 collector Lnet/minecraft/class_3441$class_10271;
+	METHOD <init> (Lnet/minecraft/class_3441$class_10271;)V
+		ARG 1 collector
 	METHOD method_14900 lockRecipes (Ljava/util/Collection;Lnet/minecraft/class_3222;)I
 		ARG 1 recipes
 		ARG 2 player
 	METHOD method_14901 readNbt (Lnet/minecraft/class_2487;Ljava/util/function/Predicate;)V
 		ARG 1 nbt
+		ARG 2 validPredicate
 	METHOD method_14902 toNbt ()Lnet/minecraft/class_2487;
 	METHOD method_14903 unlockRecipes (Ljava/util/Collection;Lnet/minecraft/class_3222;)I
 		ARG 1 recipes
@@ -15,4 +24,26 @@ CLASS net/minecraft/class_3441 net/minecraft/server/network/ServerRecipeBook
 	METHOD method_20732 handleList (Lnet/minecraft/class_2499;Ljava/util/function/Consumer;Ljava/util/function/Predicate;)V
 		ARG 1 list
 		ARG 2 handler
+		ARG 3 validPredicate
+	METHOD method_64588 unlock (Lnet/minecraft/class_5321;)V
+		ARG 1 recipeKey
 	METHOD method_64589 copyFrom (Lnet/minecraft/class_3441;)V
+		ARG 1 recipeBook
+	METHOD method_64590 (Ljava/util/List;Lnet/minecraft/class_5321;Lnet/minecraft/class_10297;)V
+		ARG 3 display
+	METHOD method_64591 (Ljava/util/List;Lnet/minecraft/class_8786;Lnet/minecraft/class_10297;)V
+		ARG 2 display
+	METHOD method_64592 (Ljava/util/List;Lnet/minecraft/class_10297;)V
+		ARG 1 display
+	METHOD method_64593 isUnlocked (Lnet/minecraft/class_5321;)Z
+		ARG 1 recipeKey
+	METHOD method_64594 lock (Lnet/minecraft/class_5321;)V
+		ARG 1 recipeKey
+	METHOD method_64595 unmarkToBeDisplayed (Lnet/minecraft/class_5321;)V
+		ARG 1 recipeKey
+	METHOD method_64596 markToBeDisplayed (Lnet/minecraft/class_5321;)V
+		ARG 1 recipeKey
+	CLASS class_10271 DisplayCollector
+		METHOD displaysForRecipe (Lnet/minecraft/class_5321;Ljava/util/function/Consumer;)V
+			ARG 1 recipeKey
+			ARG 2 adder

--- a/unpick-definitions/network_packets.unpick
+++ b/unpick-definitions/network_packets.unpick
@@ -63,3 +63,9 @@ target_method net/minecraft/network/packet/s2c/play/TeamS2CPacket containsPlayer
 	param 0 s2c_team_packet_type
 target_method net/minecraft/network/packet/s2c/play/TeamS2CPacket containsTeamInfo (I)Z
 	param 0 s2c_team_packet_type
+
+flag s2c_recipe_book_setting_flags net/minecraft/network/packet/s2c/play/RecipeBookSettingsS2CPacket$Entry SHOW_NOTIFICATION
+flag s2c_recipe_book_setting_flags net/minecraft/network/packet/s2c/play/RecipeBookSettingsS2CPacket$Entry TO_BE_DISPLAYED
+
+target_method net/minecraft/network/packet/s2c/play/RecipeBookSettingsS2CPacket$Entry <init> (Lnet/minecraft/recipe/RecipeDisplayEntry;B)V
+	param 1 s2c_recipe_book_setting_flags

--- a/unpick-definitions/network_packets.unpick
+++ b/unpick-definitions/network_packets.unpick
@@ -65,7 +65,7 @@ target_method net/minecraft/network/packet/s2c/play/TeamS2CPacket containsTeamIn
 	param 0 s2c_team_packet_type
 
 flag s2c_recipe_book_setting_flags net/minecraft/network/packet/s2c/play/RecipeBookSettingsS2CPacket$Entry SHOW_NOTIFICATION
-flag s2c_recipe_book_setting_flags net/minecraft/network/packet/s2c/play/RecipeBookSettingsS2CPacket$Entry TO_BE_DISPLAYED
+flag s2c_recipe_book_setting_flags net/minecraft/network/packet/s2c/play/RecipeBookSettingsS2CPacket$Entry HIGHLIGHTED
 
 target_method net/minecraft/network/packet/s2c/play/RecipeBookSettingsS2CPacket$Entry <init> (Lnet/minecraft/recipe/RecipeDisplayEntry;B)V
 	param 1 s2c_recipe_book_setting_flags


### PR DESCRIPTION
Resolves #4011

Also fixes some more yarnbugs, including the only remaining common class in client pkg, and `drawItemInSlot` (to `drawStackOverlay`)