### PR TITLE
Draw sprite fixes

### DIFF
--- a/mappings/net/minecraft/client/gui/DrawContext.mapping
+++ b/mappings/net/minecraft/client/gui/DrawContext.mapping
@@ -377,14 +377,14 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawContext
 		ARG 8 y
 		ARG 9 width
 		ARG 10 height
-	METHOD method_52709 drawSprite (Ljava/util/function/Function;Lnet/minecraft/class_1058;IIII)V
+	METHOD method_52709 drawSpriteStretched (Ljava/util/function/Function;Lnet/minecraft/class_1058;IIII)V
 		ARG 1 renderLayers
 		ARG 2 sprite
 		ARG 3 x
 		ARG 4 y
 		ARG 5 width
 		ARG 6 height
-	METHOD method_52710 drawSprite (Ljava/util/function/Function;Lnet/minecraft/class_1058;IIIII)V
+	METHOD method_52710 drawSpriteStretched (Ljava/util/function/Function;Lnet/minecraft/class_1058;IIIII)V
 		ARG 1 renderLayers
 		ARG 2 sprite
 		ARG 3 x
@@ -418,7 +418,7 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawContext
 		ARG 11 textureWidth
 		ARG 12 textureHeight
 		ARG 13 color
-	METHOD method_52713 drawSprite (Ljava/util/function/Function;Lnet/minecraft/class_1058;Lnet/minecraft/class_8690$class_8691;IIIII)V
+	METHOD method_52713 drawSpriteNineSliced (Ljava/util/function/Function;Lnet/minecraft/class_1058;Lnet/minecraft/class_8690$class_8691;IIIII)V
 		ARG 1 renderLayers
 		ARG 2 sprite
 		ARG 3 nineSlice

--- a/mappings/net/minecraft/client/gui/DrawContext.mapping
+++ b/mappings/net/minecraft/client/gui/DrawContext.mapping
@@ -371,23 +371,22 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawContext
 		COMMENT
 		COMMENT <p>The width and height of the region are the same as
 		COMMENT the dimensions of the rectangle.
-		COMMENT
-		COMMENT @param textureWidth the width of the entire texture
-		COMMENT @param textureHeight the height of the entire texture
-		COMMENT @param u the x starting position of the region in the texture
-		COMMENT @param v the y starting position of the region in the texture
-		COMMENT @param width the width of the drawn rectangle and of the region in the texture
-		COMMENT @param height the height of the drawn rectangle and of the region in the texture
 		ARG 1 renderLayers
 		ARG 2 sprite
 		ARG 3 textureWidth
+			COMMENT the width of the entire texture
 		ARG 4 textureHeight
+			COMMENT the height of the entire texture
 		ARG 5 u
+			COMMENT the x starting position of the region in the texture
 		ARG 6 v
+			COMMENT the y starting position of the region in the texture
 		ARG 7 x
 		ARG 8 y
 		ARG 9 width
+			COMMENT the width of the drawn rectangle and of the region in the texture
 		ARG 10 height
+			COMMENT the height of the drawn rectangle and of the region in the texture
 	METHOD method_52709 drawSpriteStretched (Ljava/util/function/Function;Lnet/minecraft/class_1058;IIII)V
 		ARG 1 renderLayers
 		ARG 2 sprite

--- a/mappings/net/minecraft/client/gui/DrawContext.mapping
+++ b/mappings/net/minecraft/client/gui/DrawContext.mapping
@@ -367,6 +367,17 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawContext
 		ARG 6 height
 		ARG 7 color
 	METHOD method_52708 drawGuiTexture (Ljava/util/function/Function;Lnet/minecraft/class_2960;IIIIIIII)V
+		COMMENT Draws a textured rectangle from a region in a gui texture.
+		COMMENT
+		COMMENT <p>The width and height of the region are the same as
+		COMMENT the dimensions of the rectangle.
+		COMMENT
+		COMMENT @param textureWidth the width of the entire texture
+		COMMENT @param textureHeight the height of the entire texture
+		COMMENT @param u the x starting position of the region in the texture
+		COMMENT @param v the y starting position of the region in the texture
+		COMMENT @param width the width of the drawn rectangle and of the region in the texture
+		COMMENT @param height the height of the drawn rectangle and of the region in the texture
 		ARG 1 renderLayers
 		ARG 2 sprite
 		ARG 3 textureWidth
@@ -392,7 +403,7 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawContext
 		ARG 5 width
 		ARG 6 height
 		ARG 7 color
-	METHOD method_52711 drawSprite (Ljava/util/function/Function;Lnet/minecraft/class_1058;IIIIIIIII)V
+	METHOD method_52711 drawSpriteRegion (Ljava/util/function/Function;Lnet/minecraft/class_1058;IIIIIIIII)V
 		ARG 1 renderLayers
 		ARG 2 sprite
 		ARG 3 textureWidth


### PR DESCRIPTION
* Update `drawSprite -> drawSpriteStretched` and `drawSprite -> drawSpriteNineSliced` for stretched and nine slice scaling modes to match `drawSpriteTiled`.
* Add Javadocs for `drawGuiTexture` that can draw a region of a texture.
* Update `drawSprite -> drawSpriteRegion`. (Can remove if not desirable.)