### PR TITLE
Fixed order of argument names of `TestContext.assertEquals`

### DIFF
--- a/mappings/net/minecraft/test/TestContext.mapping
+++ b/mappings/net/minecraft/test/TestContext.mapping
@@ -410,8 +410,8 @@ CLASS net/minecraft/class_4516 net/minecraft/test/TestContext
 	METHOD method_56208 getEntities (Lnet/minecraft/class_1299;)Ljava/util/List;
 		ARG 1 type
 	METHOD method_56606 assertEquals (Ljava/lang/Object;Ljava/lang/Object;Lnet/minecraft/class_2561;)V
-		ARG 1 value
-		ARG 2 expected
+		ARG 1 expected
+		ARG 2 value
 		ARG 3 message
 	METHOD method_57099 setEntityPos (Lnet/minecraft/class_1308;FFF)V
 		ARG 1 entity


### PR DESCRIPTION
This pull request swaps the order of the `expected` and the `value` argument of `TestContext.assertEqual`, such that `expected` is the first argument. 

This order is correct, since the error message translation (`"Expected %s to be %s, was %s"`) uses the first argument (now `expected`) in place of the second `%s` and the second argument (now `value`) in place of the third `%s`.