### PR TITLE
Fix Screen#onDisplayed JD to mention Screen#refreshWidgetPositions

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/Screen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/Screen.mapping
@@ -138,7 +138,7 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 	METHOD method_48640 refreshWidgetPositions ()V
 	METHOD method_49589 onDisplayed ()V
 		COMMENT Called when the screen is displayed using {@link MinecraftClient#setScreen}
-		COMMENT before {@link #init()} or {@link #initTabNavigation()} is called.
+		COMMENT before {@link #init()} or {@link #refreshWidgetPositions()} is called.
 	METHOD method_50024 getMusic ()Lnet/minecraft/class_5195;
 	METHOD method_52221 (Ljava/lang/Runnable;)V
 		ARG 1 runnable


### PR DESCRIPTION
In yarn 1.21.2, Screen#initTabNavigation got renamed to #refreshWidgetPositions