### PR TITLE
Map object text content

### DIFF
--- a/mappings/net/minecraft/client/font/FontManager.mapping
+++ b/mappings/net/minecraft/client/font/FontManager.mapping
@@ -10,6 +10,10 @@ CLASS net/minecraft/class_378 net/minecraft/client/font/FontManager
 	FIELD field_44758 fonts Ljava/util/List;
 	FIELD field_61605 anyFonts Lnet/minecraft/class_378$class_11638;
 	FIELD field_61606 advanceValidatedFonts Lnet/minecraft/class_378$class_11638;
+	FIELD field_61934 atlasManager Lnet/minecraft/class_11697;
+	METHOD <init> (Lnet/minecraft/class_1060;Lnet/minecraft/class_11697;)V
+		ARG 1 textureManager
+		ARG 2 atlasManager
 	METHOD method_27539 createTextRenderer ()Lnet/minecraft/class_327;
 	METHOD method_45078 createAdvanceValidatingTextRenderer ()Lnet/minecraft/class_327;
 	METHOD method_51607 (Ljava/util/Set;Lnet/minecraft/class_2960;Ljava/util/List;)V
@@ -107,3 +111,5 @@ CLASS net/minecraft/class_378 net/minecraft/client/font/FontManager
 		METHOD <init> (Lnet/minecraft/class_378;Z)V
 			ARG 2 advanceValidating
 		METHOD method_72786 clear ()V
+		METHOD method_73149 (Lnet/minecraft/class_11719;)Lnet/minecraft/class_11603;
+			ARG 1 source

--- a/mappings/net/minecraft/client/font/TextRenderer.mapping
+++ b/mappings/net/minecraft/client/font/TextRenderer.mapping
@@ -214,3 +214,4 @@ CLASS net/minecraft/class_327 net/minecraft/client/font/TextRenderer
 	CLASS class_11602 GlyphsProvider
 		METHOD method_72734 defaultGlyph ()Lnet/minecraft/class_11643;
 		METHOD method_72735 getGlyphs (Lnet/minecraft/class_11719;)Lnet/minecraft/class_11603;
+			ARG 1 source

--- a/mappings/net/minecraft/text/ObjectTextContent.mapping
+++ b/mappings/net/minecraft/text/ObjectTextContent.mapping
@@ -1,0 +1,19 @@
+CLASS net/minecraft/class_11722 net/minecraft/text/ObjectTextContent
+	FIELD field_61973 CODEC Lcom/mojang/serialization/MapCodec;
+	FIELD field_61974 TYPE Lnet/minecraft/class_7417$class_8823;
+	FIELD field_61975 REPLACEMENT Ljava/lang/String;
+	METHOD method_73174 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance
+	CLASS class_11723 SpriteContents
+		FIELD field_61976 atlas Lnet/minecraft/class_2960;
+		FIELD field_61977 CODEC Lcom/mojang/serialization/MapCodec;
+		METHOD method_73176 getShortIdString (Lnet/minecraft/class_2960;)Ljava/lang/String;
+			ARG 0 id
+		METHOD method_73177 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+			ARG 0 instance
+	CLASS class_11724 Contents
+		FIELD field_61978 CODEC Lcom/mojang/serialization/MapCodec;
+		METHOD method_73175 spriteSource ()Lnet/minecraft/class_11719;
+		METHOD method_73178 asText ()Ljava/lang/String;
+		METHOD method_73179 (Lnet/minecraft/class_11722$class_11724;)Lcom/mojang/serialization/DataResult;
+			ARG 0 contents

--- a/mappings/net/minecraft/text/ObjectTextContent.mapping
+++ b/mappings/net/minecraft/text/ObjectTextContent.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/class_11722 net/minecraft/text/ObjectTextContent
 	METHOD method_73174 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 0 instance
 	CLASS class_11723 SpriteContents
-		FIELD field_61976 atlas Lnet/minecraft/class_2960;
+		FIELD field_61976 DEFAULT_ATLAS Lnet/minecraft/class_2960;
 		FIELD field_61977 CODEC Lcom/mojang/serialization/MapCodec;
 		METHOD method_73176 getShortIdString (Lnet/minecraft/class_2960;)Ljava/lang/String;
 			ARG 0 id

--- a/mappings/net/minecraft/text/StyleSpriteSource.mapping
+++ b/mappings/net/minecraft/text/StyleSpriteSource.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_11719 net/minecraft/text/StyleSpriteSource
+	FIELD field_61972 DEFAULT Lnet/minecraft/class_11719$class_11721;
+	CLASS class_11720 Sprite
+	CLASS class_11721 Font

--- a/mappings/net/minecraft/text/StyleSpriteSource.mapping
+++ b/mappings/net/minecraft/text/StyleSpriteSource.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/class_11719 net/minecraft/text/StyleSpriteSource
+	FIELD field_61971 CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_61972 DEFAULT Lnet/minecraft/class_11719$class_11721;
+	METHOD method_73172 (Lnet/minecraft/class_11719;)Lcom/mojang/serialization/DataResult;
+		ARG 0 instance
 	CLASS class_11720 Sprite
 	CLASS class_11721 Font


### PR DESCRIPTION
This pull request adds mappings for the public-facing additions to support the `object` text content, namely including the `ObjectTextContent` class. The internal changes are not mapped by this pull request.