### PR TITLE
[25w36b] Mapped New `MoveItemsTask` Methods

### DIFF
--- a/mappings/net/minecraft/block/entity/LockableContainerBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/LockableContainerBlockEntity.mapping
@@ -14,3 +14,4 @@ CLASS net/minecraft/class_2624 net/minecraft/block/entity/LockableContainerBlock
 	METHOD method_17489 checkUnlocked (Lnet/minecraft/class_1657;)Z
 		ARG 1 player
 	METHOD method_17823 getContainerName ()Lnet/minecraft/class_2561;
+	METHOD method_74145 isLocked ()Z

--- a/mappings/net/minecraft/entity/ai/brain/task/MoveItemsTask.mapping
+++ b/mappings/net/minecraft/entity/ai/brain/task/MoveItemsTask.mapping
@@ -40,6 +40,7 @@ CLASS net/minecraft/class_11568 net/minecraft/entity/ai/brain/task/MoveItemsTask
 	METHOD method_72402 hasItem (Lnet/minecraft/class_1263;)Z
 		ARG 0 inventory
 	METHOD method_72403 resetVisitedPositions (Lnet/minecraft/class_1314;)V
+		ARG 1 entity
 	METHOD method_72405 canInsert (Lnet/minecraft/class_1314;Lnet/minecraft/class_1263;)Z
 		ARG 0 entity
 		ARG 1 inventory
@@ -58,6 +59,7 @@ CLASS net/minecraft/class_11568 net/minecraft/entity/ai/brain/task/MoveItemsTask
 		ARG 3 pos
 	METHOD method_72409 getStorageFor (Lnet/minecraft/class_1314;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_2586;Ljava/util/Set;Ljava/util/Set;Lnet/minecraft/class_238;)Ljava/util/Optional;
 		ARG 1 entity
+		ARG 2 world
 		ARG 3 pos
 		ARG 4 blockEntity
 		ARG 5 visitedPositions
@@ -91,7 +93,12 @@ CLASS net/minecraft/class_11568 net/minecraft/entity/ai/brain/task/MoveItemsTask
 		ARG 2 storage
 	METHOD method_72422 hasVisited (Ljava/util/Set;Ljava/util/Set;Lnet/minecraft/class_11568$class_11572;Lnet/minecraft/class_1937;)Z
 		ARG 1 visitedPositions
+		ARG 2 checkedPositions
+		ARG 3 storage
+		ARG 4 visited
 	METHOD method_72424 findNearestStorage (Lnet/minecraft/class_3218;Lnet/minecraft/class_1314;)Ljava/util/Optional;
+		ARG 1 world
+		ARG 2 entity
 	METHOD method_72426 extractStack (Lnet/minecraft/class_1263;)Lnet/minecraft/class_1799;
 		ARG 0 inventory
 	METHOD method_72427 transitionToQueuing (Lnet/minecraft/class_1314;)V
@@ -112,11 +119,13 @@ CLASS net/minecraft/class_11568 net/minecraft/entity/ai/brain/task/MoveItemsTask
 		ARG 2 world
 		ARG 3 entity
 	METHOD method_72433 (Lnet/minecraft/class_1937;Lnet/minecraft/class_11568$class_11572;)Lnet/minecraft/class_4208;
-		ARG 1 storage
+		ARG 1 checkedStorage
 	METHOD method_72434 invalidateTargetStorage (Lnet/minecraft/class_1314;)V
+		ARG 1 entity
 	METHOD method_72436 onCannotUseStorage (Lnet/minecraft/class_1314;)V
 		ARG 1 entity
 	METHOD method_72437 takeStack (Lnet/minecraft/class_1314;Lnet/minecraft/class_1263;)V
+		ARG 1 entity
 		ARG 2 inventory
 	METHOD method_72438 setLookTarget (Lnet/minecraft/class_11568$class_11572;Lnet/minecraft/class_1314;)V
 		ARG 1 storage
@@ -147,6 +156,23 @@ CLASS net/minecraft/class_11568 net/minecraft/entity/ai/brain/task/MoveItemsTask
 		ARG 1 entity
 	METHOD method_72450 resetNavigation (Lnet/minecraft/class_1314;)V
 		ARG 1 entity
+	METHOD method_74018 isVisible (Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;Lnet/minecraft/class_11568$class_11572;Lnet/minecraft/class_1314;)Z
+		ARG 1 world
+		ARG 2 blockPos
+		ARG 3 storage
+		ARG 4 entity
+	METHOD method_74021 markUnreachable (Lnet/minecraft/class_1314;Lnet/minecraft/class_1937;Lnet/minecraft/class_2338;)V
+		ARG 1 entity
+		ARG 2 world
+		ARG 3 blockPos
+	METHOD method_74022 getUnreachablePositions (Lnet/minecraft/class_1314;)Ljava/util/Set;
+		ARG 0 entity
+	METHOD method_74023 hasFinishedNavigation (Lnet/minecraft/class_1314;)Z
+		ARG 0 entity
+	METHOD method_74024 getSightRange (Lnet/minecraft/class_1314;)D
+		ARG 0 entity
+	METHOD method_74093 isLocked (Lnet/minecraft/class_11568$class_11572;)Z
+		ARG 1 storage
 	CLASS class_11569 InteractionState
 	CLASS class_11570 InteractionCallback
 	CLASS class_11571 NavigationState


### PR DESCRIPTION
This adds the missing methods for `MoveItemsTask`, along with some unnamed method paremeters
Also adds `isLocked` for `LockableContainerBlockEntity` (Since it is used within `MoveItemsTask`)