### PR TITLE
Correct typo in StringIdentifiable#createCodec Javadoc

### DIFF
--- a/mappings/net/minecraft/util/StringIdentifiable.mapping
+++ b/mappings/net/minecraft/util/StringIdentifiable.mapping
@@ -10,8 +10,7 @@ CLASS net/minecraft/class_3542 net/minecraft/util/StringIdentifiable
 		COMMENT {@return the unique string representation of the enum, used for serialization}
 	METHOD method_28140 createCodec (Ljava/util/function/Supplier;)Lnet/minecraft/class_3542$class_7292;
 		COMMENT Creates a codec that serializes an enum implementing this interface either
-		COMMENT using its ordinals (when compressed) or using its {@link #asString()} method
-		COMMENT and a given decode function.
+		COMMENT using its ordinals (when compressed) or using its {@link #asString()} method.
 		ARG 0 enumValues
 	METHOD method_28142 toKeyable ([Lnet/minecraft/class_3542;)Lcom/mojang/serialization/Keyable;
 		ARG 0 values


### PR DESCRIPTION
There is an overload which takes a decode function (`method_49454`, although it calls it `valueNameTransformer` rather than something like `decoder`), but this function doesn't and will just use `StringIdentifiable#asString` for serialisation