### PR TITLE
[1.21.5] Added AbstractNbtList get and remove

### DIFF
--- a/mappings/net/minecraft/nbt/AbstractNbtList.mapping
+++ b/mappings/net/minecraft/nbt/AbstractNbtList.mapping
@@ -7,6 +7,8 @@ CLASS net/minecraft/class_2483 net/minecraft/nbt/AbstractNbtList
 		COMMENT @return whether the element was actually added
 		ARG 1 index
 		ARG 2 element
+	METHOD method_10534 get (I)Lnet/minecraft/class_2520;
+		ARG 1 index
 	METHOD method_10535 setElement (ILnet/minecraft/class_2520;)Z
 		COMMENT Sets the element at {@code index} to {@code element}. Does nothing if
 		COMMENT the types were incompatible.
@@ -14,5 +16,7 @@ CLASS net/minecraft/class_2483 net/minecraft/nbt/AbstractNbtList
 		COMMENT @return whether the element was actually set
 		ARG 1 index
 		ARG 2 element
+	METHOD method_10536 remove (I)Lnet/minecraft/class_2520;
+		ARG 1 index
 	CLASS 1
 		FIELD field_57976 current I


### PR DESCRIPTION
In 1.21.5, `AbstractNbtList` stopped implementing `List`, so its `get` and `remove` now need to be mapped.
The current implementations of those methods is strictly identical to the old ones, so there's no doubt about their identity.