### PR TITLE
Don't apply the unpick plugin outside the yarn task

### DIFF
--- a/filament/src/main/java/net/fabricmc/filament/FilamentExtension.java
+++ b/filament/src/main/java/net/fabricmc/filament/FilamentExtension.java
@@ -28,7 +28,6 @@ public abstract class FilamentExtension {
 
 	private final MinecraftVersionMetaHelper metaHelper;
 	private final Provider<MinecraftVersionMeta> metaProvider;
-	private final DirectoryProperty unpickDirectory;
 
 	@Inject
 	public FilamentExtension() {
@@ -37,9 +36,6 @@ public abstract class FilamentExtension {
 
 		metaHelper = getProject().getObjects().newInstance(MinecraftVersionMetaHelper.class, this);
 		metaProvider = getProject().provider(metaHelper::setup);
-		unpickDirectory = getProject().getObjects().directoryProperty().convention(
-				getProject().getLayout().dir(getProject().provider(() -> getProject().file("unpick-definitions")))
-		);
 	}
 
 	public DirectoryProperty getCacheDirectory() {
@@ -56,9 +52,5 @@ public abstract class FilamentExtension {
 
 	public Provider<MinecraftVersionMeta> getMinecraftVersionMetadata() {
 		return metaProvider;
-	}
-
-	public DirectoryProperty getUnpickDirectory() {
-		return unpickDirectory;
 	}
 }

--- a/filament/src/main/java/net/fabricmc/filament/FilamentGradlePlugin.java
+++ b/filament/src/main/java/net/fabricmc/filament/FilamentGradlePlugin.java
@@ -75,8 +75,6 @@ public final class FilamentGradlePlugin implements Plugin<Project> {
 		var minecraftLibraries = project.getConfigurations().register("minecraftLibraries");
 
 		GradleUtils.afterSuccessfulEvaluation(project, () -> {
-			System.setProperty("unpick.directory", extension.getUnpickDirectory().get().getAsFile().getAbsolutePath());
-
 			var name = minecraftLibraries.getName();
 
 			for (Dependency dependency : getDependencies(metaProvider.get(), project.getDependencies())) {

--- a/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickDecompilerInputTransformerService.java
+++ b/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickDecompilerInputTransformerService.java
@@ -105,12 +105,12 @@ public class UnpickDecompilerInputTransformerService implements DecompilerInputT
 		Map<Path, String> unpickFileContents = new LinkedHashMap<>();
 
 		try {
-			Files.walkFileTree(UnpickEnigmaPlugin.UNPICK_DIR, new SimpleFileVisitor<>() {
+			Files.walkFileTree(UnpickEnigmaPlugin.unpickDir, new SimpleFileVisitor<>() {
 				@Override
 				@NotNull
 				public FileVisitResult visitFile(@NotNull Path file, @NotNull BasicFileAttributes attrs) throws IOException {
 					if (file.toString().endsWith(".unpick")) {
-						unpickFileContents.put(UnpickEnigmaPlugin.UNPICK_DIR.relativize(file), Files.readString(file));
+						unpickFileContents.put(UnpickEnigmaPlugin.unpickDir.relativize(file), Files.readString(file));
 					}
 
 					return FileVisitResult.CONTINUE;

--- a/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickEnigmaPlugin.java
+++ b/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickEnigmaPlugin.java
@@ -34,7 +34,7 @@ import daomephsta.unpick.api.ConstantUninliner;
 import org.jetbrains.annotations.NotNull;
 
 public class UnpickEnigmaPlugin implements EnigmaPlugin {
-	public static final Path UNPICK_DIR = Path.of(System.getProperty("unpick.directory"));
+	public static Path unpickDir;
 	public ProjectView project;
 	public boolean isWindowFocused = true;
 	public JFrame theFrame;
@@ -47,6 +47,14 @@ public class UnpickEnigmaPlugin implements EnigmaPlugin {
 
 	@Override
 	public void init(EnigmaPluginContext ctx) {
+		String unpickPath = System.getProperty("unpick.directory");
+
+		if (unpickPath == null) {
+			return;
+		}
+
+		unpickDir = Path.of(System.getProperty("unpick.directory"));
+
 		ctx.registerService("unpick:i18n", I18nService.TYPE, UnpickI18nService::new);
 		ctx.registerService("unpick:project", ProjectService.TYPE, () -> new UnpickProjectService(this));
 		ctx.registerService("unpick:gui", GuiService.TYPE, () -> new UnpickGuiService(this));
@@ -68,7 +76,7 @@ public class UnpickEnigmaPlugin implements EnigmaPlugin {
 			try (WatchService watchService = FileSystems.getDefault().newWatchService()) {
 				Set<Path> alreadyWatchingDirs = new HashSet<>();
 				Map<WatchKey, Path> keys = new HashMap<>();
-				registerAll(watchService, alreadyWatchingDirs, keys, UNPICK_DIR);
+				registerAll(watchService, alreadyWatchingDirs, keys, unpickDir);
 				pollFileWatchEvents(watchService, alreadyWatchingDirs, keys);
 			} catch (IOException e) {
 				throw new UncheckedIOException(e);

--- a/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickEnigmaPlugin.java
+++ b/filament/src/main/java/net/fabricmc/filament/unpick/enigma/UnpickEnigmaPlugin.java
@@ -53,7 +53,7 @@ public class UnpickEnigmaPlugin implements EnigmaPlugin {
 			return;
 		}
 
-		unpickDir = Path.of(System.getProperty("unpick.directory"));
+		unpickDir = Path.of(unpickPath);
 
 		ctx.registerService("unpick:i18n", I18nService.TYPE, UnpickI18nService::new);
 		ctx.registerService("unpick:project", ProjectService.TYPE, () -> new UnpickProjectService(this));


### PR DESCRIPTION
Applying the unpick plugin includes starting the unpick directory watcher thread. This means the thread now won't be started outside the yarn task. The yarn task forks the JVM, so the daemon thread should stop once the task ends.