### PR TITLE
Rename `CommandTreeS2CPacket.rootSize` to `rootIndex`

### DIFF
--- a/mappings/net/minecraft/network/packet/s2c/play/CommandTreeS2CPacket.mapping
+++ b/mappings/net/minecraft/network/packet/s2c/play/CommandTreeS2CPacket.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_2641 net/minecraft/network/packet/s2c/play/CommandTree
 	FIELD field_38039 nodes Ljava/util/List;
 	FIELD field_47914 CODEC Lnet/minecraft/class_9139;
 	METHOD <init> (Lcom/mojang/brigadier/tree/RootCommandNode;)V
-		ARG 1 rootNode
+		ARG 1 rootIndex
 	METHOD <init> (Lnet/minecraft/class_2540;)V
 		ARG 1 buf
 	METHOD method_11401 createNodeData (Lcom/mojang/brigadier/tree/CommandNode;Lit/unimi/dsi/fastutil/objects/Object2IntMap;)Lnet/minecraft/class_2641$class_2642;


### PR DESCRIPTION
It would be more logical because it has nothing to do with size/length.

This is the context it is used in:
```java
// CommandTreeS2CPacket lines 183 - 185
public RootCommandNode<CommandSource> getCommandTree(CommandRegistryAccess commandRegistryAccess) {
    return (RootCommandNode)new CommandTree(commandRegistryAccess, this.nodes).getNode(this.rootSize /* here */);
}
```