### PR TITLE
Rename tickDelta to tickProgress

### DIFF
--- a/mappings/com/mojang/blaze3d/systems/RenderSystem.mapping
+++ b/mappings/com/mojang/blaze3d/systems/RenderSystem.mapping
@@ -170,7 +170,7 @@ CLASS com/mojang/blaze3d/systems/RenderSystem
 		ARG 3 alpha
 	METHOD setShaderGameTime (JF)V
 		ARG 0 time
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 	METHOD setShaderTexture (II)V
 		ARG 0 texture
 		ARG 1 glId

--- a/mappings/net/minecraft/block/ChestBlock.mapping
+++ b/mappings/net/minecraft/block/ChestBlock.mapping
@@ -43,4 +43,4 @@ CLASS net/minecraft/class_2281 net/minecraft/block/ChestBlock
 		ARG 0 state
 	CLASS 3
 		METHOD method_23900 (Lnet/minecraft/class_2595;Lnet/minecraft/class_2595;F)F
-			ARG 2 tickDelta
+			ARG 2 tickProgress

--- a/mappings/net/minecraft/block/entity/ChestLidAnimator.mapping
+++ b/mappings/net/minecraft/block/entity/ChestLidAnimator.mapping
@@ -5,6 +5,6 @@ CLASS net/minecraft/class_5560 net/minecraft/block/entity/ChestLidAnimator
 	FIELD field_27214 lastProgress F
 	METHOD method_31672 step ()V
 	METHOD method_31673 getProgress (F)F
-		ARG 1 delta
+		ARG 1 tickProgress
 	METHOD method_31674 setOpen (Z)V
 		ARG 1 open

--- a/mappings/net/minecraft/block/entity/ConduitBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/ConduitBlockEntity.mapping
@@ -27,7 +27,7 @@ CLASS net/minecraft/class_2597 net/minecraft/block/entity/ConduitBlockEntity
 	METHOD method_11060 (Lnet/minecraft/class_1309;)Z
 		ARG 0 entity
 	METHOD method_11061 getRotation (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_11062 setEyeOpen (Z)V
 		ARG 1 eyeOpen
 	METHOD method_11063 spawnNautilusParticles (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Ljava/util/List;Lnet/minecraft/class_1297;I)V

--- a/mappings/net/minecraft/block/entity/EndGatewayBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/EndGatewayBlockEntity.mapping
@@ -15,7 +15,7 @@ CLASS net/minecraft/class_2643 net/minecraft/block/entity/EndGatewayBlockEntity
 		ARG 2 state
 		ARG 3 blockEntity
 	METHOD method_11412 getCooldownBeamHeight (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_11413 findPortalPosition (Lnet/minecraft/class_2818;)Lnet/minecraft/class_2338;
 		ARG 0 chunk
 	METHOD method_11414 getChunk (Lnet/minecraft/class_1937;Lnet/minecraft/class_243;)Lnet/minecraft/class_2818;
@@ -27,7 +27,7 @@ CLASS net/minecraft/class_2643 net/minecraft/block/entity/EndGatewayBlockEntity
 		ARG 1 pos
 		ARG 2 config
 	METHOD method_11417 getRecentlyGeneratedBeamHeight (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_11418 setExitPortalPos (Lnet/minecraft/class_2338;Z)V
 		ARG 1 pos
 		ARG 2 exactTeleport

--- a/mappings/net/minecraft/block/entity/LidOpenable.mapping
+++ b/mappings/net/minecraft/block/entity/LidOpenable.mapping
@@ -2,4 +2,4 @@ CLASS net/minecraft/class_2618 net/minecraft/block/entity/LidOpenable
 	COMMENT An interface implemented by block entities with openable lids,
 	COMMENT such as chests or ender chests.
 	METHOD method_11274 getAnimationProgress (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress

--- a/mappings/net/minecraft/block/entity/PistonBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/PistonBlockEntity.mapping
@@ -19,13 +19,13 @@ CLASS net/minecraft/class_2669 net/minecraft/block/entity/PistonBlockEntity
 		ARG 5 extending
 		ARG 6 source
 	METHOD method_11494 getRenderOffsetX (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_11495 getPushedBlock ()Lnet/minecraft/class_2680;
 	METHOD method_11496 getHeadBlockState ()Lnet/minecraft/class_2680;
 	METHOD method_11497 getIntersectionSize (Lnet/minecraft/class_238;Lnet/minecraft/class_2350;Lnet/minecraft/class_238;)D
 	METHOD method_11498 getFacing ()Lnet/minecraft/class_2350;
 	METHOD method_11499 getProgress (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_11500 offsetHeadBox (Lnet/minecraft/class_2338;Lnet/minecraft/class_238;Lnet/minecraft/class_2669;)Lnet/minecraft/class_238;
 		ARG 0 pos
 		ARG 1 box
@@ -39,10 +39,10 @@ CLASS net/minecraft/class_2669 net/minecraft/block/entity/PistonBlockEntity
 		ARG 1 progress
 	METHOD method_11506 getMovementDirection ()Lnet/minecraft/class_2350;
 	METHOD method_11507 getRenderOffsetZ (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_11508 getSavedWorldTime ()J
 	METHOD method_11511 getRenderOffsetY (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_11512 getCollisionShape (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Lnet/minecraft/class_265;
 		ARG 1 world
 		ARG 2 pos

--- a/mappings/net/minecraft/block/entity/ShulkerBoxBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/ShulkerBoxBlockEntity.mapping
@@ -15,7 +15,7 @@ CLASS net/minecraft/class_2627 net/minecraft/block/entity/ShulkerBoxBlockEntity
 		ARG 1 pos
 		ARG 2 state
 	METHOD method_11312 getAnimationProgress (F)F
-		ARG 1 delta
+		ARG 1 tickProgress
 	METHOD method_11313 getAnimationStage ()Lnet/minecraft/class_2627$class_2628;
 	METHOD method_11314 getBoundingBox (Lnet/minecraft/class_2680;)Lnet/minecraft/class_238;
 		ARG 1 state

--- a/mappings/net/minecraft/block/entity/SkullBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/SkullBlockEntity.mapping
@@ -24,7 +24,7 @@ CLASS net/minecraft/class_2631 net/minecraft/block/entity/SkullBlockEntity
 		ARG 1 executor
 	METHOD method_39766 clearServices ()V
 	METHOD method_47588 getPoweredTicks (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_47589 tick (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2631;)V
 		ARG 0 world
 		ARG 1 pos

--- a/mappings/net/minecraft/client/gui/Drawable.mapping
+++ b/mappings/net/minecraft/client/gui/Drawable.mapping
@@ -3,4 +3,4 @@ CLASS net/minecraft/class_4068 net/minecraft/client/gui/Drawable
 		ARG 1 context
 		ARG 2 mouseX
 		ARG 3 mouseY
-		ARG 4 delta
+		ARG 4 tickDelta

--- a/mappings/net/minecraft/client/gui/Drawable.mapping
+++ b/mappings/net/minecraft/client/gui/Drawable.mapping
@@ -3,4 +3,4 @@ CLASS net/minecraft/class_4068 net/minecraft/client/gui/Drawable
 		ARG 1 context
 		ARG 2 mouseX
 		ARG 3 mouseY
-		ARG 4 tickDelta
+		ARG 4 deltaTicks

--- a/mappings/net/minecraft/client/gui/RotatingCubeMapRenderer.mapping
+++ b/mappings/net/minecraft/client/gui/RotatingCubeMapRenderer.mapping
@@ -10,7 +10,7 @@ CLASS net/minecraft/class_766 net/minecraft/client/gui/RotatingCubeMapRenderer
 		ARG 2 width
 		ARG 3 height
 		ARG 4 alpha
-		ARG 5 tickDelta
+		ARG 5 tickProgress
 	METHOD method_45780 wrapOnce (FF)F
 		ARG 0 a
 		ARG 1 b

--- a/mappings/net/minecraft/client/gui/screen/Screen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/Screen.mapping
@@ -57,7 +57,7 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 		ARG 1 context
 		ARG 2 mouseX
 		ARG 3 mouseY
-		ARG 4 tickDelta
+		ARG 4 deltaTicks
 	METHOD method_25421 shouldPause ()Z
 	METHOD method_25422 shouldCloseOnEsc ()Z
 		COMMENT Checks whether this screen should be closed when the escape key is pressed.
@@ -129,7 +129,7 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 		ARG 1 context
 		ARG 2 mouseX
 		ARG 3 mouseY
-		ARG 4 tickDelta
+		ARG 4 deltaTicks
 	METHOD method_47414 setTooltip (Ljava/util/List;)V
 		ARG 1 tooltip
 	METHOD method_47415 setTooltip (Lnet/minecraft/class_2561;)V
@@ -165,7 +165,7 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 		COMMENT This should be overridden with a call to {@link #setInitialFocus(Element)} to set the element that is initially focused.
 	METHOD method_57728 renderPanoramaBackground (Lnet/minecraft/class_332;F)V
 		ARG 1 context
-		ARG 2 tickDelta
+		ARG 2 deltaTicks
 	METHOD method_57734 applyBlur ()V
 	METHOD method_57735 renderDarkening (Lnet/minecraft/class_332;)V
 		ARG 1 context

--- a/mappings/net/minecraft/client/gui/screen/Screen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/Screen.mapping
@@ -57,7 +57,7 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 		ARG 1 context
 		ARG 2 mouseX
 		ARG 3 mouseY
-		ARG 4 delta
+		ARG 4 tickDelta
 	METHOD method_25421 shouldPause ()Z
 	METHOD method_25422 shouldCloseOnEsc ()Z
 		COMMENT Checks whether this screen should be closed when the escape key is pressed.
@@ -129,7 +129,7 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 		ARG 1 context
 		ARG 2 mouseX
 		ARG 3 mouseY
-		ARG 4 delta
+		ARG 4 tickDelta
 	METHOD method_47414 setTooltip (Ljava/util/List;)V
 		ARG 1 tooltip
 	METHOD method_47415 setTooltip (Lnet/minecraft/class_2561;)V
@@ -165,7 +165,7 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 		COMMENT This should be overridden with a call to {@link #setInitialFocus(Element)} to set the element that is initially focused.
 	METHOD method_57728 renderPanoramaBackground (Lnet/minecraft/class_332;F)V
 		ARG 1 context
-		ARG 2 delta
+		ARG 2 tickDelta
 	METHOD method_57734 applyBlur ()V
 	METHOD method_57735 renderDarkening (Lnet/minecraft/class_332;)V
 		ARG 1 context

--- a/mappings/net/minecraft/client/gui/screen/ingame/CyclingSlotIcon.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/CyclingSlotIcon.mapping
@@ -6,11 +6,11 @@ CLASS net/minecraft/class_8064 net/minecraft/client/gui/screen/ingame/CyclingSlo
 	METHOD <init> (I)V
 		ARG 1 slotId
 	METHOD method_48468 computeAlpha (F)F
-		ARG 1 tickDelta
+		ARG 1 deltaTicks
 	METHOD method_48469 render (Lnet/minecraft/class_1703;Lnet/minecraft/class_332;FII)V
 		ARG 1 screenHandler
 		ARG 2 context
-		ARG 3 tickDelta
+		ARG 3 deltaTicks
 		ARG 4 x
 		ARG 5 y
 	METHOD method_48470 drawIcon (Lnet/minecraft/class_1735;Lnet/minecraft/class_2960;FLnet/minecraft/class_332;II)V

--- a/mappings/net/minecraft/client/gui/screen/ingame/CyclingSlotIcon.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/CyclingSlotIcon.mapping
@@ -6,11 +6,11 @@ CLASS net/minecraft/class_8064 net/minecraft/client/gui/screen/ingame/CyclingSlo
 	METHOD <init> (I)V
 		ARG 1 slotId
 	METHOD method_48468 computeAlpha (F)F
-		ARG 1 delta
+		ARG 1 tickDelta
 	METHOD method_48469 render (Lnet/minecraft/class_1703;Lnet/minecraft/class_332;FII)V
 		ARG 1 screenHandler
 		ARG 2 context
-		ARG 3 delta
+		ARG 3 tickDelta
 		ARG 4 x
 		ARG 5 y
 	METHOD method_48470 drawIcon (Lnet/minecraft/class_1735;Lnet/minecraft/class_2960;FLnet/minecraft/class_332;II)V

--- a/mappings/net/minecraft/client/gui/screen/ingame/EnchantmentScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/EnchantmentScreen.mapping
@@ -24,6 +24,6 @@ CLASS net/minecraft/class_486 net/minecraft/client/gui/screen/ingame/Enchantment
 		ARG 1 context
 		ARG 2 x
 		ARG 3 y
-		ARG 4 delta
+		ARG 4 tickDelta
 	METHOD method_64044 (Lnet/minecraft/class_332;Lnet/minecraft/class_4597;)V
 		ARG 2 vertexConsumers

--- a/mappings/net/minecraft/client/gui/screen/ingame/EnchantmentScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/EnchantmentScreen.mapping
@@ -24,6 +24,6 @@ CLASS net/minecraft/class_486 net/minecraft/client/gui/screen/ingame/Enchantment
 		ARG 1 context
 		ARG 2 x
 		ARG 3 y
-		ARG 4 tickDelta
+		ARG 4 deltaTicks
 	METHOD method_64044 (Lnet/minecraft/class_332;Lnet/minecraft/class_4597;)V
 		ARG 2 vertexConsumers

--- a/mappings/net/minecraft/client/gui/screen/ingame/ForgingScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/ForgingScreen.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_4894 net/minecraft/client/gui/screen/ingame/ForgingScr
 		ARG 1 context
 		ARG 2 mouseX
 		ARG 3 mouseY
-		ARG 4 tickDelta
+		ARG 4 deltaTicks
 	METHOD method_25445 setup ()V
 	METHOD method_48467 drawInvalidRecipeArrow (Lnet/minecraft/class_332;II)V
 		ARG 1 context

--- a/mappings/net/minecraft/client/gui/screen/ingame/ForgingScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/ForgingScreen.mapping
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_4894 net/minecraft/client/gui/screen/ingame/ForgingScr
 		ARG 1 context
 		ARG 2 mouseX
 		ARG 3 mouseY
-		ARG 4 delta
+		ARG 4 tickDelta
 	METHOD method_25445 setup ()V
 	METHOD method_48467 drawInvalidRecipeArrow (Lnet/minecraft/class_332;II)V
 		ARG 1 context

--- a/mappings/net/minecraft/client/gui/screen/ingame/HandledScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/HandledScreen.mapping
@@ -85,7 +85,7 @@ CLASS net/minecraft/class_465 net/minecraft/client/gui/screen/ingame/HandledScre
 		ARG 3 mouseY
 	METHOD method_2389 drawBackground (Lnet/minecraft/class_332;FII)V
 		ARG 1 context
-		ARG 2 delta
+		ARG 2 tickDelta
 		ARG 3 mouseX
 		ARG 4 mouseY
 	METHOD method_30107 onMouseClick (I)V

--- a/mappings/net/minecraft/client/gui/screen/ingame/HandledScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/HandledScreen.mapping
@@ -85,7 +85,7 @@ CLASS net/minecraft/class_465 net/minecraft/client/gui/screen/ingame/HandledScre
 		ARG 3 mouseY
 	METHOD method_2389 drawBackground (Lnet/minecraft/class_332;FII)V
 		ARG 1 context
-		ARG 2 tickDelta
+		ARG 2 deltaTicks
 		ARG 3 mouseX
 		ARG 4 mouseY
 	METHOD method_30107 onMouseClick (I)V

--- a/mappings/net/minecraft/client/gui/screen/ingame/StatusEffectsDisplay.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/StatusEffectsDisplay.mapping
@@ -33,4 +33,4 @@ CLASS net/minecraft/class_485 net/minecraft/client/gui/screen/ingame/StatusEffec
 		ARG 1 context
 		ARG 2 mouseX
 		ARG 3 mouseY
-		ARG 4 tickDelta
+		ARG 4 tickProgress

--- a/mappings/net/minecraft/client/gui/screen/recipebook/RecipeBookResults.mapping
+++ b/mappings/net/minecraft/client/gui/screen/recipebook/RecipeBookResults.mapping
@@ -44,7 +44,7 @@ CLASS net/minecraft/class_513 net/minecraft/client/gui/screen/recipebook/RecipeB
 		ARG 3 y
 		ARG 4 mouseX
 		ARG 5 mouseY
-		ARG 6 delta
+		ARG 6 tickDelta
 	METHOD method_2635 getLastClickedResults ()Lnet/minecraft/class_516;
 	METHOD method_2636 initialize (Lnet/minecraft/class_310;II)V
 		ARG 1 client

--- a/mappings/net/minecraft/client/gui/screen/recipebook/RecipeBookResults.mapping
+++ b/mappings/net/minecraft/client/gui/screen/recipebook/RecipeBookResults.mapping
@@ -44,7 +44,7 @@ CLASS net/minecraft/class_513 net/minecraft/client/gui/screen/recipebook/RecipeB
 		ARG 3 y
 		ARG 4 mouseX
 		ARG 5 mouseY
-		ARG 6 tickDelta
+		ARG 6 deltaTicks
 	METHOD method_2635 getLastClickedResults ()Lnet/minecraft/class_516;
 	METHOD method_2636 initialize (Lnet/minecraft/class_310;II)V
 		ARG 1 client

--- a/mappings/net/minecraft/client/gui/widget/ClickableWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ClickableWidget.mapping
@@ -58,7 +58,7 @@ CLASS net/minecraft/class_339 net/minecraft/client/gui/widget/ClickableWidget
 		ARG 1 context
 		ARG 2 mouseX
 		ARG 3 mouseY
-		ARG 4 tickDelta
+		ARG 4 deltaTicks
 	METHOD method_48591 setNavigationOrder (I)V
 		ARG 1 navigationOrder
 	METHOD method_49604 drawScrollableText (Lnet/minecraft/class_332;Lnet/minecraft/class_327;II)V

--- a/mappings/net/minecraft/client/gui/widget/ClickableWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ClickableWidget.mapping
@@ -58,7 +58,7 @@ CLASS net/minecraft/class_339 net/minecraft/client/gui/widget/ClickableWidget
 		ARG 1 context
 		ARG 2 mouseX
 		ARG 3 mouseY
-		ARG 4 delta
+		ARG 4 tickDelta
 	METHOD method_48591 setNavigationOrder (I)V
 		ARG 1 navigationOrder
 	METHOD method_49604 drawScrollableText (Lnet/minecraft/class_332;Lnet/minecraft/class_327;II)V

--- a/mappings/net/minecraft/client/gui/widget/EntryListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/EntryListWidget.mapping
@@ -31,7 +31,7 @@ CLASS net/minecraft/class_350 net/minecraft/client/gui/widget/EntryListWidget
 		ARG 1 context
 		ARG 2 mouseX
 		ARG 3 mouseY
-		ARG 4 delta
+		ARG 4 tickDelta
 	METHOD method_25312 renderHeader (Lnet/minecraft/class_332;II)V
 		ARG 1 context
 		ARG 2 x

--- a/mappings/net/minecraft/client/gui/widget/EntryListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/EntryListWidget.mapping
@@ -144,7 +144,7 @@ CLASS net/minecraft/class_350 net/minecraft/client/gui/widget/EntryListWidget
 				COMMENT the Y coordinate of the mouse
 			ARG 9 hovered
 				COMMENT whether the mouse is hovering over the entry
-			ARG 10 tickDelta
+			ARG 10 tickProgress
 		METHOD method_49568 drawBorder (Lnet/minecraft/class_332;IIIIIIIZF)V
 			ARG 1 context
 			ARG 2 index
@@ -155,7 +155,7 @@ CLASS net/minecraft/class_350 net/minecraft/client/gui/widget/EntryListWidget
 			ARG 7 mouseX
 			ARG 8 mouseY
 			ARG 9 hovered
-			ARG 10 tickDelta
+			ARG 10 tickProgress
 	CLASS class_352 Entries
 		FIELD field_2146 entries Ljava/util/List;
 		METHOD add (ILjava/lang/Object;)V

--- a/mappings/net/minecraft/client/gui/widget/EntryListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/EntryListWidget.mapping
@@ -31,7 +31,7 @@ CLASS net/minecraft/class_350 net/minecraft/client/gui/widget/EntryListWidget
 		ARG 1 context
 		ARG 2 mouseX
 		ARG 3 mouseY
-		ARG 4 tickDelta
+		ARG 4 deltaTicks
 	METHOD method_25312 renderHeader (Lnet/minecraft/class_332;II)V
 		ARG 1 context
 		ARG 2 x

--- a/mappings/net/minecraft/client/gui/widget/ScrollableTextFieldWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ScrollableTextFieldWidget.mapping
@@ -8,7 +8,7 @@ CLASS net/minecraft/class_10415 net/minecraft/client/gui/widget/ScrollableTextFi
 		ARG 1 context
 		ARG 2 mouseX
 		ARG 3 mouseY
-		ARG 4 delta
+		ARG 4 tickDelta
 	METHOD method_44391 getContentsHeight ()I
 	METHOD method_65509 getTextMargin ()I
 	METHOD method_65510 isVisible (II)Z

--- a/mappings/net/minecraft/client/gui/widget/ScrollableTextFieldWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ScrollableTextFieldWidget.mapping
@@ -8,7 +8,7 @@ CLASS net/minecraft/class_10415 net/minecraft/client/gui/widget/ScrollableTextFi
 		ARG 1 context
 		ARG 2 mouseX
 		ARG 3 mouseY
-		ARG 4 tickDelta
+		ARG 4 deltaTicks
 	METHOD method_44391 getContentsHeight ()I
 	METHOD method_65509 getTextMargin ()I
 	METHOD method_65510 isVisible (II)Z

--- a/mappings/net/minecraft/client/network/AbstractClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/network/AbstractClientPlayerEntity.mapping
@@ -15,5 +15,5 @@ CLASS net/minecraft/class_742 net/minecraft/client/network/AbstractClientPlayerE
 		ARG 2 fovEffectScale
 	METHOD method_3123 getPlayerListEntry ()Lnet/minecraft/class_640;
 	METHOD method_49339 lerpVelocity (F)Lnet/minecraft/class_243;
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_52814 getSkinTextures ()Lnet/minecraft/class_8685;

--- a/mappings/net/minecraft/client/particle/BillboardParticle.mapping
+++ b/mappings/net/minecraft/client/particle/BillboardParticle.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_3940 net/minecraft/client/particle/BillboardParticle
 	FIELD field_17867 scale F
 	METHOD method_18132 getSize (F)F
 		COMMENT {@return the draw scale of this particle, which is used while rendering in {@link #buildGeometry}}
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_18133 getMinU ()F
 		COMMENT {@return the lower U coordinate of the UV coordinates used to draw this particle}
 	METHOD method_18134 getMaxU ()F
@@ -16,13 +16,13 @@ CLASS net/minecraft/class_3940 net/minecraft/client/particle/BillboardParticle
 	METHOD method_60373 render (Lnet/minecraft/class_4588;Lnet/minecraft/class_4184;Lorg/joml/Quaternionf;F)V
 		ARG 1 vertexConsumer
 		ARG 2 camera
-		ARG 4 tickDelta
+		ARG 4 tickProgress
 	METHOD method_60374 render (Lnet/minecraft/class_4588;Lorg/joml/Quaternionf;FFFF)V
 		ARG 1 vertexConsumer
 		ARG 3 x
 		ARG 4 y
 		ARG 5 z
-		ARG 6 tickDelta
+		ARG 6 tickProgress
 	METHOD method_60375 renderVertex (Lnet/minecraft/class_4588;Lorg/joml/Quaternionf;FFFFFFFFI)V
 		ARG 1 vertexConsumer
 		ARG 3 x
@@ -38,12 +38,12 @@ CLASS net/minecraft/class_3940 net/minecraft/client/particle/BillboardParticle
 		METHOD method_55246 (Lorg/joml/Quaternionf;Lnet/minecraft/class_4184;F)V
 			ARG 0 quaternion
 			ARG 1 camera
-			ARG 2 tickDelta
+			ARG 2 tickProgress
 		METHOD method_55247 (Lorg/joml/Quaternionf;Lnet/minecraft/class_4184;F)V
 			ARG 0 quaternion
 			ARG 1 camera
-			ARG 2 tickDelta
+			ARG 2 tickProgress
 		METHOD setRotation (Lorg/joml/Quaternionf;Lnet/minecraft/class_4184;F)V
 			ARG 1 quaternion
 			ARG 2 camera
-			ARG 3 tickDelta
+			ARG 3 tickProgress

--- a/mappings/net/minecraft/client/particle/DustColorTransitionParticle.mapping
+++ b/mappings/net/minecraft/client/particle/DustColorTransitionParticle.mapping
@@ -15,7 +15,7 @@ CLASS net/minecraft/class_5734 net/minecraft/client/particle/DustColorTransition
 		ARG 1 color
 		ARG 2 multiplier
 	METHOD method_33074 updateColor (F)V
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	CLASS class_5735 Factory
 		FIELD field_28246 spriteProvider Lnet/minecraft/class_4002;
 		METHOD <init> (Lnet/minecraft/class_4002;)V

--- a/mappings/net/minecraft/client/particle/Particle.mapping
+++ b/mappings/net/minecraft/client/particle/Particle.mapping
@@ -98,7 +98,6 @@ CLASS net/minecraft/class_703 net/minecraft/client/particle/Particle
 		ARG 2 camera
 			COMMENT the current active game {@link Camera}
 		ARG 3 tickProgress
-			COMMENT frame tick delta amount
 	METHOD method_3075 move (F)Lnet/minecraft/class_703;
 		COMMENT Multiplies this particle's current velocity by the target {@code speed} amount.
 		ARG 1 speed

--- a/mappings/net/minecraft/client/particle/Particle.mapping
+++ b/mappings/net/minecraft/client/particle/Particle.mapping
@@ -97,7 +97,7 @@ CLASS net/minecraft/class_703 net/minecraft/client/particle/Particle
 			COMMENT the buffer to render to
 		ARG 2 camera
 			COMMENT the current active game {@link Camera}
-		ARG 3 tickDelta
+		ARG 3 tickProgress
 			COMMENT frame tick delta amount
 	METHOD method_3075 move (F)Lnet/minecraft/class_703;
 		COMMENT Multiplies this particle's current velocity by the target {@code speed} amount.
@@ -163,11 +163,11 @@ CLASS net/minecraft/class_703 net/minecraft/client/particle/Particle
 		ARG 1 matrices
 		ARG 2 vertexConsumers
 		ARG 3 camera
-		ARG 4 tickDelta
+		ARG 4 tickProgress
 	CLASS class_9213 DynamicAlpha
 		FIELD field_48941 OPAQUE Lnet/minecraft/class_703$class_9213;
 		METHOD method_56833 isOpaque ()Z
 		METHOD method_56834 getAlpha (IIF)F
 			ARG 1 age
 			ARG 2 maxAge
-			ARG 3 tickDelta
+			ARG 3 tickProgress

--- a/mappings/net/minecraft/client/particle/ParticleManager.mapping
+++ b/mappings/net/minecraft/client/particle/ParticleManager.mapping
@@ -41,7 +41,7 @@ CLASS net/minecraft/class_702 net/minecraft/client/particle/ParticleManager
 			COMMENT a collection of particles from the same sheet
 	METHOD method_3049 renderParticles (Lnet/minecraft/class_4184;FLnet/minecraft/class_4597$class_4598;)V
 		ARG 1 camera
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 		ARG 3 vertexConsumers
 	METHOD method_3051 addEmitter (Lnet/minecraft/class_1297;Lnet/minecraft/class_2394;I)V
 		ARG 1 entity
@@ -116,13 +116,13 @@ CLASS net/minecraft/class_702 net/minecraft/client/particle/ParticleManager
 		ARG 2 factory
 	METHOD method_65199 renderParticles (Lnet/minecraft/class_4184;FLnet/minecraft/class_4597$class_4598;Lnet/minecraft/class_3999;Ljava/util/Queue;)V
 		ARG 0 camera
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 		ARG 2 vertexConsumers
 		ARG 3 sheet
 		ARG 4 particles
 	METHOD method_65200 renderCustomParticles (Lnet/minecraft/class_4184;FLnet/minecraft/class_4597$class_4598;Ljava/util/Queue;)V
 		ARG 0 camera
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 		ARG 2 vertexConsumers
 		ARG 3 particles
 	CLASS class_4090 SimpleSpriteProvider

--- a/mappings/net/minecraft/client/render/BackgroundRenderer.mapping
+++ b/mappings/net/minecraft/client/render/BackgroundRenderer.mapping
@@ -12,15 +12,15 @@ CLASS net/minecraft/class_758 net/minecraft/client/render/BackgroundRenderer
 		ARG 2 color
 		ARG 3 viewDistance
 		ARG 4 thickenFog
-		ARG 5 tickDelta
+		ARG 5 tickProgress
 	METHOD method_42588 getFogModifier (Lnet/minecraft/class_1297;F)Lnet/minecraft/class_758$class_7286;
 		ARG 0 entity
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_42589 (Lnet/minecraft/class_1309;FLnet/minecraft/class_758$class_7286;)Z
 		ARG 2 modifier
 	METHOD method_62185 getFogColor (Lnet/minecraft/class_4184;FLnet/minecraft/class_638;IF)Lorg/joml/Vector4f;
 		ARG 0 camera
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 		ARG 2 world
 		ARG 3 clampedViewDistance
 		ARG 4 skyDarkness
@@ -42,12 +42,12 @@ CLASS net/minecraft/class_758 net/minecraft/client/render/BackgroundRenderer
 			ARG 2 entity
 			ARG 3 effect
 			ARG 4 viewDistance
-			ARG 5 tickDelta
+			ARG 5 tickProgress
 		METHOD method_42592 applyColorModifier (Lnet/minecraft/class_1309;Lnet/minecraft/class_1293;FF)F
 			ARG 1 entity
 			ARG 2 effect
 			ARG 3 defaultModifier
-			ARG 4 tickDelta
+			ARG 4 tickProgress
 		METHOD method_42593 shouldApply (Lnet/minecraft/class_1309;F)Z
 			ARG 1 entity
-			ARG 2 tickDelta
+			ARG 2 tickProgress

--- a/mappings/net/minecraft/client/render/Camera.mapping
+++ b/mappings/net/minecraft/client/render/Camera.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/class_4184 net/minecraft/client/render/Camera
 	FIELD field_18721 cameraY F
 	FIELD field_18722 lastCameraY F
 	FIELD field_21518 rotation Lorg/joml/Quaternionf;
-	FIELD field_47549 lastTickDelta F
+	FIELD field_47549 lastTickProgress F
 	FIELD field_47841 BASE_CAMERA_DISTANCE F
 	FIELD field_52123 HORIZONTAL Lorg/joml/Vector3f;
 	FIELD field_52124 VERTICAL Lorg/joml/Vector3f;
@@ -53,7 +53,7 @@ CLASS net/minecraft/class_4184 net/minecraft/client/render/Camera
 		COMMENT {@return the field of vision of this camera}
 		COMMENT
 		COMMENT @see GameRenderer#CAMERA_DEPTH
-	METHOD method_55437 getLastTickDelta ()F
+	METHOD method_55437 getLastTickProgress ()F
 	CLASS class_6355 Projection
 		COMMENT A projection of a camera. It is a 2-D rectangle in a 3-D volume.
 		COMMENT

--- a/mappings/net/minecraft/client/render/Camera.mapping
+++ b/mappings/net/minecraft/client/render/Camera.mapping
@@ -25,7 +25,7 @@ CLASS net/minecraft/class_4184 net/minecraft/client/render/Camera
 		ARG 2 focusedEntity
 		ARG 3 thirdPerson
 		ARG 4 inverseView
-		ARG 5 tickDelta
+		ARG 5 tickProgress
 	METHOD method_19322 setPos (Lnet/minecraft/class_243;)V
 		ARG 1 pos
 	METHOD method_19324 moveBy (FFF)V

--- a/mappings/net/minecraft/client/render/GameRenderer.mapping
+++ b/mappings/net/minecraft/client/render/GameRenderer.mapping
@@ -54,39 +54,39 @@ CLASS net/minecraft/class_757 net/minecraft/client/render/GameRenderer
 		ARG 2 height
 	METHOD method_3171 renderFloatingItem (Lnet/minecraft/class_332;F)V
 		ARG 1 context
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 	METHOD method_3172 renderHand (Lnet/minecraft/class_4184;FLorg/joml/Matrix4f;)V
 		ARG 1 camera
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 	METHOD method_3174 getNightVisionStrength (Lnet/minecraft/class_1309;F)F
 		ARG 0 entity
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_3176 updateWorldIcon (Ljava/nio/file/Path;)V
 		ARG 1 path
 	METHOD method_3182 tick ()V
 	METHOD method_3184 togglePostProcessorEnabled ()V
 	METHOD method_3186 bobView (Lnet/minecraft/class_4587;F)V
 		ARG 1 matrices
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 	METHOD method_3188 renderWorld (Lnet/minecraft/class_9779;)V
 		ARG 1 renderTickCounter
 	METHOD method_3189 showFloatingItem (Lnet/minecraft/class_1799;)V
 		ARG 1 floatingItem
 	METHOD method_3190 updateCrosshairTarget (F)V
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_3192 render (Lnet/minecraft/class_9779;Z)V
 		ARG 1 tickCounter
 		ARG 2 tick
 	METHOD method_3193 getViewDistance ()F
 	METHOD method_3195 getSkyDarkness (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_3196 getFov (Lnet/minecraft/class_4184;FZ)F
 		ARG 1 camera
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 		ARG 3 changingFov
 	METHOD method_3198 tiltViewWhenHurt (Lnet/minecraft/class_4587;F)V
 		ARG 1 matrices
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 	METHOD method_3199 updateFovMultiplier ()V
 	METHOD method_3202 shouldRenderBlockOutline ()Z
 	METHOD method_3203 reset ()V
@@ -112,7 +112,7 @@ CLASS net/minecraft/class_757 net/minecraft/client/render/GameRenderer
 		ARG 1 camera
 		ARG 2 blockInteractionRange
 		ARG 4 entityInteractionRange
-		ARG 6 tickDelta
+		ARG 6 tickProgress
 	METHOD method_56154 ensureTargetInRange (Lnet/minecraft/class_239;Lnet/minecraft/class_243;D)Lnet/minecraft/class_239;
 		ARG 0 hitResult
 		ARG 1 cameraPos

--- a/mappings/net/minecraft/client/render/LightmapTextureManager.mapping
+++ b/mappings/net/minecraft/client/render/LightmapTextureManager.mapping
@@ -31,14 +31,14 @@ CLASS net/minecraft/class_765 net/minecraft/client/render/LightmapTextureManager
 	METHOD method_24187 getSkyLightCoordinates (I)I
 		ARG 0 light
 	METHOD method_3313 update (F)V
-		ARG 1 delta
+		ARG 1 tickProgress
 	METHOD method_3314 tick ()V
 	METHOD method_3315 disable ()V
 	METHOD method_3316 enable ()V
 	METHOD method_42596 getDarkness (Lnet/minecraft/class_1309;FF)F
 		ARG 1 entity
 		ARG 2 factor
-		ARG 3 delta
+		ARG 3 tickProgress
 	METHOD method_62226 getBrightness (FI)F
 		ARG 0 ambientLight
 		ARG 1 lightLevel

--- a/mappings/net/minecraft/client/render/RenderTickCounter.mapping
+++ b/mappings/net/minecraft/client/render/RenderTickCounter.mapping
@@ -1,18 +1,18 @@
 CLASS net/minecraft/class_9779 net/minecraft/client/render/RenderTickCounter
 	FIELD field_51955 ZERO Lnet/minecraft/class_9779;
 	FIELD field_51956 ONE Lnet/minecraft/class_9779;
-	METHOD method_60636 getLastFrameDuration ()F
+	METHOD method_60636 getDynamicTickDelta ()F
 	METHOD method_60637 getTickProgress (Z)F
 		ARG 1 ignoreFreeze
-	METHOD method_60638 getLastDuration ()F
+	METHOD method_60638 getStaticTickDelta ()F
 	CLASS class_9780 Constant
 		FIELD field_51957 value F
 		METHOD <init> (F)V
 			ARG 1 value
 	CLASS class_9781 Dynamic
-		FIELD field_51958 lastFrameDuration F
+		FIELD field_51958 dynamicTickDelta F
 		FIELD field_51959 tickProgress F
-		FIELD field_51960 lastDuration F
+		FIELD field_51960 staticTickDelta F
 		FIELD field_51961 tickProgressBeforePause F
 		FIELD field_51962 lastTimeMillis J
 		FIELD field_51963 timeMillis J

--- a/mappings/net/minecraft/client/render/RenderTickCounter.mapping
+++ b/mappings/net/minecraft/client/render/RenderTickCounter.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_9779 net/minecraft/client/render/RenderTickCounter
 	FIELD field_51955 ZERO Lnet/minecraft/class_9779;
 	FIELD field_51956 ONE Lnet/minecraft/class_9779;
 	METHOD method_60636 getLastFrameDuration ()F
-	METHOD method_60637 getTickDelta (Z)F
+	METHOD method_60637 getTickProgress (Z)F
 		ARG 1 ignoreFreeze
 	METHOD method_60638 getLastDuration ()F
 	CLASS class_9780 Constant

--- a/mappings/net/minecraft/client/render/RenderTickCounter.mapping
+++ b/mappings/net/minecraft/client/render/RenderTickCounter.mapping
@@ -1,18 +1,18 @@
 CLASS net/minecraft/class_9779 net/minecraft/client/render/RenderTickCounter
 	FIELD field_51955 ZERO Lnet/minecraft/class_9779;
 	FIELD field_51956 ONE Lnet/minecraft/class_9779;
-	METHOD method_60636 getDynamicTickDelta ()F
+	METHOD method_60636 getDynamicDeltaTicks ()F
 	METHOD method_60637 getTickProgress (Z)F
 		ARG 1 ignoreFreeze
-	METHOD method_60638 getStaticTickDelta ()F
+	METHOD method_60638 getFixedDeltaTicks ()F
 	CLASS class_9780 Constant
 		FIELD field_51957 value F
 		METHOD <init> (F)V
 			ARG 1 value
 	CLASS class_9781 Dynamic
-		FIELD field_51958 dynamicTickDelta F
+		FIELD field_51958 dynamicDeltaTicks F
 		FIELD field_51959 tickProgress F
-		FIELD field_51960 staticTickDelta F
+		FIELD field_51960 fixedDeltaTicks F
 		FIELD field_51961 tickProgressBeforePause F
 		FIELD field_51962 lastTimeMillis J
 		FIELD field_51963 timeMillis J

--- a/mappings/net/minecraft/client/render/RenderTickCounter.mapping
+++ b/mappings/net/minecraft/client/render/RenderTickCounter.mapping
@@ -11,9 +11,9 @@ CLASS net/minecraft/class_9779 net/minecraft/client/render/RenderTickCounter
 			ARG 1 value
 	CLASS class_9781 Dynamic
 		FIELD field_51958 lastFrameDuration F
-		FIELD field_51959 tickDelta F
+		FIELD field_51959 tickProgress F
 		FIELD field_51960 lastDuration F
-		FIELD field_51961 tickDeltaBeforePause F
+		FIELD field_51961 tickProgressBeforePause F
 		FIELD field_51962 lastTimeMillis J
 		FIELD field_51963 timeMillis J
 		FIELD field_51964 tickTime F

--- a/mappings/net/minecraft/client/render/WeatherRendering.mapping
+++ b/mappings/net/minecraft/client/render/WeatherRendering.mapping
@@ -21,7 +21,7 @@ CLASS net/minecraft/class_9976 net/minecraft/client/render/WeatherRendering
 	METHOD method_62315 buildPrecipitationPieces (Lnet/minecraft/class_1937;IFLnet/minecraft/class_243;ILjava/util/List;Ljava/util/List;)V
 		ARG 1 world
 		ARG 2 ticks
-		ARG 3 delta
+		ARG 3 tickProgress
 		ARG 4 pos
 		ARG 5 range
 		ARG 6 rainOut
@@ -30,7 +30,7 @@ CLASS net/minecraft/class_9976 net/minecraft/client/render/WeatherRendering
 		ARG 1 world
 		ARG 2 vertexConsumers
 		ARG 3 ticks
-		ARG 4 delta
+		ARG 4 tickProgress
 		ARG 5 pos
 	METHOD method_62317 getPrecipitationAt (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)Lnet/minecraft/class_1959$class_1963;
 		ARG 1 world

--- a/mappings/net/minecraft/client/render/WeatherRendering.mapping
+++ b/mappings/net/minecraft/client/render/WeatherRendering.mapping
@@ -17,7 +17,7 @@ CLASS net/minecraft/class_9976 net/minecraft/client/render/WeatherRendering
 		ARG 5 yMax
 		ARG 6 z
 		ARG 7 light
-		ARG 8 tickDelta
+		ARG 8 tickProgress
 	METHOD method_62315 buildPrecipitationPieces (Lnet/minecraft/class_1937;IFLnet/minecraft/class_243;ILjava/util/List;Ljava/util/List;)V
 		ARG 1 world
 		ARG 2 ticks
@@ -62,5 +62,5 @@ CLASS net/minecraft/class_9976 net/minecraft/client/render/WeatherRendering
 		ARG 5 yMax
 		ARG 6 z
 		ARG 7 light
-		ARG 8 tickDelta
+		ARG 8 tickProgress
 	CLASS class_9977 Piece

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -84,7 +84,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 		ARG 2 cameraX
 		ARG 4 cameraY
 		ARG 6 cameraZ
-		ARG 8 tickDelta
+		ARG 8 tickProgress
 		ARG 9 matrices
 		ARG 10 vertexConsumers
 	METHOD method_22979 checkEmpty (Lnet/minecraft/class_4587;)V
@@ -191,7 +191,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 		ARG 0 frustum
 	METHOD method_62196 getCloudRenderer ()Lnet/minecraft/class_9955;
 	METHOD method_62197 isSkyDark (F)Z
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_62198 translucencySort (Lnet/minecraft/class_243;)V
 		ARG 1 cameraPos
 	METHOD method_62199 renderLateDebug (Lnet/minecraft/class_9909;Lnet/minecraft/class_243;Lnet/minecraft/class_9958;)V
@@ -201,12 +201,12 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	METHOD method_62200 renderSky (Lnet/minecraft/class_9909;Lnet/minecraft/class_4184;FLnet/minecraft/class_9958;)V
 		ARG 1 frameGraphBuilder
 		ARG 2 camera
-		ARG 3 tickDelta
+		ARG 3 tickProgress
 		ARG 4 fog
 	METHOD method_62201 renderParticles (Lnet/minecraft/class_9909;Lnet/minecraft/class_4184;FLnet/minecraft/class_9958;)V
 		ARG 1 frameGraphBuilder
 		ARG 2 camera
-		ARG 3 tickDelta
+		ARG 3 tickProgress
 		ARG 4 fog
 	METHOD method_62202 renderMain (Lnet/minecraft/class_9909;Lnet/minecraft/class_4604;Lnet/minecraft/class_4184;Lorg/joml/Matrix4f;Lorg/joml/Matrix4f;Lnet/minecraft/class_9958;ZZLnet/minecraft/class_9779;Lnet/minecraft/class_3695;)V
 		ARG 1 frameGraphBuilder
@@ -222,7 +222,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	METHOD method_62203 renderWeather (Lnet/minecraft/class_9909;Lnet/minecraft/class_243;FLnet/minecraft/class_9958;)V
 		ARG 1 frameGraphBuilder
 		ARG 2 pos
-		ARG 3 tickDelta
+		ARG 3 tickProgress
 		ARG 4 fog
 	METHOD method_62204 renderClouds (Lnet/minecraft/class_9909;Lorg/joml/Matrix4f;Lorg/joml/Matrix4f;Lnet/minecraft/class_4063;Lnet/minecraft/class_243;FIF)V
 		ARG 1 frameGraphBuilder
@@ -245,7 +245,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	METHOD method_62208 renderBlockEntities (Lnet/minecraft/class_4587;Lnet/minecraft/class_4597$class_4598;Lnet/minecraft/class_4597$class_4598;Lnet/minecraft/class_4184;F)V
 		ARG 1 matrices
 		ARG 4 camera
-		ARG 5 tickDelta
+		ARG 5 tickProgress
 	METHOD method_62209 addWeatherParticlesAndSound (Lnet/minecraft/class_4184;)V
 		ARG 1 camera
 	METHOD method_62210 renderTargetBlockOutline (Lnet/minecraft/class_4184;Lnet/minecraft/class_4597$class_4598;Lnet/minecraft/class_4587;Z)V

--- a/mappings/net/minecraft/client/render/block/entity/BeaconBlockEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/block/entity/BeaconBlockEntityRenderer.mapping
@@ -47,7 +47,7 @@ CLASS net/minecraft/class_822 net/minecraft/client/render/block/entity/BeaconBlo
 	METHOD method_3543 renderBeam (Lnet/minecraft/class_4587;Lnet/minecraft/class_4597;FJIII)V
 		ARG 0 matrices
 		ARG 1 vertexConsumers
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 		ARG 3 worldTime
 		ARG 5 yOffset
 		ARG 6 maxY
@@ -56,7 +56,7 @@ CLASS net/minecraft/class_822 net/minecraft/client/render/block/entity/BeaconBlo
 		ARG 0 matrices
 		ARG 1 vertexConsumers
 		ARG 2 textureId
-		ARG 3 tickDelta
+		ARG 3 tickProgress
 		ARG 4 heightScale
 		ARG 5 worldTime
 		ARG 7 yOffset

--- a/mappings/net/minecraft/client/render/block/entity/BlockEntityRenderDispatcher.mapping
+++ b/mappings/net/minecraft/client/render/block/entity/BlockEntityRenderDispatcher.mapping
@@ -19,7 +19,7 @@ CLASS net/minecraft/class_824 net/minecraft/client/render/block/entity/BlockEnti
 	METHOD method_23079 render (Lnet/minecraft/class_827;Lnet/minecraft/class_2586;FLnet/minecraft/class_4587;Lnet/minecraft/class_4597;)V
 		ARG 0 renderer
 		ARG 1 blockEntity
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 		ARG 3 matrices
 		ARG 4 vertexConsumers
 	METHOD method_3549 configure (Lnet/minecraft/class_1937;Lnet/minecraft/class_4184;Lnet/minecraft/class_239;)V
@@ -32,6 +32,6 @@ CLASS net/minecraft/class_824 net/minecraft/client/render/block/entity/BlockEnti
 		ARG 1 world
 	METHOD method_3555 render (Lnet/minecraft/class_2586;FLnet/minecraft/class_4587;Lnet/minecraft/class_4597;)V
 		ARG 1 blockEntity
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 		ARG 3 matrices
 		ARG 4 vertexConsumers

--- a/mappings/net/minecraft/client/render/block/entity/BlockEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/block/entity/BlockEntityRenderer.mapping
@@ -7,7 +7,7 @@ CLASS net/minecraft/class_827 net/minecraft/client/render/block/entity/BlockEnti
 		ARG 1 blockEntity
 	METHOD method_3569 render (Lnet/minecraft/class_2586;FLnet/minecraft/class_4587;Lnet/minecraft/class_4597;II)V
 		ARG 1 entity
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 		ARG 3 matrices
 		ARG 4 vertexConsumers
 		ARG 5 light

--- a/mappings/net/minecraft/client/render/block/entity/MobSpawnerBlockEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/block/entity/MobSpawnerBlockEntityRenderer.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_839 net/minecraft/client/render/block/entity/MobSpawne
 	METHOD <init> (Lnet/minecraft/class_5614$class_5615;)V
 		ARG 1 ctx
 	METHOD method_55253 render (FLnet/minecraft/class_4587;Lnet/minecraft/class_4597;ILnet/minecraft/class_1297;Lnet/minecraft/class_898;DD)V
-		ARG 0 tickDelta
+		ARG 0 tickProgress
 		ARG 1 matrices
 		ARG 2 vertexConsumers
 		ARG 3 light

--- a/mappings/net/minecraft/client/render/block/entity/model/BellBlockModel.mapping
+++ b/mappings/net/minecraft/client/render/block/entity/model/BellBlockModel.mapping
@@ -5,5 +5,5 @@ CLASS net/minecraft/class_9943 net/minecraft/client/render/block/entity/model/Be
 		ARG 1 root
 	METHOD method_62063 update (Lnet/minecraft/class_3721;F)V
 		ARG 1 blockEntity
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 	METHOD method_62064 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/AbstractMinecartEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/AbstractMinecartEntityRenderer.mapping
@@ -15,12 +15,12 @@ CLASS net/minecraft/class_925 net/minecraft/client/render/entity/AbstractMinecar
 		ARG 0 minecart
 		ARG 1 controller
 		ARG 2 state
-		ARG 3 tickDelta
+		ARG 3 tickProgress
 	METHOD method_62361 updateFromDefaultController (Lnet/minecraft/class_1688;Lnet/minecraft/class_9883;Lnet/minecraft/class_10045;F)V
 		ARG 0 minecart
 		ARG 1 controller
 		ARG 2 state
-		ARG 3 tickDelta
+		ARG 3 tickProgress
 	METHOD method_62363 transformExperimentalControllerMinecart (Lnet/minecraft/class_10045;Lnet/minecraft/class_4587;)V
 		ARG 0 state
 		ARG 1 matrices

--- a/mappings/net/minecraft/client/render/entity/BipedEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/BipedEntityRenderer.mapping
@@ -17,7 +17,7 @@ CLASS net/minecraft/class_909 net/minecraft/client/render/entity/BipedEntityRend
 	METHOD method_62461 updateBipedRenderState (Lnet/minecraft/class_1309;Lnet/minecraft/class_10034;FLnet/minecraft/class_10442;)V
 		ARG 0 entity
 		ARG 1 state
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 		ARG 3 itemModelResolver
 	METHOD method_62462 getPreferredArm (Lnet/minecraft/class_1309;)Lnet/minecraft/class_1306;
 		ARG 0 entity

--- a/mappings/net/minecraft/client/render/entity/CreakingEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/CreakingEntityRenderer.mapping
@@ -3,4 +3,4 @@ CLASS net/minecraft/class_10337 net/minecraft/client/render/entity/CreakingEntit
 	FIELD field_54860 EYES_TEXTURE Lnet/minecraft/class_2960;
 	METHOD method_64918 (Lnet/minecraft/class_10338;F)F
 		ARG 0 state
-		ARG 1 tickDelta
+		ARG 1 tickProgress

--- a/mappings/net/minecraft/client/render/entity/DisplayEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/DisplayEntityRenderer.mapping
@@ -11,12 +11,12 @@ CLASS net/minecraft/class_8138 net/minecraft/client/render/entity/DisplayEntityR
 		ARG 2 state
 	METHOD method_52844 lerpYaw (Lnet/minecraft/class_8113;F)F
 		ARG 0 entity
-		ARG 1 tickDelta
+		ARG 1 deltaTicks
 	METHOD method_52845 getBackwardsYaw (Lnet/minecraft/class_4184;)F
 		ARG 0 camera
 	METHOD method_52846 lerpPitch (Lnet/minecraft/class_8113;F)F
 		ARG 0 entity
-		ARG 1 tickDelta
+		ARG 1 deltaTicks
 	METHOD method_52847 getNegatedPitch (Lnet/minecraft/class_4184;)F
 		ARG 0 camera
 	METHOD method_63531 getBrightnessOverride (Lnet/minecraft/class_8113;)I

--- a/mappings/net/minecraft/client/render/entity/DisplayEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/DisplayEntityRenderer.mapping
@@ -11,12 +11,12 @@ CLASS net/minecraft/class_8138 net/minecraft/client/render/entity/DisplayEntityR
 		ARG 2 state
 	METHOD method_52844 lerpYaw (Lnet/minecraft/class_8113;F)F
 		ARG 0 entity
-		ARG 1 delta
+		ARG 1 tickDelta
 	METHOD method_52845 getBackwardsYaw (Lnet/minecraft/class_4184;)F
 		ARG 0 camera
 	METHOD method_52846 lerpPitch (Lnet/minecraft/class_8113;F)F
 		ARG 0 entity
-		ARG 1 delta
+		ARG 1 tickDelta
 	METHOD method_52847 getNegatedPitch (Lnet/minecraft/class_4184;)F
 		ARG 0 camera
 	METHOD method_63531 getBrightnessOverride (Lnet/minecraft/class_8113;)I

--- a/mappings/net/minecraft/client/render/entity/DisplayEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/DisplayEntityRenderer.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/class_8138 net/minecraft/client/render/entity/DisplayEntityR
 		ARG 2 matrices
 		ARG 3 vertexConsumers
 		ARG 4 light
-		ARG 5 tickDelta
+		ARG 5 tickProgress
 	METHOD method_49053 getBillboardRotation (Lnet/minecraft/class_8113$class_8229;Lnet/minecraft/class_10011;Lorg/joml/Quaternionf;)Lorg/joml/Quaternionf;
 		ARG 1 renderState
 		ARG 2 state

--- a/mappings/net/minecraft/client/render/entity/EnderDragonEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EnderDragonEntityRenderer.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/class_895 net/minecraft/client/render/entity/EnderDragonEnti
 		ARG 0 dx
 		ARG 1 dy
 		ARG 2 dz
-		ARG 3 tickDelta
+		ARG 3 tickProgress
 		ARG 4 matrices
 		ARG 5 vertexConsumers
 		ARG 6 light

--- a/mappings/net/minecraft/client/render/entity/EntityRenderDispatcher.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderDispatcher.mapping
@@ -66,14 +66,14 @@ CLASS net/minecraft/class_898 net/minecraft/client/render/entity/EntityRenderDis
 		ARG 1 vertexConsumers
 		ARG 2 renderState
 		ARG 3 opacity
-		ARG 4 tickDelta
+		ARG 4 tickProgress
 		ARG 5 world
 		ARG 6 radius
 	METHOD method_23168 getSquaredDistanceToCamera (Lnet/minecraft/class_1297;)D
 		ARG 1 entity
 	METHOD method_23839 getLight (Lnet/minecraft/class_1297;F)I
 		ARG 1 entity
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 	METHOD method_24196 setRotation (Lorg/joml/Quaternionf;)V
 		ARG 1 rotation
 	METHOD method_24197 getRotation ()Lorg/joml/Quaternionf;
@@ -98,7 +98,7 @@ CLASS net/minecraft/class_898 net/minecraft/client/render/entity/EntityRenderDis
 		ARG 2 x
 		ARG 4 y
 		ARG 6 z
-		ARG 8 tickDelta
+		ARG 8 tickProgress
 		ARG 9 matrices
 		ARG 10 vertexConsumers
 		ARG 11 light
@@ -109,7 +109,7 @@ CLASS net/minecraft/class_898 net/minecraft/client/render/entity/EntityRenderDis
 		ARG 0 matrices
 		ARG 1 vertices
 		ARG 2 entity
-		ARG 3 tickDelta
+		ARG 3 tickProgress
 		ARG 4 red
 		ARG 5 green
 		ARG 6 blue
@@ -130,7 +130,7 @@ CLASS net/minecraft/class_898 net/minecraft/client/render/entity/EntityRenderDis
 		ARG 2 x
 		ARG 4 y
 		ARG 6 z
-		ARG 8 tickDelta
+		ARG 8 tickProgress
 		ARG 9 matrices
 		ARG 10 vertexConsumers
 		ARG 11 light

--- a/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/class_897 net/minecraft/client/render/entity/EntityRenderer
 		ARG 2 pos
 	METHOD method_24088 getLight (Lnet/minecraft/class_1297;F)I
 		ARG 1 entity
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 	METHOD method_27950 getSkyLight (Lnet/minecraft/class_1297;Lnet/minecraft/class_2338;)I
 		ARG 1 entity
 		ARG 2 pos
@@ -63,14 +63,14 @@ CLASS net/minecraft/class_897 net/minecraft/client/render/entity/EntityRenderer
 	METHOD method_62354 updateRenderState (Lnet/minecraft/class_1297;Lnet/minecraft/class_10017;F)V
 		ARG 1 entity
 		ARG 2 state
-		ARG 3 tickDelta
+		ARG 3 tickProgress
 	METHOD method_62358 getBoundingBox (Lnet/minecraft/class_1297;)Lnet/minecraft/class_238;
 		ARG 1 entity
 	METHOD method_62406 canBeCulled (Lnet/minecraft/class_1297;)Z
 		ARG 1 entity
 	METHOD method_62425 getAndUpdateRenderState (Lnet/minecraft/class_1297;F)Lnet/minecraft/class_10017;
 		ARG 1 entity
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 	METHOD method_62426 getDisplayName (Lnet/minecraft/class_1297;)Lnet/minecraft/class_2561;
 		ARG 1 entity
 	METHOD method_65247 getShadowOpacity (Lnet/minecraft/class_10017;)F

--- a/mappings/net/minecraft/client/render/entity/FishingBobberEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/FishingBobberEntityRenderer.mapping
@@ -22,6 +22,6 @@ CLASS net/minecraft/class_906 net/minecraft/client/render/entity/FishingBobberEn
 		ARG 1 denominator
 	METHOD method_59755 getHandPos (Lnet/minecraft/class_1657;FF)Lnet/minecraft/class_243;
 		ARG 1 player
-		ARG 3 tickDelta
+		ARG 3 tickProgress
 	METHOD method_65567 getArmHoldingRod (Lnet/minecraft/class_1657;)Lnet/minecraft/class_1306;
 		ARG 0 player

--- a/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/LivingEntityRenderer.mapping
@@ -43,7 +43,7 @@ CLASS net/minecraft/class_922 net/minecraft/client/render/entity/LivingEntityRen
 	METHOD method_62482 clampBodyYaw (Lnet/minecraft/class_1309;FF)F
 		ARG 0 entity
 		ARG 1 degrees
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 	METHOD method_62483 shouldRenderFeatures (Lnet/minecraft/class_10042;)Z
 		ARG 1 state
 	METHOD method_62484 getMixColor (Lnet/minecraft/class_10042;)I

--- a/mappings/net/minecraft/client/render/entity/PlayerEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/PlayerEntityRenderer.mapping
@@ -33,11 +33,11 @@ CLASS net/minecraft/class_1007 net/minecraft/client/render/entity/PlayerEntityRe
 	METHOD method_62607 updateGliding (Lnet/minecraft/class_742;Lnet/minecraft/class_10055;F)V
 		ARG 0 player
 		ARG 1 state
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 	METHOD method_62609 updateCape (Lnet/minecraft/class_742;Lnet/minecraft/class_10055;F)V
 		ARG 0 player
 		ARG 1 state
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 	METHOD method_64258 getArmPose (Lnet/minecraft/class_742;Lnet/minecraft/class_1306;)Lnet/minecraft/class_572$class_573;
 		ARG 0 player
 		ARG 1 arm

--- a/mappings/net/minecraft/client/render/entity/WardenEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/WardenEntityRenderer.mapping
@@ -6,16 +6,16 @@ CLASS net/minecraft/class_7287 net/minecraft/client/render/entity/WardenEntityRe
 	FIELD field_38354 PULSATING_SPOTS_2_TEXTURE Lnet/minecraft/class_2960;
 	METHOD method_42607 (Lnet/minecraft/class_10081;F)F
 		ARG 0 state
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_42609 (Lnet/minecraft/class_10081;F)F
 		ARG 0 state
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_42610 (Lnet/minecraft/class_10081;F)F
 		ARG 0 state
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_42611 (Lnet/minecraft/class_10081;F)F
 		ARG 0 state
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_42612 (Lnet/minecraft/class_10081;F)F
 		ARG 0 state
-		ARG 1 tickDelta
+		ARG 1 tickProgress

--- a/mappings/net/minecraft/client/render/entity/WindChargeEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/WindChargeEntityRenderer.mapping
@@ -2,4 +2,4 @@ CLASS net/minecraft/class_8987 net/minecraft/client/render/entity/WindChargeEnti
 	FIELD field_47477 TEXTURE Lnet/minecraft/class_2960;
 	FIELD field_47478 model Lnet/minecraft/class_8974;
 	METHOD method_55268 getXOffset (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress

--- a/mappings/net/minecraft/client/render/entity/feature/BreezeWindFeatureRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/BreezeWindFeatureRenderer.mapping
@@ -5,4 +5,4 @@ CLASS net/minecraft/class_8989 net/minecraft/client/render/entity/feature/Breeze
 		ARG 1 entityRendererContext
 		ARG 2 featureContext
 	METHOD method_55273 getXOffset (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress

--- a/mappings/net/minecraft/client/render/entity/feature/EmissiveFeatureRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/EmissiveFeatureRenderer.mapping
@@ -23,7 +23,7 @@ CLASS net/minecraft/class_7288 net/minecraft/client/render/entity/feature/Emissi
 	CLASS class_7289 AnimationAlphaAdjuster
 		METHOD apply (Lnet/minecraft/class_10042;F)F
 			ARG 1 state
-			ARG 2 tickDelta
+			ARG 2 tickProgress
 	CLASS class_7311 ModelPartVisibility
 		METHOD getPartsToDraw (Lnet/minecraft/class_583;Lnet/minecraft/class_10042;)Ljava/util/List;
 			ARG 1 model

--- a/mappings/net/minecraft/client/render/entity/state/EnderDragonEntityRenderState.mapping
+++ b/mappings/net/minecraft/client/render/entity/state/EnderDragonEntityRenderState.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/class_10015 net/minecraft/client/render/entity/state/EnderDr
 	FIELD field_53317 inLandingOrTakeoffPhase Z
 	FIELD field_53318 sittingOrHovering Z
 	FIELD field_53319 squaredDistanceFromOrigin D
-	FIELD field_53320 tickDelta F
+	FIELD field_53320 tickProgress F
 	FIELD field_53321 frameTracker Lnet/minecraft/class_9871;
 	METHOD method_62611 getLerpedFrame (I)Lnet/minecraft/class_9871$class_9872;
 		ARG 1 age

--- a/mappings/net/minecraft/client/render/item/HeldItemRenderer.mapping
+++ b/mappings/net/minecraft/client/render/item/HeldItemRenderer.mapping
@@ -41,7 +41,7 @@ CLASS net/minecraft/class_759 net/minecraft/client/render/item/HeldItemRenderer
 		ARG 3 itemRenderer
 		ARG 4 itemModelManager
 	METHOD method_22976 renderItem (FLnet/minecraft/class_4587;Lnet/minecraft/class_4597$class_4598;Lnet/minecraft/class_746;I)V
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 		ARG 2 matrices
 		ARG 3 vertexConsumers
 		ARG 4 player
@@ -59,7 +59,7 @@ CLASS net/minecraft/class_759 net/minecraft/client/render/item/HeldItemRenderer
 		ARG 3 swingProgress
 	METHOD method_3218 applyEatOrDrinkTransformation (Lnet/minecraft/class_4587;FLnet/minecraft/class_1306;Lnet/minecraft/class_1799;Lnet/minecraft/class_1657;)V
 		ARG 1 matrices
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 		ARG 3 arm
 		ARG 4 stack
 		ARG 5 player
@@ -89,10 +89,10 @@ CLASS net/minecraft/class_759 net/minecraft/client/render/item/HeldItemRenderer
 		ARG 2 arm
 		ARG 3 equipProgress
 	METHOD method_3227 getMapAngle (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_3228 renderFirstPersonItem (Lnet/minecraft/class_742;FFLnet/minecraft/class_1268;FLnet/minecraft/class_1799;FLnet/minecraft/class_4587;Lnet/minecraft/class_4597;I)V
 		ARG 1 player
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 		ARG 3 pitch
 		ARG 4 hand
 		ARG 5 swingProgress
@@ -124,7 +124,7 @@ CLASS net/minecraft/class_759 net/minecraft/client/render/item/HeldItemRenderer
 		ARG 0 player
 	METHOD method_49340 applyBrushTransformation (Lnet/minecraft/class_4587;FLnet/minecraft/class_1306;Lnet/minecraft/class_1799;Lnet/minecraft/class_1657;F)V
 		ARG 1 matrices
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 		ARG 3 arm
 		ARG 4 stack
 		ARG 5 player

--- a/mappings/net/minecraft/client/world/ClientWorld.mapping
+++ b/mappings/net/minecraft/client/world/ClientWorld.mapping
@@ -50,7 +50,7 @@ CLASS net/minecraft/class_638 net/minecraft/client/world/ClientWorld
 		ARG 2 passenger
 	METHOD method_23777 getSkyColor (Lnet/minecraft/class_243;F)I
 		ARG 1 cameraPos
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 	METHOD method_23778 (Lit/unimi/dsi/fastutil/objects/Object2ObjectArrayMap;)V
 		ARG 1 map
 	METHOD method_23779 (Lnet/minecraft/class_6539;Lnet/minecraft/class_4700;)V
@@ -62,12 +62,12 @@ CLASS net/minecraft/class_638 net/minecraft/client/world/ClientWorld
 	METHOD method_23782 resetChunkColor (Lnet/minecraft/class_1923;)V
 		ARG 1 chunkPos
 	METHOD method_23783 getSkyBrightness (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_23784 reloadColor ()V
 	METHOD method_23785 getCloudsColor (F)I
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_23787 getStarBrightness (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_23789 getLightningTicksLeft ()I
 	METHOD method_24462 (Lnet/minecraft/class_2338$class_2339;Lnet/minecraft/class_4761;)V
 		ARG 2 config

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -512,7 +512,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT @see #isCollidable
 		ARG 1 other
 	METHOD method_30950 getLerpedPos (F)Lnet/minecraft/class_243;
-		ARG 1 delta
+		ARG 1 tickDelta
 	METHOD method_30951 getLeashPos (F)Lnet/minecraft/class_243;
 		COMMENT {@return the position of the leash this entity holds}
 		COMMENT
@@ -521,7 +521,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT
 		COMMENT @see #getLeashOffset
 		COMMENT @see #getStandingEyeHeight
-		ARG 1 delta
+		ARG 1 tickProgress
 	METHOD method_31166 getClientCameraPosVec (F)Lnet/minecraft/class_243;
 		ARG 1 tickProgress
 	METHOD method_31471 onSpawnPacket (Lnet/minecraft/class_2604;)V
@@ -2166,7 +2166,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_60950 addPortalChunkTicketAt (Lnet/minecraft/class_2338;)V
 		ARG 1 pos
 	METHOD method_60951 lerpYaw (F)F
-		ARG 1 delta
+		ARG 1 tickProgress
 	METHOD method_61113 canTeleportBetween (Lnet/minecraft/class_1937;Lnet/minecraft/class_1937;)Z
 		ARG 1 from
 		ARG 2 to

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -512,7 +512,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT @see #isCollidable
 		ARG 1 other
 	METHOD method_30950 getLerpedPos (F)Lnet/minecraft/class_243;
-		ARG 1 tickDelta
+		ARG 1 deltaTicks
 	METHOD method_30951 getLeashPos (F)Lnet/minecraft/class_243;
 		COMMENT {@return the position of the leash this entity holds}
 		COMMENT

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -286,7 +286,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		ARG 1 pitch
 		ARG 2 yaw
 	METHOD method_18864 getOppositeRotationVector (F)Lnet/minecraft/class_243;
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_19538 getPos ()Lnet/minecraft/class_243;
 		COMMENT {@return the exact position of the entity}
 		COMMENT
@@ -523,7 +523,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT @see #getStandingEyeHeight
 		ARG 1 delta
 	METHOD method_31166 getClientCameraPosVec (F)Lnet/minecraft/class_243;
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_31471 onSpawnPacket (Lnet/minecraft/class_2604;)V
 		COMMENT Called on the client when the entity receives a spawn packet.
 		COMMENT
@@ -860,7 +860,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	METHOD method_45319 addVelocityInternal (Lnet/minecraft/class_243;)V
 		ARG 1 velocity
 	METHOD method_45321 getLeashOffset (F)Lnet/minecraft/class_243;
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_46395 extinguishWithSound ()V
 	METHOD method_46396 reinitDimensions ()V
 	METHOD method_48105 teleport (Lnet/minecraft/class_3218;DDDLjava/util/Set;FFZ)Z
@@ -1258,7 +1258,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT such as picking up item entities, experience orbs, or arrows.
 		ARG 1 player
 	METHOD method_5695 getPitch (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_5696 canAvoidTraps ()Z
 		COMMENT {@return whether the entity cannot trigger pressure plates or tripwires}
 		COMMENT
@@ -1322,7 +1322,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT @see #hasPassenger(Entity)
 		ARG 1 predicate
 	METHOD method_5705 getYaw (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_5706 dropItem (Lnet/minecraft/class_3218;Lnet/minecraft/class_1935;)Lnet/minecraft/class_1542;
 		COMMENT Drops one {@code item} at the entity's position.
 		COMMENT
@@ -1487,7 +1487,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		ARG 1 player
 	METHOD method_5745 raycast (DFZ)Lnet/minecraft/class_239;
 		ARG 1 maxDistance
-		ARG 3 tickDelta
+		ARG 3 tickProgress
 		ARG 4 includeFluids
 	METHOD method_5746 onSwimmingStart ()V
 	METHOD method_5747 handleFallDamage (DFLnet/minecraft/class_1282;)Z
@@ -1883,7 +1883,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT @see #getUuidAsString
 		ARG 1 uuid
 	METHOD method_5828 getRotationVec (F)Lnet/minecraft/class_243;
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_5832 applyRotation (Lnet/minecraft/class_2470;)F
 		COMMENT Applies {@code rotation} to the entity's yaw.
 		ARG 1 rotation
@@ -1895,7 +1895,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		COMMENT @see #isGlowing
 		ARG 1 glowing
 	METHOD method_5836 getCameraPosVec (F)Lnet/minecraft/class_243;
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_5837 onStartedTrackingBy (Lnet/minecraft/class_3222;)V
 		COMMENT Called when {@code player} starts tracking this entity.
 		COMMENT
@@ -2182,9 +2182,9 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 		ARG 1 pos
 		ARG 2 flags
 	METHOD method_61414 getLerpedPitch (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_61415 getLerpedYaw (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_61416 isInSameTeam (Lnet/minecraft/class_1297;)Z
 		ARG 1 other
 	METHOD method_63612 collides (Lnet/minecraft/class_243;Lnet/minecraft/class_243;Ljava/util/List;)Z

--- a/mappings/net/minecraft/entity/LimbAnimator.mapping
+++ b/mappings/net/minecraft/entity/LimbAnimator.mapping
@@ -12,8 +12,8 @@ CLASS net/minecraft/class_8080 net/minecraft/entity/LimbAnimator
 		ARG 3 scale
 	METHOD method_48569 getPos ()F
 	METHOD method_48570 getSpeed (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_48571 isLimbMoving ()Z
 	METHOD method_48572 getPos (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_61433 reset ()V

--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -411,7 +411,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_6022 getStuckArrowCount ()I
 	METHOD method_6023 tickNewAi ()V
 	METHOD method_6024 getLeaningPitch (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_6025 heal (F)V
 		COMMENT Heals this entity by the given {@code amount} of half-hearts.
 		COMMENT
@@ -474,7 +474,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		COMMENT @see #shouldAlwaysDropExperience()
 		COMMENT @see #getExperienceToDrop()
 	METHOD method_6055 getHandSwingProgress (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_6057 canSee (Lnet/minecraft/class_1297;)Z
 		ARG 1 entity
 	METHOD method_6058 getActiveHand ()Lnet/minecraft/class_1268;
@@ -728,7 +728,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 		ARG 2 playerHitTimer
 	METHOD method_66279 getEffectFadeFactor (Lnet/minecraft/class_6880;F)F
 		ARG 1 effect
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 	METHOD method_66280 getAttackingPlayer ()Lnet/minecraft/class_1657;
 	METHOD method_66281 stopGliding ()V
 	METHOD method_66282 tickMovementInput ()V

--- a/mappings/net/minecraft/entity/boss/dragon/EnderDragonEntity.mapping
+++ b/mappings/net/minecraft/entity/boss/dragon/EnderDragonEntity.mapping
@@ -93,4 +93,4 @@ CLASS net/minecraft/class_1510 net/minecraft/entity/boss/dragon/EnderDragonEntit
 		ARG 2 to
 		ARG 3 pathNode
 	METHOD method_6834 getRotationVectorFromPhase (F)Lnet/minecraft/class_243;
-		ARG 1 tickDelta
+		ARG 1 tickProgress

--- a/mappings/net/minecraft/entity/boss/dragon/EnderDragonFrameTracker.mapping
+++ b/mappings/net/minecraft/entity/boss/dragon/EnderDragonFrameTracker.mapping
@@ -8,7 +8,7 @@ CLASS net/minecraft/class_9871 net/minecraft/entity/boss/dragon/EnderDragonFrame
 		ARG 1 age
 	METHOD method_61485 getLerpedFrame (IF)Lnet/minecraft/class_9871$class_9872;
 		ARG 1 age
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 	METHOD method_61486 copyFrom (Lnet/minecraft/class_9871;)V
 		ARG 1 other
 	CLASS class_9872 Frame

--- a/mappings/net/minecraft/entity/decoration/DisplayEntity.mapping
+++ b/mappings/net/minecraft/entity/decoration/DisplayEntity.mapping
@@ -39,7 +39,7 @@ CLASS net/minecraft/class_8113 net/minecraft/entity/decoration/DisplayEntity
 	FIELD field_52434 tooSmallToRender Z
 	FIELD field_55654 interpolator Lnet/minecraft/class_10584;
 	METHOD method_48844 getLerpProgress (F)F
-		ARG 1 delta
+		ARG 1 tickProgress
 	METHOD method_48845 getTransformation (Lnet/minecraft/class_2945;)Lnet/minecraft/class_4590;
 		ARG 0 dataTracker
 	METHOD method_48846 setBrightness (Lnet/minecraft/class_8104;)V

--- a/mappings/net/minecraft/entity/effect/StatusEffectInstance.mapping
+++ b/mappings/net/minecraft/entity/effect/StatusEffectInstance.mapping
@@ -79,7 +79,7 @@ CLASS net/minecraft/class_1293 net/minecraft/entity/effect/StatusEffectInstance
 		COMMENT
 		COMMENT @see StatusEffect#fadeTicks(int)
 		ARG 1 entity
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 	METHOD method_55654 equals (Lnet/minecraft/class_6880;)Z
 		ARG 1 effect
 	METHOD method_55656 copyFadingFrom (Lnet/minecraft/class_1293;)V
@@ -146,7 +146,7 @@ CLASS net/minecraft/class_1293 net/minecraft/entity/effect/StatusEffectInstance
 			ARG 1 effect
 		METHOD method_55660 calculate (Lnet/minecraft/class_1309;F)F
 			ARG 1 entity
-			ARG 2 tickDelta
+			ARG 2 tickProgress
 		METHOD method_55661 update (Lnet/minecraft/class_1293;)V
 			ARG 1 effect
 		METHOD method_66231 shouldFadeIn (Lnet/minecraft/class_1293;)Z

--- a/mappings/net/minecraft/entity/mob/CreeperEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/CreeperEntity.mapping
@@ -12,8 +12,8 @@ CLASS net/minecraft/class_1548 net/minecraft/entity/mob/CreeperEntity
 	METHOD method_7000 isIgnited ()Z
 	METHOD method_7001 spawnEffectsCloud ()V
 	METHOD method_7002 onHeadDropped ()V
-	METHOD method_7003 getClientFuseTime (F)F
-		ARG 1 timeDelta
+	METHOD method_7003 getLerpedFuseTime (F)F
+		ARG 1 tickProgress
 	METHOD method_7004 ignite ()V
 	METHOD method_7005 setFuseSpeed (I)V
 		ARG 1 fuseSpeed

--- a/mappings/net/minecraft/entity/mob/ElytraFlightController.mapping
+++ b/mappings/net/minecraft/entity/mob/ElytraFlightController.mapping
@@ -10,8 +10,8 @@ CLASS net/minecraft/class_9863 net/minecraft/entity/mob/ElytraFlightController
 		ARG 1 entity
 	METHOD method_61403 update ()V
 	METHOD method_61404 leftWingPitch (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_61405 leftWingYaw (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_61406 leftWingRoll (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress

--- a/mappings/net/minecraft/entity/mob/EvokerFangsEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/EvokerFangsEntity.mapping
@@ -16,6 +16,6 @@ CLASS net/minecraft/class_1669 net/minecraft/entity/mob/EvokerFangsEntity
 	METHOD method_7471 damage (Lnet/minecraft/class_1309;)V
 		ARG 1 target
 	METHOD method_7472 getAnimationProgress (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_7473 setOwner (Lnet/minecraft/class_1309;)V
 		ARG 1 owner

--- a/mappings/net/minecraft/entity/mob/GuardianEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/GuardianEntity.mapping
@@ -21,17 +21,17 @@ CLASS net/minecraft/class_1577 net/minecraft/entity/mob/GuardianEntity
 	METHOD method_48161 getBeamTicks ()F
 	METHOD method_7052 getBeamTarget ()Lnet/minecraft/class_1309;
 	METHOD method_7053 getSpikesExtension (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_7054 setSpikesRetracted (Z)V
 		ARG 1 retracted
 	METHOD method_7055 getWarmupTime ()I
 	METHOD method_7057 getTailAngle (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_7058 areSpikesRetracted ()Z
 	METHOD method_7060 setBeamTarget (I)V
 		ARG 1 entityId
 	METHOD method_7061 getBeamProgress (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_7062 getFlopSound ()Lnet/minecraft/class_3414;
 	METHOD method_7063 hasBeamTarget ()Z
 	CLASS class_1578 FireBeamGoal

--- a/mappings/net/minecraft/entity/mob/IllusionerEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/IllusionerEntity.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_1581 net/minecraft/entity/mob/IllusionerEntity
 	FIELD field_7297 mirrorCopyOffsets [[Lnet/minecraft/class_243;
 	METHOD method_26916 createIllusionerAttributes ()Lnet/minecraft/class_5132$class_5133;
 	METHOD method_7065 getMirrorCopyOffsets (F)[Lnet/minecraft/class_243;
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	CLASS class_1582 BlindTargetGoal
 		FIELD field_7298 targetId I
 	CLASS class_1583 GiveInvisibilityGoal

--- a/mappings/net/minecraft/entity/mob/ShulkerEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/ShulkerEntity.mapping
@@ -35,7 +35,7 @@ CLASS net/minecraft/class_1606 net/minecraft/entity/mob/ShulkerEntity
 	METHOD method_33351 isInvalidPosition (Lnet/minecraft/class_2338;)Z
 		ARG 1 pos
 	METHOD method_33352 getRenderPositionOffset (F)Lnet/minecraft/class_243;
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_35192 setAttachedFace (Lnet/minecraft/class_2350;)V
 		ARG 1 face
 	METHOD method_47879 (Lnet/minecraft/class_1767;)Ljava/lang/Byte;

--- a/mappings/net/minecraft/entity/mob/ShulkerEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/ShulkerEntity.mapping
@@ -45,7 +45,7 @@ CLASS net/minecraft/class_1606 net/minecraft/entity/mob/ShulkerEntity
 	METHOD method_47881 getColorOptional ()Ljava/util/Optional;
 	METHOD method_7115 getPeekAmount ()I
 	METHOD method_7116 getOpenProgress (F)F
-		ARG 1 delta
+		ARG 1 tickProgress
 	METHOD method_7119 getAttachedFace ()Lnet/minecraft/class_2350;
 	METHOD method_7121 getColor ()Lnet/minecraft/class_1767;
 	METHOD method_7122 setPeekAmount (I)V

--- a/mappings/net/minecraft/entity/mob/WardenEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/WardenEntity.mapping
@@ -24,7 +24,7 @@ CLASS net/minecraft/class_7260 net/minecraft/entity/mob/WardenEntity
 	FIELD field_44599 vibrationListenerData Lnet/minecraft/class_8514$class_8515;
 	FIELD field_52503 FOLLOW_RANGE I
 	METHOD method_42202 getHeartAlpha (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_42204 addDarknessToClosePlayers (Lnet/minecraft/class_3218;Lnet/minecraft/class_243;Lnet/minecraft/class_1297;I)V
 		ARG 0 world
 		ARG 1 pos
@@ -55,7 +55,7 @@ CLASS net/minecraft/class_7260 net/minecraft/entity/mob/WardenEntity
 	METHOD method_42221 addAttributes ()Lnet/minecraft/class_5132$class_5133;
 	METHOD method_42222 getAnger ()I
 	METHOD method_42223 getTendrilAlpha (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_42669 (Lnet/minecraft/class_2487;Lnet/minecraft/class_2520;)V
 		ARG 1 listenerData
 	METHOD method_43113 isDiggingOrEmerging ()Z

--- a/mappings/net/minecraft/entity/passive/AbstractHorseEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/AbstractHorseEntity.mapping
@@ -97,7 +97,7 @@ CLASS net/minecraft/class_1496 net/minecraft/entity/passive/AbstractHorseEntity
 		ARG 1 angry
 	METHOD method_6738 setEating ()V
 	METHOD method_6739 getEatingGrassAnimationProgress (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_6740 setEatingGrass (Z)V
 		ARG 1 eatingGrass
 	METHOD method_6741 (Lnet/minecraft/class_1309;Lnet/minecraft/class_3218;)Z
@@ -140,11 +140,11 @@ CLASS net/minecraft/class_1496 net/minecraft/entity/passive/AbstractHorseEntity
 	METHOD method_6766 setTame (Z)V
 		ARG 1 tame
 	METHOD method_6767 getAngryAnimationProgress (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_6769 setHorseFlag (IZ)V
 		ARG 1 bitmask
 		ARG 2 flag
 	METHOD method_6772 getEatingAnimationProgress (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_6774 getChildJumpStrengthBonus (Ljava/util/function/DoubleSupplier;)D
 		ARG 0 randomDoubleGetter

--- a/mappings/net/minecraft/entity/passive/AllayEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/AllayEntity.mapping
@@ -23,7 +23,7 @@ CLASS net/minecraft/class_7298 net/minecraft/entity/passive/AllayEntity
 	METHOD method_42655 createAllayAttributes ()Lnet/minecraft/class_5132$class_5133;
 	METHOD method_43396 isHoldingItem ()Z
 	METHOD method_43397 getItemHoldAnimationTicks (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_43536 (Lnet/minecraft/class_8514$class_8515;)V
 		ARG 1 vibrationListenerData
 	METHOD method_43537 (Lnet/minecraft/class_2487;Lnet/minecraft/class_2520;)V
@@ -44,7 +44,7 @@ CLASS net/minecraft/class_7298 net/minecraft/entity/passive/AllayEntity
 	METHOD method_44367 setDancing (Z)V
 		ARG 1 dancing
 	METHOD method_44368 getSpinningAnimationTicks (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_44608 addHeartParticle ()V
 	METHOD method_45340 areItemsEqual (Lnet/minecraft/class_1799;Lnet/minecraft/class_1799;)Z
 		ARG 1 stack

--- a/mappings/net/minecraft/entity/passive/BeeEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/BeeEntity.mapping
@@ -75,7 +75,7 @@ CLASS net/minecraft/class_4466 net/minecraft/entity/passive/BeeEntity
 	METHOD method_21808 setNearTarget (Z)V
 		ARG 1 nearTarget
 	METHOD method_21811 getBodyPitch (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_21812 getBeeFlag (I)Z
 		ARG 1 location
 	METHOD method_23884 getHivePos ()Lnet/minecraft/class_2338;

--- a/mappings/net/minecraft/entity/passive/CamelBrain.mapping
+++ b/mappings/net/minecraft/entity/passive/CamelBrain.mapping
@@ -25,6 +25,6 @@ CLASS net/minecraft/class_7691 net/minecraft/entity/passive/CamelBrain
 		ARG 0 stack
 	CLASS class_7692 CamelWalkTask
 	CLASS class_7693 SitOrStandTask
-		FIELD field_40160 lastPoseTickDelta I
+		FIELD field_40160 lastPoseTickProgress I
 		METHOD <init> (I)V
 			ARG 1 lastPoseSecondsDelta

--- a/mappings/net/minecraft/entity/passive/CamelBrain.mapping
+++ b/mappings/net/minecraft/entity/passive/CamelBrain.mapping
@@ -25,6 +25,6 @@ CLASS net/minecraft/class_7691 net/minecraft/entity/passive/CamelBrain
 		ARG 0 stack
 	CLASS class_7692 CamelWalkTask
 	CLASS class_7693 SitOrStandTask
-		FIELD field_40160 lastPoseTickProgress I
+		FIELD field_40160 lastTimeSinceLastPoseTick I
 		METHOD <init> (I)V
 			ARG 1 lastPoseSecondsDelta

--- a/mappings/net/minecraft/entity/passive/CamelEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/CamelEntity.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/class_7689 net/minecraft/entity/passive/CamelEntity
 		ARG 1 lastPoseTick
 	METHOD method_45346 getPassengerAttachmentY (ZFLnet/minecraft/class_4048;F)D
 		ARG 1 primaryPassenger
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 		ARG 3 dimensions
 		ARG 4 scaleFactor
 	METHOD method_45350 isSitting ()Z

--- a/mappings/net/minecraft/entity/passive/CamelEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/CamelEntity.mapping
@@ -21,7 +21,7 @@ CLASS net/minecraft/class_7689 net/minecraft/entity/passive/CamelEntity
 	METHOD method_45352 startSitting ()V
 	METHOD method_45353 startStanding ()V
 	METHOD method_45354 setStanding ()V
-	METHOD method_45355 getLastPoseTickDelta ()J
+	METHOD method_45355 getLastPoseTickProgress ()J
 	METHOD method_45356 updateAnimations ()V
 	METHOD method_45357 isStationary ()Z
 	METHOD method_45360 createCamelAttributes ()Lnet/minecraft/class_5132$class_5133;

--- a/mappings/net/minecraft/entity/passive/CamelEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/CamelEntity.mapping
@@ -21,7 +21,7 @@ CLASS net/minecraft/class_7689 net/minecraft/entity/passive/CamelEntity
 	METHOD method_45352 startSitting ()V
 	METHOD method_45353 startStanding ()V
 	METHOD method_45354 setStanding ()V
-	METHOD method_45355 getLastPoseTickProgress ()J
+	METHOD method_45355 getTimeSinceLastPoseTick ()J
 	METHOD method_45356 updateAnimations ()V
 	METHOD method_45357 isStationary ()Z
 	METHOD method_45360 createCamelAttributes ()Lnet/minecraft/class_5132$class_5133;

--- a/mappings/net/minecraft/entity/passive/CatEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/CatEntity.mapping
@@ -18,7 +18,7 @@ CLASS net/minecraft/class_1451 net/minecraft/entity/passive/CatEntity
 	FIELD field_6810 temptGoal Lnet/minecraft/class_1391;
 	FIELD field_6811 CAT_VARIANT Lnet/minecraft/class_2940;
 	METHOD method_16082 getSleepAnimationProgress (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_16084 updateHeadDownAnimation ()V
 	METHOD method_16085 updateAnimations ()V
 	METHOD method_16086 isInSleepingPose ()Z
@@ -32,12 +32,12 @@ CLASS net/minecraft/class_1451 net/minecraft/entity/passive/CatEntity
 	METHOD method_16089 hiss ()V
 	METHOD method_16090 updateSleepAnimation ()V
 	METHOD method_16091 getTailCurlAnimationProgress (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_16093 isHeadDown ()Z
 	METHOD method_16094 setCollarColor (Lnet/minecraft/class_1767;)V
 		ARG 1 color
 	METHOD method_16095 getHeadDownAnimationProgress (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_16096 getCollarColor ()Lnet/minecraft/class_1767;
 	METHOD method_26881 createCatAttributes ()Lnet/minecraft/class_5132$class_5133;
 	METHOD method_47842 setVariant (Lnet/minecraft/class_6880;)V

--- a/mappings/net/minecraft/entity/passive/FoxEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/FoxEntity.mapping
@@ -69,11 +69,11 @@ CLASS net/minecraft/class_4019 net/minecraft/entity/passive/FoxEntity
 	METHOD method_18297 setCrouching (Z)V
 		ARG 1 crouching
 	METHOD method_18298 getHeadRoll (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_18299 setRollingHead (Z)V
 		ARG 1 rollingHead
 	METHOD method_18300 getBodyRotationHeightOffset (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_18301 setAggressive (Z)V
 		ARG 1 aggressive
 	METHOD method_18302 setSleeping (Z)V

--- a/mappings/net/minecraft/entity/passive/PandaEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/PandaEntity.mapping
@@ -62,7 +62,7 @@ CLASS net/minecraft/class_1440 net/minecraft/entity/passive/PandaEntity
 	METHOD method_6533 hasPandaFlag (I)Z
 		ARG 1 bitmask
 	METHOD method_6534 getSittingAnimationProgress (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_6535 isSitting ()Z
 	METHOD method_6536 updateEatingAnimation ()V
 	METHOD method_6537 updatePlaying ()V
@@ -84,14 +84,14 @@ CLASS net/minecraft/class_1440 net/minecraft/entity/passive/PandaEntity
 		ARG 1 eating
 	METHOD method_6554 getProductGene ()Lnet/minecraft/class_1440$class_1443;
 	METHOD method_6555 getLieOnBackAnimationProgress (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_6557 setPandaFlag (IZ)V
 		ARG 1 mask
 		ARG 2 value
 	METHOD method_6558 setEatingTicks (I)V
 		ARG 1 eatingTicks
 	METHOD method_6560 getRollOverAnimationProgress (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	CLASS class_1441 PandaFleeGoal
 		FIELD field_6782 panda Lnet/minecraft/class_1440;
 		METHOD <init> (Lnet/minecraft/class_1440;Ljava/lang/Class;FDD)V

--- a/mappings/net/minecraft/entity/passive/PolarBearEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/PolarBearEntity.mapping
@@ -17,7 +17,7 @@ CLASS net/minecraft/class_1456 net/minecraft/entity/passive/PolarBearEntity
 		ARG 0 polarBear
 	METHOD method_6600 isWarning ()Z
 	METHOD method_6601 getWarningAnimationProgress (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_6602 playWarningSound ()V
 	METHOD method_6603 setWarning (Z)V
 		ARG 1 warning

--- a/mappings/net/minecraft/entity/passive/RabbitEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/RabbitEntity.mapping
@@ -25,7 +25,7 @@ CLASS net/minecraft/class_1463 net/minecraft/entity/passive/RabbitEntity
 	METHOD method_58374 (Lnet/minecraft/class_1799;)Z
 		ARG 0 stack
 	METHOD method_6605 getJumpProgress (F)F
-		ARG 1 delta
+		ARG 1 tickProgress
 	METHOD method_6606 setSpeed (D)V
 		ARG 1 speed
 	METHOD method_6607 wantsCarrots ()Z

--- a/mappings/net/minecraft/entity/passive/SheepEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/SheepEntity.mapping
@@ -8,7 +8,7 @@ CLASS net/minecraft/class_1472 net/minecraft/entity/passive/SheepEntity
 	METHOD method_58375 (Lnet/minecraft/class_1799;)Z
 		ARG 0 stack
 	METHOD method_6628 getNeckAngle (F)F
-		ARG 1 delta
+		ARG 1 tickProgress
 	METHOD method_6629 isSheared ()Z
 	METHOD method_6630 getDyedColor (Lnet/minecraft/class_1767;)I
 		ARG 0 color
@@ -22,4 +22,4 @@ CLASS net/minecraft/class_1472 net/minecraft/entity/passive/SheepEntity
 	METHOD method_6635 setSheared (Z)V
 		ARG 1 sheared
 	METHOD method_6641 getHeadAngle (F)F
-		ARG 1 delta
+		ARG 1 tickProgress

--- a/mappings/net/minecraft/entity/passive/WolfEntity.mapping
+++ b/mappings/net/minecraft/entity/passive/WolfEntity.mapping
@@ -34,7 +34,7 @@ CLASS net/minecraft/class_1493 net/minecraft/entity/passive/WolfEntity
 	METHOD method_58169 tryTame (Lnet/minecraft/class_1657;)V
 		ARG 1 player
 	METHOD method_61477 getShakeProgress (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_6707 getFurWetBrightnessMultiplier (F)F
 		COMMENT Returns this wolf's brightness multiplier based on the fur wetness.
 		COMMENT <p>
@@ -42,7 +42,7 @@ CLASS net/minecraft/class_1493 net/minecraft/entity/passive/WolfEntity
 		COMMENT
 		COMMENT @return Brightness as a float value between 0.75 and 1.0.
 		COMMENT @see net.minecraft.client.render.entity.model.TintableAnimalModel#setColorMultiplier(float, float, float)
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 			COMMENT progress for linearly interpolating between the previous and current game state
 	METHOD method_6708 setCollarColor (Lnet/minecraft/class_1767;)V
 		ARG 1 color
@@ -52,7 +52,7 @@ CLASS net/minecraft/class_1493 net/minecraft/entity/passive/WolfEntity
 	METHOD method_6713 getCollarColor ()Lnet/minecraft/class_1767;
 	METHOD method_6714 getTailAngle ()F
 	METHOD method_6719 getBegAnimationProgress (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	CLASS class_1494 AvoidLlamaGoal
 		FIELD field_6954 wolf Lnet/minecraft/class_1493;
 		METHOD <init> (Lnet/minecraft/class_1493;Lnet/minecraft/class_1493;Ljava/lang/Class;FDD)V

--- a/mappings/net/minecraft/entity/player/ItemCooldownManager.mapping
+++ b/mappings/net/minecraft/entity/player/ItemCooldownManager.mapping
@@ -18,7 +18,7 @@ CLASS net/minecraft/class_1796 net/minecraft/entity/player/ItemCooldownManager
 		ARG 1 stack
 	METHOD method_7905 getCooldownProgress (Lnet/minecraft/class_1799;F)F
 		ARG 1 stack
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 	METHOD method_7906 set (Lnet/minecraft/class_2960;I)V
 		ARG 1 groupId
 		ARG 2 duration

--- a/mappings/net/minecraft/entity/projectile/ProjectileUtil.mapping
+++ b/mappings/net/minecraft/entity/projectile/ProjectileUtil.mapping
@@ -51,4 +51,4 @@ CLASS net/minecraft/class_1675 net/minecraft/entity/projectile/ProjectileUtil
 		ARG 2 raycastShapeType
 	METHOD method_7484 setRotationFromVelocity (Lnet/minecraft/class_1297;F)V
 		ARG 0 entity
-		ARG 1 delta
+		ARG 1 tickProgress

--- a/mappings/net/minecraft/entity/vehicle/AbstractBoatEntity.mapping
+++ b/mappings/net/minecraft/entity/vehicle/AbstractBoatEntity.mapping
@@ -37,10 +37,10 @@ CLASS net/minecraft/class_10255 net/minecraft/entity/vehicle/AbstractBoatEntity
 	METHOD method_64482 updatePaddles ()V
 	METHOD method_64483 getBubbleWobbleTicks ()I
 	METHOD method_64484 lerpBubbleWobble (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_64485 lerpPaddlePhase (IF)F
 		ARG 1 paddle
-		ARG 2 tickDelta
+		ARG 2 tickProgress
 	METHOD method_64486 canCollide (Lnet/minecraft/class_1297;Lnet/minecraft/class_1297;)Z
 		ARG 0 entity
 		ARG 1 other

--- a/mappings/net/minecraft/entity/vehicle/ExperimentalMinecartController.mapping
+++ b/mappings/net/minecraft/entity/vehicle/ExperimentalMinecartController.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/class_9879 net/minecraft/entity/vehicle/ExperimentalMinecart
 	FIELD field_52532 initialStep Lnet/minecraft/class_9879$class_9880;
 	FIELD field_52533 lastReturnedInterpolatedStep Lnet/minecraft/class_9879$class_9881;
 	FIELD field_52534 lastQueriedTicksToNextRefresh I
-	FIELD field_52535 lastQueriedTickDelta F
+	FIELD field_52535 lastQueriedTickProgress F
 	FIELD field_52536 ticksToNextRefresh I
 	METHOD method_61601 calcNewHorizontalVelocity (Lnet/minecraft/class_3218;Lnet/minecraft/class_243;Lnet/minecraft/class_9879$class_9882;Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;Lnet/minecraft/class_2768;)Lnet/minecraft/class_243;
 		ARG 1 world

--- a/mappings/net/minecraft/entity/vehicle/ExperimentalMinecartController.mapping
+++ b/mappings/net/minecraft/entity/vehicle/ExperimentalMinecartController.mapping
@@ -33,17 +33,17 @@ CLASS net/minecraft/class_9879 net/minecraft/entity/vehicle/ExperimentalMinecart
 		ARG 1 velocity
 		ARG 2 railShape
 	METHOD method_61607 getLerpedPitch (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_61608 getLerpedYaw (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_61609 applyInitialVelocity (Lnet/minecraft/class_243;)Lnet/minecraft/class_243;
 		ARG 1 horizontalVelocity
 	METHOD method_61610 getLerpedPosition (F)Lnet/minecraft/class_243;
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_61611 getLerpedVelocity (F)Lnet/minecraft/class_243;
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_61612 getLerpedStep (F)Lnet/minecraft/class_9879$class_9881;
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_61613 setInitialStep ()V
 	METHOD method_61614 hasCurrentLerpSteps ()Z
 	METHOD method_61615 tickClient ()V

--- a/mappings/net/minecraft/util/InterpolatedFlipFlop.mapping
+++ b/mappings/net/minecraft/util/InterpolatedFlipFlop.mapping
@@ -10,11 +10,11 @@ CLASS net/minecraft/class_9849 net/minecraft/util/InterpolatedFlipFlop
 		ARG 1 frames
 		ARG 2 smoothingFunction
 	METHOD method_61339 getValue (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_61340 tick (Z)V
 		ARG 1 active
 	METHOD method_61341 (F)F
-		ARG 0 tickDelta
+		ARG 0 tickProgress
 	CLASS class_9850 SmoothingFunction
 		METHOD apply (F)F
-			ARG 1 tickDelta
+			ARG 1 tickProgress

--- a/mappings/net/minecraft/world/LunarWorldView.mapping
+++ b/mappings/net/minecraft/world/LunarWorldView.mapping
@@ -9,4 +9,4 @@ CLASS net/minecraft/class_5424 net/minecraft/world/LunarWorldView
 		COMMENT
 		COMMENT <p>This is typically used to determine the size of the moon that should be rendered.
 	METHOD method_30274 getSkyAngle (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -299,7 +299,7 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 	METHOD method_8438 addBlockEntity (Lnet/minecraft/class_2586;)V
 		ARG 1 blockEntity
 	METHOD method_8442 getSkyAngleRadians (F)F
-		ARG 1 tickDelta
+		ARG 1 tickProgress
 	METHOD method_8449 playSoundFromEntity (Lnet/minecraft/class_1297;Lnet/minecraft/class_1297;Lnet/minecraft/class_6880;Lnet/minecraft/class_3419;FFJ)V
 		COMMENT Plays a sound caused by a source at the provided entity's position. On the client, the sound will only play if the source is the same as the client's player.
 		COMMENT On the server, sound packets will be sent to players around the source, excluding the source itself.

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -28,8 +28,8 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 	FIELD field_9236 isClient Z
 	FIELD field_9238 lcgBlockSeedIncrement I
 	FIELD field_9249 iteratingTickingBlockEntities Z
-	FIELD field_9251 thunderGradientPrev F
-	FIELD field_9253 rainGradientPrev F
+	FIELD field_9251 lastThunderGradient F
+	FIELD field_9253 lastRainGradient F
 	FIELD field_9256 lcgBlockSeed I
 	METHOD <init> (Lnet/minecraft/class_5269;Lnet/minecraft/class_5321;Lnet/minecraft/class_5455;Lnet/minecraft/class_6880;ZZJI)V
 		ARG 1 properties
@@ -284,7 +284,7 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 4 data
 	METHOD method_8428 getScoreboard ()Lnet/minecraft/class_269;
 	METHOD method_8430 getRainGradient (F)F
-		ARG 1 delta
+		ARG 1 tickProgress
 	METHOD method_8433 getRecipeManager ()Lnet/minecraft/class_10286;
 	METHOD method_8437 createExplosion (Lnet/minecraft/class_1297;DDDFLnet/minecraft/class_1937$class_7867;)V
 		COMMENT Creates an explosion without creating fire.
@@ -383,7 +383,7 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 	METHOD method_8477 isPosLoaded (Lnet/minecraft/class_2338;)Z
 		ARG 1 pos
 	METHOD method_8478 getThunderGradient (F)F
-		ARG 1 delta
+		ARG 1 tickProgress
 	METHOD method_8486 playSoundClient (DDDLnet/minecraft/class_3414;Lnet/minecraft/class_3419;FFZ)V
 		ARG 1 x
 		ARG 3 y

--- a/mappings/net/minecraft/world/chunk/Chunk.mapping
+++ b/mappings/net/minecraft/world/chunk/Chunk.mapping
@@ -103,7 +103,7 @@ CLASS net/minecraft/class_2791 net/minecraft/world/chunk/Chunk
 	METHOD method_38261 (Lnet/minecraft/class_3195;)Lit/unimi/dsi/fastutil/longs/LongSet;
 		ARG 0 type2
 	METHOD method_38870 increaseInhabitedTime (J)V
-		ARG 1 delta
+		ARG 1 timeDelta
 	METHOD method_38871 hasStructureReferences ()Z
 	METHOD method_39295 hasHeightmap (Lnet/minecraft/class_2902$class_2903;)Z
 		ARG 1 type


### PR DESCRIPTION
This PR replaces all mentions of 'tickDelta' with 'tickProgress'. For an explanation of 'tickDelta', see https://github.com/FabricMC/fabric-docs/issues/173

I hesitated to make this pull request for a while. I think the name 'tickProgress' is not as good as it can be. Parchment uses 'partialTick', but some Fabricord members argued that it is too vague and it should be named 'fractionalTick' instead
I went with 'tickProgress' because it lines up with its main chunk of usages - MathHelper#lerp (`MathHelper.lerp(tickProgress, prevPos, pos)` sounds more obvious than `MathHelper.lerp(partialTick, prevPos, pos)`)
If you have any suggestions for a better name, please don't be afraid to leave a comment
