### PR TITLE
Unify the names of watching sender fields in the EntityTrackerEntry class

### DIFF
--- a/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
+++ b/mappings/net/minecraft/server/network/EntityTrackerEntry.mapping
@@ -12,18 +12,18 @@ CLASS net/minecraft/class_3231 net/minecraft/server/network/EntityTrackerEntry
 	FIELD field_14059 lastHeadYaw B
 	FIELD field_14060 lastYaw B
 	FIELD field_18258 world Lnet/minecraft/class_3218;
-	FIELD field_18259 receiver Ljava/util/function/Consumer;
+	FIELD field_18259 watchingSender Ljava/util/function/Consumer;
 	FIELD field_18278 velocity Lnet/minecraft/class_243;
 	FIELD field_39019 trackedPos Lnet/minecraft/class_7422;
 	FIELD field_41697 changedEntries Ljava/util/List;
-	FIELD field_55595 packetSender Ljava/util/function/BiConsumer;
+	FIELD field_55595 filteredWatchingSender Ljava/util/function/BiConsumer;
 	METHOD <init> (Lnet/minecraft/class_3218;Lnet/minecraft/class_1297;IZLjava/util/function/Consumer;Ljava/util/function/BiConsumer;)V
 		ARG 1 world
 		ARG 2 entity
 		ARG 3 tickInterval
 		ARG 4 alwaysUpdateVelocity
-		ARG 5 receiver
-		ARG 6 packetSender
+		ARG 5 watchingSender
+		ARG 6 filteredWatchingSender
 	METHOD method_14302 stopTracking (Lnet/minecraft/class_3222;)V
 		ARG 1 player
 	METHOD method_14306 syncEntityData ()V


### PR DESCRIPTION
The `EntityTrackerEntry` class contains two fields that represent a packet consumer. In vanilla, these fields are passed two different `ServerChunkLoadingManager#sendToOtherNearbyPlayers` methods: one with a UUID filter and one without. Currently, these fields are named `packetSender` and `receiver` respectively. This pull request clarifies the unified intent of these parameters and fields by renaming them to `filteredWatchingSender` and `watchingSender` respectively.