### PR TITLE
Map exchange values

### DIFF
--- a/mappings/net/minecraft/component/DataComponentTypes.mapping
+++ b/mappings/net/minecraft/component/DataComponentTypes.mapping
@@ -222,3 +222,5 @@ CLASS net/minecraft/class_9334 net/minecraft/component/DataComponentTypes
 		ARG 0 builder
 	METHOD method_68171 (Lnet/minecraft/class_9331$class_9332;)Lnet/minecraft/class_9331$class_9332;
 		ARG 0 builder
+	METHOD method_70535 (Lnet/minecraft/class_9331$class_9332;)Lnet/minecraft/class_9331$class_9332;
+		ARG 0 builder

--- a/mappings/net/minecraft/component/type/ExchangeValueComponent.mapping
+++ b/mappings/net/minecraft/component/type/ExchangeValueComponent.mapping
@@ -1,0 +1,9 @@
+CLASS net/minecraft/class_11054 net/minecraft/component/type/ExchangeValueComponent
+	FIELD field_58851 CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_58852 PACKET_CODEC Lnet/minecraft/class_9139;
+	METHOD method_69583 getValue (Lnet/minecraft/class_1657;Lnet/minecraft/class_1799;)F
+		ARG 1 player
+		ARG 2 stack
+	METHOD method_69584 getValue (Lnet/minecraft/class_1657;Ljava/lang/Iterable;)F
+		ARG 1 player
+		ARG 2 items

--- a/mappings/net/minecraft/item/Item.mapping
+++ b/mappings/net/minecraft/item/Item.mapping
@@ -37,6 +37,7 @@ CLASS net/minecraft/class_1792 net/minecraft/item/Item
 	FIELD field_54952 ENTRY_CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_55708 ENTRY_PACKET_CODEC Lnet/minecraft/class_9139;
 	FIELD field_56296 DEFAULT_BLOCKS_ATTACKS_MAX_USE_TIME I
+	FIELD field_58828 DEFAULT_EXCHANGE_VALUE Lnet/minecraft/class_11054;
 	METHOD <init> (Lnet/minecraft/class_1792$class_1793;)V
 		ARG 1 settings
 	METHOD method_7836 use (Lnet/minecraft/class_1937;Lnet/minecraft/class_1657;Lnet/minecraft/class_1268;)Lnet/minecraft/class_1269;
@@ -465,6 +466,10 @@ CLASS net/minecraft/class_1792 net/minecraft/item/Item
 			ARG 1 material
 			ARG 2 attackDamage
 			ARG 3 attackSpeed
+		METHOD method_69559 excludeComponent (Lnet/minecraft/class_9331;)Lnet/minecraft/class_1792$class_1793;
+			ARG 1 type
+		METHOD method_69560 exchangeValue (F)Lnet/minecraft/class_1792$class_1793;
+			ARG 1 exchangeValue
 	CLASS class_9635 TooltipContext
 		FIELD field_51353 DEFAULT Lnet/minecraft/class_1792$class_9635;
 		METHOD method_59527 getRegistryLookup ()Lnet/minecraft/class_7225$class_7874;

--- a/mappings/net/minecraft/item/tooltip/TooltipAppender.mapping
+++ b/mappings/net/minecraft/item/tooltip/TooltipAppender.mapping
@@ -3,3 +3,5 @@ CLASS net/minecraft/class_9299 net/minecraft/item/tooltip/TooltipAppender
 		ARG 1 context
 		ARG 2 textConsumer
 		ARG 3 type
+		ARG 4 player
+		ARG 5 stack


### PR DESCRIPTION
This pull request adds mappings for Craftmine's `minecraft:exchange_value` data component type. Note that the `Items.field_58827` field appears to be unused.