### PR TITLE
Rename Entity.getWorld() -> getEntityWorld()

### DIFF
--- a/mappings/net/minecraft/entity/Tameable.mapping
+++ b/mappings/net/minecraft/entity/Tameable.mapping
@@ -2,4 +2,4 @@ CLASS net/minecraft/class_6025 net/minecraft/entity/Tameable
 	METHOD method_35057 getOwner ()Lnet/minecraft/class_1309;
 	METHOD method_66287 getOwnerReference ()Lnet/minecraft/class_10583;
 	METHOD method_67519 getTopLevelOwner ()Lnet/minecraft/class_1309;
-	METHOD method_73183 world ()Lnet/minecraft/class_1937;
+	METHOD method_73183 getEntityWorld ()Lnet/minecraft/class_1937;

--- a/mappings/net/minecraft/entity/vehicle/VehicleInventory.mapping
+++ b/mappings/net/minecraft/entity/vehicle/VehicleInventory.mapping
@@ -37,5 +37,5 @@ CLASS net/minecraft/class_7265 net/minecraft/entity/vehicle/VehicleInventory
 	METHOD method_42294 canPlayerAccess (Lnet/minecraft/class_1657;)Z
 		ARG 1 player
 	METHOD method_42295 isInventoryEmpty ()Z
-	METHOD method_73183 world ()Lnet/minecraft/class_1937;
+	METHOD method_73183 getEntityWorld ()Lnet/minecraft/class_1937;
 	METHOD method_73189 getPos ()Lnet/minecraft/class_243;

--- a/mappings/net/minecraft/util/HeldItemContext.mapping
+++ b/mappings/net/minecraft/util/HeldItemContext.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_11566 net/minecraft/util/HeldItemContext
 	METHOD method_72393 getEntity ()Lnet/minecraft/class_1309;
-	METHOD method_73183 world ()Lnet/minecraft/class_1937;
+	METHOD method_73183 getEntityWorld ()Lnet/minecraft/class_1937;
 	METHOD method_73188 getBodyYaw ()F
 	METHOD method_73189 getPos ()Lnet/minecraft/class_243;


### PR DESCRIPTION
In the latest snapshot Entity.getWorld() cannot have the same name as BlockEntity.getWorld() due to a complex mess of interfaces that have differing world getters that are implimited by both classes.

The diff of this PR improves the quick hackfix I did just to get mods building again: https://github.com/FabricMC/yarn/commit/bffba7c3dccf5b19e0a704beafe20e52458f7b85 