### PR TITLE
Rename entityRenderStates to worldRenderState in GameRenderer and WorldRenderer

### DIFF
--- a/mappings/net/minecraft/client/render/GameRenderer.mapping
+++ b/mappings/net/minecraft/client/render/GameRenderer.mapping
@@ -38,7 +38,7 @@ CLASS net/minecraft/class_757 net/minecraft/client/render/GameRenderer
 	FIELD field_60579 panoramaRenderer Lnet/minecraft/class_751;
 	FIELD field_60580 rotatingPanoramaRenderer Lnet/minecraft/class_766;
 	FIELD field_60793 fogRenderer Lnet/minecraft/class_758;
-	FIELD field_61732 entityRenderStates Lnet/minecraft/class_11658;
+	FIELD field_61732 worldRenderState Lnet/minecraft/class_11658;
 	FIELD field_61733 orderedRenderCommandQueue Lnet/minecraft/class_11661;
 	FIELD field_61734 entityRenderDispatcher Lnet/minecraft/class_11684;
 	METHOD <init> (Lnet/minecraft/class_310;Lnet/minecraft/class_759;Lnet/minecraft/class_4599;Lnet/minecraft/class_776;)V

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -49,7 +49,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 		ARG 2 entityRenderManager
 		ARG 3 blockEntityRenderManager
 		ARG 4 bufferBuilders
-		ARG 5 entityRenderStates
+		ARG 5 worldRenderState
 		ARG 6 entityRenderDispatcher
 	METHOD method_3242 onResized (II)V
 		ARG 1 width

--- a/mappings/net/minecraft/client/render/WorldRenderer.mapping
+++ b/mappings/net/minecraft/client/render/WorldRenderer.mapping
@@ -37,7 +37,7 @@ CLASS net/minecraft/class_761 net/minecraft/client/render/WorldRenderer
 	FIELD field_54162 NEARBY_SECTION_DISTANCE I
 	FIELD field_54163 MIN_TRANSPARENT_SORT_COUNT I
 	FIELD field_54164 nearbyChunks Lit/unimi/dsi/fastutil/objects/ObjectArrayList;
-	FIELD field_61737 entityRenderStates Lnet/minecraft/class_11658;
+	FIELD field_61737 worldRenderState Lnet/minecraft/class_11658;
 	FIELD field_61738 entityRenderCommandQueue Lnet/minecraft/class_11661;
 	FIELD field_61739 entityRenderDispatcher Lnet/minecraft/class_11684;
 	FIELD field_62647 particleBatch Lnet/minecraft/class_11943;

--- a/mappings/net/minecraft/client/render/state/WorldRenderState.mapping
+++ b/mappings/net/minecraft/client/render/state/WorldRenderState.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_11658 net/minecraft/client/render/state/WorldRenderState
-	FIELD field_61735 entityStates Ljava/util/List;
+	FIELD field_61735 entityRenderStates Ljava/util/List;
 	FIELD field_61736 hasOutline Z
 	FIELD field_62646 blockEntityRenderStates Ljava/util/List;
 	FIELD field_63082 cameraRenderState Lnet/minecraft/class_12075;


### PR DESCRIPTION
Also renames WorldRenderState#entityStates to entityRenderStates for consistency.