### PR TITLE
Fix/Refactor `VillagerEntity.canBreed` and `wantsToStartBreeding`

### DIFF
--- a/mappings/net/minecraft/entity/passive/VillagerEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/VillagerEntity.mapping
@@ -77,7 +77,7 @@ CLASS net/minecraft/class_1646 net/minecraft/entity/passive/VillagerEntity
 		ARG 2 villager
 	METHOD method_20696 decayGossip ()V
 	METHOD method_20697 eatForBreeding ()V
-	METHOD method_20698 lacksFood ()Z
+	METHOD method_20698 canEatFood ()Z
 	METHOD method_20699 (Lnet/minecraft/class_3218;Lnet/minecraft/class_1297;Lnet/minecraft/class_1309;)V
 		ARG 2 observer
 	METHOD method_20741 hasRecentlySlept (J)Z

--- a/mappings/net/minecraft/entity/passive/VillagerEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/VillagerEntity.mapping
@@ -109,5 +109,5 @@ CLASS net/minecraft/class_1646 net/minecraft/entity/passive/VillagerEntity
 		ARG 2 lastSlept
 	METHOD method_63666 (Lnet/minecraft/class_3218;Lnet/minecraft/class_1640;)V
 		ARG 2 witch
-	METHOD method_7234 wantsToStartBreeding ()Z
-	METHOD method_7239 canBreed ()Z
+	METHOD method_7234 canShareFoodForBreeding ()Z
+	METHOD method_7239 needsFoodForBreeding ()Z


### PR DESCRIPTION
The method `VillagerEntity.canBreed` returns true if the villager is **unable** to breed.
The method `VillagerEntity.wantsToStartBreeding` may sometimes return false even if the villager is willing to breed. It only returns true if the villager has *twice over* the amount of food required to start breeding.

In practice, these methods are only ever used to check whether two villagers should share food with each other. They're never used to trigger or prevent the actual breeding task. (The method used for that purpose is `isReadyToBreed`.)

I propose:
`can(not)Breed` -> `needsFoodForBreeding`
`wantsToStartBreeding` -> `canShareFoodForBreeding`