### PR TITLE
Small renames

### DIFF
--- a/mappings/net/minecraft/client/gui/DrawContext.mapping
+++ b/mappings/net/minecraft/client/gui/DrawContext.mapping
@@ -88,7 +88,7 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawContext
 		ARG 6 v
 		ARG 7 width
 		ARG 8 height
-		ARG 9 regionWith
+		ARG 9 regionWidth
 		ARG 10 regionHeight
 		ARG 11 textureWidth
 		ARG 12 textureHeight

--- a/mappings/net/minecraft/recipe/Ingredient.mapping
+++ b/mappings/net/minecraft/recipe/Ingredient.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/class_1856 net/minecraft/recipe/Ingredient
 	METHOD method_8101 ofItem (Lnet/minecraft/class_1935;)Lnet/minecraft/class_1856;
 		ARG 0 item
 	METHOD method_8105 getMatchingItems ()Ljava/util/stream/Stream;
-	METHOD method_8106 fromTag (Lnet/minecraft/class_6885;)Lnet/minecraft/class_1856;
+	METHOD method_8106 ofTag (Lnet/minecraft/class_6885;)Lnet/minecraft/class_1856;
 		ARG 0 tag
 	METHOD method_26964 ofItems (Ljava/util/stream/Stream;)Lnet/minecraft/class_1856;
 		ARG 0 stacks

--- a/mappings/net/minecraft/recipe/display/RecipeDisplay.mapping
+++ b/mappings/net/minecraft/recipe/display/RecipeDisplay.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_10295 net/minecraft/recipe/display/RecipeDisplay
 	FIELD field_54661 CODEC Lcom/mojang/serialization/Codec;
-	FIELD field_54662 STREAM_CODEC Lnet/minecraft/class_9139;
+	FIELD field_54662 PACKET_CODEC Lnet/minecraft/class_9139;
 	METHOD method_64726 serializer ()Lnet/minecraft/class_10295$class_10296;
 	METHOD method_64728 isEnabled (Lnet/minecraft/class_7699;)Z
 		ARG 1 features


### PR DESCRIPTION
- `RecipeDisplay.STREAM_CODEC` -> `PACKET_CODEC` (that's what the interface is called)
- `Ingredient.fromTag` -> `ofTag` (that's what all the other methods are called too)
\+ a parameter name fix in one of the `DrawContext.drawTexture` overloads