### PR TITLE
Rename the EntityRenderer#getRenderState method to createRenderState

### DIFF
--- a/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
@@ -41,7 +41,7 @@ CLASS net/minecraft/class_897 net/minecraft/client/render/entity/EntityRenderer
 		ARG 2 matrices
 		ARG 3 vertexConsumers
 		ARG 4 light
-	METHOD method_55269 getRenderState ()Lnet/minecraft/class_10017;
+	METHOD method_55269 createRenderState ()Lnet/minecraft/class_10017;
 	METHOD method_55831 getShadowRadius (Lnet/minecraft/class_10017;)F
 		ARG 1 state
 	METHOD method_61049 renderLeash (Lnet/minecraft/class_4587;Lnet/minecraft/class_4597;Lnet/minecraft/class_10017$class_10018;)V


### PR DESCRIPTION
The `EntityRenderer#getRenderState` method is only used to initialize a field:

```java
private final S state = this.getRenderState();
```

It also returns a new `EntityRenderState` instance each time, as can be seen in the `EmptyEntityRenderer#getRenderState` method as well as other implementations:

```java
@Override
public EntityRenderState getRenderState() {
	return new EntityRenderState();
}
```

As such, `createRenderState` would be a more fitting name.