### PR TITLE
Rename wrong arguments in GridWidget

### DIFF
--- a/mappings/net/minecraft/client/gui/widget/GridWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/GridWidget.mapping
@@ -46,8 +46,8 @@ CLASS net/minecraft/class_7845 net/minecraft/client/gui/widget/GridWidget
 		ARG 1 widget
 		ARG 2 row
 		ARG 3 column
-		ARG 4 occupiedBelow
-		ARG 5 occupiedAbove
+		ARG 4 occupiedRows
+		ARG 5 occupiedColumns
 		ARG 6 callback
 	METHOD method_52734 add (Lnet/minecraft/class_8021;IILjava/util/function/Consumer;)Lnet/minecraft/class_8021;
 		ARG 1 widget


### PR DESCRIPTION
This can probably be backported. Idk if ya all do that