### PR TITLE
25w31a density functions, misc. worldgen mappings

### DIFF
--- a/mappings/net/minecraft/world/gen/chunk/Blender.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/Blender.mapping
@@ -102,6 +102,7 @@ CLASS net/minecraft/class_6748 net/minecraft/world/gen/chunk/Blender
 	METHOD method_40027 (IILorg/apache/commons/lang3/mutable/MutableDouble;Lorg/apache/commons/lang3/mutable/MutableDouble;Lorg/apache/commons/lang3/mutable/MutableDouble;Ljava/lang/Long;Lnet/minecraft/class_6749;)V
 		ARG 5 chunkPos
 		ARG 6 data
+	METHOD method_72689 isEmpty ()Z
 	CLASS class_6781 BlendingSampler
 		METHOD get (Lnet/minecraft/class_6749;III)D
 			ARG 1 data

--- a/mappings/net/minecraft/world/gen/chunk/BlendingData.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/BlendingData.mapping
@@ -54,6 +54,8 @@ CLASS net/minecraft/class_6749 net/minecraft/world/gen/chunk/BlendingData
 		ARG 2 chunkBlockX
 		ARG 3 chunkBlockZ
 		ARG 4 surfaceHeight
+	METHOD method_39355 clampPositive (I)I
+		ARG 0 value
 	METHOD method_39570 getBlendingData (Lnet/minecraft/class_3233;II)Lnet/minecraft/class_6749;
 		ARG 0 chunkRegion
 		ARG 1 chunkX

--- a/mappings/net/minecraft/world/gen/chunk/ChunkNoiseSampler.mapping
+++ b/mappings/net/minecraft/world/gen/chunk/ChunkNoiseSampler.mapping
@@ -43,12 +43,16 @@ CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
 	FIELD field_36593 isSamplingForCaches Z
 	FIELD field_36594 startBlockX I
 	FIELD field_37113 beardifying Lnet/minecraft/class_6916$class_7050;
+	FIELD field_61471 surfaceHeightEstimateCache Lit/unimi/dsi/fastutil/longs/Long2IntMap;
+	FIELD field_61472 preliminarySurfaceLevel Lnet/minecraft/class_6910;
 	METHOD <init> (ILnet/minecraft/class_7138;IILnet/minecraft/class_5309;Lnet/minecraft/class_6916$class_7050;Lnet/minecraft/class_5284;Lnet/minecraft/class_6350$class_6565;Lnet/minecraft/class_6748;)V
 		ARG 1 horizontalCellCount
+		ARG 2 noiseConfig
 		ARG 3 startBlockX
 		ARG 4 startBlockZ
 		ARG 5 generationShapeConfig
 		ARG 6 beardifying
+		ARG 7 chunkGeneratorSettings
 		ARG 8 fluidLevelSampler
 		ARG 9 blender
 	METHOD method_38336 sampleStartDensity ()V
@@ -137,6 +141,11 @@ CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
 		COMMENT Stops the interpolation loop for this chunk.
 	METHOD method_42361 getHorizontalCellBlockCount ()I
 	METHOD method_42362 getVerticalCellBlockCount ()I
+	METHOD method_72685 estimateHighestSurfaceLevel (IIII)I
+		ARG 1 minX
+		ARG 2 minZ
+		ARG 3 maxX
+		ARG 4 maxZ
 	CLASS class_5917 DensityInterpolator
 		FIELD field_29227 startDensityBuffer [[D
 		FIELD field_29228 endDensityBuffer [[D
@@ -205,6 +214,8 @@ CLASS net/minecraft/class_6568 net/minecraft/world/gen/chunk/ChunkNoiseSampler
 	CLASS class_6951 FlatCache
 		FIELD field_36612 delegate Lnet/minecraft/class_6910;
 		FIELD field_36613 cache [D
+		FIELD field_61473 horizontalCacheSize I
 		METHOD <init> (Lnet/minecraft/class_6568;Lnet/minecraft/class_6910;Z)V
+			ARG 2 delegate
 			ARG 3 sample
 	CLASS class_6952 ParentedNoiseType

--- a/mappings/net/minecraft/world/gen/densityfunction/DensityFunction.mapping
+++ b/mappings/net/minecraft/world/gen/densityfunction/DensityFunction.mapping
@@ -36,6 +36,7 @@ CLASS net/minecraft/class_6910 net/minecraft/world/gen/densityfunction/DensityFu
 	METHOD method_41061 (Lnet/minecraft/class_6910;)Lnet/minecraft/class_6880;
 		ARG 0 function
 	METHOD method_41062 getCodecHolder ()Lnet/minecraft/class_7243;
+	METHOD method_72682 invert ()Lnet/minecraft/class_6910;
 	CLASS class_6911 EachApplier
 		COMMENT {@code EachApplier} is used to fill an array of densities, like a density buffer
 		COMMENT or cache, with values from a density function.

--- a/mappings/net/minecraft/world/gen/densityfunction/DensityFunctionTypes.mapping
+++ b/mappings/net/minecraft/world/gen/densityfunction/DensityFunctionTypes.mapping
@@ -148,6 +148,11 @@ CLASS net/minecraft/class_6916 net/minecraft/world/gen/densityfunction/DensityFu
 			COMMENT the function used for the end value, for the {@code delta} value {@code 1.0}
 	METHOD method_42360 (Lnet/minecraft/class_6910;)Lcom/mojang/serialization/MapCodec;
 		ARG 0 densityFunction
+	METHOD method_72683 findTopSurface (Lnet/minecraft/class_6910;Lnet/minecraft/class_6910;II)Lnet/minecraft/class_6910;
+		ARG 0 density
+		ARG 1 upperBound
+		ARG 2 lowerBound
+		ARG 3 cellHeight
 	CLASS class_6917 BinaryOperation
 	CLASS class_6919 BlendAlpha
 		FIELD field_37079 CODEC Lnet/minecraft/class_7243;
@@ -273,3 +278,8 @@ CLASS net/minecraft/class_6916 net/minecraft/world/gen/densityfunction/DensityFu
 			METHOD method_41530 apply (Lnet/minecraft/class_6910$class_6915;)Lnet/minecraft/class_6916$class_7076$class_7135;
 				ARG 1 visitor
 		CLASS class_7136 SplinePos
+	CLASS class_11599 FindTopSurface
+		FIELD field_61468 CODEC_HOLDER Lnet/minecraft/class_7243;
+		FIELD field_61469 FIND_TOP_SURFACE_CODEC Lcom/mojang/serialization/MapCodec;
+		METHOD method_72684 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+			ARG 0 instance

--- a/mappings/net/minecraft/world/gen/densityfunction/DensityFunctions.mapping
+++ b/mappings/net/minecraft/world/gen/densityfunction/DensityFunctions.mapping
@@ -1,6 +1,11 @@
 CLASS net/minecraft/class_6954 net/minecraft/world/gen/densityfunction/DensityFunctions
 	FIELD field_36618 TEN_FUNCTION Lnet/minecraft/class_6910;
 	FIELD field_36619 ZERO_FUNCTION Lnet/minecraft/class_6910;
+	FIELD field_61475 WORLD_BOTTOM_Y I
+	FIELD field_61476 WORLD_TOP_HEIGHT I
+	FIELD field_61477 WORLD_BOTTOM_OFFSET D
+	FIELD field_61478 WORLD_TOP_OFFSET D
+	FIELD field_61479 BOTTOM_RELATIVE_SLIDE_MAX_Y I
 	METHOD method_40539 verticalRangeChoice (Lnet/minecraft/class_6910;Lnet/minecraft/class_6910;III)Lnet/minecraft/class_6910;
 		ARG 0 y
 		ARG 1 whenInRange
@@ -155,6 +160,18 @@ CLASS net/minecraft/class_6954 net/minecraft/world/gen/densityfunction/DensityFu
 		ARG 0 slopedCheese
 			COMMENT the base density function
 	METHOD method_44324 createMissingNoiseRouter ()Lnet/minecraft/class_6953;
+	METHOD method_72686 applyHeightGradient (Lnet/minecraft/class_6910;)Lnet/minecraft/class_6910;
+		ARG 0 function
+	METHOD method_72687 estimateUpperBound (Lnet/minecraft/class_6910;DDDD)Lnet/minecraft/class_6910;
+		ARG 0 density
+		ARG 1 bottomDensity
+		ARG 3 topDensity
+		ARG 5 bottomY
+		ARG 7 topY
+	METHOD method_72688 findTopSurface (Lnet/minecraft/class_6910;Lnet/minecraft/class_6910;Z)Lnet/minecraft/class_6910;
+		ARG 0 offset
+		ARG 1 factor
+		ARG 2 amplified
 	CLASS class_5841 CaveScaler
 		METHOD method_33835 scaleCaves (D)D
 			ARG 0 value

--- a/mappings/net/minecraft/world/gen/feature/util/CaveSurface.mapping
+++ b/mappings/net/minecraft/world/gen/feature/util/CaveSurface.mapping
@@ -29,6 +29,9 @@ CLASS net/minecraft/class_5721 net/minecraft/world/gen/feature/util/CaveSurface
 		ARG 4 mutablePos
 		ARG 5 y
 		ARG 6 direction
+	METHOD method_35326 (II)Lnet/minecraft/class_5721$class_5723;
+		ARG 0 floor
+		ARG 1 ceiling
 	METHOD method_35328 withCeiling (Ljava/util/OptionalInt;)Lnet/minecraft/class_5721;
 		ARG 1 ceiling
 	CLASS class_5722 Empty


### PR DESCRIPTION
Mostly for the new `minecraft:find_top_surface` and `minecraft:invert` density functions.