### PR TITLE
Allow for multiple unpick errors per file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,10 +94,10 @@ def libs = new File("build/libs/")
 def minecraftLibraries = configurations.minecraftLibraries
 
 import cuchaz.enigma.command.CheckMappingsCommand
-import net.fabricmc.filament.task.CheckUnpickDefinitionsTask
 import net.fabricmc.filament.task.DownloadTask
 import net.fabricmc.filament.task.MapJarTask
-import net.fabricmc.filament.task.UnpickJarTask
+import net.fabricmc.filament.task.unpick.CheckUnpickDefinitionsTask
+import net.fabricmc.filament.task.unpick.UnpickJarTask
 import net.fabricmc.filament.task.MappingPoetTask
 import net.fabricmc.filament.task.base.WithFileInput
 import net.fabricmc.filament.task.base.WithFileOutput

--- a/filament/src/main/java/net/fabricmc/filament/FilamentGradlePlugin.java
+++ b/filament/src/main/java/net/fabricmc/filament/FilamentGradlePlugin.java
@@ -12,11 +12,11 @@ import org.gradle.api.tasks.Delete;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 
-import net.fabricmc.filament.task.CombineUnpickDefinitionsTask;
+import net.fabricmc.filament.task.unpick.CombineUnpickDefinitionsTask;
 import net.fabricmc.filament.task.DownloadTask;
 import net.fabricmc.filament.task.GeneratePackageInfoMappingsTask;
 import net.fabricmc.filament.task.JavadocLintTask;
-import net.fabricmc.filament.task.RemapUnpickDefinitionsTask;
+import net.fabricmc.filament.task.unpick.RemapUnpickDefinitionsTask;
 import net.fabricmc.filament.task.base.WithFileOutput;
 import net.fabricmc.filament.task.minecraft.ExtractBundledServerTask;
 import net.fabricmc.filament.task.minecraft.MergeMinecraftTask;

--- a/filament/src/main/java/net/fabricmc/filament/task/unpick/CheckUnpickDefinitionsTask.java
+++ b/filament/src/main/java/net/fabricmc/filament/task/unpick/CheckUnpickDefinitionsTask.java
@@ -1,4 +1,4 @@
-package net.fabricmc.filament.task;
+package net.fabricmc.filament.task.unpick;
 
 import java.io.File;
 import java.io.FileReader;
@@ -84,14 +84,19 @@ public abstract class CheckUnpickDefinitionsTask extends DefaultTask {
 						return;
 					}
 
+					List<UnpickSyntaxException> errors;
 					try {
-						validateUnpickFile(unpickFile, classResolver, classpathJars);
-					} catch (UnpickSyntaxException e) {
-						Path relativePath = getParameters().getInput().getAsFile().get().toPath().relativize(unpickFile.toPath());
-						LOGGER.error("{}: {}", relativePath, e.getMessage());
-						failureCount.incrementAndGet();
+						errors = validateUnpickFile(unpickFile, classResolver, classpathJars);
 					} catch (IOException e) {
 						throw new UncheckedIOException(e);
+					}
+
+					if (!errors.isEmpty()) {
+						Path relativePath = getParameters().getInput().getAsFile().get().toPath().relativize(unpickFile.toPath());
+						for (UnpickSyntaxException error : errors) {
+							LOGGER.error("{}: {}", relativePath, error.getMessage());
+						}
+						failureCount.addAndGet(errors.size());
 					}
 				});
 
@@ -123,14 +128,16 @@ public abstract class CheckUnpickDefinitionsTask extends DefaultTask {
 			return result;
 		}
 
-		private static void validateUnpickFile(File file, IClassResolver classResolver, List<FileSystemUtil.Delegate> classpathJars) throws IOException {
+		private static List<UnpickSyntaxException> validateUnpickFile(File file, IClassResolver classResolver, List<FileSystemUtil.Delegate> classpathJars) throws IOException {
 			try (UnpickV3Reader reader = new UnpickV3Reader(new FileReader(file))) {
-				reader.accept(new ValidatingUnpickV3Visitor(classResolver) {
+				ValidatingUnpickV3Visitor validator = new ValidatingUnpickV3Visitor(classResolver) {
 					@Override
 					public boolean packageExists(String packageName) {
 						return CheckAction.packageExists(classpathJars, packageName);
 					}
-				});
+				};
+				reader.accept(validator);
+				return validator.finishValidation();
 			}
 		}
 

--- a/filament/src/main/java/net/fabricmc/filament/task/unpick/CheckUnpickDefinitionsTask.java
+++ b/filament/src/main/java/net/fabricmc/filament/task/unpick/CheckUnpickDefinitionsTask.java
@@ -85,6 +85,7 @@ public abstract class CheckUnpickDefinitionsTask extends DefaultTask {
 					}
 
 					List<UnpickSyntaxException> errors;
+
 					try {
 						errors = validateUnpickFile(unpickFile, classResolver, classpathJars);
 					} catch (IOException e) {
@@ -93,9 +94,11 @@ public abstract class CheckUnpickDefinitionsTask extends DefaultTask {
 
 					if (!errors.isEmpty()) {
 						Path relativePath = getParameters().getInput().getAsFile().get().toPath().relativize(unpickFile.toPath());
+
 						for (UnpickSyntaxException error : errors) {
 							LOGGER.error("{}: {}", relativePath, error.getMessage());
 						}
+
 						failureCount.addAndGet(errors.size());
 					}
 				});

--- a/filament/src/main/java/net/fabricmc/filament/task/unpick/CombineUnpickDefinitionsTask.java
+++ b/filament/src/main/java/net/fabricmc/filament/task/unpick/CombineUnpickDefinitionsTask.java
@@ -1,4 +1,4 @@
-package net.fabricmc.filament.task;
+package net.fabricmc.filament.task.unpick;
 
 import java.io.File;
 import java.io.FileReader;

--- a/filament/src/main/java/net/fabricmc/filament/task/unpick/RemapUnpickDefinitionsTask.java
+++ b/filament/src/main/java/net/fabricmc/filament/task/unpick/RemapUnpickDefinitionsTask.java
@@ -1,4 +1,4 @@
-package net.fabricmc.filament.task;
+package net.fabricmc.filament.task.unpick;
 
 import java.io.File;
 import java.io.FileReader;

--- a/filament/src/main/java/net/fabricmc/filament/task/unpick/UnpickJarTask.java
+++ b/filament/src/main/java/net/fabricmc/filament/task/unpick/UnpickJarTask.java
@@ -1,4 +1,4 @@
-package net.fabricmc.filament.task;
+package net.fabricmc.filament.task.unpick;
 
 import java.io.BufferedReader;
 import java.io.File;

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.parallel=true
 org.gradle.configuration-cache=true
 
 enigma_version=2.5.2
-unpick_version=3.0.0-beta.10
+unpick_version=3.0.0-beta.11
 cfr_version=0.2.2
 vineflower_version=1.11.1
 asm_version=9.8


### PR DESCRIPTION
The yarn side of https://github.com/FabricMC/unpick/pull/39. I also put all the unpick tasks in their own package.