### PR TITLE
[1.20.6] Force LWJGL from Mojang's repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,12 @@ if (ENV.BRANCH_NAME) {
 }
 
 repositories {
-	mavenCentral()
+	mavenCentral {
+		content {
+			// Force LWJGL from Mojang's repo, as they have custom patched versions since 1.21-pre1
+			excludeGroupByRegex("org.lwjgl")
+		}
+	}
 	maven {
 		name "Fabric Repository"
 		url 'https://maven.fabricmc.net'


### PR DESCRIPTION
Fixes #3901
Fixes #4069 

It's an old version, but I think an exception can be made given that two issues were created because of this