### PR TITLE
Remove MC libs from the remap classpath.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,6 @@ tasks.register('mapIntermediaryJar', MapJarTask) {
 	output = layout.buildDirectory.file("${minecraft_version}-intermediary.jar")
 	input = mergeMinecraftJars.output
 	mappings = downloadIntermediary.output
-	classpath.from minecraftLibraries
 	from = 'official'
 	to = 'intermediary'
 }
@@ -139,7 +138,6 @@ tasks.register('mapServerIntermediaryJar', MapJarTask) {
 	output = layout.buildDirectory.file("${minecraft_version}-server-intermediary.jar")
 	input = extractBundledServer.output
 	mappings = downloadIntermediary.output
-	classpath.from minecraftLibraries
 	from = 'official'
 	to = 'intermediary'
 }
@@ -419,7 +417,6 @@ tasks.register('mapNamedNoUnpickJar', MapJarTask) {
 	output = layout.buildDirectory.file("${minecraft_version}-named-no-unpick.jar")
 	input = mapIntermediaryJar.output
 	mappings = mergeV2.output
-	classpath.from minecraftLibraries
 	from = 'intermediary'
 	to = 'named'
 }


### PR DESCRIPTION
The MC libs are not required on the classpath as they arent involved in the obfuscation, this change is something we have already done in loom ages ago.