### PR TITLE
Rename the WitherEntity#shouldRenderOverlay method to isArmored

### DIFF
--- a/mappings/net/minecraft/client/render/entity/state/WitherEntityRenderState.mapping
+++ b/mappings/net/minecraft/client/render/entity/state/WitherEntityRenderState.mapping
@@ -2,4 +2,4 @@ CLASS net/minecraft/class_10083 net/minecraft/client/render/entity/state/WitherE
 	FIELD field_53617 sideHeadPitches [F
 	FIELD field_53618 sideHeadYaws [F
 	FIELD field_53619 invulnerableTimer F
-	FIELD field_53620 renderOverlay Z
+	FIELD field_53620 armored Z

--- a/mappings/net/minecraft/entity/boss/WitherEntity.mapping
+++ b/mappings/net/minecraft/entity/boss/WitherEntity.mapping
@@ -16,7 +16,7 @@ CLASS net/minecraft/class_1528 net/minecraft/entity/boss/WitherEntity
 	FIELD field_18125 HEAD_TARGET_PREDICATE Lnet/minecraft/class_4051;
 	FIELD field_30441 ON_SUMMONED_INVUL_TIMER I
 	FIELD field_57643 DEFAULT_INVUL_TIMER I
-	METHOD method_6872 shouldRenderOverlay ()Z
+	METHOD method_6872 isArmored ()Z
 	METHOD method_6873 (Lnet/minecraft/class_1309;Lnet/minecraft/class_3218;)Z
 		ARG 0 entity
 		ARG 1 world


### PR DESCRIPTION
The overlay is already referred to as armor by textures and the `WitherArmorFeatureRenderer` class name, so the `WitherEntity` method and `WitherEntityRenderState` field are renamed to match.

Fixes #4295