### PR TITLE
Rename misleading new name calculateReceivedDamage() to original one

### DIFF
--- a/mappings/net/minecraft/world/explosion/ExplosionImpl.mapping
+++ b/mappings/net/minecraft/world/explosion/ExplosionImpl.mapping
@@ -18,7 +18,7 @@ CLASS net/minecraft/class_9892 net/minecraft/world/explosion/ExplosionImpl
 		ARG 6 power
 		ARG 7 createFire
 		ARG 8 destructionType
-	METHOD method_61731 calculateReceivedDamage (Lnet/minecraft/class_243;Lnet/minecraft/class_1297;)F
+	METHOD method_61731 getExposure (Lnet/minecraft/class_243;Lnet/minecraft/class_1297;)F
 		ARG 0 pos
 		ARG 1 entity
 	METHOD method_61732 destroyBlocks (Ljava/util/List;)V


### PR DESCRIPTION
Explosion.calculateReceivedDamage() only calculates what is previously called exposure, which has a value between 0 and 1 and is used to calculate damage and acceleration later. The actual value of damage is not directly calculated here.