### PR TITLE
More block state flag changes

### DIFF
--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -46,25 +46,25 @@ CLASS net/minecraft/class_2248 net/minecraft/block/Block
 		COMMENT Prevents the previous block (container) from dropping items when destroyed.
 	FIELD field_31033 MOVED I
 		COMMENT Signals that the current block is being moved to a different location, usually because of a piston.
-	FIELD field_31035 SKIP_REDRAW_AND_ON_STATE_REPLACED I
+	FIELD field_31035 SKIP_REDRAW_AND_BLOCK_ENTITY_REPLACED_CALLBACK I
 		COMMENT @see #NO_REDRAW
-		COMMENT @see #SKIP_ON_STATE_REPLACED
+		COMMENT @see #SKIP_BLOCK_ENTITY_REPLACED_CALLBACK
 	FIELD field_31036 NOTIFY_ALL I
 		COMMENT The default setBlockState behavior. Same as {@code NOTIFY_NEIGHBORS | NOTIFY_LISTENERS}.
 	FIELD field_36404 registryEntry Lnet/minecraft/class_6880$class_6883;
 	FIELD field_46280 CODEC Lcom/mojang/serialization/MapCodec;
 	FIELD field_53822 SKIP_REDSTONE_WIRE_STATE_REPLACEMENT I
 		COMMENT Skips {@link AbstractBlock#getStateForNeighborUpdate} call for redstone wire.
-	FIELD field_55739 SKIP_ON_STATE_REPLACED I
-		COMMENT Skips {@link BlockEntity#onStateReplaced}.
+	FIELD field_55739 SKIP_BLOCK_ENTITY_REPLACED_CALLBACK I
+		COMMENT Skips {@link BlockEntity#onBlockReplaced}.
 		COMMENT Used when placing structures.
 	FIELD field_55740 FORCE_STATE_AND_SKIP_CALLBACKS_AND_DROPS I
 		COMMENT Used for 'strict' block placement by commands and structures.
-		COMMENT @see #SKIP_ON_BLOCK_ADDED
-		COMMENT @see #SKIP_ON_STATE_REPLACED
+		COMMENT @see #SKIP_BLOCK_ADDED_CALLBACK
+		COMMENT @see #SKIP_BLOCK_ENTITY_REPLACED_CALLBACK
 		COMMENT @see #SKIP_DROPS
 		COMMENT @see #FORCE_STATE
-	FIELD field_56561 SKIP_ON_BLOCK_ADDED I
+	FIELD field_56561 SKIP_BLOCK_ADDED_CALLBACK I
 		COMMENT Skips {@link AbstractBlock#onBlockAdded}.
 		COMMENT Used when placing structures.
 	METHOD method_16361 hasTopRim (Lnet/minecraft/class_1922;Lnet/minecraft/class_2338;)Z

--- a/mappings/net/minecraft/block/MangroveLeavesBlock.mapping
+++ b/mappings/net/minecraft/block/MangroveLeavesBlock.mapping
@@ -2,3 +2,5 @@ CLASS net/minecraft/class_7114 net/minecraft/block/MangroveLeavesBlock
 	FIELD field_46394 CODEC Lcom/mojang/serialization/MapCodec;
 	METHOD method_67235 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 0 instance
+	METHOD method_67236 (Lnet/minecraft/class_7114;)Ljava/lang/Float;
+		ARG 0 block

--- a/mappings/net/minecraft/block/entity/BlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntity.mapping
@@ -249,7 +249,7 @@ CLASS net/minecraft/class_2586 net/minecraft/block/entity/BlockEntity
 	METHOD method_61176 supports (Lnet/minecraft/class_2680;)Z
 		ARG 1 state
 	METHOD method_61177 getNameForReport ()Ljava/lang/String;
-	METHOD method_66473 onStateReplaced (Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)V
+	METHOD method_66473 onBlockReplaced (Lnet/minecraft/class_2338;Lnet/minecraft/class_2680;)V
 		ARG 1 pos
 		ARG 2 oldState
 	METHOD method_66474 (Ljava/lang/String;)V

--- a/unpick-definitions/set_block_state_flags.unpick
+++ b/unpick-definitions/set_block_state_flags.unpick
@@ -1,7 +1,7 @@
 v2
 
 flag set_block_state_flags net/minecraft/block/Block FORCE_STATE_AND_SKIP_CALLBACKS_AND_DROPS
-flag set_block_state_flags net/minecraft/block/Block SKIP_REDRAW_AND_ON_STATE_REPLACED
+flag set_block_state_flags net/minecraft/block/Block SKIP_REDRAW_AND_BLOCK_ENTITY_REPLACED_CALLBACK
 flag set_block_state_flags net/minecraft/block/Block NOTIFY_ALL_AND_REDRAW
 flag set_block_state_flags net/minecraft/block/Block NOTIFY_ALL
 flag set_block_state_flags net/minecraft/block/Block NOTIFY_NEIGHBORS
@@ -12,8 +12,8 @@ flag set_block_state_flags net/minecraft/block/Block FORCE_STATE
 flag set_block_state_flags net/minecraft/block/Block SKIP_DROPS
 flag set_block_state_flags net/minecraft/block/Block MOVED
 flag set_block_state_flags net/minecraft/block/Block SKIP_REDSTONE_WIRE_STATE_REPLACEMENT
-flag set_block_state_flags net/minecraft/block/Block SKIP_ON_STATE_REPLACED
-flag set_block_state_flags net/minecraft/block/Block SKIP_ON_BLOCK_ADDED
+flag set_block_state_flags net/minecraft/block/Block SKIP_BLOCK_ENTITY_REPLACED_CALLBACK
+flag set_block_state_flags net/minecraft/block/Block SKIP_BLOCK_ADDED_CALLBACK
 
 target_method net/minecraft/world/ModifiableWorld setBlockState (Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;I)Z
 	param 2 set_block_state_flags
@@ -43,10 +43,6 @@ target_method net/minecraft/client/network/ClientPlayNetworkHandler method_34007
 	param 0 set_block_state_flags
 target_method net/minecraft/command/argument/BlockStateArgument setBlockState (Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/util/math/BlockPos;I)Z
 	param 2 set_block_state_flags
-target_method net/minecraft/structure/Structure place (Lnet/minecraft/world/ServerWorldAccess;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/structure/StructurePlacementData;Ljava/util/Random;I)Z
-	param 5 set_block_state_flags
-target_method net/minecraft/structure/Structure updateCorner (Lnet/minecraft/world/WorldAccess;ILnet/minecraft/util/shape/VoxelSet;III)V
-	param 1 set_block_state_flags
 target_method net/minecraft/world/block/NeighborUpdater replaceWithStateForNeighborUpdate (Lnet/minecraft/util/math/Direction;Lnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/BlockPos;II)V
 	param 4 set_block_state_flags
 target_method net/minecraft/world/block/NeighborUpdater replaceWithStateForNeighborUpdate (Lnet/minecraft/world/WorldAccess;Lnet/minecraft/util/math/Direction;Lnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/BlockPos;II)V
@@ -69,3 +65,9 @@ target_method net/minecraft/world/chunk/Chunk setBlockState (Lnet/minecraft/util
 	param 2 set_block_state_flags
 target_method net/minecraft/world/chunk/EmptyChunk setBlockState (Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;I)Lnet/minecraft/block/BlockState;
 	param 2 set_block_state_flags
+target_method net/minecraft/structure/StructureTemplate place (Lnet/minecraft/world/ServerWorldAccess;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/structure/StructurePlacementData;Lnet/minecraft/util/math/random/Random;I)Z
+	param 5 set_block_state_flags
+target_method net/minecraft/structure/StructureTemplate updateCorner (Lnet/minecraft/world/WorldAccess;ILnet/minecraft/util/shape/VoxelSet;Lnet/minecraft/util/math/BlockPos;)V
+	param 1 set_block_state_flags
+target_method net/minecraft/structure/StructureTemplate updateCorner (Lnet/minecraft/world/WorldAccess;ILnet/minecraft/util/shape/VoxelSet;III)V
+	param 1 set_block_state_flags


### PR DESCRIPTION
- Fix unpicks not being set for `StructureTemplate` methods (unpick definition file hadn't been updated to reflect the rename from `Structure`, as well as an additional method)
- Rename some flags to be more accurate
- Rename BlockEntity#onStateReplaced to onBlockReplaced to reflect it only being called when the actual block is changed, not just when a state change is made