### PR TITLE
Add 'Client' suffix to some 'World' methods to indicate that they only work on the client

### DIFF
--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -45,6 +45,10 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 2 old
 		ARG 3 updated
 	METHOD method_17452 addImportantParticleClient (Lnet/minecraft/class_2394;ZDDDDDD)V
+		COMMENT Adds an important particle to the client's world renderer. Important particles get added even if the Particles graphics option is set to Minimal
+		COMMENT Does nothing on the server.
+		COMMENT
+		COMMENT @see ServerWorld#spawnParticles
 		ARG 1 parameters
 		ARG 2 force
 		ARG 3 x
@@ -135,9 +139,10 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 	METHOD method_43126 getSpawnPos ()Lnet/minecraft/class_2338;
 	METHOD method_43127 getSpawnAngle ()F
 	METHOD method_43128 playSound (Lnet/minecraft/class_1297;DDDLnet/minecraft/class_3414;Lnet/minecraft/class_3419;FF)V
+		COMMENT Plays a sound caused by a source. On the client, the sound will only play if the source is the same as the client's player.
+		COMMENT On the server, sound packets will be sent to players around the source, excluding the source itself.
 		ARG 1 source
-			COMMENT the player that caused this sound, or {@code null}. On the client, the sound will only if if the source is the same as the client's player.
-			COMMENT On the server, sound packets will be sent to players around the source, excluding the source itself.
+			COMMENT the player that caused this sound, or {@code null}
 		ARG 2 x
 		ARG 4 y
 		ARG 6 z
@@ -146,9 +151,10 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 10 volume
 		ARG 11 pitch
 	METHOD method_43129 playSoundFromEntity (Lnet/minecraft/class_1297;Lnet/minecraft/class_1297;Lnet/minecraft/class_3414;Lnet/minecraft/class_3419;FF)V
+		COMMENT Plays a sound caused by a source at the provided entity's position. On the client, the sound will only play if the source is the same as the client's player.
+		COMMENT On the server, sound packets will be sent to players around the source, excluding the source itself.
 		ARG 1 source
-			COMMENT the player that caused this sound, or {@code null}. On the client, the sound will only if if the source is the same as the client's player.
-			COMMENT On the server, sound packets will be sent to players around the source, excluding the source itself.
+			COMMENT the player that caused this sound, or {@code null}
 		ARG 2 entity
 		ARG 3 sound
 		ARG 4 category
@@ -190,9 +196,10 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 	METHOD method_47576 (Ljava/util/function/Predicate;Ljava/util/List;ILnet/minecraft/class_5575;Lnet/minecraft/class_1297;)Lnet/minecraft/class_7927$class_7928;
 		ARG 4 entity
 	METHOD method_47967 playSound (Lnet/minecraft/class_1297;DDDLnet/minecraft/class_3414;Lnet/minecraft/class_3419;FFJ)V
+		COMMENT Plays a sound caused by a source. On the client, the sound will only play if the source is the same as the client's player.
+		COMMENT On the server, sound packets will be sent to players around the source, excluding the source itself.
 		ARG 1 source
-			COMMENT the player that caused this sound, or {@code null}. On the client, the sound will only if if the source is the same as the client's player.
-			COMMENT On the server, sound packets will be sent to players around the source, excluding the source itself.
+			COMMENT the player that caused this sound, or {@code null}
 		ARG 2 x
 		ARG 4 y
 		ARG 6 z
@@ -285,9 +292,10 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 	METHOD method_8442 getSkyAngleRadians (F)F
 		ARG 1 tickDelta
 	METHOD method_8449 playSoundFromEntity (Lnet/minecraft/class_1297;Lnet/minecraft/class_1297;Lnet/minecraft/class_6880;Lnet/minecraft/class_3419;FFJ)V
+		COMMENT Plays a sound caused by a source at the provided entity's position. On the client, the sound will only play if the source is the same as the client's player.
+		COMMENT On the server, sound packets will be sent to players around the source, excluding the source itself.
 		ARG 1 source
-			COMMENT the player that caused this sound, or {@code null}. On the client, the sound will only if if the source is the same as the client's player.
-			COMMENT On the server, sound packets will be sent to players around the source, excluding the source itself.
+			COMMENT the player that caused this sound, or {@code null}
 		ARG 2 entity
 		ARG 3 sound
 		ARG 4 category
@@ -325,9 +333,10 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 2 block
 	METHOD method_8458 isSavingDisabled ()Z
 	METHOD method_8465 playSound (Lnet/minecraft/class_1297;DDDLnet/minecraft/class_6880;Lnet/minecraft/class_3419;FFJ)V
+		COMMENT Plays a sound caused by a source. On the client, the sound will only play if the source is the same as the client's player.
+		COMMENT On the server, sound packets will be sent to players around the source, excluding the source itself.
 		ARG 1 source
-			COMMENT the player that caused this sound, or {@code null}. On the client, the sound will only if if the source is the same as the client's player.
-			COMMENT On the server, sound packets will be sent to players around the source, excluding the source itself.
+			COMMENT the player that caused this sound, or {@code null}
 		ARG 2 x
 		ARG 4 y
 		ARG 6 z
@@ -337,6 +346,10 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 11 pitch
 		ARG 12 seed
 	METHOD method_8466 addParticleClient (Lnet/minecraft/class_2394;ZZDDDDDD)V
+		COMMENT Adds a particle to the client's world renderer.
+		COMMENT Does nothing on the server.
+		COMMENT
+		COMMENT @see ServerWorld#spawnParticles
 		ARG 1 parameters
 		ARG 2 force
 		ARG 3 canSpawnOnMinimal
@@ -380,6 +393,10 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 2 sourceBlock
 		ARG 3 orientation
 	METHOD method_8494 addImportantParticleClient (Lnet/minecraft/class_2394;DDDDDD)V
+		COMMENT Adds an important particle to the client's world renderer. Important particles get added even if the Particles graphics option is set to Minimal
+		COMMENT Does nothing on the server.
+		COMMENT
+		COMMENT @see ServerWorld#spawnParticles
 		ARG 1 parameters
 		ARG 2 x
 		ARG 4 y

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -135,6 +135,9 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 	METHOD method_43126 getSpawnPos ()Lnet/minecraft/class_2338;
 	METHOD method_43127 getSpawnAngle ()F
 	METHOD method_43128 playSound (Lnet/minecraft/class_1297;DDDLnet/minecraft/class_3414;Lnet/minecraft/class_3419;FF)V
+		ARG 1 source
+			COMMENT the player that caused this sound, or {@code null}. On the client, the sound will only if if the source is the same as the client's player.
+			COMMENT On the server, sound packets will be sent to players around the source, excluding the source itself.
 		ARG 2 x
 		ARG 4 y
 		ARG 6 z
@@ -143,6 +146,9 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 10 volume
 		ARG 11 pitch
 	METHOD method_43129 playSoundFromEntity (Lnet/minecraft/class_1297;Lnet/minecraft/class_1297;Lnet/minecraft/class_3414;Lnet/minecraft/class_3419;FF)V
+		ARG 1 source
+			COMMENT the player that caused this sound, or {@code null}. On the client, the sound will only if if the source is the same as the client's player.
+			COMMENT On the server, sound packets will be sent to players around the source, excluding the source itself.
 		ARG 2 entity
 		ARG 3 sound
 		ARG 4 category
@@ -184,6 +190,9 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 	METHOD method_47576 (Ljava/util/function/Predicate;Ljava/util/List;ILnet/minecraft/class_5575;Lnet/minecraft/class_1297;)Lnet/minecraft/class_7927$class_7928;
 		ARG 4 entity
 	METHOD method_47967 playSound (Lnet/minecraft/class_1297;DDDLnet/minecraft/class_3414;Lnet/minecraft/class_3419;FFJ)V
+		ARG 1 source
+			COMMENT the player that caused this sound, or {@code null}. On the client, the sound will only if if the source is the same as the client's player.
+			COMMENT On the server, sound packets will be sent to players around the source, excluding the source itself.
 		ARG 2 x
 		ARG 4 y
 		ARG 6 z
@@ -277,6 +286,8 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 1 tickDelta
 	METHOD method_8449 playSoundFromEntity (Lnet/minecraft/class_1297;Lnet/minecraft/class_1297;Lnet/minecraft/class_6880;Lnet/minecraft/class_3419;FFJ)V
 		ARG 1 source
+			COMMENT the player that caused this sound, or {@code null}. On the client, the sound will only if if the source is the same as the client's player.
+			COMMENT On the server, sound packets will be sent to players around the source, excluding the source itself.
 		ARG 2 entity
 		ARG 3 sound
 		ARG 4 category
@@ -315,6 +326,8 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 	METHOD method_8458 isSavingDisabled ()Z
 	METHOD method_8465 playSound (Lnet/minecraft/class_1297;DDDLnet/minecraft/class_6880;Lnet/minecraft/class_3419;FFJ)V
 		ARG 1 source
+			COMMENT the player that caused this sound, or {@code null}. On the client, the sound will only if if the source is the same as the client's player.
+			COMMENT On the server, sound packets will be sent to players around the source, excluding the source itself.
 		ARG 2 x
 		ARG 4 y
 		ARG 6 z

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -44,7 +44,7 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 1 pos
 		ARG 2 old
 		ARG 3 updated
-	METHOD method_17452 addImportantParticle (Lnet/minecraft/class_2394;ZDDDDDD)V
+	METHOD method_17452 addImportantParticleClient (Lnet/minecraft/class_2394;ZDDDDDD)V
 		ARG 1 parameters
 		ARG 2 force
 		ARG 3 x
@@ -148,7 +148,7 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 4 category
 		ARG 5 volume
 		ARG 6 pitch
-	METHOD method_45446 playSoundAtBlockCenter (Lnet/minecraft/class_2338;Lnet/minecraft/class_3414;Lnet/minecraft/class_3419;FFZ)V
+	METHOD method_45446 playSoundAtBlockCenterClient (Lnet/minecraft/class_2338;Lnet/minecraft/class_3414;Lnet/minecraft/class_3419;FFZ)V
 		ARG 1 pos
 		ARG 2 sound
 		ARG 3 category
@@ -203,7 +203,7 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 6 z
 		ARG 8 sound
 		ARG 9 category
-	METHOD method_55116 playSoundFromEntity (Lnet/minecraft/class_1297;Lnet/minecraft/class_3414;Lnet/minecraft/class_3419;FF)V
+	METHOD method_55116 playSoundFromEntityClient (Lnet/minecraft/class_1297;Lnet/minecraft/class_3414;Lnet/minecraft/class_3419;FF)V
 		ARG 1 entity
 		ARG 2 sound
 		ARG 3 category
@@ -323,7 +323,7 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 10 volume
 		ARG 11 pitch
 		ARG 12 seed
-	METHOD method_8466 addParticle (Lnet/minecraft/class_2394;ZZDDDDDD)V
+	METHOD method_8466 addParticleClient (Lnet/minecraft/class_2394;ZZDDDDDD)V
 		ARG 1 parameters
 		ARG 2 force
 		ARG 3 canSpawnOnMinimal
@@ -349,7 +349,7 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 1 pos
 	METHOD method_8478 getThunderGradient (F)F
 		ARG 1 delta
-	METHOD method_8486 playSound (DDDLnet/minecraft/class_3414;Lnet/minecraft/class_3419;FFZ)V
+	METHOD method_8486 playSoundClient (DDDLnet/minecraft/class_3414;Lnet/minecraft/class_3419;FFZ)V
 		ARG 1 x
 		ARG 3 y
 		ARG 5 z
@@ -366,7 +366,7 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 1 pos
 		ARG 2 sourceBlock
 		ARG 3 orientation
-	METHOD method_8494 addImportantParticle (Lnet/minecraft/class_2394;DDDDDD)V
+	METHOD method_8494 addImportantParticleClient (Lnet/minecraft/class_2394;DDDDDD)V
 		ARG 1 parameters
 		ARG 2 x
 		ARG 4 y

--- a/mappings/net/minecraft/world/WorldAccess.mapping
+++ b/mappings/net/minecraft/world/WorldAccess.mapping
@@ -46,7 +46,7 @@ CLASS net/minecraft/class_1936 net/minecraft/world/WorldAccess
 	METHOD method_8401 getLevelProperties ()Lnet/minecraft/class_5217;
 	METHOD method_8404 getLocalDifficulty (Lnet/minecraft/class_2338;)Lnet/minecraft/class_1266;
 		ARG 1 pos
-	METHOD method_8406 addParticle (Lnet/minecraft/class_2394;DDDDDD)V
+	METHOD method_8406 addParticleClient (Lnet/minecraft/class_2394;DDDDDD)V
 		ARG 1 parameters
 		ARG 2 x
 		ARG 4 y

--- a/mappings/net/minecraft/world/WorldAccess.mapping
+++ b/mappings/net/minecraft/world/WorldAccess.mapping
@@ -47,6 +47,10 @@ CLASS net/minecraft/class_1936 net/minecraft/world/WorldAccess
 	METHOD method_8404 getLocalDifficulty (Lnet/minecraft/class_2338;)Lnet/minecraft/class_1266;
 		ARG 1 pos
 	METHOD method_8406 addParticleClient (Lnet/minecraft/class_2394;DDDDDD)V
+		COMMENT Adds a particle to the client's world renderer.
+		COMMENT Does nothing on the server.
+		COMMENT
+		COMMENT @see ServerWorld#spawnParticles
 		ARG 1 parameters
 		ARG 2 x
 		ARG 4 y


### PR DESCRIPTION
- **change: add 'Client' suffix to some 'World' methods to indicate that they only work on the client**
Self-explanatory.
- **change(World#playSound): explain the behavior on client vs. server in more detail**
Explains that, on the client, the sound will play if it's the same as the client's player (`source == this.client.player`). On the server, every player *except the source* will get a sound packet.
- **Add Javadocs to World#add(Important)ParticlesClient**
The Javadocs explain what an "important" particle is, what these methods do on the server (nothing), and reference the `ServerWorld` method used for spawning particles in case the developer is looking for it.
