### PR TITLE
Fix outdated unpick mappings

### DIFF
--- a/mappings/net/minecraft/client/gui/widget/ClickableWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ClickableWidget.mapping
@@ -14,6 +14,8 @@ CLASS net/minecraft/class_339 net/minecraft/client/gui/widget/ClickableWidget
 	FIELD field_22765 alpha F
 	FIELD field_41095 tooltip Lnet/minecraft/class_9110;
 	FIELD field_42116 navigationOrder I
+	FIELD field_43055 FOCUSED_NARRATION_DELAY D
+	FIELD field_43056 UNFOCUSED_NARRATION_DELAY D
 	METHOD <init> (IIIILnet/minecraft/class_2561;)V
 		ARG 1 x
 		ARG 2 y

--- a/unpick-definitions/network_packets.unpick
+++ b/unpick-definitions/network_packets.unpick
@@ -43,9 +43,6 @@ target_method net/minecraft/network/packet/s2c/play/ScoreboardObjectiveUpdateS2C
 target_method net/minecraft/network/packet/s2c/play/ScoreboardObjectiveUpdateS2CPacket getMode ()I
 	return s2c_scoreboard_objective_update_mode
 
-constant s2c_screen_handler_slot_sync_id net/minecraft/network/packet/s2c/play/ScreenHandlerSlotUpdateS2CPacket UPDATE_CURSOR_SYNC_ID
-constant s2c_screen_handler_slot_sync_id net/minecraft/network/packet/s2c/play/ScreenHandlerSlotUpdateS2CPacket UPDATE_PLAYER_INVENTORY_SYNC_ID
-
 target_method net/minecraft/network/packet/s2c/play/ScreenHandlerSlotUpdateS2CPacket <init> (IILnet/minecraft/item/ItemStack;)V
 	param 0 s2c_screen_handler_slot_sync_id
 target_method net/minecraft/network/packet/s2c/play/ScreenHandlerSlotUpdateS2CPacket getSyncId ()I
@@ -64,8 +61,8 @@ target_method net/minecraft/network/packet/s2c/play/TeamS2CPacket containsPlayer
 target_method net/minecraft/network/packet/s2c/play/TeamS2CPacket containsTeamInfo (I)Z
 	param 0 s2c_team_packet_type
 
-flag s2c_recipe_book_setting_flags net/minecraft/network/packet/s2c/play/RecipeBookSettingsS2CPacket$Entry SHOW_NOTIFICATION
-flag s2c_recipe_book_setting_flags net/minecraft/network/packet/s2c/play/RecipeBookSettingsS2CPacket$Entry HIGHLIGHTED
+flag s2c_recipe_book_setting_flags net/minecraft/network/packet/s2c/play/RecipeBookAddS2CPacket$Entry SHOW_NOTIFICATION
+flag s2c_recipe_book_setting_flags net/minecraft/network/packet/s2c/play/RecipeBookAddS2CPacket$Entry HIGHLIGHTED
 
-target_method net/minecraft/network/packet/s2c/play/RecipeBookSettingsS2CPacket$Entry <init> (Lnet/minecraft/recipe/RecipeDisplayEntry;B)V
+target_method net/minecraft/network/packet/s2c/play/RecipeBookAddS2CPacket$Entry <init> (Lnet/minecraft/recipe/RecipeDisplayEntry;B)V
 	param 1 s2c_recipe_book_setting_flags


### PR DESCRIPTION
There were some outdated unpick mappings. I'm not sure where the `ScreenHandlerSlotUpdateS2CPacket` constants went, I couldn't find them.