### PR TITLE
Map cursors

### DIFF
--- a/mappings/net/minecraft/client/gui/DrawContext.mapping
+++ b/mappings/net/minecraft/client/gui/DrawContext.mapping
@@ -5,6 +5,7 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawContext
 	FIELD field_44659 scissorStack Lnet/minecraft/class_332$class_8214;
 	FIELD field_59826 state Lnet/minecraft/class_11246;
 	FIELD field_60305 tooltipDrawer Ljava/lang/Runnable;
+	FIELD field_62463 cursor Lnet/minecraft/class_11875;
 	METHOD <init> (Lnet/minecraft/class_310;Lnet/minecraft/class_11246;)V
 		ARG 1 client
 		ARG 2 state
@@ -245,6 +246,7 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawContext
 		ARG 7 shadow
 	METHOD method_51441 drawHoverEvent (Lnet/minecraft/class_327;Lnet/minecraft/class_2583;II)V
 		ARG 1 textRenderer
+		ARG 2 style
 		ARG 3 x
 		ARG 4 y
 	METHOD method_51443 getScaledWindowHeight ()I
@@ -572,6 +574,10 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawContext
 		ARG 4 y2
 	METHOD method_72740 getScaling (Lnet/minecraft/class_1058;)Lnet/minecraft/class_8690;
 		ARG 0 sprite
+	METHOD method_74036 applyCursorTo (Lnet/minecraft/class_1041;)V
+		ARG 1 window
+	METHOD method_74037 setCursor (Lnet/minecraft/class_11875;)V
+		ARG 1 cursor
 	CLASS class_8214 ScissorStack
 		FIELD field_43099 stack Ljava/util/Deque;
 		METHOD method_49699 pop ()Lnet/minecraft/class_8030;

--- a/mappings/net/minecraft/client/gui/cursor/Cursor.mapping
+++ b/mappings/net/minecraft/client/gui/cursor/Cursor.mapping
@@ -1,0 +1,12 @@
+CLASS net/minecraft/class_11875 net/minecraft/client/gui/cursor/Cursor
+	FIELD field_62450 name Ljava/lang/String;
+	FIELD field_62451 handle J
+	METHOD <init> (Ljava/lang/String;J)V
+		ARG 1 name
+		ARG 2 handle
+	METHOD method_74031 createStandard (ILjava/lang/String;Lnet/minecraft/class_11875;)Lnet/minecraft/class_11875;
+		ARG 0 handle
+		ARG 1 name
+		ARG 2 fallback
+	METHOD method_74032 applyTo (Lnet/minecraft/class_1041;)V
+		ARG 1 window

--- a/mappings/net/minecraft/client/gui/cursor/StandardCursors.mapping
+++ b/mappings/net/minecraft/client/gui/cursor/StandardCursors.mapping
@@ -1,0 +1,9 @@
+CLASS net/minecraft/class_11876 net/minecraft/client/gui/cursor/StandardCursors
+	FIELD field_62452 ARROW Lnet/minecraft/class_11875;
+	FIELD field_62453 IBEAM Lnet/minecraft/class_11875;
+	FIELD field_62454 CROSSHAIR Lnet/minecraft/class_11875;
+	FIELD field_62455 POINTING_HAND Lnet/minecraft/class_11875;
+	FIELD field_62456 RESIZE_NS Lnet/minecraft/class_11875;
+	FIELD field_62457 RESIZE_EW Lnet/minecraft/class_11875;
+	FIELD field_62458 RESIZE_ALL Lnet/minecraft/class_11875;
+	FIELD field_62459 NOT_ALLOWED Lnet/minecraft/class_11875;

--- a/mappings/net/minecraft/client/option/GameOptions.mapping
+++ b/mappings/net/minecraft/client/option/GameOptions.mapping
@@ -249,6 +249,8 @@ CLASS net/minecraft/class_315 net/minecraft/client/option/GameOptions
 	FIELD field_61513 invertMouseX Lnet/minecraft/class_7172;
 	FIELD field_61999 CHAT_DRAFTS_TOOLTIP Lnet/minecraft/class_2561;
 	FIELD field_62000 chatDrafts Lnet/minecraft/class_7172;
+	FIELD field_62461 ALLOW_CURSOR_CHANGES_TOOLTIP Lnet/minecraft/class_2561;
+	FIELD field_62462 allowCursorChanges Lnet/minecraft/class_7172;
 	METHOD <init> (Lnet/minecraft/class_310;Ljava/io/File;)V
 		ARG 1 client
 		ARG 2 optionsFile
@@ -658,6 +660,8 @@ CLASS net/minecraft/class_315 net/minecraft/client/option/GameOptions
 	METHOD method_72717 (Ljava/lang/Boolean;)V
 		ARG 0 value
 	METHOD method_73197 getChatDrafts ()Lnet/minecraft/class_7172;
+	METHOD method_74035 (Ljava/lang/Boolean;)V
+		ARG 0 value
 	CLASS 2
 		METHOD method_33676 find (Ljava/lang/String;)Ljava/lang/String;
 			ARG 1 key

--- a/mappings/net/minecraft/client/util/Window.mapping
+++ b/mappings/net/minecraft/client/util/Window.mapping
@@ -25,6 +25,8 @@ CLASS net/minecraft/class_1041 net/minecraft/client/util/Window
 	FIELD field_16517 vsync Z
 	FIELD field_52735 minimized Z
 	FIELD field_55579 zeroWidthOrHeight Z
+	FIELD field_62447 allowCursorChanges Z
+	FIELD field_62448 cursor Lnet/minecraft/class_11875;
 	METHOD <init> (Lnet/minecraft/class_3678;Lnet/minecraft/class_323;Lnet/minecraft/class_543;Ljava/lang/String;Ljava/lang/String;)V
 		ARG 1 eventHandler
 		ARG 3 settings
@@ -115,4 +117,8 @@ CLASS net/minecraft/class_1041 net/minecraft/client/util/Window
 		ARG 3 minimized
 	METHOD method_61946 isMinimized ()Z
 	METHOD method_65966 hasZeroWidthOrHeight ()Z
+	METHOD method_74029 setCursor (Lnet/minecraft/class_11875;)V
+		ARG 1 cursor
+	METHOD method_74030 setAllowCursorChanges (Z)V
+		ARG 1 allowCursorChanges
 	CLASS class_4716 GlErroredException


### PR DESCRIPTION
This pull request maps classes and methods relating to the cursor-changing functionality implemented in Minecraft snapshot 25w35a. These names match the GLFW methods used to implement the new cursor behavior, including [standard cursors](https://www.glfw.org/docs/latest/group__shapes.html).

In a future pull request, the constants used for standard cursors could be uninlined.