### PR TITLE
Map changes to object text content in 25w35a

### DIFF
--- a/mappings/net/minecraft/text/Contents.mapping
+++ b/mappings/net/minecraft/text/Contents.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/class_11724 net/minecraft/text/Contents
-	METHOD method_73178 asText ()Ljava/lang/String;

--- a/mappings/net/minecraft/text/StyleSpriteSource.mapping
+++ b/mappings/net/minecraft/text/StyleSpriteSource.mapping
@@ -5,3 +5,4 @@ CLASS net/minecraft/class_11719 net/minecraft/text/StyleSpriteSource
 		ARG 0 instance
 	CLASS class_11720 Sprite
 	CLASS class_11721 Font
+	CLASS class_11881 Player

--- a/mappings/net/minecraft/text/TextContent.mapping
+++ b/mappings/net/minecraft/text/TextContent.mapping
@@ -24,3 +24,4 @@ CLASS net/minecraft/class_7417 net/minecraft/text/TextContent
 		COMMENT @see Text#visit(StringVisitable.StyledVisitor, Style)
 		ARG 1 visitor
 		ARG 2 style
+	METHOD method_74063 getCodec ()Lcom/mojang/serialization/MapCodec;

--- a/mappings/net/minecraft/text/object/AtlasTextObjectContents.mapping
+++ b/mappings/net/minecraft/text/object/AtlasTextObjectContents.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_11723 net/minecraft/text/SpriteContents
+CLASS net/minecraft/class_11723 net/minecraft/text/object/AtlasTextObjectContents
 	FIELD field_61976 DEFAULT_ATLAS Lnet/minecraft/class_2960;
 	FIELD field_61977 CODEC Lcom/mojang/serialization/MapCodec;
 	METHOD method_73176 getShortIdString (Lnet/minecraft/class_2960;)Ljava/lang/String;

--- a/mappings/net/minecraft/text/object/PlayerTextObjectContents.mapping
+++ b/mappings/net/minecraft/text/object/PlayerTextObjectContents.mapping
@@ -1,0 +1,6 @@
+CLASS net/minecraft/class_11885 net/minecraft/text/object/PlayerTextObjectContents
+	FIELD field_62500 CODEC Lcom/mojang/serialization/MapCodec;
+	METHOD method_74069 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance
+	METHOD method_74070 (Ljava/lang/String;)Ljava/lang/String;
+		ARG 0 name

--- a/mappings/net/minecraft/text/object/TextObjectContentTypes.mapping
+++ b/mappings/net/minecraft/text/object/TextObjectContentTypes.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_11884 net/minecraft/text/object/TextObjectContentTypes
+	FIELD field_62498 CODEC Lcom/mojang/serialization/MapCodec;
+	FIELD field_62499 ID_MAPPER Lnet/minecraft/class_5699$class_10388;

--- a/mappings/net/minecraft/text/object/TextObjectContents.mapping
+++ b/mappings/net/minecraft/text/object/TextObjectContents.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_11724 net/minecraft/text/object/TextObjectContents
+	METHOD method_73178 asText ()Ljava/lang/String;
+	METHOD method_74067 getCodec ()Lcom/mojang/serialization/MapCodec;
+	METHOD method_74068 spriteSource ()Lnet/minecraft/class_11719;


### PR DESCRIPTION
This pull request follows up #4235 with the revisions introduced in Minecraft snapshot 25w35a, notably including the new player text object contents.