### PR TITLE
Rename the BlockPredicatesChecker class to BlockPredicatesComponent

### DIFF
--- a/mappings/net/minecraft/component/type/BlockPredicatesComponent.mapping
+++ b/mappings/net/minecraft/component/type/BlockPredicatesComponent.mapping
@@ -1,13 +1,13 @@
 CLASS net/minecraft/class_6538 net/minecraft/component/type/BlockPredicatesComponent
-	COMMENT Checks if a block predicate stored inside {@link ItemStack}'s NBT
-	COMMENT matches the block in a world. The predicate must be stored inside
-	COMMENT the {@code key} sub NBT of the item stack.
+	COMMENT Stores a list of block predicates to match against a given
+	COMMENT block in a world.
 	COMMENT
 	COMMENT <p>The result is cached to reduce cost for successive lookups
 	COMMENT on the same block.
 	COMMENT
-	COMMENT @apiNote This is used to implement checks for restrictions specified
-	COMMENT using {@code CanPlaceOn} or {@code CanDestroy}.
+	COMMENT @apiNote This class is used to store the data and implement
+	COMMENT the functionality of the {@code minecraft:can_place_on} and
+	COMMENT {@code minecraft:can_break} components.
 	FIELD field_34450 cachedPos Lnet/minecraft/class_2694;
 	FIELD field_34451 lastResult Z
 	FIELD field_34452 nbtAware Z
@@ -24,7 +24,7 @@ CLASS net/minecraft/class_6538 net/minecraft/component/type/BlockPredicatesCompo
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 o
 	METHOD method_38070 check (Lnet/minecraft/class_2694;)Z
-		COMMENT {@return true if any of the predicates in the {@code stack}'s NBT
+		COMMENT {@return true if any of the predicates in this component
 		COMMENT matched against the block at {@code pos}, false otherwise}
 		ARG 1 cachedPos
 	METHOD method_38071 canUseCache (Lnet/minecraft/class_2694;Lnet/minecraft/class_2694;Z)Z

--- a/mappings/net/minecraft/component/type/BlockPredicatesComponent.mapping
+++ b/mappings/net/minecraft/component/type/BlockPredicatesComponent.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_6538 net/minecraft/item/BlockPredicatesComponent
+CLASS net/minecraft/class_6538 net/minecraft/component/type/BlockPredicatesComponent
 	COMMENT Checks if a block predicate stored inside {@link ItemStack}'s NBT
 	COMMENT matches the block in a world. The predicate must be stored inside
 	COMMENT the {@code key} sub NBT of the item stack.

--- a/mappings/net/minecraft/item/BlockPredicatesComponent.mapping
+++ b/mappings/net/minecraft/item/BlockPredicatesComponent.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_6538 net/minecraft/item/BlockPredicatesChecker
+CLASS net/minecraft/class_6538 net/minecraft/item/BlockPredicatesComponent
 	COMMENT Checks if a block predicate stored inside {@link ItemStack}'s NBT
 	COMMENT matches the block in a world. The predicate must be stored inside
 	COMMENT the {@code key} sub NBT of the item stack.


### PR DESCRIPTION
This class was not properly updated at the time to reflect the componentization, so the necessary changes to the `BlockPredicatesChecker` class's name, package, and documentation have been made in this pull request.