### PR TITLE
Map 'swapZIndex' in more TextRenderer methods

### DIFF
--- a/mappings/net/minecraft/client/font/TextRenderer.mapping
+++ b/mappings/net/minecraft/client/font/TextRenderer.mapping
@@ -45,6 +45,7 @@ CLASS net/minecraft/class_327 net/minecraft/client/font/TextRenderer
 		ARG 8 layerType
 		ARG 9 backgroundColor
 		ARG 10 light
+		ARG 11 swapZIndex
 	METHOD method_1724 drawLayer (Ljava/lang/String;FFIZLorg/joml/Matrix4f;Lnet/minecraft/class_4597;Lnet/minecraft/class_327$class_6415;IIZ)F
 		ARG 1 text
 		ARG 2 x
@@ -56,6 +57,7 @@ CLASS net/minecraft/class_327 net/minecraft/client/font/TextRenderer
 		ARG 8 layerType
 		ARG 9 backgroundColor
 		ARG 10 light
+		ARG 11 swapZIndex
 	METHOD method_1726 isRightToLeft ()Z
 		COMMENT Checks if the currently set language uses right to left writing.
 	METHOD method_1727 getWidth (Ljava/lang/String;)I
@@ -153,6 +155,7 @@ CLASS net/minecraft/class_327 net/minecraft/client/font/TextRenderer
 		ARG 8 layerType
 		ARG 9 backgroundColor
 		ARG 10 light
+		ARG 11 swapZIndex
 	METHOD method_30880 getWidth (Lnet/minecraft/class_5481;)I
 		COMMENT Gets the width of some text when rendered.
 		ARG 1 text


### PR DESCRIPTION
Noticed while reviewing #4025
