### PR TITLE
Allow Yarn Maintainers to make code changes.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @FabricMC/developers
+* @FabricMC/yarn-maintainers
 
 mappings/
 unpick-definitions/

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,2 +1,0 @@
-asiekierka <asiekierka@gmail.com>
-shadowfacts <me@shadowfacts.net>


### PR DESCRIPTION
The @FabricMC/yarn-triage team can now approve and merge changes to mappings or unpick definitions but not build system changes.
@FabricMC/yarn-maintainers can now merge any approved PR (by someone else) removing the need for trivial fixes to go through me or Player.

Also removes an old file.