### PR TITLE
Map more record constructors

### DIFF
--- a/filament/src/main/java/net/fabricmc/filament/nameproposal/MappingNameCompleter.java
+++ b/filament/src/main/java/net/fabricmc/filament/nameproposal/MappingNameCompleter.java
@@ -117,7 +117,7 @@ public class MappingNameCompleter {
 			for (RecordComponentNode recordComponentNode : recordComponents) {
 				int currentLvIndex = lvIndex;
 				lvIndex += Type.getType(recordComponentNode.descriptor).getSize();
-				String name = getNameForComponent(recordComponentNode, recordNames, classMapping, yarnIntermediaryNs, yarnNamedNs);
+				String name = getNameForComponent(recordComponentNode, classMapping, yarnIntermediaryNs, yarnNamedNs);
 
 				if (name == null) {
 					continue;
@@ -127,14 +127,12 @@ public class MappingNameCompleter {
 
 				if (classMapping == null) {
 					classMapping = yarn.getClass(classNameIntermediary, yarnIntermediaryNs);
-					classMapping.setDstName(classNameIntermediary, yarnNamedNs);
 				}
 
 				yarn.visitMethod("<init>", initDesc);
 
 				if (constructorMapping == null) {
 					constructorMapping = classMapping.getMethod("<init>", initDesc, yarnIntermediaryNs);
-					constructorMapping.setDstName("<init>", yarnNamedNs);
 				}
 
 				yarn.visitMethodArg(-1, currentLvIndex, null);
@@ -154,12 +152,8 @@ public class MappingNameCompleter {
 		}
 	}
 
-	private static @Nullable String getNameForComponent(RecordComponentNode recordComponentNode, Map<String, String> recordNames,
-														MappingTree.ClassMapping classMapping, int yarnIntermediaryNs, int yarnNamedNs) {
-		if (recordNames.containsKey(recordComponentNode.name)) {
-			return recordNames.get(recordComponentNode.name);
-		}
-
+	private static @Nullable String getNameForComponent(RecordComponentNode recordComponentNode, MappingTree.ClassMapping classMapping,
+														int yarnIntermediaryNs, int yarnNamedNs) {
 		if (!recordComponentNode.name.startsWith("comp_")) {
 			return recordComponentNode.name;
 		}

--- a/filament/src/main/java/net/fabricmc/filament/nameproposal/MappingNameCompleter.java
+++ b/filament/src/main/java/net/fabricmc/filament/nameproposal/MappingNameCompleter.java
@@ -28,6 +28,7 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 import java.util.regex.Pattern;
 
+import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.ClassNode;
@@ -107,40 +108,37 @@ public class MappingNameCompleter {
 			String classNameIntermediary = entry.getKey();
 			List<RecordComponentNode> recordComponents = entry.getValue();
 
-			yarn.visitClass(classNameIntermediary);
 			MappingTree.ClassMapping classMapping = yarn.getClass(classNameIntermediary, yarnIntermediaryNs);
-			String className = classMapping.getName(yarnNamedNs);
+			String initDesc = getConstructorDesc(recordComponents);
 
-			if (className == null) {
-				classMapping.setDstName(classNameIntermediary, yarnNamedNs);
-			}
-
-			StringBuilder initDescBuilder = new StringBuilder();
-			initDescBuilder.append("(");
-
-			for (RecordComponentNode node : recordComponents) {
-				initDescBuilder.append(node.descriptor);
-			}
-
-			initDescBuilder.append(")V");
-			String initDesc = initDescBuilder.toString();
-
-			yarn.visitMethod("<init>", initDesc);
-			MappingTree.MethodMapping methodMapping = classMapping.getMethod("<init>", initDesc, yarnIntermediaryNs);
-			methodMapping.setDstName("<init>", yarnNamedNs);
+			MappingTree.MethodMapping constructorMapping = classMapping == null ? null : classMapping.getMethod("<init>", initDesc, yarnIntermediaryNs);
 			int lvIndex = 1;
 
 			for (RecordComponentNode recordComponentNode : recordComponents) {
 				int currentLvIndex = lvIndex;
 				lvIndex += Type.getType(recordComponentNode.descriptor).getSize();
-				String name = recordNames.get(recordComponentNode.name);
+				String name = getNameForComponent(recordComponentNode, recordNames, classMapping, yarnIntermediaryNs, yarnNamedNs);
 
 				if (name == null) {
 					continue;
 				}
 
+				yarn.visitClass(classNameIntermediary);
+
+				if (classMapping == null) {
+					classMapping = yarn.getClass(classNameIntermediary, yarnIntermediaryNs);
+					classMapping.setDstName(classNameIntermediary, yarnNamedNs);
+				}
+
+				yarn.visitMethod("<init>", initDesc);
+
+				if (constructorMapping == null) {
+					constructorMapping = classMapping.getMethod("<init>", initDesc, yarnIntermediaryNs);
+					constructorMapping.setDstName("<init>", yarnNamedNs);
+				}
+
 				yarn.visitMethodArg(-1, currentLvIndex, null);
-				MappingTree.MethodArgMapping argMapping = methodMapping.getArg(-1, currentLvIndex, null);
+				MappingTree.MethodArgMapping argMapping = constructorMapping.getArg(-1, currentLvIndex, null);
 				String yarnArgName = argMapping.getName(yarnNamedNs);
 
 				if (yarnArgName == null) {
@@ -154,6 +152,35 @@ public class MappingNameCompleter {
 		try (MappingWriter mappingWriter = MappingWriter.create(outputYarnMappings, MappingFormat.TINY_2_FILE)) {
 			yarn.accept(mappingWriter);
 		}
+	}
+
+	private static @Nullable String getNameForComponent(RecordComponentNode recordComponentNode, Map<String, String> recordNames,
+														MappingTree.ClassMapping classMapping, int yarnIntermediaryNs, int yarnNamedNs) {
+		if (recordNames.containsKey(recordComponentNode.name)) {
+			return recordNames.get(recordComponentNode.name);
+		}
+
+		if (!recordComponentNode.name.startsWith("comp_")) {
+			return recordComponentNode.name;
+		}
+
+		if (classMapping == null) {
+			return null;
+		}
+
+		MappingTree.MethodMapping componentGetter = classMapping.getMethod(recordComponentNode.name, "()" + recordComponentNode.descriptor, yarnIntermediaryNs);
+
+		if (componentGetter != null && componentGetter.getName(yarnNamedNs) != null) {
+			return componentGetter.getName(yarnNamedNs);
+		}
+
+		MappingTree.FieldMapping componentField = classMapping.getField(recordComponentNode.name, recordComponentNode.descriptor, yarnIntermediaryNs);
+
+		if (componentField != null && componentField.getName(yarnNamedNs) != null) {
+			return componentField.getName(yarnNamedNs);
+		}
+
+		return null;
 	}
 
 	private static void acceptJar(NameFinder nameFinder, Path jar) throws IOException {
@@ -178,6 +205,18 @@ public class MappingNameCompleter {
 		MemoryMappingTree mappingTree = new MemoryMappingTree();
 		MappingReader.read(path, mappingTree);
 		return mappingTree;
+	}
+
+	private static String getConstructorDesc(List<RecordComponentNode> recordComponents) {
+		StringBuilder initDescBuilder = new StringBuilder();
+		initDescBuilder.append("(");
+
+		for (RecordComponentNode node : recordComponents) {
+			initDescBuilder.append(node.descriptor);
+		}
+
+		initDescBuilder.append(")V");
+		return initDescBuilder.toString();
 	}
 
 	/**


### PR DESCRIPTION
Previously, it would just check the recordNames.
Now:
- if the obfuscated name of the record component doesn't start with "comp_", use it
- if there is a mapped method or field with the same intermediary name, use it

the recordNames maps methods and fields right before this code, so it'll find names from recordNames too
only if those 2 checks fail, then it doesn't map the parameter

also in this PR, it no longer maps methods or classes to themselves, it now leaves them unmapped, with \t\n