### PR TITLE
Fix ItemStack#copyWithCount Javadoc

### DIFF
--- a/mappings/net/minecraft/item/ItemStack.mapping
+++ b/mappings/net/minecraft/item/ItemStack.mapping
@@ -391,8 +391,8 @@ CLASS net/minecraft/class_1799 net/minecraft/item/ItemStack
 	METHOD method_45435 isItemEnabled (Lnet/minecraft/class_7699;)Z
 		ARG 1 enabledFeatures
 	METHOD method_46651 copyWithCount (I)Lnet/minecraft/class_1799;
-		COMMENT {@return a copy of this item stack, including the components, and {@linkplain #getBobbingAnimationTime bobbing animation time}},
-		COMMENT with the item count set to {@code count}
+		COMMENT {@return a copy of this item stack, including the components, and {@linkplain #getBobbingAnimationTime bobbing animation time},
+		COMMENT with the item count set to {@code count}}
 		COMMENT
 		COMMENT @see #copy
 		COMMENT @see #copyComponentsToNewStack


### PR DESCRIPTION
Looks like the bracket was dropped when the Javadoc was first added in #3779