### PR TITLE
Clarify functionality of `ChatHud#getMessageIndex(..)` and some `Formatting` methods

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ name_proposal_version=0.1.5
 asm_version=9.5
 
 # Javadoc generation/linking
-fabric_loader_version=0.14.14
+fabric_loader_version=0.16.13
 jetbrains_annotations_version=23.0.0
 mappingpoet_version=0.3.2
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/mappings/net/minecraft/client/gui/hud/ChatHud.mapping
+++ b/mappings/net/minecraft/client/gui/hud/ChatHud.mapping
@@ -99,6 +99,14 @@ CLASS net/minecraft/class_338 net/minecraft/client/gui/hud/ChatHud
 	METHOD method_45587 queueForRemoval (Lnet/minecraft/class_7469;)Lnet/minecraft/class_338$class_7731;
 		ARG 1 signature
 	METHOD method_45588 getMessageIndex (DD)I
+		COMMENT @return The index of an {@linkplain ChatHudLine.Visible#endOfEntry end-of-entry} line
+		COMMENT in {@link #visibleMessages} at the given mouse position
+		COMMENT
+		COMMENT @apiNote <b>This method is NOT intended to be used with {@link #messages}, and it WILL
+		COMMENT return an inaccurate index for any mouse position above multiline messages.</b> This
+		COMMENT is because after a multiline message, {@link #messages} and {@link #visibleMessages}
+		COMMENT are no longer 1:1, as the long message is visually represented with multiple
+		COMMENT {@link ChatHudLine.Visible} instances.
 		ARG 1 chatLineX
 		ARG 3 chatLineY
 	METHOD method_45589 tickRemovalQueue ()V

--- a/mappings/net/minecraft/util/Formatting.mapping
+++ b/mappings/net/minecraft/util/Formatting.mapping
@@ -31,44 +31,39 @@ CLASS net/minecraft/class_124 net/minecraft/util/Formatting
 		ARG 6 colorIndex
 		ARG 7 colorValue
 	METHOD method_36145 getCode ()C
-		COMMENT {@return the code to be placed after the {@value FORMATTING_CODE_PREFIX} when this format is converted to a string}
+		COMMENT @return The code placed after the {@value FORMATTING_CODE_PREFIX} when this formatting is converted to a String}
 	METHOD method_531 (Lnet/minecraft/class_124;)Ljava/lang/String;
 		ARG 0 f
 	METHOD method_532 getColorValue ()Ljava/lang/Integer;
-		COMMENT {@return the color of the formatted text, or {@code null} if the formatting
-		COMMENT has no associated color}
+		COMMENT @return This formatting's color value (hex code) or {@code null} if not present
 	METHOD method_533 byName (Ljava/lang/String;)Lnet/minecraft/class_124;
-		COMMENT {@return the formatting with the name {@code name}, or {@code null} if there is none}
 		ARG 0 name
 	METHOD method_534 byColorIndex (I)Lnet/minecraft/class_124;
-		COMMENT {@return the formatting with the color index {@code colorIndex},
-		COMMENT or {@code null} if there is none}
+		COMMENT @return The formatting with the color index specified by {@code colorIndex}, otherwise {@link #RESET} if negative or {@code null} if none exists with the given index
 		ARG 0 colorIndex
 	METHOD method_535 sanitize (Ljava/lang/String;)Ljava/lang/String;
+		COMMENT @return The formatting's name in lowercase and with all non-letter characters removed.
 		ARG 0 name
 	METHOD method_536 getColorIndex ()I
-		COMMENT {@return the color index for the formatting, or {@code -1} to indicate no color}
+		COMMENT @return The color index of the formatting, or {@code -1} if none is present
 		COMMENT
 		COMMENT @apiNote This is also used to calculate scoreboard team display slot IDs.
 	METHOD method_537 getName ()Ljava/lang/String;
-		COMMENT {@return the name of the formatting}
+		COMMENT @return The name of this formatting in lowercase
 	METHOD method_539 strip (Ljava/lang/String;)Ljava/lang/String;
-		COMMENT {@return the {@code text} with all formatting codes removed}
+		COMMENT @return {@code text} with all formatting codes removed
 		COMMENT
 		COMMENT @see StringHelper#stripTextFormat
 		ARG 0 string
 	METHOD method_540 getNames (ZZ)Ljava/util/Collection;
-		COMMENT {@return the list of formattings matching the given condition}
+		COMMENT @return The list of formattings matching the given condition
 		ARG 0 colors
-			COMMENT whether or not to include color formattings
+			COMMENT Whether or not to include color formattings
 		ARG 1 modifiers
-			COMMENT whether or not to include modifier formattings
+			COMMENT Whether or not to include modifier formattings
 	METHOD method_541 (Lnet/minecraft/class_124;)Lnet/minecraft/class_124;
 		ARG 0 f
 	METHOD method_542 isModifier ()Z
-		COMMENT {@return true if the formatting is a modifier, false otherwise}
 	METHOD method_543 isColor ()Z
-		COMMENT {@return true if the formatting is associated with a color, false otherwise}
 	METHOD method_544 byCode (C)Lnet/minecraft/class_124;
-		COMMENT {@return the formatting with the code {@code code}, or {@code null} if there is none}
 		ARG 0 code


### PR DESCRIPTION
hi, i know this is an older branch and probably won't be accepted, but the `getMessageIndex` method name is very misleading and gave me a headache for a few days straight trying to figure out what the hell was wrong. i encourage this specific change at least to be used on all future versions of Yarn, if needed I can help with that soon.

the other `Formatting` comment tweaks aren't critical but the mistyped `{@return ...}`s everywhere and the overly verbose javadocs explaining `isColor` and similar methods were getting on my nerves.