### PR TITLE
Fix expect entity in world

### DIFF
--- a/mappings/net/minecraft/test/TestContext.mapping
+++ b/mappings/net/minecraft/test/TestContext.mapping
@@ -389,7 +389,7 @@ CLASS net/minecraft/class_4516 net/minecraft/test/TestContext
 	METHOD method_55452 forceTickIceAndSnow ()V
 	METHOD method_55453 forceTickIceAndSnow (Lnet/minecraft/class_2338;)V
 		ARG 1 pos
-	METHOD method_56201 expectEntityAtOrigin (Lnet/minecraft/class_1299;)Lnet/minecraft/class_1297;
+	METHOD method_56201 expectEntityInWorld (Lnet/minecraft/class_1299;)Lnet/minecraft/class_1297;
 		ARG 1 type
 	METHOD method_56202 expectEntity (Lnet/minecraft/class_1299;IIID)Lnet/minecraft/class_1297;
 		ARG 1 type


### PR DESCRIPTION
The actual code is checking for origin, but with a margin of integer max value.