### PR TITLE
Rename the EntityEffectParticleEffect class to TintedParticleEffect

### DIFF
--- a/mappings/net/minecraft/particle/TintedParticleEffect.mapping
+++ b/mappings/net/minecraft/particle/TintedParticleEffect.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_9381 net/minecraft/particle/EntityEffectParticleEffect
+CLASS net/minecraft/class_9381 net/minecraft/particle/TintedParticleEffect
 	FIELD field_49909 type Lnet/minecraft/class_2396;
 	FIELD field_49910 color I
 	METHOD <init> (Lnet/minecraft/class_2396;I)V


### PR DESCRIPTION
The `EntityEffectParticleEffect` class is now used for both the `minecraft:entity_effect` and `minecraft:tinted_leaves` particle types, which both support specifying a color.