### PR TITLE
Fix misleading `LEVEL_3_MIN` field

### DIFF
--- a/mappings/net/minecraft/state/property/Properties.mapping
+++ b/mappings/net/minecraft/state/property/Properties.mapping
@@ -216,7 +216,7 @@ CLASS net/minecraft/class_2741 net/minecraft/state/property/Properties
 		COMMENT A property that specifies the amount of berries in a cave vines block.
 	FIELD field_28717 TILT Lnet/minecraft/class_2754;
 		COMMENT A property that specifies how a big dripleaf is tilted down.
-	FIELD field_31387 LEVEL_3_MIN I
+	FIELD field_31387 LEVEL_8_MIN I
 	FIELD field_31388 LEVEL_1_8_MIN I
 	FIELD field_31389 LEVEL_3_MAX I
 	FIELD field_31390 LEVEL_1_8_MAX I


### PR DESCRIPTION
`LEVEL_3` is 1 - 3 (e.g. non-empty cauldrons), so a constant field of zero won't be its minimum.
`LEVEL_8` is 0 - 8 (e.g. composters), and is just after, so `field_31387` is more likely to be for that.

It does leave `field_31388` immediately underneath in a slightly awkward position, as it's a constant of one, so could either be `LEVEL_1_8_MIN` (as it is now) or `LEVEL_3_MIN` (to match `field_31389` immediate after it).
I suppose `field_31390` is in a similar position being a constant of eight, it could be `LEVEL_1_8_MAX` (as it is now) or `LEVEL_8_MAX` (to correspond to `LEVEL_8_MIN`).