### PR TITLE
Rename the LivingEntity#getKnockbackAgainst method to getAttackKnockbackAgainst

### DIFF
--- a/mappings/net/minecraft/entity/LivingEntity.mapping
+++ b/mappings/net/minecraft/entity/LivingEntity.mapping
@@ -353,7 +353,7 @@ CLASS net/minecraft/class_1309 net/minecraft/entity/LivingEntity
 	METHOD method_59923 getExperienceToDrop (Lnet/minecraft/class_3218;Lnet/minecraft/class_1297;)I
 		ARG 1 world
 		ARG 2 attacker
-	METHOD method_59924 getKnockbackAgainst (Lnet/minecraft/class_1297;Lnet/minecraft/class_1282;)F
+	METHOD method_59924 getAttackKnockbackAgainst (Lnet/minecraft/class_1297;Lnet/minecraft/class_1282;)F
 		ARG 1 target
 		ARG 2 damageSource
 	METHOD method_59925 hasLandedInFluid ()Z


### PR DESCRIPTION
The `LivingEntity#getKnockbackAgainst` method deals specifically with direct attacks from players and mobs, as indicated by its use of the `minecraft:attack_knockback` attribute. It does not apply to other cases where damage results in knockback, so its name has been changed accordingly.