### PR TITLE
HeldItemContext mapping rename fix for compatibility with BlockEntity classes

### DIFF
--- a/mappings/net/minecraft/util/HeldItemContext.mapping
+++ b/mappings/net/minecraft/util/HeldItemContext.mapping
@@ -2,4 +2,4 @@ CLASS net/minecraft/class_11566 net/minecraft/util/HeldItemContext
 	METHOD method_72393 getEntity ()Lnet/minecraft/class_1309;
 	METHOD method_73183 getEntityWorld ()Lnet/minecraft/class_1937;
 	METHOD method_73188 getBodyYaw ()F
-	METHOD method_73189 getPos ()Lnet/minecraft/class_243;
+	METHOD method_73189 getEntityPos ()Lnet/minecraft/class_243;


### PR DESCRIPTION
Basically the method from the HeldItemContext interface clashes with BlockEntity's getPos() method causing an error, so I renamed HeldItemContext's "getPos()" into "getEntityPos()" for avoiding this issue

Also this is my first pull request btw :)
<img width="974" height="362" alt="image" src="https://github.com/user-attachments/assets/16f84357-f6e0-492e-916d-494192f8a641" />
