### PR TITLE
Add Unpick Enigma plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,8 @@ jobs:
           java-version: '21'
           distribution: 'microsoft'
       - uses: actions/checkout@v4
-      - run: ./gradlew build javadocJar checkMappings --stacktrace --warning-mode fail
-      - run: ./gradlew formatMappings --stacktrace --warning-mode fail -Dorg.gradle.jvmargs="-XX:+HeapDumpOnOutOfMemoryError"
+      - run: ./gradlew build javadocJar checkMappings --stacktrace --warning-mode fail -Dorg.gradle.jvmargs="-XX:+HeapDumpOnOutOfMemoryError"
+      - run: ./gradlew formatMappings --stacktrace --warning-mode fail
       - name: Upload Heap Dump (if present)
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,14 @@ jobs:
           distribution: 'microsoft'
       - uses: actions/checkout@v4
       - run: ./gradlew build javadocJar checkMappings --stacktrace --warning-mode fail
-      - run: ./gradlew formatMappings --stacktrace --warning-mode fail
+      - run: ./gradlew formatMappings --stacktrace --warning-mode fail -Dorg.gradle.jvmargs="-XX:+HeapDumpOnOutOfMemoryError"
+      - name: Upload Heap Dump (if present)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: heap-dump
+          path: ./*.hprof
+          if-no-files-found: ignore
       - name: Check mapping format
         run: |
           git add -A

--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@ Setup and download and launch the latest version of [Enigma](https://github.com/
 
 Compared to launching Enigma externally, the gradle task adds a name guesser plugin that automatically maps enums and a few constant field names.
 
-### `yarnUnpicked`
-Same as above, but unpicks the constants and launches Enigma with them. Can be a little bit slower to get going.
-
 ### `yarnCommon`
 Same as `yarn`, but will only show common classes.
 

--- a/build.gradle
+++ b/build.gradle
@@ -333,15 +333,6 @@ tasks.register('unpickIntermediaryJar', UnpickJarTask) {
 	classpath.from minecraftLibraries
 }
 
-tasks.register('yarnUnpicked', EnigmaTask) {
-	dependsOn "unpickIntermediaryJar"
-	group = yarnGroup
-	jar = unpickIntermediaryJar.output
-	libraries.from minecraftLibraries
-	mappings = mappingsDir
-	unpickDefinitions = file('unpick-definitions')
-}
-
 tasks.register('mergeV2', MergeMappingsTask) {
 	group = buildMappingGroup
 	output = new File(tempDir, "merged-v2.tiny")

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,8 @@ dependencies {
 	enigmaRuntime "cuchaz:enigma-swing:${project.enigma_version}"
 	enigmaRuntime "net.fabricmc:cfr:${project.cfr_version}"
 	enigmaRuntime "org.vineflower:vineflower:${project.vineflower_version}"
+	enigmaRuntime "net.fabricmc.unpick:unpick:${project.unpick_version}"
+	enigmaRuntime "net.fabricmc.unpick:unpick-format-utils:${project.unpick_version}"
 	javadocClasspath "net.fabricmc:fabric-loader:${project.fabric_loader_version}"
 	javadocClasspath "org.jetbrains:annotations:${project.jetbrains_annotations_version}"
 	javadocClasspath "com.google.code.findbugs:jsr305:3.0.2" // for some other jsr annotations
@@ -147,13 +149,17 @@ tasks.register('yarn', EnigmaTask) {
 	dependsOn mapIntermediaryJar
 	group = yarnGroup
 	jar = mapIntermediaryJar.output
+	libraries.from minecraftLibraries
 	mappings = mappingsDir
+	unpickDefinitions = file('unpick-definitions')
 }
 
 tasks.register('yarnCommon', EnigmaTask) {
 	group = yarnGroup
 	jar = mapServerIntermediaryJar.output
+	libraries.from minecraftLibraries
 	mappings = mappingsDir
+	unpickDefinitions = file('unpick-definitions')
 }
 
 def checkPackages = tasks.register('checkPackages') {
@@ -331,7 +337,9 @@ tasks.register('yarnUnpicked', EnigmaTask) {
 	dependsOn "unpickIntermediaryJar"
 	group = yarnGroup
 	jar = unpickIntermediaryJar.output
+	libraries.from minecraftLibraries
 	mappings = mappingsDir
+	unpickDefinitions = file('unpick-definitions')
 }
 
 tasks.register('mergeV2', MergeMappingsTask) {
@@ -645,6 +653,12 @@ abstract class EnigmaTask extends JavaExec {
 	@Input
 	abstract Property<File> getMappings()
 
+	@InputFiles
+	abstract ConfigurableFileCollection getLibraries()
+
+	@InputDirectory
+	abstract DirectoryProperty getUnpickDefinitions()
+
 	EnigmaTask() {
 		def filamentCodeSource = MappingPoetTask.class.getProtectionDomain().getCodeSource()
 		def filamentJarFile = new File(filamentCodeSource.getLocation().getFile())
@@ -665,6 +679,13 @@ abstract class EnigmaTask extends JavaExec {
 		args mappings.get().absolutePath
 		args '-profile'
 		args 'enigma_profile.json'
+
+		for (def library in getLibraries().files) {
+			args '-library', library.absolutePath
+		}
+
+		systemProperties 'unpick.directory': getUnpickDefinitions().get().asFile.absolutePath
+
 		super.exec()
 	}
 }

--- a/enigma_profile.json
+++ b/enigma_profile.json
@@ -1,14 +1,5 @@
 {
-    "services" : {
-        "name_proposal": {
-            "id": "nameproposal:name_proposal"
-        },
-        "jar_indexer": {
-            "id": "nameproposal:jar_indexer"
-        },
-	"obfuscation_test": {
-            "id": "nameproposal:intermediary_obfuscation_test",
-            "args": {}
-        }
-    }
+  "disabled_plugins": [
+    "cuchaz.enigma.analysis.BuiltinNameProposalPlugin"
+  ]
 }

--- a/filament/build.gradle
+++ b/filament/build.gradle
@@ -28,8 +28,10 @@ repositories {
 }
 
 dependencies {
+	implementation "com.google.code.gson:gson:${properties.gson_version}"
 	implementation "org.ow2.asm:asm:${properties.asm_version}"
 	implementation "org.ow2.asm:asm-tree:${properties.asm_version}"
+	implementation "org.ow2.asm:asm-analysis:${properties.asm_version}"
 	implementation "cuchaz:enigma:$properties.enigma_version"
 	implementation "cuchaz:enigma-cli:$properties.enigma_version"
 	implementation "net.fabricmc.unpick:unpick:$properties.unpick_version"

--- a/filament/src/main/java/net/fabricmc/filament/FilamentExtension.java
+++ b/filament/src/main/java/net/fabricmc/filament/FilamentExtension.java
@@ -28,6 +28,7 @@ public abstract class FilamentExtension {
 
 	private final MinecraftVersionMetaHelper metaHelper;
 	private final Provider<MinecraftVersionMeta> metaProvider;
+	private final DirectoryProperty unpickDirectory;
 
 	@Inject
 	public FilamentExtension() {
@@ -36,6 +37,9 @@ public abstract class FilamentExtension {
 
 		metaHelper = getProject().getObjects().newInstance(MinecraftVersionMetaHelper.class, this);
 		metaProvider = getProject().provider(metaHelper::setup);
+		unpickDirectory = getProject().getObjects().directoryProperty().convention(
+				getProject().getLayout().dir(getProject().provider(() -> getProject().file("unpick-definitions")))
+		);
 	}
 
 	public DirectoryProperty getCacheDirectory() {
@@ -52,5 +56,9 @@ public abstract class FilamentExtension {
 
 	public Provider<MinecraftVersionMeta> getMinecraftVersionMetadata() {
 		return metaProvider;
+	}
+
+	public DirectoryProperty getUnpickDirectory() {
+		return unpickDirectory;
 	}
 }

--- a/filament/src/main/java/net/fabricmc/filament/FilamentGradlePlugin.java
+++ b/filament/src/main/java/net/fabricmc/filament/FilamentGradlePlugin.java
@@ -75,6 +75,8 @@ public final class FilamentGradlePlugin implements Plugin<Project> {
 		var minecraftLibraries = project.getConfigurations().register("minecraftLibraries");
 
 		GradleUtils.afterSuccessfulEvaluation(project, () -> {
+			System.setProperty("unpick.directory", extension.getUnpickDirectory().get().getAsFile().getAbsolutePath());
+
 			var name = minecraftLibraries.getName();
 
 			for (Dependency dependency : getDependencies(metaProvider.get(), project.getDependencies())) {

--- a/filament/src/main/java/net/fabricmc/filament/nameproposal/enigma/EnigmaNameProposalService.java
+++ b/filament/src/main/java/net/fabricmc/filament/nameproposal/enigma/EnigmaNameProposalService.java
@@ -21,9 +21,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import cuchaz.enigma.analysis.index.JarIndex;
 import cuchaz.enigma.api.service.JarIndexerService;
 import cuchaz.enigma.api.service.NameProposalService;
+import cuchaz.enigma.api.view.index.JarIndexView;
 import cuchaz.enigma.classprovider.ClassProvider;
 import cuchaz.enigma.translation.mapping.EntryRemapper;
 import cuchaz.enigma.translation.representation.entry.Entry;
@@ -46,7 +46,7 @@ public class EnigmaNameProposalService implements JarIndexerService, NameProposa
 	}
 
 	@Override
-	public void acceptJar(Set<String> classNames, ClassProvider classProvider, JarIndex jarIndex) {
+	public void acceptJar(Set<String> classNames, ClassProvider classProvider, JarIndexView jarIndex) {
 		NameFinder nameFinder = new NameFinder(config);
 
 		for (String className : classNames) {

--- a/filament/src/main/java/net/fabricmc/filament/nameproposal/enigma/IntermediaryObfuscationTestService.java
+++ b/filament/src/main/java/net/fabricmc/filament/nameproposal/enigma/IntermediaryObfuscationTestService.java
@@ -16,7 +16,6 @@
 
 package net.fabricmc.filament.nameproposal.enigma;
 
-import cuchaz.enigma.api.service.EnigmaServiceContext;
 import cuchaz.enigma.api.service.ObfuscationTestService;
 import cuchaz.enigma.translation.representation.entry.ClassEntry;
 import cuchaz.enigma.translation.representation.entry.Entry;
@@ -26,12 +25,12 @@ import cuchaz.enigma.translation.representation.entry.MethodEntry;
 public class IntermediaryObfuscationTestService implements ObfuscationTestService {
 	private final String prefix, classPrefix, classPackagePrefix, fieldPrefix, methodPrefix, componentPrefix;
 
-	public IntermediaryObfuscationTestService(EnigmaServiceContext<ObfuscationTestService> context) {
-		this.prefix = context.getArgument("package").orElse("net/minecraft") + "/";
-		this.classPrefix = context.getArgument("classPrefix").orElse("class_");
-		this.fieldPrefix = context.getArgument("fieldPrefix").orElse("field_");
-		this.methodPrefix = context.getArgument("methodPrefix").orElse("method_");
-		this.componentPrefix = context.getArgument("componentPrefix").orElse("comp_");
+	public IntermediaryObfuscationTestService() {
+		this.prefix = System.getProperty("obfTest.package", "net/minecraft") + "/";
+		this.classPrefix = System.getProperty("obfTest.classPrefix", "class_");
+		this.fieldPrefix = System.getProperty("obfTest.fieldPrefix", "field_");
+		this.methodPrefix = System.getProperty("obfTest.methodPrefix", "method_");
+		this.componentPrefix = System.getProperty("obfTest.componentPrefix", "comp_");
 
 		this.classPackagePrefix = this.prefix + this.classPrefix;
 	}

--- a/filament/src/main/java/net/fabricmc/filament/nameproposal/enigma/NameProposalServiceEnigmaPlugin.java
+++ b/filament/src/main/java/net/fabricmc/filament/nameproposal/enigma/NameProposalServiceEnigmaPlugin.java
@@ -32,7 +32,7 @@ public class NameProposalServiceEnigmaPlugin implements EnigmaPlugin {
 		ctx.registerService(ID_PREFIX + "intermediary_obfuscation_test", ObfuscationTestService.TYPE, IntermediaryObfuscationTestService::new);
 
 		EnigmaNameProposalService service = new EnigmaNameProposalService(NameProposalConfig.DEFAULT);
-		ctx.registerService(ID_PREFIX + "jar_indexer", JarIndexerService.TYPE, ctx1 -> service);
-		ctx.registerService(ID_PREFIX + "name_proposal", NameProposalService.TYPE, ctx1 -> service);
+		ctx.registerService(ID_PREFIX + "jar_indexer", JarIndexerService.TYPE, () -> service);
+		ctx.registerService(ID_PREFIX + "name_proposal", NameProposalService.TYPE, () -> service);
 	}
 }

--- a/filament/src/main/java/net/fabricmc/filament/task/JavadocLintTask.java
+++ b/filament/src/main/java/net/fabricmc/filament/task/JavadocLintTask.java
@@ -12,9 +12,12 @@ import javax.inject.Inject;
 
 import cuchaz.enigma.ProgressListener;
 import cuchaz.enigma.translation.mapping.EntryMapping;
+import cuchaz.enigma.translation.mapping.serde.MappingFileNameFormat;
+import cuchaz.enigma.translation.mapping.serde.MappingFormat;
 import cuchaz.enigma.translation.mapping.serde.MappingParseException;
-import cuchaz.enigma.translation.mapping.serde.enigma.EnigmaMappingsReader;
+import cuchaz.enigma.translation.mapping.serde.MappingSaveParameters;
 import cuchaz.enigma.translation.mapping.tree.EntryTree;
+import cuchaz.enigma.translation.mapping.tree.HashEntryTree;
 import cuchaz.enigma.translation.representation.entry.Entry;
 import cuchaz.enigma.translation.representation.entry.LocalVariableEntry;
 import cuchaz.enigma.translation.representation.entry.MethodEntry;
@@ -113,7 +116,12 @@ public abstract class JavadocLintTask extends DefaultTask {
 		public void execute() {
 			try {
 				Path[] files = FileUtil.toPaths(getParameters().getMappingFiles().getFiles()).toArray(new Path[0]);
-				EntryTree<EntryMapping> mappings = EnigmaMappingsReader.readFiles(ProgressListener.none(), files);
+				EntryTree<EntryMapping> mappings = new HashEntryTree<>();
+
+				for (Path file : files) {
+					MappingFormat.ENIGMA_FILE.read(file, ProgressListener.none(), new MappingSaveParameters(MappingFileNameFormat.BY_DEOBF), null);
+				}
+
 				List<String> errors = new ArrayList<>();
 
 				mappings.getAllEntries().parallel().forEach(entry -> {

--- a/filament/src/main/java/net/fabricmc/filament/task/JavadocLintTask.java
+++ b/filament/src/main/java/net/fabricmc/filament/task/JavadocLintTask.java
@@ -119,7 +119,8 @@ public abstract class JavadocLintTask extends DefaultTask {
 				EntryTree<EntryMapping> mappings = new HashEntryTree<>();
 
 				for (Path file : files) {
-					MappingFormat.ENIGMA_FILE.read(file, ProgressListener.none(), new MappingSaveParameters(MappingFileNameFormat.BY_DEOBF), null);
+					EntryTree<EntryMapping> read = MappingFormat.ENIGMA_FILE.read(file, ProgressListener.none(), new MappingSaveParameters(MappingFileNameFormat.BY_DEOBF), null);
+					read.forEach(entry -> mappings.insert(entry.getEntry(), entry.getValue()));
 				}
 
 				List<String> errors = new ArrayList<>();

--- a/filament/src/main/java/net/fabricmc/filament/task/unpick/CheckUnpickDefinitionsTask.java
+++ b/filament/src/main/java/net/fabricmc/filament/task/unpick/CheckUnpickDefinitionsTask.java
@@ -13,7 +13,6 @@ import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
-import com.google.common.base.Preconditions;
 import daomephsta.unpick.api.ValidatingUnpickV3Visitor;
 import daomephsta.unpick.api.classresolvers.ClassResolvers;
 import daomephsta.unpick.api.classresolvers.IClassResolver;
@@ -120,7 +119,9 @@ public abstract class CheckUnpickDefinitionsTask extends DefaultTask {
 		}
 
 		private static IClassResolver combineClassResolver(List<IClassResolver> classResolvers) {
-			Preconditions.checkArgument(!classResolvers.isEmpty(), "classResolvers cannot be empty");
+			if (classResolvers.isEmpty()) {
+				throw new IllegalArgumentException("classResolvers cannot be empty");
+			}
 
 			IClassResolver result = classResolvers.getFirst();
 

--- a/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickDecompilerInputTransformerService.java
+++ b/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickDecompilerInputTransformerService.java
@@ -1,0 +1,336 @@
+package net.fabricmc.filament.unpick.enigma;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import cuchaz.enigma.api.I18n;
+import cuchaz.enigma.api.service.DecompilerInputTransformerService;
+import cuchaz.enigma.api.view.ProjectView;
+import cuchaz.enigma.api.view.entry.ClassEntryView;
+import cuchaz.enigma.api.view.entry.FieldEntryView;
+import cuchaz.enigma.api.view.entry.MethodEntryView;
+import daomephsta.unpick.api.ConstantUninliner;
+import daomephsta.unpick.api.ValidatingUnpickV3Visitor;
+import daomephsta.unpick.api.classresolvers.ClassResolvers;
+import daomephsta.unpick.api.classresolvers.IClassResolver;
+import daomephsta.unpick.api.constantgroupers.ConstantGroupers;
+import daomephsta.unpick.api.constantgroupers.IConstantGrouper;
+import daomephsta.unpick.constantmappers.datadriven.parser.UnpickSyntaxException;
+import daomephsta.unpick.constantmappers.datadriven.parser.v3.UnpickV3Reader;
+import daomephsta.unpick.constantmappers.datadriven.parser.v3.UnpickV3Remapper;
+import daomephsta.unpick.constantmappers.datadriven.tree.UnpickV3Visitor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.ClassRemapper;
+import org.objectweb.asm.commons.Remapper;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldNode;
+
+public class UnpickDecompilerInputTransformerService implements DecompilerInputTransformerService {
+	private final UnpickEnigmaPlugin plugin;
+
+	public UnpickDecompilerInputTransformerService(UnpickEnigmaPlugin plugin) {
+		this.plugin = plugin;
+	}
+
+	@Override
+	public void transform(ClassNode classNode) {
+		ProjectView project = plugin.project;
+
+		if (project == null) {
+			return;
+		}
+
+		ConstantUninliner uninliner = plugin.uninliner;
+
+		if (uninliner == null) {
+			synchronized (UnpickEnigmaPlugin.UNINLINER_CREATION_LOCK) {
+				uninliner = plugin.uninliner;
+
+				if (uninliner == null) {
+					uninliner = plugin.uninliner = createUninliner(project);
+				}
+			}
+		}
+
+		uninliner.transform(classNode);
+	}
+
+	private ConstantUninliner createUninliner(ProjectView project) {
+		Map<Path, String> unpickFileContents = readUnpickFiles();
+
+		if (unpickFileContents == null) {
+			return defaultConstantUninliner();
+		}
+
+		if (!validateUnpickFiles(project, unpickFileContents)) {
+			return defaultConstantUninliner();
+		}
+
+		IClassResolver classResolver = new EnigmaClassResolver(project).chain(ClassResolvers.classpath(null));
+		IConstantGrouper grouper = ConstantGroupers.dataDriven()
+				.classResolver(classResolver)
+				.mappingSource(data -> {
+					unpickFileContents.forEach((path, contents) -> {
+						try (UnpickV3Reader reader = new UnpickV3Reader(new StringReader(contents))) {
+							// Remap our yarn-mapped unpick files to intermediary, so that they can be used for
+							// intermediary-mapped class files that are fed into the decompiler by Enigma.
+							reader.accept(new EnigmaUnpickYarnToIntermediaryRemapper(data, plugin, project));
+						} catch (IOException | UnpickSyntaxException e) {
+							throw new AssertionError("Should not get I/O or syntax error after unpick file is already validated", e);
+						}
+					});
+				})
+				.build();
+
+		return ConstantUninliner.builder()
+				.classResolver(classResolver)
+				.grouper(grouper)
+				.build();
+	}
+
+	@Nullable
+	private static Map<Path, String> readUnpickFiles() {
+		Map<Path, String> unpickFileContents = new LinkedHashMap<>();
+
+		try {
+			Files.walkFileTree(UnpickEnigmaPlugin.UNPICK_DIR, new SimpleFileVisitor<>() {
+				@Override
+				@NotNull
+				public FileVisitResult visitFile(@NotNull Path file, @NotNull BasicFileAttributes attrs) throws IOException {
+					if (file.toString().endsWith(".unpick")) {
+						unpickFileContents.put(UnpickEnigmaPlugin.UNPICK_DIR.relativize(file), Files.readString(file));
+					}
+
+					return FileVisitResult.CONTINUE;
+				}
+			});
+		} catch (IOException e) {
+			System.out.println("Failed to read unpick files: " + e.getMessage());
+			return null;
+		}
+
+		return unpickFileContents;
+	}
+
+	private boolean validateUnpickFiles(ProjectView project, Map<Path, String> unpickFileContents) {
+		// Unpick files are validated with yarn mappings rather than intermediary. This is to make the errors more
+		// readable and directly relevant to what is written in the files. The consequence of this is that the bytecode
+		// from the class provider, which is in intermediary mappings, needs to be remapped to yarn before being fed to
+		// the unpick validator. Luckily, ASM's remapper is sufficient for this purpose, which is good because tiny
+		// remapper doesn't seem to have an API for remapping an individual ClassNode or class file.
+
+		IClassResolver validatingResolver = new IntermediaryToYarnRemappingClassResolver(new EnigmaClassResolver(project), project, new IntermediaryToYarnEnigmaRemapper(project))
+				.chain(ClassResolvers.classpath(null));
+		ValidatingUnpickV3Visitor globalValidator = new EnigmaUnpickValidator(plugin, validatingResolver);
+
+		boolean[] hadErrors = { false };
+
+		unpickFileContents.forEach((path, contents) -> {
+			try (UnpickV3Reader reader = new UnpickV3Reader(new StringReader(contents))) {
+				reader.accept(globalValidator);
+			} catch (UnpickSyntaxException | IOException e) {
+				System.out.println(path + ": " + e.getMessage());
+				hadErrors[0] = true;
+				return;
+			}
+
+			try (UnpickV3Reader reader = new UnpickV3Reader(new StringReader(contents))) {
+				ValidatingUnpickV3Visitor localValidator = new EnigmaUnpickValidator(plugin, validatingResolver);
+				reader.accept(localValidator);
+				List<UnpickSyntaxException> errors = localValidator.finishValidation();
+
+				if (!errors.isEmpty()) {
+					hadErrors[0] = true;
+
+					for (UnpickSyntaxException error : errors) {
+						System.out.println(path + ": " + error.getMessage());
+					}
+				}
+			} catch (UnpickSyntaxException | IOException e) {
+				throw new AssertionError("This error should have already been caught by the global validator", e);
+			}
+		});
+
+		if (hadErrors[0]) {
+			plugin.showUserVisibleError(I18n.translate("unpick.errors.title"), I18n.translate("unpick.errors"));
+			return false;
+		}
+
+		List<UnpickSyntaxException> globalErrors = globalValidator.finishValidation();
+
+		if (!globalErrors.isEmpty()) {
+			for (UnpickSyntaxException error : globalErrors) {
+				System.out.println(error.getMessage());
+			}
+
+			plugin.showUserVisibleError(I18n.translate("unpick.errors.title"), I18n.translate("unpick.errors"));
+
+			return false;
+		}
+
+		return true;
+	}
+
+	private static ConstantUninliner defaultConstantUninliner() {
+		return ConstantUninliner.builder()
+				.classResolver(ClassResolvers.classpath(null))
+				.grouper(ConstantGroupers.dataDriven().classResolver(ClassResolvers.classpath(null)).build())
+				.build();
+	}
+
+	private record EnigmaClassResolver(ProjectView project) implements IClassResolver {
+		@Override
+		@Nullable
+		public ClassReader resolveClass(String internalName) {
+			ClassNode node = project.getBytecode(internalName);
+
+			if (node == null) {
+				return null;
+			}
+
+			ClassWriter writer = new ClassWriter(0);
+			node.accept(writer);
+			return new ClassReader(writer.toByteArray());
+		}
+	}
+
+	private static class IntermediaryToYarnEnigmaRemapper extends Remapper {
+		private final ProjectView project;
+
+		private IntermediaryToYarnEnigmaRemapper(ProjectView project) {
+			this.project = project;
+		}
+
+		@Override
+		public String map(String internalName) {
+			return project.deobfuscate(ClassEntryView.create(internalName)).getFullName();
+		}
+
+		@Override
+		public String mapFieldName(String owner, String name, String descriptor) {
+			return project.deobfuscate(FieldEntryView.create(owner, name, descriptor)).getName();
+		}
+
+		@Override
+		public String mapRecordComponentName(String owner, String name, String desc) {
+			return mapFieldName(owner, name, desc);
+		}
+
+		@Override
+		public String mapMethodName(String owner, String name, String desc) {
+			if (!desc.startsWith("(")) { // workaround for Remapper.mapValue calling mapMethodName even if the Handle is a field one
+				return mapFieldName(owner, name, desc);
+			}
+
+			return project.deobfuscate(MethodEntryView.create(owner, name, desc)).getName();
+		}
+	}
+
+	private record IntermediaryToYarnRemappingClassResolver(IClassResolver downstream, ProjectView project, Remapper remapper) implements IClassResolver {
+		@Override
+		@Nullable
+		public ClassReader resolveClass(String internalName) {
+			ClassReader reader = downstream.resolveClass(project.obfuscate(ClassEntryView.create(internalName)).getFullName());
+
+			if (reader == null) {
+				return null;
+			}
+
+			ClassWriter writer = new ClassWriter(0);
+			reader.accept(new ClassRemapper(writer, remapper), 0);
+			return new ClassReader(writer.toByteArray());
+		}
+	}
+
+	private static class EnigmaUnpickValidator extends ValidatingUnpickV3Visitor {
+		private final UnpickEnigmaPlugin plugin;
+
+		private EnigmaUnpickValidator(UnpickEnigmaPlugin plugin, IClassResolver classResolver) {
+			super(classResolver);
+			this.plugin = plugin;
+		}
+
+		@Override
+		public boolean packageExists(String packageName) {
+			return plugin.classesInPackages.containsKey(packageName.replace('.', '/'));
+		}
+	}
+
+	private static final class EnigmaUnpickYarnToIntermediaryRemapper extends UnpickV3Remapper {
+		private final UnpickEnigmaPlugin plugin;
+		private final ProjectView project;
+
+		private EnigmaUnpickYarnToIntermediaryRemapper(UnpickV3Visitor downstream, UnpickEnigmaPlugin plugin, ProjectView project) {
+			super(downstream);
+			this.plugin = plugin;
+			this.project = project;
+		}
+
+		@Override
+		protected String mapClassName(String className) {
+			return project.obfuscate(ClassEntryView.create(className.replace('.', '/'))).getFullName().replace('/', '.');
+		}
+
+		@Override
+		protected String mapFieldName(String className, String fieldName, String fieldDesc) {
+			return project.obfuscate(FieldEntryView.create(className.replace('.', '/'), fieldName, fieldDesc)).getName();
+		}
+
+		@Override
+		protected String mapMethodName(String className, String methodName, String methodDesc) {
+			return project.obfuscate(MethodEntryView.create(className.replace('.', '/'), methodName, methodDesc)).getName();
+		}
+
+		@Override
+		protected List<String> getClassesInPackage(String pkg) {
+			return plugin.classesInPackages.getOrDefault(pkg.replace('.', '/'), List.of())
+					.stream()
+					.map(clazz -> pkg + "." + clazz)
+					.toList();
+		}
+
+		@Override
+		protected String getFieldDesc(String className, String fieldName) {
+			String obfClassName = project.obfuscate(ClassEntryView.create(className.replace('.', '/'))).getFullName();
+			ClassNode bytecode = project.getBytecode(obfClassName);
+
+			if (bytecode == null) {
+				throw new IllegalStateException("Could not find class " + className);
+			}
+
+			if (bytecode.fields != null) {
+				for (FieldNode field : bytecode.fields) {
+					String deobfName = project.deobfuscate(FieldEntryView.create(obfClassName, field.name, field.desc)).getName();
+
+					if (deobfName.equals(fieldName)) {
+						return fieldDescObfToDeobf(Type.getType(field.desc));
+					}
+				}
+			}
+
+			throw new IllegalStateException("Could not find field " + className + "." + fieldName);
+		}
+
+		private String fieldDescObfToDeobf(Type desc) {
+			if (desc.getSort() == Type.OBJECT) {
+				return "L" + project.deobfuscate(ClassEntryView.create(desc.getInternalName())).getFullName() + ";";
+			} else if (desc.getSort() == Type.ARRAY) {
+				return "[".repeat(desc.getDimensions()) + fieldDescObfToDeobf(desc.getElementType());
+			} else {
+				return desc.getDescriptor();
+			}
+		}
+	}
+}

--- a/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickEnigmaPlugin.java
+++ b/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickEnigmaPlugin.java
@@ -1,0 +1,152 @@
+package net.fabricmc.filament.unpick.enigma;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
+
+import cuchaz.enigma.api.DataInvalidationEvent;
+import cuchaz.enigma.api.EnigmaPlugin;
+import cuchaz.enigma.api.EnigmaPluginContext;
+import cuchaz.enigma.api.service.DecompilerInputTransformerService;
+import cuchaz.enigma.api.service.GuiService;
+import cuchaz.enigma.api.service.I18nService;
+import cuchaz.enigma.api.service.ProjectService;
+import cuchaz.enigma.api.view.ProjectView;
+import daomephsta.unpick.api.ConstantUninliner;
+import org.jetbrains.annotations.NotNull;
+
+public class UnpickEnigmaPlugin implements EnigmaPlugin {
+	public static final Path UNPICK_DIR = Path.of(System.getProperty("unpick.directory"));
+	public ProjectView project;
+	public boolean isWindowFocused = true;
+	public JFrame theFrame;
+
+	static final Object UNINLINER_CREATION_LOCK = new Object();
+	public boolean unpickNeedsRefresh = true;
+	public ConstantUninliner uninliner;
+
+	public final Map<String, List<String>> classesInPackages = new HashMap<>();
+
+	@Override
+	public void init(EnigmaPluginContext ctx) {
+		ctx.registerService("unpick:i18n", I18nService.TYPE, UnpickI18nService::new);
+		ctx.registerService("unpick:project", ProjectService.TYPE, () -> new UnpickProjectService(this));
+		ctx.registerService("unpick:gui", GuiService.TYPE, () -> new UnpickGuiService(this));
+		ctx.registerService("unpick:decompiler_input_transformer", DecompilerInputTransformerService.TYPE, () -> new UnpickDecompilerInputTransformerService(this));
+
+		registerFileWatcher();
+	}
+
+	public void showUserVisibleError(String title, String message) {
+		if (theFrame != null) {
+			JOptionPane.showMessageDialog(theFrame, message, title, JOptionPane.ERROR_MESSAGE);
+		} else {
+			System.out.println("[" + title + "] " + message);
+		}
+	}
+
+	private void registerFileWatcher() {
+		Thread thread = new Thread(() -> {
+			try (WatchService watchService = FileSystems.getDefault().newWatchService()) {
+				Set<Path> alreadyWatchingDirs = new HashSet<>();
+				Map<WatchKey, Path> keys = new HashMap<>();
+				registerAll(watchService, alreadyWatchingDirs, keys, UNPICK_DIR);
+				pollFileWatchEvents(watchService, alreadyWatchingDirs, keys);
+			} catch (IOException e) {
+				throw new UncheckedIOException(e);
+			}
+		}, "Unpick directory watcher");
+		thread.setDaemon(true);
+		thread.start();
+	}
+
+	private static void registerAll(WatchService watchService, Set<Path> alreadyWatchingDirs, Map<WatchKey, Path> keys, Path dir) {
+		try {
+			Files.walkFileTree(dir, new SimpleFileVisitor<>() {
+				@Override
+				@NotNull
+				public FileVisitResult preVisitDirectory(@NotNull Path dir, @NotNull BasicFileAttributes attrs) throws IOException {
+					Path realPath = dir.toRealPath();
+
+					if (alreadyWatchingDirs.add(realPath)) {
+						WatchKey key = dir.register(watchService, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY);
+						keys.put(key, realPath);
+					}
+
+					return FileVisitResult.CONTINUE;
+				}
+			});
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+	}
+
+	private void pollFileWatchEvents(WatchService watchService, Set<Path> alreadyWatchingDirs, Map<WatchKey, Path> keys) {
+		while (true) {
+			WatchKey key;
+
+			try {
+				key = watchService.take();
+			} catch (InterruptedException e) {
+				return;
+			}
+
+			Path dir = keys.get(key);
+
+			if (dir == null) {
+				key.cancel();
+				continue;
+			}
+
+			for (WatchEvent<?> event : key.pollEvents()) {
+				if (event.kind() == StandardWatchEventKinds.OVERFLOW) {
+					continue;
+				}
+
+				Path filename = (Path) event.context();
+				Path path = dir.resolve(filename);
+
+				// if a file ending with .unpick is created, modified, or deleted, or if a directory is deleted, then
+				// we need to refresh the unpick definitions
+				if (filename.toString().endsWith(".unpick") || event.kind() == StandardWatchEventKinds.ENTRY_DELETE) {
+					unpickNeedsRefresh = true;
+					SwingUtilities.invokeLater(() -> {
+						if (unpickNeedsRefresh && isWindowFocused) {
+							uninliner = null;
+							unpickNeedsRefresh = false;
+
+							if (project != null) {
+								project.invalidateData(DataInvalidationEvent.InvalidationType.DECOMPILE);
+							}
+						}
+					});
+				} else if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE && Files.isDirectory(path)) {
+					registerAll(watchService, alreadyWatchingDirs, keys, path);
+				}
+			}
+
+			if (!key.reset()) {
+				keys.remove(key);
+				alreadyWatchingDirs.remove(dir);
+			}
+		}
+	}
+}

--- a/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickGuiService.java
+++ b/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickGuiService.java
@@ -1,0 +1,164 @@
+package net.fabricmc.filament.unpick.enigma;
+
+import java.awt.Toolkit;
+import java.awt.datatransfer.StringSelection;
+import java.awt.event.KeyEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.Objects;
+
+import cuchaz.enigma.api.DataInvalidationEvent;
+import cuchaz.enigma.api.service.GuiService;
+import cuchaz.enigma.api.view.GuiView;
+import cuchaz.enigma.api.view.ProjectView;
+import cuchaz.enigma.api.view.entry.EntryReferenceView;
+import cuchaz.enigma.api.view.entry.EntryView;
+import cuchaz.enigma.api.view.entry.FieldEntryView;
+import cuchaz.enigma.api.view.entry.LocalVariableEntryView;
+import cuchaz.enigma.api.view.entry.MethodEntryView;
+import org.jetbrains.annotations.Nullable;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+import javax.swing.KeyStroke;
+
+public class UnpickGuiService implements GuiService {
+	private final UnpickEnigmaPlugin plugin;
+
+	public UnpickGuiService(UnpickEnigmaPlugin plugin) {
+		this.plugin = plugin;
+	}
+
+	@Override
+	public void onStart(GuiView gui) {
+		plugin.theFrame = gui.getFrame();
+
+		gui.getFrame().addWindowFocusListener(new WindowAdapter() {
+			@Override
+			public void windowGainedFocus(WindowEvent e) {
+				plugin.isWindowFocused = true;
+
+				if (plugin.unpickNeedsRefresh) {
+					plugin.uninliner = null;
+					plugin.unpickNeedsRefresh = false;
+
+					if (plugin.project != null) {
+						plugin.project.invalidateData(DataInvalidationEvent.InvalidationType.DECOMPILE);
+					}
+				}
+			}
+
+			@Override
+			public void windowLostFocus(WindowEvent e) {
+				plugin.isWindowFocused = false;
+			}
+		});
+	}
+
+	@Override
+	public void addToEditorContextMenu(GuiView gui, MenuRegistrar registrar) {
+		registrar.addSeparator();
+
+		registrar.add("unpick.copyTargetReference")
+				.setEnabledWhen(() -> getCursorTargetReference(gui) != null)
+				.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_U, KeyEvent.CTRL_DOWN_MASK))
+				.setAction(() -> {
+					String textToCopy = getCursorTargetReference(gui);
+
+					if (textToCopy != null) {
+						Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(textToCopy), null);
+					}
+				});
+		registrar.add("unpick.copyConstantReference")
+				.setEnabledWhen(() -> canBeConstant(gui.getCursorReference()))
+				.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_U, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK))
+				.setAction(() -> {
+					if (!canBeConstant(gui.getCursorReference())) {
+						return;
+					}
+
+					ProjectView project = gui.getProject();
+
+					if (project == null) {
+						return;
+					}
+
+					FieldEntryView obfField = (FieldEntryView) Objects.requireNonNull(gui.getCursorReference()).getEntry();
+					FieldEntryView deobfField = project.deobfuscate(obfField);
+					String textToCopy = deobfField.getParent().getFullName().replace('/', '.') + "." + deobfField.getName();
+					Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(textToCopy), null);
+				});
+	}
+
+	@Nullable
+	private String getCursorTargetReference(GuiView gui) {
+		EntryReferenceView hoveredReference = gui.getCursorReference();
+
+		if (hoveredReference == null) {
+			return null;
+		}
+
+		ProjectView project = gui.getProject();
+
+		if (project == null) {
+			return null;
+		}
+
+		EntryView obfEntry = hoveredReference.getEntry();
+		EntryView deobfEntry = project.deobfuscate(hoveredReference.getEntry());
+
+		return switch (deobfEntry) {
+			case FieldEntryView field -> "target_field %s %s %s".formatted(
+					field.getParent().getFullName().replace('/', '.'),
+					field.getName(),
+					field.getDescriptor()
+			);
+			case MethodEntryView method -> "target_method %s %s %s".formatted(
+					method.getParent().getFullName().replace('/', '.'),
+					method.getName(),
+					method.getDescriptor()
+			);
+			case LocalVariableEntryView ignored -> {
+				int localIndex = getLocalIndex(project, (LocalVariableEntryView) obfEntry);
+				yield localIndex == -1 ? null : "param " + localIndex;
+			}
+			default -> null;
+		};
+	}
+
+	private int getLocalIndex(ProjectView project, LocalVariableEntryView local) {
+		Type[] argTypes = Type.getArgumentTypes(local.getParent().getDescriptor());
+		int methodAccess = project.getJarIndex().getEntryIndex().getAccess(local.getParent());
+		int varIndex = (methodAccess & Opcodes.ACC_STATIC) != 0 ? 0 : 1;
+
+		for (int localIndex = 0; localIndex < argTypes.length; localIndex++) {
+			if (varIndex == local.getIndex()) {
+				return localIndex;
+			}
+			varIndex += argTypes[localIndex].getSize();
+		}
+
+		return -1;
+	}
+
+	private boolean canBeConstant(@Nullable EntryReferenceView reference) {
+		if (reference == null || plugin.project == null) {
+			return false;
+		}
+
+		if (!(reference.getEntry() instanceof FieldEntryView field)) {
+			return false;
+		}
+
+		int access = plugin.project.getJarIndex().getEntryIndex().getAccess(field);
+
+		if ((access & Opcodes.ACC_FINAL) == 0) {
+			return false;
+		}
+
+		return switch (field.getDescriptor()) {
+			case "B", "C", "D", "F", "I", "J", "S", "Ljava/lang/String;", "Ljava/lang/Class;" -> true;
+			default -> false;
+		};
+	}
+}

--- a/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickGuiService.java
+++ b/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickGuiService.java
@@ -7,6 +7,8 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.util.Objects;
 
+import javax.swing.KeyStroke;
+
 import cuchaz.enigma.api.DataInvalidationEvent;
 import cuchaz.enigma.api.service.GuiService;
 import cuchaz.enigma.api.view.GuiView;
@@ -19,8 +21,6 @@ import cuchaz.enigma.api.view.entry.MethodEntryView;
 import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
-
-import javax.swing.KeyStroke;
 
 public class UnpickGuiService implements GuiService {
 	private final UnpickEnigmaPlugin plugin;
@@ -108,21 +108,21 @@ public class UnpickGuiService implements GuiService {
 		EntryView deobfEntry = project.deobfuscate(hoveredReference.getEntry());
 
 		return switch (deobfEntry) {
-			case FieldEntryView field -> "target_field %s %s %s".formatted(
-					field.getParent().getFullName().replace('/', '.'),
-					field.getName(),
-					field.getDescriptor()
-			);
-			case MethodEntryView method -> "target_method %s %s %s".formatted(
-					method.getParent().getFullName().replace('/', '.'),
-					method.getName(),
-					method.getDescriptor()
-			);
-			case LocalVariableEntryView ignored -> {
-				int localIndex = getLocalIndex(project, (LocalVariableEntryView) obfEntry);
-				yield localIndex == -1 ? null : "param " + localIndex;
-			}
-			default -> null;
+		case FieldEntryView field -> "target_field %s %s %s".formatted(
+				field.getParent().getFullName().replace('/', '.'),
+				field.getName(),
+				field.getDescriptor()
+		);
+		case MethodEntryView method -> "target_method %s %s %s".formatted(
+				method.getParent().getFullName().replace('/', '.'),
+				method.getName(),
+				method.getDescriptor()
+		);
+		case LocalVariableEntryView ignored -> {
+			int localIndex = getLocalIndex(project, (LocalVariableEntryView) obfEntry);
+			yield localIndex == -1 ? null : "param " + localIndex;
+		}
+		default -> null;
 		};
 	}
 
@@ -135,6 +135,7 @@ public class UnpickGuiService implements GuiService {
 			if (varIndex == local.getIndex()) {
 				return localIndex;
 			}
+
 			varIndex += argTypes[localIndex].getSize();
 		}
 
@@ -157,8 +158,8 @@ public class UnpickGuiService implements GuiService {
 		}
 
 		return switch (field.getDescriptor()) {
-			case "B", "C", "D", "F", "I", "J", "S", "Ljava/lang/String;", "Ljava/lang/Class;" -> true;
-			default -> false;
+		case "B", "C", "D", "F", "I", "J", "S", "Ljava/lang/String;", "Ljava/lang/Class;" -> true;
+		default -> false;
 		};
 	}
 }

--- a/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickI18nService.java
+++ b/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickI18nService.java
@@ -1,9 +1,9 @@
 package net.fabricmc.filament.unpick.enigma;
 
+import java.io.InputStream;
+
 import cuchaz.enigma.api.service.I18nService;
 import org.jetbrains.annotations.Nullable;
-
-import java.io.InputStream;
 
 public class UnpickI18nService implements I18nService {
 	@Override

--- a/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickI18nService.java
+++ b/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickI18nService.java
@@ -1,0 +1,14 @@
+package net.fabricmc.filament.unpick.enigma;
+
+import cuchaz.enigma.api.service.I18nService;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.InputStream;
+
+public class UnpickI18nService implements I18nService {
+	@Override
+	@Nullable
+	public InputStream getTranslationResource(String language) {
+		return UnpickI18nService.class.getResourceAsStream("/unpick_lang/" + language + ".json");
+	}
+}

--- a/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickProjectService.java
+++ b/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickProjectService.java
@@ -1,0 +1,46 @@
+package net.fabricmc.filament.unpick.enigma;
+
+import java.util.ArrayList;
+
+import cuchaz.enigma.api.service.ProjectService;
+import cuchaz.enigma.api.view.ProjectView;
+import cuchaz.enigma.api.view.entry.ClassEntryView;
+
+public class UnpickProjectService implements ProjectService {
+	private final UnpickEnigmaPlugin plugin;
+
+	public UnpickProjectService(UnpickEnigmaPlugin plugin) {
+		this.plugin = plugin;
+	}
+
+	@Override
+	public void onProjectOpen(ProjectView project) {
+		plugin.project = project;
+		project.registerForInverseMappings();
+		refreshClassesInPackages();
+
+		project.addDataInvalidationListener(event -> refreshClassesInPackages());
+	}
+
+	@Override
+	public void onProjectClose(ProjectView project) {
+		plugin.project = null;
+	}
+
+	private void refreshClassesInPackages() {
+		synchronized (UnpickEnigmaPlugin.UNINLINER_CREATION_LOCK) {
+			plugin.classesInPackages.clear();
+
+			for (String clazz : plugin.project.getProjectClasses()) {
+				String mappedClass = plugin.project.deobfuscate(ClassEntryView.create(clazz)).getFullName();
+				int slashIndex = mappedClass.lastIndexOf('/');
+
+				if (slashIndex == -1) {
+					plugin.classesInPackages.computeIfAbsent("", k -> new ArrayList<>()).add(mappedClass);
+				} else {
+					plugin.classesInPackages.computeIfAbsent(mappedClass.substring(0, slashIndex), k -> new ArrayList<>()).add(mappedClass.substring(slashIndex + 1));
+				}
+			}
+		}
+	}
+}

--- a/filament/src/main/resources/META-INF/services/cuchaz.enigma.api.EnigmaPlugin
+++ b/filament/src/main/resources/META-INF/services/cuchaz.enigma.api.EnigmaPlugin
@@ -1,1 +1,2 @@
 net.fabricmc.filament.nameproposal.enigma.NameProposalServiceEnigmaPlugin
+net.fabricmc.filament.unpick.enigma.UnpickEnigmaPlugin

--- a/filament/src/main/resources/unpick_lang/en_us.json
+++ b/filament/src/main/resources/unpick_lang/en_us.json
@@ -1,0 +1,6 @@
+{
+  "unpick.copyConstantReference": "Copy unpick constant reference",
+  "unpick.copyTargetReference": "Copy unpick target reference",
+  "unpick.errors": "There were unpick errors. See log for details.",
+  "unpick.errors.title": "Unpick Error"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx1G
+org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 org.gradle.configuration-cache=true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx1G
 org.gradle.parallel=true
 org.gradle.configuration-cache=true
 
-enigma_version=2.5.2+local
+enigma_version=3.0.0
 unpick_version=3.0.0-beta.11
 cfr_version=0.2.2
 vineflower_version=1.11.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,11 +3,12 @@ org.gradle.jvmargs=-Xmx1G
 org.gradle.parallel=true
 org.gradle.configuration-cache=true
 
-enigma_version=2.5.2
+enigma_version=2.5.2+local
 unpick_version=3.0.0-beta.11
 cfr_version=0.2.2
 vineflower_version=1.11.1
 asm_version=9.8
+gson_version=2.10.1
 
 # Javadoc generation/linking
 fabric_loader_version=0.16.10


### PR DESCRIPTION
Dynamically loads unpick mappings and hot reloads them in Enigma when they are changed. Also adds a couple of context menu items to copy paste unpick targets, to speed up writing unpick mappings.

This removes the `./gradlew yarnUnpicked` task. `./gradlew yarn` on its own will now show unpicked files, as unpick is now called from Enigma via the unpick plugin.