### PR TITLE
Rename none static field names in ParticleSpriteManager

### DIFF
--- a/mappings/net/minecraft/client/particle/ParticleSpriteManager.mapping
+++ b/mappings/net/minecraft/client/particle/ParticleSpriteManager.mapping
@@ -1,8 +1,8 @@
 CLASS net/minecraft/class_11939 net/minecraft/client/particle/ParticleSpriteManager
 	FIELD field_62625 LOGGER Lorg/slf4j/Logger;
 	FIELD field_62626 PARTICLE_RESOURCE_FINDER Lnet/minecraft/class_7654;
-	FIELD field_62627 SPRITE_AWARE_PARTICLE_FACTORIES Ljava/util/Map;
-	FIELD field_62628 PARTICLE_FACTORIES Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
+	FIELD field_62627 spriteAwareParticleFactories Ljava/util/Map;
+	FIELD field_62628 particleFactories Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
 	FIELD field_62629 onPreparedTask Ljava/lang/Runnable;
 	METHOD method_74292 getParticleFactories ()Lit/unimi/dsi/fastutil/ints/Int2ObjectMap;
 	METHOD method_74293 load (Lnet/minecraft/class_2960;Lnet/minecraft/class_3298;)Ljava/util/Optional;


### PR DESCRIPTION
Noticed when porting FAPI's particle module.