### PR TITLE
added mapping for field_19178 in BeaconBeamEntity

### DIFF
--- a/mappings/net/minecraft/block/entity/BeaconBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BeaconBlockEntity.mapping
@@ -8,6 +8,7 @@ CLASS net/minecraft/class_2580 net/minecraft/block/entity/BeaconBlockEntity
 	FIELD field_17377 lock Lnet/minecraft/class_1273;
 	FIELD field_17378 propertyDelegate Lnet/minecraft/class_3913;
 	FIELD field_19177 beamSegments Ljava/util/List;
+	FIELD field_19178 tempBeamSegments Ljava/util/List;
 	FIELD field_19179 minY I
 	FIELD field_31300 LEVEL_PROPERTY_INDEX I
 	FIELD field_31301 PRIMARY_PROPERTY_INDEX I


### PR DESCRIPTION
## Class Location
`net.minecraft.block.entity.BeaconBeamEntity`
## Field Definition
```java
private List<BeamSegment> field_19178 = Lists.newArrayList();
```
## Proposed Name
`tempBeaconSegments`

## Usage
This field is used exclusively in the `BeaconBlockEntity#tick` method as a buffer to temporarily hold the new instances of `BeamSegment` before they are pushed to the main list, which is used for rendering, `beamSegments`.