### PR TITLE
Mapping Poet: Don't generate method bodies for native methods

### DIFF
--- a/filament/src/main/java/net/fabricmc/filament/mappingpoet/MethodBuilder.java
+++ b/filament/src/main/java/net/fabricmc/filament/mappingpoet/MethodBuilder.java
@@ -202,7 +202,7 @@ public class MethodBuilder {
 
 		builder.returns(typeName);
 
-		if (typeName != TypeName.VOID && !builder.modifiers.contains(Modifier.ABSTRACT)) {
+		if (typeName != TypeName.VOID && !builder.modifiers.contains(Modifier.ABSTRACT) && !builder.modifiers.contains(Modifier.NATIVE)) {
 			builder.addStatement("throw new RuntimeException()");
 		} else if (methodNode.annotationDefault != null) {
 			builder.defaultValue(FieldBuilder.codeFromAnnoValue(methodNode.annotationDefault));


### PR DESCRIPTION
Before:
```java
public native long nativeCreateContainer(byte[] byte2, byte[] byte3, int[] int2,
	JavaRuntime.NativeInstanceProxyCreator[] nativeInstanceProxyCreator,
	long long2)throw new RuntimeException();
;
```
After:
```java
public native long nativeCreateContainer(byte[] byte2, byte[] byte3, int[] int2,
	JavaRuntime.NativeInstanceProxyCreator[] nativeInstanceProxyCreator, long long2);
```