### PR TITLE
Map environment attribute maps

### DIFF
--- a/mappings/net/minecraft/registry/Registries.mapping
+++ b/mappings/net/minecraft/registry/Registries.mapping
@@ -95,6 +95,7 @@ CLASS net/minecraft/class_7923 net/minecraft/registry/Registries
 	FIELD field_62996 DEBUG_SUBSCRIPTION Lnet/minecraft/class_2378;
 	FIELD field_63643 PERMISSION_TYPE Lnet/minecraft/class_2378;
 	FIELD field_63644 PERMISSION_CHECK_TYPE Lnet/minecraft/class_2378;
+	FIELD field_63925 ENVIRONMENT_ATTRIBUTE Lnet/minecraft/class_2378;
 	METHOD method_47452 (Lnet/minecraft/class_2378;)Ljava/lang/Object;
 		ARG 0 registry
 	METHOD method_47453 (Lnet/minecraft/class_2378;)Ljava/lang/Object;

--- a/mappings/net/minecraft/world/attribute/EnvironmentAttribute.mapping
+++ b/mappings/net/minecraft/world/attribute/EnvironmentAttribute.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_12197 net/minecraft/world/attribute/EnvironmentAttribute
+	CLASS class_12198 Builder
+		FIELD field_63719 defaultValue Ljava/lang/Object;
+		METHOD method_75660 build ()Lnet/minecraft/class_12197;

--- a/mappings/net/minecraft/world/attribute/EnvironmentAttributeMap.mapping
+++ b/mappings/net/minecraft/world/attribute/EnvironmentAttributeMap.mapping
@@ -1,0 +1,35 @@
+CLASS net/minecraft/class_12199 net/minecraft/world/attribute/EnvironmentAttributeMap
+	FIELD field_63724 EMPTY Lnet/minecraft/class_12199;
+	FIELD field_63728 entries Ljava/util/Map;
+	METHOD <init> (Ljava/util/Map;)V
+		ARG 1 entries
+	METHOD equals (Ljava/lang/Object;)Z
+		ARG 1 o
+	METHOD method_75661 builder ()Lnet/minecraft/class_12199$class_12200;
+	METHOD method_75662 getEntry (Lnet/minecraft/class_12197;)Lnet/minecraft/class_12199$class_12201;
+		ARG 1 key
+	METHOD method_75663 get (Lnet/minecraft/class_12197;Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 1 key
+		ARG 2 value
+	METHOD method_75664 (Lnet/minecraft/class_12199;)Lnet/minecraft/class_12199;
+		ARG 0 map
+	METHOD method_75666 keys ()Ljava/util/Set;
+	METHOD method_75667 containsKey (Lnet/minecraft/class_12197;)Z
+		ARG 1 key
+	METHOD method_75668 (Lnet/minecraft/class_12199;)Lcom/mojang/serialization/DataResult;
+		ARG 0 map
+	CLASS class_12200 Builder
+		FIELD field_63729 entries Ljava/util/Map;
+		METHOD method_75672 build ()Lnet/minecraft/class_12199;
+		METHOD method_75673 setModifier (Lnet/minecraft/class_12197;Lnet/minecraft/class_12212;Ljava/lang/Object;)Lnet/minecraft/class_12199$class_12200;
+			ARG 1 key
+			ARG 2 modifier
+			ARG 3 value
+		METHOD method_75674 set (Lnet/minecraft/class_12197;Ljava/lang/Object;)Lnet/minecraft/class_12199$class_12200;
+			ARG 1 key
+			ARG 2 value
+		METHOD method_75675 addAll (Lnet/minecraft/class_12199;)Lnet/minecraft/class_12199$class_12200;
+			ARG 1 map
+	CLASS class_12201 Entry
+		METHOD method_75679 (Lnet/minecraft/class_12212;Lnet/minecraft/class_12197;Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+			ARG 2 instance

--- a/mappings/net/minecraft/world/attribute/EnvironmentAttributes.mapping
+++ b/mappings/net/minecraft/world/attribute/EnvironmentAttributes.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_12206 net/minecraft/world/attribute/EnvironmentAttributes
+	METHOD method_75703 register (Ljava/lang/String;Lnet/minecraft/class_12197$class_12198;)Lnet/minecraft/class_12197;
+		ARG 0 path
+		ARG 1 builder
+	METHOD method_75704 registerAndGetDefault (Lnet/minecraft/class_2378;)Lnet/minecraft/class_12197;


### PR DESCRIPTION
This pull request adds mappings for a selection of environment attribute-related classes and methods to align with the API surface introduced in FabricMC/fabric#4930.