### PR TITLE
Rename the LootTable#shuffle method to spreadStacks

### DIFF
--- a/mappings/net/minecraft/loot/LootTable.mapping
+++ b/mappings/net/minecraft/loot/LootTable.mapping
@@ -39,8 +39,8 @@ CLASS net/minecraft/class_52 net/minecraft/loot/LootTable
 	METHOD method_332 processStacks (Lnet/minecraft/class_3218;Ljava/util/function/Consumer;)Ljava/util/function/Consumer;
 		ARG 0 world
 		ARG 1 consumer
-	METHOD method_333 shuffle (Lit/unimi/dsi/fastutil/objects/ObjectArrayList;ILnet/minecraft/class_5819;)V
-		ARG 1 drops
+	METHOD method_333 spreadStacks (Lit/unimi/dsi/fastutil/objects/ObjectArrayList;ILnet/minecraft/class_5819;)V
+		ARG 1 stacks
 		ARG 2 freeSlots
 		ARG 3 random
 	METHOD method_51878 generateLoot (Lnet/minecraft/class_8567;)Lit/unimi/dsi/fastutil/objects/ObjectArrayList;


### PR DESCRIPTION
This pull request changes fixes the misleading name of the `LootTable#shuffle` method, which is primarily meant to change the distribution of items in stacks when generating container loot. While this method does shuffle the resulting list, shuffling is also a side effect of ensuring the stack distribution is random as opposed to shuffling the input stacks, and other steps of the loot generation process shuffle the stacks themselves anyways.