### PR TITLE
25w31a entity render command queue

### DIFF
--- a/mappings/net/minecraft/class_11683.mapping
+++ b/mappings/net/minecraft/class_11683.mapping
@@ -1,0 +1,11 @@
+CLASS net/minecraft/class_11683
+	FIELD field_61827 matrices Lnet/minecraft/class_4587;
+	METHOD method_73000 render (Lnet/minecraft/class_11661$class_11670;Lnet/minecraft/class_1921;Lnet/minecraft/class_4588;Lnet/minecraft/class_4618;)V
+		ARG 1 modelCommand
+		ARG 2 renderLayer
+		ARG 3 vertexConsumer
+		ARG 4 outlineVertexConsumers
+	METHOD method_73001 (Lnet/minecraft/class_11661;Lnet/minecraft/class_4597$class_4598;Lnet/minecraft/class_4618;)V
+		ARG 1 queue
+		ARG 2 vertexConsumers
+		ARG 3 outlineVertexConsumers

--- a/mappings/net/minecraft/class_11689.mapping
+++ b/mappings/net/minecraft/class_11689.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_11689
+	METHOD method_73014 (Lnet/minecraft/class_11661;Lnet/minecraft/class_4597$class_4598;Lnet/minecraft/class_327;)V
+		ARG 1 queue
+		ARG 3 renderer

--- a/mappings/net/minecraft/class_11690.mapping
+++ b/mappings/net/minecraft/class_11690.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_11690
 	METHOD method_73016 vertex (Lorg/joml/Matrix4f;Lnet/minecraft/class_4588;IFFFFF)V
-		ARG 0 trasformationMatrix
+		ARG 0 matrix
 		ARG 1 vertexConsumer
 		ARG 2 color
 		ARG 3 x

--- a/mappings/net/minecraft/class_11690.mapping
+++ b/mappings/net/minecraft/class_11690.mapping
@@ -1,0 +1,10 @@
+CLASS net/minecraft/class_11690
+	METHOD method_73016 vertex (Lorg/joml/Matrix4f;Lnet/minecraft/class_4588;IFFFFF)V
+		ARG 0 trasformationMatrix
+		ARG 1 vertexConsumer
+		ARG 2 color
+		ARG 3 x
+		ARG 4 y
+		ARG 5 z
+		ARG 6 u
+		ARG 7 v

--- a/mappings/net/minecraft/class_11697.mapping
+++ b/mappings/net/minecraft/class_11697.mapping
@@ -1,2 +1,26 @@
 CLASS net/minecraft/class_11697
-	CLASS class_7772 Atlas
+	FIELD field_61862 ATLAS_METADATA Ljava/util/List;
+	METHOD <init> (Lnet/minecraft/class_1060;I)V
+		ARG 1 textureManager
+	CLASS class_7772 Entry
+		FIELD comp_4557 metadata Lnet/minecraft/class_11697$class_11698;
+		METHOD comp_4557 metadata ()Lnet/minecraft/class_11697$class_11698;
+		METHOD method_73034 load (Lnet/minecraft/class_3300;Ljava/util/concurrent/Executor;I)Ljava/util/concurrent/CompletableFuture;
+			ARG 1 manager
+			ARG 2 executor
+			ARG 3 mipLevel
+	CLASS class_11698 Metadata
+		FIELD comp_4554 definitionId Lnet/minecraft/class_2960;
+		METHOD <init> (Lnet/minecraft/class_2960;Lnet/minecraft/class_2960;Z)V
+			ARG 1 textureId
+			ARG 2 definitionId
+			ARG 3 createMipmaps
+		METHOD comp_4554 definitionId ()Lnet/minecraft/class_2960;
+	CLASS class_11699
+		METHOD method_73035 (Ljava/util/Map;)V
+			ARG 1 sprites
+		METHOD method_73036 (Ljava/util/Map;Lnet/minecraft/class_2960;Lnet/minecraft/class_1058;)V
+			ARG 2 id
+			ARG 3 sprite
+	CLASS class_11700 Stitch
+		FIELD field_61867 stitchResults Ljava/util/Map;

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -282,6 +282,8 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 		ARG 1 chunkPos
 	METHOD method_71118 rotate ()V
 	METHOD method_72157 renderBlockLayers (Lorg/joml/Matrix4fc;DDD)Lnet/minecraft/class_11532;
+	METHOD method_72916 (Lnet/minecraft/class_4587;Lnet/minecraft/class_4184;Lnet/minecraft/class_11658;Lnet/minecraft/class_11659;)V
+		ARG 2 camera
 	CLASS class_10948 BrightnessGetter
 		FIELD field_58200 DEFAULT Lnet/minecraft/class_761$class_10948;
 		METHOD method_68890 (Lnet/minecraft/class_1920;Lnet/minecraft/class_2338;)I

--- a/mappings/net/minecraft/client/render/entity/EnderDragonEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EnderDragonEntityRenderer.mapping
@@ -17,4 +17,5 @@ CLASS net/minecraft/class_895 net/minecraft/client/render/entity/EnderDragonEnti
 		ARG 4 matrices
 		ARG 6 light
 	METHOD method_61158 renderDeathAnimation (Lnet/minecraft/class_4587;FLnet/minecraft/class_11659;Lnet/minecraft/class_1921;)V
+		ARG 0 matrices
 		ARG 1 animationProgress

--- a/mappings/net/minecraft/client/render/entity/EntityRenderDispatcher.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderDispatcher.mapping
@@ -15,9 +15,18 @@ CLASS net/minecraft/class_898 net/minecraft/client/render/entity/EntityRenderDis
 	FIELD field_55290 equipmentModelLoader Lnet/minecraft/class_10201;
 	METHOD <init> (Lnet/minecraft/class_310;Lnet/minecraft/class_1060;Lnet/minecraft/class_10442;Lnet/minecraft/class_918;Lnet/minecraft/class_330;Lnet/minecraft/class_776;Lnet/minecraft/class_11697;Lnet/minecraft/class_327;Lnet/minecraft/class_315;Ljava/util/function/Supplier;Lnet/minecraft/class_10201;)V
 		ARG 1 client
+		ARG 2 textureManager
+		ARG 3 itemModelManager
 		ARG 4 itemRenderer
+		ARG 5 mapRenderer
 		ARG 6 blockRenderManager
+		ARG 8 textRenderer
+		ARG 9 gameOptions
+		ARG 10 entityModelsGetter
+		ARG 11 equipmentModelLoader
 	METHOD method_3941 configure (Lnet/minecraft/class_4184;Lnet/minecraft/class_1297;)V
+		ARG 1 camera
+		ARG 2 targetedEntity
 	METHOD method_3950 shouldRender (Lnet/minecraft/class_1297;Lnet/minecraft/class_4604;DDD)Z
 		ARG 1 entity
 		ARG 2 frustum
@@ -42,3 +51,13 @@ CLASS net/minecraft/class_898 net/minecraft/client/render/entity/EntityRenderDis
 	METHOD method_68829 addRendererDetails (Lnet/minecraft/class_897;Lnet/minecraft/class_128;)Lnet/minecraft/class_129;
 	METHOD method_68832 getRenderer (Lnet/minecraft/class_10017;)Lnet/minecraft/class_897;
 		ARG 1 state
+	METHOD method_72976 render (Lnet/minecraft/class_10017;DDDLnet/minecraft/class_4587;Lnet/minecraft/class_11659;)V
+		ARG 1 renderState
+		ARG 2 x
+		ARG 4 y
+		ARG 6 z
+		ARG 8 matrices
+		ARG 9 queue
+	METHOD method_72977 getAndUpdateRenderState (Lnet/minecraft/class_1297;F)Lnet/minecraft/class_10017;
+		ARG 1 entity
+		ARG 2 tickProgress

--- a/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
@@ -13,6 +13,7 @@ CLASS net/minecraft/class_897 net/minecraft/client/render/entity/EntityRenderer
 		ARG 2 squaredDistanceToCamera
 	METHOD method_3926 renderLabelIfPresent (Lnet/minecraft/class_10017;Lnet/minecraft/class_4587;Lnet/minecraft/class_11659;)V
 		ARG 1 state
+		ARG 2 matrices
 	METHOD method_3932 getTextRenderer ()Lnet/minecraft/class_327;
 	METHOD method_3933 shouldRender (Lnet/minecraft/class_1297;Lnet/minecraft/class_4604;DDD)Z
 		ARG 1 entity
@@ -21,6 +22,9 @@ CLASS net/minecraft/class_897 net/minecraft/client/render/entity/EntityRenderer
 		ARG 5 y
 		ARG 7 z
 	METHOD method_3936 render (Lnet/minecraft/class_10017;Lnet/minecraft/class_4587;Lnet/minecraft/class_11659;)V
+		ARG 1 renderState
+		ARG 2 matrices
+		ARG 3 queue
 	METHOD method_23169 getPositionOffset (Lnet/minecraft/class_10017;)Lnet/minecraft/class_243;
 		ARG 1 state
 	METHOD method_24087 getBlockLight (Lnet/minecraft/class_1297;Lnet/minecraft/class_2338;)I
@@ -64,3 +68,13 @@ CLASS net/minecraft/class_897 net/minecraft/client/render/entity/EntityRenderer
 		ARG 3 tickProgress
 	METHOD method_68837 getServerEntity (Lnet/minecraft/class_1297;)Lnet/minecraft/class_1297;
 		ARG 0 clientEntity
+	METHOD method_72978 (Lnet/minecraft/class_10017;Lnet/minecraft/class_1937;FLnet/minecraft/class_2338$class_2339;Lnet/minecraft/class_2791;)V
+		ARG 1 renderState
+		ARG 2 world
+		ARG 3 shadowOpacity
+		ARG 4 pos
+		ARG 5 chunk
+	METHOD method_72979 (Lnet/minecraft/class_10017;Lnet/minecraft/class_310;Lnet/minecraft/class_1937;)V
+		ARG 1 renderState
+		ARG 2 client
+		ARG 3 world

--- a/mappings/net/minecraft/client/render/entity/TntMinecartEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/TntMinecartEntityRenderer.mapping
@@ -2,3 +2,5 @@ CLASS net/minecraft/class_957 net/minecraft/client/render/entity/TntMinecartEnti
 	METHOD method_23190 renderFlashingBlock (Lnet/minecraft/class_2680;Lnet/minecraft/class_4587;Lnet/minecraft/class_11659;IZ)V
 		COMMENT Renders a given block state into the given buffers either normally or with a bright white overlay.
 		COMMENT Used for rendering primed TNT either standalone or as part of a TNT minecart.
+		ARG 0 state
+		ARG 1 matrices

--- a/mappings/net/minecraft/client/render/entity/command/EntityRenderCommandQueue.mapping
+++ b/mappings/net/minecraft/client/render/entity/command/EntityRenderCommandQueue.mapping
@@ -1,0 +1,82 @@
+CLASS net/minecraft/class_11659 net/minecraft/client/render/entity/command/EntityRenderCommandQueue
+	METHOD method_72921 pushText (Lnet/minecraft/class_4587;FFLnet/minecraft/class_5481;ZLnet/minecraft/class_327$class_6415;III)V
+		ARG 1 matrices
+		ARG 2 x
+		ARG 3 y
+		ARG 4 text
+		ARG 5 dropShadow
+		ARG 6 layerType
+		ARG 7 light
+		ARG 8 color
+		ARG 9 backgroundColor
+	METHOD method_72922 pushShadowPieces (Lnet/minecraft/class_4587;FLjava/util/List;)V
+		ARG 1 matrices
+		ARG 2 shadowRadius
+		ARG 3 pieces
+	METHOD method_72923 pushBlock (Lnet/minecraft/class_4587;Lnet/minecraft/class_2680;II)V
+		ARG 1 matrices
+		ARG 2 state
+		ARG 3 light
+		ARG 4 overlay
+	METHOD method_72924 pushLabel (Lnet/minecraft/class_4587;Lnet/minecraft/class_243;Lnet/minecraft/class_2561;ZID)V
+		ARG 1 matrices
+		ARG 2 pos
+		ARG 3 label
+		ARG 4 notSneaking
+		ARG 5 light
+		ARG 6 squaredDistanceToCamera
+	METHOD method_72925 pushCustom (Lnet/minecraft/class_4587;Lnet/minecraft/class_1921;Lnet/minecraft/class_11659$class_11660;)V
+		ARG 1 matrices
+		ARG 2 renderLayer
+		ARG 3 vertices
+	METHOD method_72926 pushBlockStateModel (Lnet/minecraft/class_4587;Lnet/minecraft/class_1921;Lnet/minecraft/class_1087;FFFII)V
+		ARG 1 matrices
+		ARG 2 renderLayer
+		ARG 3 model
+		ARG 4 r
+		ARG 5 g
+		ARG 6 b
+		ARG 7 light
+		ARG 8 overlay
+	METHOD method_72927 pushLeash (Lnet/minecraft/class_4587;Lnet/minecraft/class_10017$class_10018;)V
+		ARG 1 matrices
+		ARG 2 data
+	METHOD method_72928 pushDebugHitbox (Lnet/minecraft/class_4587;Lnet/minecraft/class_10017;Lnet/minecraft/class_10933;)V
+		ARG 1 matrices
+		ARG 2 renderState
+		ARG 3 hitboxAndView
+	METHOD method_72929 pushFire (Lnet/minecraft/class_4587;Lnet/minecraft/class_10017;Lorg/joml/Quaternionf;)V
+		ARG 1 matrices
+		ARG 2 renderState
+		ARG 3 rotation
+	METHOD method_72930 pushFallingBlock (Lnet/minecraft/class_4587;Lnet/minecraft/class_10023;)V
+		ARG 1 matrices
+		ARG 2 renderState
+	METHOD method_72931 pushItem (Lnet/minecraft/class_4587;Lnet/minecraft/class_10444;II)V
+		ARG 1 matrices
+		ARG 2 renderState
+		ARG 3 light
+		ARG 4 overlay
+	METHOD method_72932 pushModel (Lnet/minecraft/class_3879;Ljava/lang/Object;Lnet/minecraft/class_4587;Lnet/minecraft/class_1921;III)V
+		ARG 1 model
+		ARG 2 state
+		ARG 3 matrices
+		ARG 4 renderLayer
+		ARG 5 light
+		ARG 6 overlay
+		ARG 7 outlineColor
+	METHOD method_72933 pushModel (Lnet/minecraft/class_3879;Ljava/lang/Object;Lnet/minecraft/class_4587;Lnet/minecraft/class_1921;IIILnet/minecraft/class_1058;II)V
+		ARG 1 model
+		ARG 2 state
+		ARG 3 matrices
+		ARG 4 renderLayer
+		ARG 5 light
+		ARG 6 overlay
+		ARG 7 tintedColor
+		ARG 8 sprite
+		ARG 9 outlineColor
+		ARG 10 order
+	CLASS class_11660 Custom
+		METHOD render (Lnet/minecraft/class_4587$class_4665;Lnet/minecraft/class_4588;)V
+			ARG 1 matricesEntry
+			ARG 2 vertexConsumer

--- a/mappings/net/minecraft/client/render/entity/command/EntityRenderCommandQueueImpl.mapping
+++ b/mappings/net/minecraft/client/render/entity/command/EntityRenderCommandQueueImpl.mapping
@@ -1,0 +1,55 @@
+CLASS net/minecraft/class_11661 net/minecraft/client/render/entity/command/EntityRenderCommandQueueImpl
+	FIELD field_61762 shadowPiecesCommands Ljava/util/List;
+	FIELD field_61763 fireCommands Ljava/util/List;
+	FIELD field_61764 seeThroughLabelCommands Ljava/util/List;
+	FIELD field_61765 labelCommands Ljava/util/List;
+	FIELD field_61766 textCommands Ljava/util/List;
+	FIELD field_61767 debugHitboxCommands Ljava/util/List;
+	FIELD field_61768 leashCommands Ljava/util/List;
+	FIELD field_61769 blockCommands Ljava/util/List;
+	FIELD field_61770 fallingBlockCommands Ljava/util/List;
+	FIELD field_61771 blockStateModelCommands Ljava/util/List;
+	FIELD field_61772 itemCommands Ljava/util/List;
+	FIELD field_61773 modelCommands Lit/unimi/dsi/fastutil/ints/Int2ObjectAVLTreeMap;
+	FIELD field_61774 renderLayerOrders Ljava/util/Set;
+	FIELD field_61775 customCommands Ljava/util/Map;
+	METHOD method_72934 shadowPiecesCommands ()Ljava/util/List;
+	METHOD method_72939 fireCommands ()Ljava/util/List;
+	METHOD method_72940 (Lnet/minecraft/class_1921;)Ljava/util/List;
+		ARG 0 layer
+	METHOD method_72941 seeThroughLabelCommands ()Ljava/util/List;
+	METHOD method_72942 (Lnet/minecraft/class_1921;)Ljava/util/List;
+		ARG 0 layer
+	METHOD method_72943 labelCommands ()Ljava/util/List;
+	METHOD method_72944 textCommands ()Ljava/util/List;
+	METHOD method_72945 debugHitboxCommands ()Ljava/util/List;
+	METHOD method_72946 leashCommands ()Ljava/util/List;
+	METHOD method_72947 blockCommands ()Ljava/util/List;
+	METHOD method_72948 fallingBlockCommands ()Ljava/util/List;
+	METHOD method_72949 blockStateModelCommands ()Ljava/util/List;
+	METHOD method_72950 itemCommands ()Ljava/util/List;
+	METHOD method_72951 modelCommands ()Lit/unimi/dsi/fastutil/ints/Int2ObjectAVLTreeMap;
+	METHOD method_72952 customCommands ()Ljava/util/Map;
+	METHOD method_72953 clear ()V
+	METHOD method_72954 render ()V
+	CLASS class_11662 BlockStateModelCommand
+	CLASS class_11663 BlockCommand
+	CLASS class_11664 CustomCommand
+	CLASS class_11665 FallingBlockCommand
+		FIELD comp_4491 renderState Lnet/minecraft/class_10023;
+		METHOD comp_4491 renderState ()Lnet/minecraft/class_10023;
+	CLASS class_11666 FireCommand
+		FIELD comp_4493 renderState Lnet/minecraft/class_10017;
+		METHOD comp_4493 renderState ()Lnet/minecraft/class_10017;
+	CLASS class_11667 DebugHitboxCommand
+		FIELD comp_4496 renderState Lnet/minecraft/class_10017;
+		FIELD comp_4497 hitboxAndView Lnet/minecraft/class_10933;
+		METHOD comp_4496 renderState ()Lnet/minecraft/class_10017;
+		METHOD comp_4497 hitboxAndView ()Lnet/minecraft/class_10933;
+	CLASS class_11668 ItemCommand
+	CLASS class_11669 LeashCommand
+	CLASS class_11670 ModelCommand
+	CLASS class_11671 RenderLayerAndOrder
+	CLASS class_11672 LabelCommand
+	CLASS class_11673 ShadowPiecesCommand
+	CLASS class_11674 TextCommand

--- a/mappings/net/minecraft/client/render/entity/feature/MooshroomMushroomFeatureRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/feature/MooshroomMushroomFeatureRenderer.mapping
@@ -4,6 +4,7 @@ CLASS net/minecraft/class_991 net/minecraft/client/render/entity/feature/Mooshro
 		ARG 1 context
 		ARG 2 blockRenderManager
 	METHOD method_37314 renderMushroom (Lnet/minecraft/class_4587;Lnet/minecraft/class_11659;IZLnet/minecraft/class_2680;ILnet/minecraft/class_1087;)V
+		ARG 1 matrices
 		ARG 3 light
 		ARG 4 renderAsModel
 		ARG 6 overlay

--- a/mappings/net/minecraft/client/render/entity/state/EntityRenderState.mapping
+++ b/mappings/net/minecraft/client/render/entity/state/EntityRenderState.mapping
@@ -17,8 +17,13 @@ CLASS net/minecraft/class_10017 net/minecraft/client/render/entity/state/EntityR
 	FIELD field_58170 debugInfo Lnet/minecraft/class_10934;
 	FIELD field_58171 entityType Lnet/minecraft/class_1299;
 	FIELD field_60160 leashDatas Ljava/util/List;
+	FIELD field_61820 light I
+	FIELD field_61821 outlineColor I
+	FIELD field_61822 shadowRadius F
+	FIELD field_61823 shadowPieces Ljava/util/List;
 	METHOD method_68839 addCrashReportDetails (Lnet/minecraft/class_129;)V
 		ARG 1 crashReportSection
+	METHOD method_72997 hasOutline ()Z
 	CLASS class_10018 LeashData
 		FIELD field_53339 offset Lnet/minecraft/class_243;
 		FIELD field_53340 startPos Lnet/minecraft/class_243;
@@ -27,3 +32,4 @@ CLASS net/minecraft/class_10017 net/minecraft/client/render/entity/state/EntityR
 		FIELD field_53343 leashHolderBlockLight I
 		FIELD field_53344 leashedEntitySkyLight I
 		FIELD field_53345 leashHolderSkyLight I
+	CLASS class_11680 ShadowPiece

--- a/mappings/net/minecraft/client/texture/SpriteLoader.mapping
+++ b/mappings/net/minecraft/client/texture/SpriteLoader.mapping
@@ -45,3 +45,7 @@ CLASS net/minecraft/class_7766 net/minecraft/client/texture/SpriteLoader
 	METHOD method_47666 (Lnet/minecraft/class_8684;Ljava/util/concurrent/Executor;Ljava/util/function/Function;)Ljava/util/concurrent/CompletableFuture;
 		ARG 2 sprite
 	CLASS class_7767 StitchResult
+		FIELD comp_1044 sprites Ljava/util/Map;
+		METHOD comp_1044 sprites ()Ljava/util/Map;
+		METHOD method_73022 getSprite (Lnet/minecraft/class_2960;)Lnet/minecraft/class_1058;
+			ARG 1 id

--- a/mappings/net/minecraft/resource/ResourceReloader.mapping
+++ b/mappings/net/minecraft/resource/ResourceReloader.mapping
@@ -52,3 +52,4 @@ CLASS net/minecraft/class_3302 net/minecraft/resource/ResourceReloader
 			COMMENT @return a completable future as the precondition for the apply stage
 			ARG 1 preparedObject
 				COMMENT the result of the prepare stage
+	CLASS class_11559 Key


### PR DESCRIPTION
I'm not familiar with Minecraft's rendering, so please do check if everything here is correct :)

It's in a new package because of all the classes that will actually render the commands at the end, which are not mapped in this PR.

I've also thought about giving `class_11659` a different name, since the command queue is technically internals (like `EntityRendering`, is that too generic?), but this is probably fine for now.