### PR TITLE
Rename the LootContext#requireParameter method to getOrThrow

### DIFF
--- a/mappings/net/minecraft/loot/context/LootContext.mapping
+++ b/mappings/net/minecraft/loot/context/LootContext.mapping
@@ -19,7 +19,7 @@ CLASS net/minecraft/class_47 net/minecraft/loot/context/LootContext
 	METHOD method_300 hasParameter (Lnet/minecraft/class_169;)Z
 		ARG 1 parameter
 	METHOD method_302 getLuck ()F
-	METHOD method_35508 requireParameter (Lnet/minecraft/class_169;)Ljava/lang/Object;
+	METHOD method_35508 getOrThrow (Lnet/minecraft/class_169;)Ljava/lang/Object;
 		ARG 1 parameter
 	METHOD method_51183 getLookup ()Lnet/minecraft/class_7871$class_7872;
 	METHOD method_51184 isActive (Lnet/minecraft/class_47$class_8487;)Z


### PR DESCRIPTION
This pull request renames the `LootContext#requireParameter` method to be more consistent with other classes that expose combinations of throwing, nullable-returning, and optional-returning methods for lookups. In fact, the implementation of this method calls the `ContextParameterMap#getOrThrow` method.