### PR TITLE
Add 25w42a mappings

### DIFF
--- a/mappings/net/minecraft/client/font/Alignment.mapping
+++ b/mappings/net/minecraft/client/font/Alignment.mapping
@@ -2,3 +2,7 @@ CLASS net/minecraft/class_11735 net/minecraft/client/font/Alignment
 	METHOD method_73214 getAdjustedX (II)I
 		ARG 1 x
 		ARG 2 width
+	METHOD method_75792 getAdjustedX (ILnet/minecraft/class_327;Lnet/minecraft/class_5481;)I
+		ARG 1 x
+		ARG 2 textRenderer
+		ARG 3 text

--- a/mappings/net/minecraft/client/font/BoundedGlyph.mapping
+++ b/mappings/net/minecraft/client/font/BoundedGlyph.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_12236 net/minecraft/client/font/BoundedGlyph
+	METHOD method_75818 getLeft ()F
+	METHOD method_75819 getTop ()F
+	METHOD method_75820 getRight ()F
+	METHOD method_75821 getBottom ()F

--- a/mappings/net/minecraft/client/font/SkeletonGlyph.mapping
+++ b/mappings/net/minecraft/client/font/SkeletonGlyph.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_12237 net/minecraft/client/font/SkeletonGlyph
+	FIELD field_63886 DEFAULT_HEIGHT F
+	FIELD field_63887 DEFAULT_ASCENT F

--- a/mappings/net/minecraft/client/font/TextConsumer.mapping
+++ b/mappings/net/minecraft/client/font/TextConsumer.mapping
@@ -1,0 +1,118 @@
+CLASS net/minecraft/class_12225 net/minecraft/client/font/TextConsumer
+	FIELD field_63832 MARQUEE_PERIOD_PER_EXCESS_WIDTH D
+	FIELD field_63833 MARQUEE_MIN_PERIOD D
+	METHOD method_75760 getTransformation ()Lnet/minecraft/class_12225$class_12227;
+	METHOD method_75761 isWithinBounds (FFFFFF)Z
+		ARG 0 x
+		ARG 1 y
+		ARG 2 left
+		ARG 3 top
+		ARG 4 right
+		ARG 5 bottom
+	METHOD method_75762 text (IILnet/minecraft/class_5481;)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 text
+	METHOD method_75763 text (IILnet/minecraft/class_2561;)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 text
+	METHOD method_75764 getTransformation (Lnet/minecraft/class_12225$class_12227;)V
+		ARG 1 transformation
+	METHOD method_75765 text (Lnet/minecraft/class_11735;IILnet/minecraft/class_5481;)V
+		ARG 1 alignment
+		ARG 2 x
+		ARG 3 y
+		ARG 4 text
+	METHOD method_75766 text (Lnet/minecraft/class_11735;IILnet/minecraft/class_12225$class_12227;Lnet/minecraft/class_5481;)V
+		ARG 1 alignment
+		ARG 2 x
+		ARG 3 y
+		ARG 4 transformation
+		ARG 5 text
+	METHOD method_75767 text (Lnet/minecraft/class_11735;IILnet/minecraft/class_12225$class_12227;Lnet/minecraft/class_2561;)V
+		ARG 1 alignment
+		ARG 2 x
+		ARG 3 y
+		ARG 4 transformation
+		ARG 5 text
+	METHOD method_75768 text (Lnet/minecraft/class_11735;IILnet/minecraft/class_2561;)V
+		ARG 1 alignment
+		ARG 2 x
+		ARG 3 y
+		ARG 4 text
+	METHOD method_75769 handleHover (Lnet/minecraft/class_11247;FFLjava/util/function/Consumer;)V
+		COMMENT If the cursor is hovering over a piece of text, calls {@code styleCallback} on its style.
+		ARG 0 renderState
+			COMMENT the text to check the cursor against
+		ARG 1 mouseX
+			COMMENT the X-coordinate of the cursor, in scaled units
+		ARG 2 mouseY
+			COMMENT the Y-coordinate of the cursor, in scaled units
+		ARG 3 styleCallback
+			COMMENT a callback to call on the style that the cursor is hovering over
+	METHOD method_75770 text (Lnet/minecraft/class_2561;IIII)V
+		ARG 1 text
+		ARG 2 left
+		ARG 3 right
+		ARG 4 top
+		ARG 5 bottom
+	METHOD method_75771 marqueedText (Lnet/minecraft/class_2561;IIIII)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 left
+		ARG 4 right
+		ARG 5 top
+		ARG 6 bottom
+	METHOD method_75772 marqueedText (Lnet/minecraft/class_2561;IIIIIIILnet/minecraft/class_12225$class_12227;)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 left
+		ARG 4 right
+		ARG 5 top
+		ARG 6 bottom
+		ARG 7 width
+		ARG 8 lineHeight
+		ARG 9 transformation
+	METHOD method_75773 marqueedText (Lnet/minecraft/class_2561;IIIIILnet/minecraft/class_12225$class_12227;)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 left
+		ARG 4 right
+		ARG 5 top
+		ARG 6 bottom
+		ARG 7 transformation
+	CLASS 1
+		METHOD method_75774 addGlyphInternal (Lnet/minecraft/class_12236;)V
+			ARG 1 glyph
+	CLASS class_12226 ClickHandler
+		FIELD field_63837 DEFAULT_TRANSFORMATION Lnet/minecraft/class_12225$class_12227;
+		FIELD field_63838 textRenderer Lnet/minecraft/class_327;
+		FIELD field_63839 clickX I
+		FIELD field_63840 clickY I
+		FIELD field_63841 transformation Lnet/minecraft/class_12225$class_12227;
+		FIELD field_63842 style Lnet/minecraft/class_2583;
+		FIELD field_63843 setStyleCallback Ljava/util/function/Consumer;
+		METHOD <init> (Lnet/minecraft/class_327;II)V
+			ARG 1 textRenderer
+			ARG 2 clickX
+			ARG 3 clickY
+		METHOD method_75776 (Lnet/minecraft/class_2583;)V
+			ARG 1 style
+		METHOD method_75777 getStyle ()Lnet/minecraft/class_2583;
+	CLASS class_12227 Transformation
+		METHOD <init> (Lorg/joml/Matrix3x2fc;)V
+			ARG 1 pose
+		METHOD method_75778 scaled (F)Lnet/minecraft/class_12225$class_12227;
+			ARG 1 scale
+		METHOD method_75779 withScissor (IIII)Lnet/minecraft/class_12225$class_12227;
+			ARG 1 left
+			ARG 2 right
+			ARG 3 top
+			ARG 4 bottom
+		METHOD method_75780 withScissor (Lnet/minecraft/class_8030;)Lnet/minecraft/class_12225$class_12227;
+			ARG 1 scissor
+		METHOD method_75781 withPose (Lorg/joml/Matrix3x2fc;)Lnet/minecraft/class_12225$class_12227;
+			ARG 1 pose
+		METHOD method_75782 withOpacity (F)Lnet/minecraft/class_12225$class_12227;
+			ARG 1 opacity

--- a/mappings/net/minecraft/client/font/TextDrawable.mapping
+++ b/mappings/net/minecraft/client/font/TextDrawable.mapping
@@ -11,3 +11,4 @@ CLASS net/minecraft/class_11767 net/minecraft/client/font/TextDrawable
 		ARG 2 consumer
 		ARG 3 light
 		ARG 4 noDepth
+	CLASS class_12238 DrawnGlyph

--- a/mappings/net/minecraft/client/font/TextRenderer.mapping
+++ b/mappings/net/minecraft/client/font/TextRenderer.mapping
@@ -123,6 +123,8 @@ CLASS net/minecraft/class_327 net/minecraft/client/font/TextRenderer
 		ARG 3 y
 		ARG 4 color
 		ARG 5 shadow
+		ARG 6 trackSkeletons
+		ARG 7 backgroundColor
 	METHOD method_71796 prepare (Ljava/lang/String;FFIZI)Lnet/minecraft/class_327$class_11465;
 		ARG 1 string
 		ARG 2 x
@@ -154,17 +156,21 @@ CLASS net/minecraft/class_327 net/minecraft/client/font/TextRenderer
 		FIELD field_60705 maxBackgroundX F
 		FIELD field_60706 maxBackgroundY F
 		FIELD field_60707 drawnGlyphs Ljava/util/List;
+		FIELD field_63844 trackSkeletons Z
+		FIELD field_63845 skeletonGlyphs Ljava/util/List;
 		METHOD <init> (Lnet/minecraft/class_327;FFIIZZ)V
 			ARG 2 x
 			ARG 3 y
 			ARG 4 color
 			ARG 5 backgroundColor
 			ARG 6 shadow
+			ARG 7 trackSkeletons
 		METHOD <init> (Lnet/minecraft/class_327;FFIZZ)V
 			ARG 2 x
 			ARG 3 y
 			ARG 4 color
 			ARG 5 shadow
+			ARG 6 trackSkeletons
 		METHOD method_27532 addRectangle (Lnet/minecraft/class_11767;)V
 			ARG 1 rectangle
 		METHOD method_65177 getShadowColor (Lnet/minecraft/class_2583;I)I
@@ -182,13 +188,17 @@ CLASS net/minecraft/class_327 net/minecraft/client/font/TextRenderer
 			ARG 3 maxX
 			ARG 4 maxY
 		METHOD method_71804 addGlyph (Lnet/minecraft/class_11767$class_12238;)V
+			ARG 1 glyph
 		METHOD method_72733 accept (ILnet/minecraft/class_2583;Lnet/minecraft/class_11768;)Z
 			ARG 1 index
 			ARG 2 style
 			ARG 3 glyph
+		METHOD method_75783 addSkeletonGlyph (Lnet/minecraft/class_12237;)V
+			ARG 1 glyph
 	CLASS class_6415 TextLayerType
 	CLASS class_11464 GlyphDrawer
 		METHOD method_71797 drawGlyph (Lnet/minecraft/class_11767$class_12238;)V
+			ARG 1 glyph
 		METHOD method_71798 drawRectangle (Lnet/minecraft/class_11767;)V
 			ARG 1 bakedGlyph
 		METHOD method_71799 drawing (Lnet/minecraft/class_4597;Lorg/joml/Matrix4f;Lnet/minecraft/class_327$class_6415;I)Lnet/minecraft/class_327$class_11464;
@@ -196,6 +206,8 @@ CLASS net/minecraft/class_327 net/minecraft/client/font/TextRenderer
 			ARG 1 matrix
 			ARG 2 layerType
 			ARG 3 light
+		METHOD method_75775 addSkeleton (Lnet/minecraft/class_12237;)V
+			ARG 1 glyph
 		CLASS 1
 			METHOD method_73365 draw (Lnet/minecraft/class_11767;)V
 				ARG 1 glyph

--- a/mappings/net/minecraft/client/gl/GlCommandEncoder.mapping
+++ b/mappings/net/minecraft/client/gl/GlCommandEncoder.mapping
@@ -6,6 +6,7 @@ CLASS net/minecraft/class_10860 net/minecraft/client/gl/GlCommandEncoder
 	FIELD field_57847 currentPipeline Lcom/mojang/blaze3d/pipeline/RenderPipeline;
 	FIELD field_57848 renderPassOpen Z
 	FIELD field_57849 currentProgram Lnet/minecraft/class_5944;
+	FIELD field_63814 timerQuery Lnet/minecraft/class_12224;
 	METHOD <init> (Lnet/minecraft/class_10865;)V
 		ARG 1 backend
 	METHOD method_68346 closePass ()V

--- a/mappings/net/minecraft/client/gl/GlTimerQuery.mapping
+++ b/mappings/net/minecraft/client/gl/GlTimerQuery.mapping
@@ -1,0 +1,6 @@
+CLASS net/minecraft/class_12224 net/minecraft/client/gl/GlTimerQuery
+	FIELD field_63815 id I
+	FIELD field_63816 closed Z
+	FIELD field_63817 value Ljava/util/OptionalLong;
+	METHOD <init> (I)V
+		ARG 1 id

--- a/mappings/net/minecraft/client/gui/DrawContext.mapping
+++ b/mappings/net/minecraft/client/gui/DrawContext.mapping
@@ -8,12 +8,21 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawContext
 	FIELD field_61531 spriteHolder Lnet/minecraft/class_11701;
 	FIELD field_61532 spriteAtlasTexture Lnet/minecraft/class_1059;
 	FIELD field_62463 cursor Lnet/minecraft/class_11875;
+	FIELD field_63846 x I
+	FIELD field_63847 y I
+	FIELD field_63848 hoverStyle Lnet/minecraft/class_2583;
+	FIELD field_63849 clickStyle Lnet/minecraft/class_2583;
 	METHOD <init> (Lnet/minecraft/class_310;Lnet/minecraft/class_11246;II)V
 		ARG 1 client
 		ARG 2 state
+		ARG 3 x
+		ARG 4 y
 	METHOD <init> (Lnet/minecraft/class_310;Lorg/joml/Matrix3x2fStack;Lnet/minecraft/class_11246;II)V
+		ARG 1 client
 		ARG 2 matrices
 		ARG 3 state
+		ARG 4 x
+		ARG 5 y
 	METHOD method_25290 drawTexture (Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lnet/minecraft/class_2960;IIFFIIII)V
 		COMMENT Draws a textured rectangle from a region in a texture.
 		COMMENT
@@ -470,6 +479,16 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawContext
 	METHOD method_70847 drawTexturedQuad (Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lcom/mojang/blaze3d/textures/GpuTextureView;Lnet/minecraft/class_12137;IIIIFFFFI)V
 		ARG 1 pipeline
 		ARG 2 texture
+		ARG 3 sampler
+		ARG 4 x1
+		ARG 5 y1
+		ARG 6 x2
+		ARG 7 y2
+		ARG 8 u1
+		ARG 9 v1
+		ARG 10 u2
+		ARG 11 v2
+		ARG 12 color
 	METHOD method_70848 fill (Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lnet/minecraft/class_11231;IIIIILjava/lang/Integer;)V
 		ARG 1 pipeline
 		ARG 2 textureSetup
@@ -567,12 +586,17 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawContext
 		ARG 2 y1
 		ARG 3 x2
 		ARG 4 y2
+		ARG 5 invert
 	METHOD method_72740 getScaling (Lnet/minecraft/class_1058;)Lnet/minecraft/class_8690;
 		ARG 0 sprite
 	METHOD method_72741 getSprite (Lnet/minecraft/class_4730;)Lnet/minecraft/class_1058;
 		ARG 1 id
 	METHOD method_73198 drawStrokedRectangle (IIIII)V
+		ARG 1 x
 		ARG 2 y
+		ARG 3 width
+		ARG 4 height
+		ARG 5 color
 	METHOD method_73199 drawDeferredElements ()V
 	METHOD method_74036 applyCursorTo (Lnet/minecraft/class_1041;)V
 		ARG 1 window
@@ -581,6 +605,29 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawContext
 	METHOD method_74707 drawTiledTexturedQuad (Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lcom/mojang/blaze3d/textures/GpuTextureView;Lnet/minecraft/class_12137;IIIIIIFFFFI)V
 		ARG 1 pipeline
 		ARG 2 texture
+		ARG 3 sampler
+		ARG 4 tileWidth
+		ARG 5 tileHeight
+		ARG 6 x0
+		ARG 7 y0
+		ARG 8 x1
+		ARG 9 y1
+		ARG 10 u0
+		ARG 11 v0
+		ARG 12 u1
+		ARG 13 v1
+		ARG 14 color
+	METHOD method_75784 getTransformationForCurrentState (F)Lnet/minecraft/class_12225$class_12227;
+		ARG 1 opacity
+	METHOD method_75785 getTextConsumer (Lnet/minecraft/class_332$class_12228;)Lnet/minecraft/class_12225;
+		ARG 1 hoverType
+	METHOD method_75786 getTextConsumer (Lnet/minecraft/class_332$class_12228;Ljava/util/function/Consumer;)Lnet/minecraft/class_12225;
+		ARG 1 hoverType
+		ARG 2 styleCallback
+	METHOD method_75787 getHoverListener (Lnet/minecraft/class_339;Lnet/minecraft/class_332$class_12228;)Lnet/minecraft/class_12225;
+		ARG 1 widget
+		ARG 2 hoverType
+	METHOD method_75788 getTextConsumer ()Lnet/minecraft/class_12225;
 	CLASS class_8214 ScissorStack
 		FIELD field_43099 stack Ljava/util/Deque;
 		METHOD method_49699 pop ()Lnet/minecraft/class_8030;
@@ -590,3 +637,21 @@ CLASS net/minecraft/class_332 net/minecraft/client/gui/DrawContext
 			ARG 1 x
 			ARG 2 y
 		METHOD method_70863 peekLast ()Lnet/minecraft/class_8030;
+	CLASS class_12228 HoverType
+		FIELD field_63853 tooltip Z
+		FIELD field_63854 cursor Z
+		METHOD <init> (Ljava/lang/String;IZZ)V
+			ARG 3 tooltip
+			ARG 4 cursor
+		METHOD method_75790 fromTooltip (Z)Lnet/minecraft/class_332$class_12228;
+			ARG 0 tooltip
+	CLASS class_12229 TextConsumerImpl
+		FIELD field_63857 transformation Lnet/minecraft/class_12225$class_12227;
+		FIELD field_63858 hoverType Lnet/minecraft/class_332$class_12228;
+		FIELD field_63859 styleCallback Ljava/util/function/Consumer;
+		METHOD <init> (Lnet/minecraft/class_332;Lnet/minecraft/class_12225$class_12227;Lnet/minecraft/class_332$class_12228;Ljava/util/function/Consumer;)V
+			ARG 2 transformation
+			ARG 3 hoverType
+			ARG 4 styleCallback
+		METHOD accept (Ljava/lang/Object;)V
+			ARG 1 style

--- a/mappings/net/minecraft/client/gui/hud/ChatHud.mapping
+++ b/mappings/net/minecraft/client/gui/hud/ChatHud.mapping
@@ -17,6 +17,8 @@ CLASS net/minecraft/class_338 net/minecraft/client/gui/hud/ChatHud
 	FIELD field_40392 removalQueue Ljava/util/List;
 	FIELD field_62002 draft Lnet/minecraft/class_338$class_11733;
 	FIELD field_62003 screen Lnet/minecraft/class_408;
+	FIELD field_63863 EXPAND_CHAT_QUEUE_ID Lnet/minecraft/class_2960;
+	FIELD field_63865 CHAT_QUEUE_STYLE Lnet/minecraft/class_2583;
 	METHOD <init> (Lnet/minecraft/class_310;)V
 		ARG 1 client
 	METHOD method_1802 scroll (I)V
@@ -25,7 +27,6 @@ CLASS net/minecraft/class_338 net/minecraft/client/gui/hud/ChatHud
 		ARG 1 message
 	METHOD method_1805 render (Lnet/minecraft/class_338$class_12233;IIZ)V
 		ARG 2 currentTick
-		ARG 3 mouseX
 	METHOD method_1806 getWidth (D)I
 		ARG 0 widthOption
 	METHOD method_1808 clear (Z)V
@@ -82,6 +83,11 @@ CLASS net/minecraft/class_338 net/minecraft/client/gui/hud/ChatHud
 	METHOD method_73205 setScreen ()V
 	METHOD method_73206 removeScreen ()Lnet/minecraft/class_408;
 		COMMENT @return the previous screen
+	METHOD method_75804 (Lnet/minecraft/class_332;Lnet/minecraft/class_327;IIIZ)V
+		ARG 1 context
+		ARG 2 textRenderer
+		ARG 4 x
+		ARG 5 y
 	CLASS class_7731 RemovalQueuedMessage
 	CLASS class_9477 ChatState
 		FIELD field_50218 messages Ljava/util/List;
@@ -109,3 +115,46 @@ CLASS net/minecraft/class_338 net/minecraft/client/gui/hud/ChatHud
 			ARG 1 draft
 				COMMENT the saved draft
 	CLASS class_11733 Draft
+	CLASS class_12232
+		METHOD calculate (Lnet/minecraft/class_303$class_7590;)F
+			ARG 1 line
+		METHOD method_75805 (ILnet/minecraft/class_303$class_7590;)F
+			ARG 1 line
+	CLASS class_12233
+		METHOD method_75807 (IFLnet/minecraft/class_5481;)Z
+			ARG 1 y
+			ARG 3 text
+		METHOD method_75808 (IIIIFLnet/minecraft/class_7591;)V
+			ARG 6 indicator
+		METHOD method_75809 (IIIII)V
+			ARG 1 x1
+			ARG 2 y1
+			ARG 3 x2
+			ARG 4 y2
+			ARG 5 color
+		METHOD method_75810 (IIZLnet/minecraft/class_7591;Lnet/minecraft/class_7591$class_7592;)V
+			ARG 4 indicator
+			ARG 5 icon
+		METHOD method_75811 updatePose (Ljava/util/function/Consumer;)V
+	CLASS class_12234
+		FIELD field_63875 drawer Lnet/minecraft/class_12225;
+		METHOD <init> (Lnet/minecraft/class_12225;)V
+			ARG 1 drawer
+	CLASS class_12235
+		FIELD field_63876 context Lnet/minecraft/class_332;
+		FIELD field_63877 textRenderer Lnet/minecraft/class_327;
+		FIELD field_63879 transformation Lnet/minecraft/class_12225$class_12227;
+		FIELD field_63880 x I
+		FIELD field_63881 y I
+		FIELD field_63882 untransformedOffset Lorg/joml/Vector2f;
+		FIELD field_63883 style Lnet/minecraft/class_2583;
+		METHOD <init> (Lnet/minecraft/class_332;Lnet/minecraft/class_327;II)V
+			ARG 1 context
+			ARG 2 textRenderer
+			ARG 3 x
+			ARG 4 y
+		METHOD accept (Ljava/lang/Object;)V
+			ARG 1 style
+		METHOD method_75812 calculateUntransformedOffset ()V
+		METHOD method_75814 (Lnet/minecraft/class_7591;)V
+			ARG 1 indicator

--- a/mappings/net/minecraft/client/gui/hud/ChatHudLine.mapping
+++ b/mappings/net/minecraft/client/gui/hud/ChatHudLine.mapping
@@ -1,10 +1,16 @@
 CLASS net/minecraft/class_303 net/minecraft/client/gui/hud/ChatHudLine
 	FIELD comp_892 creationTick I
 	FIELD comp_894 indicator Lnet/minecraft/class_7591;
+	FIELD field_63831 MARGIN I
 	METHOD <init> (ILnet/minecraft/class_2561;Lnet/minecraft/class_7469;Lnet/minecraft/class_7591;)V
 		ARG 1 creationTick
 	METHOD comp_892 creationTick ()I
 	METHOD comp_894 indicator ()Lnet/minecraft/class_7591;
+	METHOD method_75757 breakLines (Lnet/minecraft/class_327;I)Ljava/util/List;
+		ARG 1 textRenderer
+		ARG 2 width
 	CLASS class_7590 Visible
 		FIELD comp_897 indicator Lnet/minecraft/class_7591;
 		METHOD comp_897 indicator ()Lnet/minecraft/class_7591;
+		METHOD method_75758 getWidth (Lnet/minecraft/class_327;)I
+			ARG 1 textRenderer

--- a/mappings/net/minecraft/client/gui/render/state/TextGuiElementRenderState.mapping
+++ b/mappings/net/minecraft/client/gui/render/state/TextGuiElementRenderState.mapping
@@ -10,12 +10,16 @@ CLASS net/minecraft/class_11247 net/minecraft/client/gui/render/state/TextGuiEle
 	FIELD field_60750 clipBounds Lnet/minecraft/class_8030;
 	FIELD field_60751 preparation Lnet/minecraft/class_327$class_11465;
 	FIELD field_60752 bounds Lnet/minecraft/class_8030;
+	FIELD field_63891 trackSkeletons Z
 	METHOD <init> (Lnet/minecraft/class_327;Lnet/minecraft/class_5481;Lorg/joml/Matrix3x2fc;IIIIZZLnet/minecraft/class_8030;)V
 		ARG 1 textRenderer
 		ARG 2 orderedText
+		ARG 3 matrix
 		ARG 4 x
 		ARG 5 y
 		ARG 6 color
 		ARG 7 backgroundColor
 		ARG 8 shadow
+		ARG 9 trackSkeletons
+		ARG 10 clipBounds
 	METHOD method_71837 prepare ()Lnet/minecraft/class_327$class_11465;

--- a/mappings/net/minecraft/client/gui/screen/DeathScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/DeathScreen.mapping
@@ -5,9 +5,12 @@ CLASS net/minecraft/class_418 net/minecraft/client/gui/screen/DeathScreen
 	FIELD field_33809 buttons Ljava/util/List;
 	FIELD field_41684 titleScreenButton Lnet/minecraft/class_4185;
 	FIELD field_45407 DRAFT_REPORT_ICON_TEXTURE Lnet/minecraft/class_2960;
+	FIELD field_63893 decedent Lnet/minecraft/class_746;
+	FIELD field_63894 scoreText Lnet/minecraft/class_2561;
 	METHOD <init> (Lnet/minecraft/class_2561;ZLnet/minecraft/class_746;)V
 		ARG 1 message
 		ARG 2 isHardcore
+		ARG 3 decedent
 	METHOD method_19809 (Lnet/minecraft/class_4185;)V
 		ARG 1 button
 	METHOD method_22364 quitLevel ()V
@@ -22,4 +25,6 @@ CLASS net/minecraft/class_418 net/minecraft/client/gui/screen/DeathScreen
 		ARG 0 context
 		ARG 1 width
 		ARG 2 height
+	METHOD method_75826 drawTitles (Lnet/minecraft/class_12225;)V
+		ARG 1 drawer
 	CLASS class_8183 TitleScreenConfirmScreen

--- a/mappings/net/minecraft/client/gui/screen/Screen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/Screen.mapping
@@ -34,6 +34,8 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 		ARG 0 client
 		ARG 1 stack
 	METHOD method_25410 resize (II)V
+		ARG 1 width
+		ARG 2 height
 	METHOD method_25414 isValidCharacterForName (Ljava/lang/String;II)Z
 		ARG 1 name
 		ARG 2 codepoint
@@ -56,6 +58,8 @@ CLASS net/minecraft/class_437 net/minecraft/client/gui/screen/Screen
 	METHOD method_25422 shouldCloseOnEsc ()Z
 		COMMENT Checks whether this screen should be closed when the escape key is pressed.
 	METHOD method_25423 init (II)V
+		ARG 1 width
+		ARG 2 height
 	METHOD method_25426 init ()V
 		COMMENT Called when a screen should be initialized.
 		COMMENT

--- a/mappings/net/minecraft/client/gui/screen/SplashTextRenderer.mapping
+++ b/mappings/net/minecraft/client/gui/screen/SplashTextRenderer.mapping
@@ -1,8 +1,15 @@
 CLASS net/minecraft/class_8519 net/minecraft/client/gui/screen/SplashTextRenderer
+	FIELD field_44661 MERRY_X_MAX Lnet/minecraft/class_8519;
+	FIELD field_44662 HAPPY_NEW_YEAR Lnet/minecraft/class_8519;
+	FIELD field_44663 OOOOO_O_O_OOOOO__SPOOKY Lnet/minecraft/class_8519;
 	FIELD field_44664 TEXT_X I
 	FIELD field_44665 TEXT_Y I
 	FIELD field_44666 text Lnet/minecraft/class_2561;
+	FIELD field_63884 TEXT_ROTATION F
+	METHOD <init> (Lnet/minecraft/class_2561;)V
+		ARG 1 text
 	METHOD method_51453 render (Lnet/minecraft/class_332;ILnet/minecraft/class_327;F)V
+		ARG 1 context
 		ARG 2 screenWidth
 		ARG 3 textRenderer
 		ARG 4 alpha

--- a/mappings/net/minecraft/client/gui/screen/ingame/BookScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/BookScreen.mapping
@@ -40,6 +40,8 @@ CLASS net/minecraft/class_3872 net/minecraft/client/gui/screen/ingame/BookScreen
 	METHOD method_71545 getPageIndicatorText ()Lnet/minecraft/class_2561;
 	METHOD method_71846 handleClickEvent (Lnet/minecraft/class_2558;)Z
 	METHOD method_72151 closeScreen ()V
+	METHOD method_75835 (Lnet/minecraft/class_12225;Z)V
+		ARG 1 drawer
 	CLASS class_3931 Contents
 		METHOD method_17560 getPageCount ()I
 		METHOD method_17562 create (Lnet/minecraft/class_1799;)Lnet/minecraft/class_3872$class_3931;

--- a/mappings/net/minecraft/client/gui/widget/ClickableWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ClickableWidget.mapping
@@ -77,3 +77,12 @@ CLASS net/minecraft/class_339 net/minecraft/client/gui/widget/ClickableWidget
 	METHOD method_72102 isInBounds (DD)Z
 		ARG 1 x
 		ARG 3 y
+	METHOD method_75798 getAlpha ()F
+	METHOD method_75799 drawTextWithMargin (Lnet/minecraft/class_12225;Lnet/minecraft/class_2561;I)V
+		ARG 1 drawer
+		ARG 2 text
+		ARG 3 xMargin
+	CLASS class_12230 ToggleableText
+		FIELD field_63861 grayedMessage Lnet/minecraft/class_2561;
+		METHOD method_75800 makeGray (Lnet/minecraft/class_2561;)Lnet/minecraft/class_2561;
+			ARG 0 text

--- a/mappings/net/minecraft/client/gui/widget/CyclingButtonWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/CyclingButtonWidget.mapping
@@ -10,6 +10,7 @@ CLASS net/minecraft/class_5676 net/minecraft/client/gui/widget/CyclingButtonWidg
 	FIELD field_27969 callback Lnet/minecraft/class_5676$class_5678;
 	FIELD field_27970 tooltipFactory Lnet/minecraft/class_7172$class_7277;
 	FIELD field_27971 optionTextOmitted Z
+	FIELD field_63504 valueSupplier Ljava/util/function/Supplier;
 	METHOD <init> (IIIILnet/minecraft/class_2561;Lnet/minecraft/class_2561;ILjava/lang/Object;Ljava/util/function/Supplier;Lnet/minecraft/class_5676$class_5680;Ljava/util/function/Function;Ljava/util/function/Function;Lnet/minecraft/class_5676$class_5678;Lnet/minecraft/class_7172$class_7277;Z)V
 		ARG 1 x
 		ARG 2 y
@@ -19,6 +20,7 @@ CLASS net/minecraft/class_5676 net/minecraft/client/gui/widget/CyclingButtonWidg
 		ARG 6 optionText
 		ARG 7 index
 		ARG 8 value
+		ARG 9 valueSupplier
 		ARG 10 values
 		ARG 11 valueToText
 		ARG 12 narrationMessageFactory
@@ -74,11 +76,13 @@ CLASS net/minecraft/class_5676 net/minecraft/client/gui/widget/CyclingButtonWidg
 		FIELD field_27976 narrationMessageFactory Ljava/util/function/Function;
 		FIELD field_27977 values Lnet/minecraft/class_5676$class_5680;
 		FIELD field_27978 optionTextOmitted Z
+		FIELD field_63505 valueSupplier Ljava/util/function/Supplier;
 		METHOD <init> (Ljava/util/function/Function;Ljava/util/function/Supplier;)V
 			COMMENT Creates a builder.
 			COMMENT
 			COMMENT @see CyclingButtonWidget#builder(Function)
 			ARG 1 valueToText
+			ARG 2 valueSupplier
 		METHOD method_32616 omitKeyText ()Lnet/minecraft/class_5676$class_5677;
 			COMMENT Makes the built button omit the option and only display the current value
 			COMMENT for its text, such as showing "Jump Mode" than "Mode: Jump Mode".

--- a/mappings/net/minecraft/client/gui/widget/PressableWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/PressableWidget.mapping
@@ -4,3 +4,14 @@ CLASS net/minecraft/class_4264 net/minecraft/client/gui/widget/PressableWidget
 	FIELD field_45339 TEXTURES Lnet/minecraft/class_8666;
 	METHOD method_25306 onPress (Lnet/minecraft/class_11907;)V
 		ARG 1 input
+	METHOD method_75752 drawIcon (Lnet/minecraft/class_332;IIF)V
+		ARG 1 context
+		ARG 2 mouseX
+		ARG 3 mouseY
+		ARG 4 deltaTicks
+	METHOD method_75793 drawLabel (Lnet/minecraft/class_12225;)V
+		ARG 1 drawer
+	METHOD method_75794 drawButton (Lnet/minecraft/class_332;)V
+		ARG 1 context
+	METHOD method_75795 setCursor (Lnet/minecraft/class_332;)V
+		ARG 1 context

--- a/mappings/net/minecraft/client/gui/widget/TextFieldWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/TextFieldWidget.mapping
@@ -26,6 +26,7 @@ CLASS net/minecraft/class_342 net/minecraft/client/gui/widget/TextFieldWidget
 	FIELD field_62008 formatters Ljava/util/List;
 	FIELD field_62465 PLACEHOLDER_STYLE Lnet/minecraft/class_2583;
 	FIELD field_62466 SEARCH_STYLE Lnet/minecraft/class_2583;
+	FIELD field_63506 invert Z
 	METHOD <init> (Lnet/minecraft/class_327;IIIILnet/minecraft/class_342;Lnet/minecraft/class_2561;)V
 		ARG 1 textRenderer
 		ARG 2 x
@@ -136,6 +137,8 @@ CLASS net/minecraft/class_342 net/minecraft/client/gui/widget/TextFieldWidget
 		ARG 1 click
 	METHOD method_74216 selectWord (Lnet/minecraft/class_11909;)V
 		ARG 1 click
+	METHOD method_75351 setInverted (Z)V
+		ARG 1 invert
 	CLASS class_11734 Formatter
 		METHOD format (Ljava/lang/String;I)Lnet/minecraft/class_5481;
 			ARG 1 string

--- a/mappings/net/minecraft/client/render/Camera.mapping
+++ b/mappings/net/minecraft/client/render/Camera.mapping
@@ -21,6 +21,7 @@ CLASS net/minecraft/class_4184 net/minecraft/client/render/Camera
 	METHOD method_19317 updateEyeHeight ()V
 	METHOD method_19318 clipToSpace (F)F
 	METHOD method_19321 update (Lnet/minecraft/class_1937;Lnet/minecraft/class_1297;ZZF)V
+		ARG 1 area
 		ARG 2 focusedEntity
 		ARG 3 thirdPerson
 		ARG 4 inverseView

--- a/mappings/net/minecraft/client/render/GameRenderer.mapping
+++ b/mappings/net/minecraft/client/render/GameRenderer.mapping
@@ -132,3 +132,11 @@ CLASS net/minecraft/class_757 net/minecraft/client/render/GameRenderer
 	METHOD method_72912 getEntityRenderStates ()Lnet/minecraft/class_11658;
 	METHOD method_74751 getProjectionMatrix (F)Lorg/joml/Matrix4f;
 	METHOD method_74920 updateCameraState (F)V
+	METHOD method_75836 (Lnet/minecraft/class_11247;)V
+		ARG 1 text
+	METHOD method_75837 renderActiveTextAreas ()V
+	CLASS 1
+		FIELD field_63914 osc I
+		METHOD method_75838 addGlyph (Lnet/minecraft/class_12236;Z)V
+			ARG 1 glyph
+			ARG 2 skeleton

--- a/mappings/net/minecraft/client/texture/AbstractTexture.mapping
+++ b/mappings/net/minecraft/client/texture/AbstractTexture.mapping
@@ -1,5 +1,7 @@
 CLASS net/minecraft/class_1044 net/minecraft/client/texture/AbstractTexture
 	FIELD field_56974 glTexture Lcom/mojang/blaze3d/textures/GpuTexture;
 	FIELD field_60597 glTextureView Lcom/mojang/blaze3d/textures/GpuTextureView;
+	FIELD field_63613 sampler Lnet/minecraft/class_12137;
 	METHOD method_68004 getGlTexture ()Lcom/mojang/blaze3d/textures/GpuTexture;
 	METHOD method_71659 getGlTextureView ()Lcom/mojang/blaze3d/textures/GpuTextureView;
+	METHOD method_75484 getSampler ()Lnet/minecraft/class_12137;

--- a/mappings/net/minecraft/util/math/Interpolator.mapping
+++ b/mappings/net/minecraft/util/math/Interpolator.mapping
@@ -1,0 +1,13 @@
+CLASS net/minecraft/class_12210 net/minecraft/util/math/Interpolator
+	METHOD apply (FLjava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 1 t
+		ARG 2 a
+		ARG 3 b
+	METHOD method_75706 ofFloat ()Lnet/minecraft/class_12210;
+	METHOD method_75707 threshold (F)Lnet/minecraft/class_12210;
+		ARG 0 threshold
+	METHOD method_75708 (FFLjava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 1 t
+		ARG 2 a
+		ARG 3 b
+	METHOD method_75709 ofColor ()Lnet/minecraft/class_12210;

--- a/mappings/net/minecraft/util/math/WeightedInterpolation.mapping
+++ b/mappings/net/minecraft/util/math/WeightedInterpolation.mapping
@@ -1,0 +1,17 @@
+CLASS net/minecraft/class_12207 net/minecraft/util/math/WeightedInterpolation
+	FIELD field_63764 FIRST_SEGMENT_OFFSET I
+	FIELD field_63765 NUM_SEGMENTS I
+	FIELD field_63766 ENDPOINT_WEIGHTS [D
+	METHOD method_75705 interpolate (Lnet/minecraft/class_243;Lnet/minecraft/class_12207$class_12209;Lnet/minecraft/class_12207$class_12208;)V
+		ARG 0 pos
+		ARG 1 f
+		ARG 2 accum
+	CLASS class_12208 Accumulator
+		METHOD accumulate (DLjava/lang/Object;)V
+			ARG 1 weight
+			ARG 3 value
+	CLASS class_12209 PositionalFunction
+		METHOD get (III)Ljava/lang/Object;
+			ARG 1 x
+			ARG 2 y
+			ARG 3 z

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -32,10 +32,12 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 	FIELD field_42476 damageSources Lnet/minecraft/class_8109;
 	FIELD field_61989 EXPLOSION_BLOCK_PARTICLES Lnet/minecraft/class_6012;
 	FIELD field_62535 palettesFactory Lnet/minecraft/class_11897;
+	FIELD field_63808 environmentAttributeAccess Lnet/minecraft/class_12205;
 	METHOD <init> (Lnet/minecraft/class_5269;Lnet/minecraft/class_5321;Lnet/minecraft/class_5455;Lnet/minecraft/class_6880;ZZJI)V
 		ARG 1 properties
 		ARG 2 registryRef
 		ARG 3 registryManager
+		ARG 4 dimensionEntry
 		ARG 5 isClient
 		ARG 6 debugWorld
 		ARG 7 seed
@@ -262,6 +264,7 @@ CLASS net/minecraft/class_1937 net/minecraft/world/World
 		ARG 1 x
 		ARG 2 y
 		ARG 3 z
+		ARG 4 yMask
 	METHOD method_8537 createExplosion (Lnet/minecraft/class_1297;DDDFZLnet/minecraft/class_1937$class_7867;)V
 		COMMENT Creates an explosion.
 		COMMENT

--- a/mappings/net/minecraft/world/WorldView.mapping
+++ b/mappings/net/minecraft/world/WorldView.mapping
@@ -98,3 +98,4 @@ CLASS net/minecraft/class_4538 net/minecraft/world/WorldView
 	METHOD method_67393 getTopY (Lnet/minecraft/class_2902$class_2903;Lnet/minecraft/class_2338;)I
 		ARG 1 heightmap
 		ARG 2 pos
+	METHOD method_75598 getEnvironmentAttributeAccess ()Lnet/minecraft/class_12204;

--- a/mappings/net/minecraft/world/attribute/AmbientSounds.mapping
+++ b/mappings/net/minecraft/world/attribute/AmbientSounds.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_12190 net/minecraft/world/attribute/AmbientSounds

--- a/mappings/net/minecraft/world/attribute/BackgroundMusic.mapping
+++ b/mappings/net/minecraft/world/attribute/BackgroundMusic.mapping
@@ -1,0 +1,12 @@
+CLASS net/minecraft/class_12194 net/minecraft/world/attribute/BackgroundMusic
+	FIELD field_63700 EMPTY Lnet/minecraft/class_12194;
+	FIELD field_63701 DEFAULT Lnet/minecraft/class_12194;
+	METHOD <init> (Lnet/minecraft/class_5195;)V
+		ARG 1 musicSound
+	METHOD <init> (Lnet/minecraft/class_6880;)V
+		ARG 1 soundEvent
+	METHOD method_75638 withUnderwater (Lnet/minecraft/class_5195;)Lnet/minecraft/class_12194;
+		ARG 1 musicSound
+	METHOD method_75640 getCurrent (ZZ)Ljava/util/Optional;
+		ARG 1 creative
+		ARG 2 underwater

--- a/mappings/net/minecraft/world/attribute/BlendArg.mapping
+++ b/mappings/net/minecraft/world/attribute/BlendArg.mapping
@@ -1,0 +1,9 @@
+CLASS net/minecraft/class_12220 net/minecraft/world/attribute/BlendArg
+	FIELD field_63805 CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_63806 INTERNAL_CODEC Lcom/mojang/serialization/Codec;
+	METHOD <init> (F)V
+		ARG 1 value
+	METHOD method_75721 (Lnet/minecraft/class_12220;)Lcom/mojang/datafixers/util/Either;
+		ARG 0 blend
+	METHOD method_75724 (Lnet/minecraft/class_12220;)Lnet/minecraft/class_12220;
+		ARG 0 blend

--- a/mappings/net/minecraft/world/attribute/BooleanModifier.mapping
+++ b/mappings/net/minecraft/world/attribute/BooleanModifier.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_12215 net/minecraft/world/attribute/BooleanModifier

--- a/mappings/net/minecraft/world/attribute/ColorModifier.mapping
+++ b/mappings/net/minecraft/world/attribute/ColorModifier.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_12216 net/minecraft/world/attribute/ColorModifier
+	FIELD field_63795 ALPHA_BLEND Lnet/minecraft/class_12216;
+	FIELD field_63796 ADD Lnet/minecraft/class_12216;
+	FIELD field_63797 SUBTRACT Lnet/minecraft/class_12216;
+	FIELD field_63798 MULTIPLY Lnet/minecraft/class_12216;

--- a/mappings/net/minecraft/world/attribute/EnvironmentAttribute.mapping
+++ b/mappings/net/minecraft/world/attribute/EnvironmentAttribute.mapping
@@ -1,4 +1,41 @@
 CLASS net/minecraft/class_12197 net/minecraft/world/attribute/EnvironmentAttribute
+	FIELD field_63712 type Lnet/minecraft/class_12192;
+	FIELD field_63713 defaultValue Ljava/lang/Object;
+	FIELD field_63714 range Lnet/minecraft/class_12191;
+	FIELD field_63715 sentThroughNetwork Z
+	FIELD field_63716 positional Z
+	FIELD field_63717 interpolated Z
+	METHOD <init> (Lnet/minecraft/class_12192;Ljava/lang/Object;Lnet/minecraft/class_12191;ZZZ)V
+		ARG 1 type
+		ARG 2 defaultValue
+		ARG 3 range
+		ARG 4 sentThroughNetwork
+		ARG 5 positional
+		ARG 6 interpolated
+	METHOD method_75647 getType ()Lnet/minecraft/class_12192;
+	METHOD method_75648 builder (Lnet/minecraft/class_12192;)Lnet/minecraft/class_12197$class_12198;
+		ARG 0 type
+	METHOD method_75649 clampToRange (Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 1 value
+	METHOD method_75650 getDefaultValue ()Ljava/lang/Object;
+	METHOD method_75651 getCodec ()Lcom/mojang/serialization/Codec;
+	METHOD method_75652 isSentThroughNetwork ()Z
+	METHOD method_75653 isPositional ()Z
+	METHOD method_75654 isInterpolated ()Z
 	CLASS class_12198 Builder
+		FIELD field_63718 type Lnet/minecraft/class_12192;
 		FIELD field_63719 defaultValue Ljava/lang/Object;
+		FIELD field_63720 range Lnet/minecraft/class_12191;
+		FIELD field_63721 sentThroughNetwork Z
+		FIELD field_63722 positional Z
+		FIELD field_63723 interpolated Z
+		METHOD <init> (Lnet/minecraft/class_12192;)V
+			ARG 1 type
+		METHOD method_75655 sentThroughNetwork ()Lnet/minecraft/class_12197$class_12198;
+		METHOD method_75656 range (Lnet/minecraft/class_12191;)Lnet/minecraft/class_12197$class_12198;
+			ARG 1 range
+		METHOD method_75657 defaultValue (Ljava/lang/Object;)Lnet/minecraft/class_12197$class_12198;
+			ARG 1 defaultValue
+		METHOD method_75658 positional ()Lnet/minecraft/class_12197$class_12198;
+		METHOD method_75659 interpolated ()Lnet/minecraft/class_12197$class_12198;
 		METHOD method_75660 build ()Lnet/minecraft/class_12197;

--- a/mappings/net/minecraft/world/attribute/EnvironmentAttributeAccess.mapping
+++ b/mappings/net/minecraft/world/attribute/EnvironmentAttributeAccess.mapping
@@ -1,0 +1,14 @@
+CLASS net/minecraft/class_12204 net/minecraft/world/attribute/EnvironmentAttributeAccess
+	FIELD field_63738 DEFAULT Lnet/minecraft/class_12204;
+	METHOD method_75694 getDimensionAttributeValue (Lnet/minecraft/class_12197;)Ljava/lang/Object;
+		ARG 1 attribute
+	METHOD method_75695 getPositionalAttributeValue (Lnet/minecraft/class_12197;Lnet/minecraft/class_243;)Ljava/lang/Object;
+		ARG 1 attribute
+		ARG 2 pos
+	METHOD method_75696 getPositionalAttributeValue (Lnet/minecraft/class_12197;Lnet/minecraft/class_243;Lnet/minecraft/class_12211;)Ljava/lang/Object;
+		ARG 1 attribute
+		ARG 2 pos
+		ARG 3 pool
+	METHOD method_75697 getPositionalAttributeValue (Lnet/minecraft/class_12197;Lnet/minecraft/class_2338;)Ljava/lang/Object;
+		ARG 1 attribute
+		ARG 2 blockPos

--- a/mappings/net/minecraft/world/attribute/EnvironmentAttributeInterpolator.mapping
+++ b/mappings/net/minecraft/world/attribute/EnvironmentAttributeInterpolator.mapping
@@ -1,0 +1,30 @@
+CLASS net/minecraft/class_12202 net/minecraft/world/attribute/EnvironmentAttributeInterpolator
+	FIELD field_63730 entries Ljava/util/Map;
+	FIELD field_63731 createEntry Ljava/util/function/Function;
+	FIELD field_63732 world Lnet/minecraft/class_1937;
+	FIELD field_63733 pos Lnet/minecraft/class_243;
+	FIELD field_63734 pool Lnet/minecraft/class_12211;
+	METHOD method_75686 reset ()V
+	METHOD method_75687 (DLnet/minecraft/class_6880;)V
+		ARG 1 weight
+		ARG 3 biome
+	METHOD method_75688 (Lnet/minecraft/class_12197;)Lnet/minecraft/class_12202$class_12203;
+		ARG 1 value
+	METHOD method_75689 get (Lnet/minecraft/class_12197;F)Ljava/lang/Object;
+		ARG 1 attribute
+		ARG 2 tickDelta
+	METHOD method_75690 update (Lnet/minecraft/class_1937;Lnet/minecraft/class_243;)V
+		ARG 1 world
+		ARG 2 pos
+	CLASS class_12203 Entry
+		FIELD field_63736 last Ljava/lang/Object;
+		FIELD field_63737 current Ljava/lang/Object;
+		METHOD <init> (Lnet/minecraft/class_12202;Lnet/minecraft/class_12197;)V
+			ARG 2 attribute
+		METHOD method_75691 update ()Z
+			COMMENT {@return whether this entry should subsequently be removed}
+		METHOD method_75692 compute (Lnet/minecraft/class_12197;)Ljava/lang/Object;
+			ARG 1 attribute
+		METHOD method_75693 get (Lnet/minecraft/class_12197;F)Ljava/lang/Object;
+			ARG 1 attribute
+			ARG 2 tickDelta

--- a/mappings/net/minecraft/world/attribute/EnvironmentAttributeMap.mapping
+++ b/mappings/net/minecraft/world/attribute/EnvironmentAttributeMap.mapping
@@ -1,5 +1,8 @@
 CLASS net/minecraft/class_12199 net/minecraft/world/attribute/EnvironmentAttributeMap
 	FIELD field_63724 EMPTY Lnet/minecraft/class_12199;
+	FIELD field_63726 NETWORK_CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_63727 POSITIONAL_CODEC Lcom/mojang/serialization/Codec;
+		COMMENT Accepts positional attributes only.
 	FIELD field_63728 entries Ljava/util/Map;
 	METHOD <init> (Ljava/util/Map;)V
 		ARG 1 entries
@@ -11,7 +14,7 @@ CLASS net/minecraft/class_12199 net/minecraft/world/attribute/EnvironmentAttribu
 	METHOD method_75663 get (Lnet/minecraft/class_12197;Ljava/lang/Object;)Ljava/lang/Object;
 		ARG 1 key
 		ARG 2 value
-	METHOD method_75664 (Lnet/minecraft/class_12199;)Lnet/minecraft/class_12199;
+	METHOD method_75664 retainNetworkedAttributes (Lnet/minecraft/class_12199;)Lnet/minecraft/class_12199;
 		ARG 0 map
 	METHOD method_75666 keys ()Ljava/util/Set;
 	METHOD method_75667 containsKey (Lnet/minecraft/class_12197;)Z
@@ -31,5 +34,12 @@ CLASS net/minecraft/class_12199 net/minecraft/world/attribute/EnvironmentAttribu
 		METHOD method_75675 addAll (Lnet/minecraft/class_12199;)Lnet/minecraft/class_12199$class_12200;
 			ARG 1 map
 	CLASS class_12201 Entry
+		METHOD method_75676 codec (Lnet/minecraft/class_12197;)Lcom/mojang/serialization/Codec;
+			ARG 0 attribute
+		METHOD method_75677 codec (Lnet/minecraft/class_12197;Lnet/minecraft/class_12212;)Lcom/mojang/serialization/MapCodec;
+			ARG 0 attribute
+			ARG 1 modifier
 		METHOD method_75679 (Lnet/minecraft/class_12212;Lnet/minecraft/class_12197;Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 			ARG 2 instance
+		METHOD method_75682 apply (Ljava/lang/Object;)Ljava/lang/Object;
+			ARG 1 value

--- a/mappings/net/minecraft/world/attribute/EnvironmentAttributeModifier.mapping
+++ b/mappings/net/minecraft/world/attribute/EnvironmentAttributeModifier.mapping
@@ -1,0 +1,16 @@
+CLASS net/minecraft/class_12212 net/minecraft/world/attribute/EnvironmentAttributeModifier
+	FIELD field_63768 BOOLEAN_MODIFIERS Ljava/util/Map;
+	FIELD field_63769 FLOAT_MODIFIERS Ljava/util/Map;
+	FIELD field_63770 COLOR_MODIFIER Ljava/util/Map;
+	METHOD apply (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 1 a
+		ARG 2 b
+	METHOD argumentCodec (Lnet/minecraft/class_12197;)Lcom/mojang/serialization/Codec;
+		ARG 1 subject
+	METHOD method_75713 replace ()Lnet/minecraft/class_12212;
+	CLASS class_12213 Id
+		FIELD field_63785 naem Ljava/lang/String;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
+			ARG 3 name
+	CLASS class_12214 Replace
+		FIELD field_63787 INSTANCE Lnet/minecraft/class_12212$class_12214;

--- a/mappings/net/minecraft/world/attribute/EnvironmentAttributeType.mapping
+++ b/mappings/net/minecraft/world/attribute/EnvironmentAttributeType.mapping
@@ -1,0 +1,15 @@
+CLASS net/minecraft/class_12192 net/minecraft/world/attribute/EnvironmentAttributeType
+	METHOD method_75630 validate (Lnet/minecraft/class_12212;)V
+		ARG 1 modifier
+	METHOD method_75631 discrete (Lcom/mojang/serialization/Codec;)Lnet/minecraft/class_12192;
+	METHOD method_75632 discrete (Lcom/mojang/serialization/Codec;Ljava/util/Map;)Lnet/minecraft/class_12192;
+		ARG 1 modifierLibrary
+	METHOD method_75633 interpolated (Lcom/mojang/serialization/Codec;Ljava/util/Map;Lnet/minecraft/class_12210;)Lnet/minecraft/class_12192;
+		ARG 1 modifierLibrary
+		ARG 2 lerp
+	METHOD method_75634 interpolated (Lcom/mojang/serialization/Codec;Ljava/util/Map;Lnet/minecraft/class_12210;Lnet/minecraft/class_12210;)Lnet/minecraft/class_12192;
+		ARG 1 modifierLibrary
+		ARG 2 spatialLerp
+		ARG 3 partialTickLerp
+	METHOD method_75635 createModifierCodec (Ljava/util/Map;)Lcom/mojang/serialization/Codec;
+		ARG 0 modifierLibrary

--- a/mappings/net/minecraft/world/attribute/EnvironmentAttributeTypes.mapping
+++ b/mappings/net/minecraft/world/attribute/EnvironmentAttributeTypes.mapping
@@ -1,5 +1,7 @@
-CLASS net/minecraft/class_12193
+CLASS net/minecraft/class_12193 net/minecraft/world/attribute/EnvironmentAttributeTypes
+	FIELD field_63699 CODEC Lcom/mojang/serialization/Codec;
 	METHOD method_75636 register (Ljava/lang/String;Lnet/minecraft/class_12192;)Lnet/minecraft/class_12192;
 		ARG 0 path
+		ARG 1 type
 	METHOD method_75637 registerAndGetDefault (Lnet/minecraft/class_2378;)Lnet/minecraft/class_12192;
 		ARG 0 registry

--- a/mappings/net/minecraft/world/attribute/EnvironmentAttributes.mapping
+++ b/mappings/net/minecraft/world/attribute/EnvironmentAttributes.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_12206 net/minecraft/world/attribute/EnvironmentAttributes
+	FIELD field_63763 CODEC Lcom/mojang/serialization/Codec;
 	METHOD method_75703 register (Ljava/lang/String;Lnet/minecraft/class_12197$class_12198;)Lnet/minecraft/class_12197;
 		ARG 0 path
 		ARG 1 builder

--- a/mappings/net/minecraft/world/attribute/FloatModifier.mapping
+++ b/mappings/net/minecraft/world/attribute/FloatModifier.mapping
@@ -1,0 +1,14 @@
+CLASS net/minecraft/class_12218 net/minecraft/world/attribute/FloatModifier
+	FIELD field_63799 ALPHA_BLEND Lnet/minecraft/class_12218;
+	FIELD field_63800 ADD Lnet/minecraft/class_12218;
+	FIELD field_63801 SUBTRACT Lnet/minecraft/class_12218;
+	FIELD field_63802 MULTIPLY Lnet/minecraft/class_12218;
+	FIELD field_63803 MINIMUM Lnet/minecraft/class_12218;
+	FIELD field_63804 MAXIMUM Lnet/minecraft/class_12218;
+	METHOD method_75718 (Ljava/lang/Float;Ljava/lang/Float;)Ljava/lang/Float;
+		ARG 0 a
+		ARG 1 b
+	METHOD method_75719 (Ljava/lang/Float;Ljava/lang/Float;)Ljava/lang/Float;
+		ARG 0 a
+		ARG 1 b
+	CLASS class_12219 Single

--- a/mappings/net/minecraft/world/attribute/Range.mapping
+++ b/mappings/net/minecraft/world/attribute/Range.mapping
@@ -1,0 +1,11 @@
+CLASS net/minecraft/class_12191 net/minecraft/world/attribute/Range
+	FIELD field_63687 UNIT Lnet/minecraft/class_12191;
+	FIELD field_63688 POSITIVE Lnet/minecraft/class_12191;
+	METHOD method_75623 unrestricted ()Lnet/minecraft/class_12191;
+	METHOD method_75624 of (FF)Lnet/minecraft/class_12191;
+		ARG 0 min
+		ARG 1 max
+	METHOD method_75625 check (Ljava/lang/Object;)Lcom/mojang/serialization/DataResult;
+		ARG 1 x
+	METHOD method_75626 clamp (Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 1 x

--- a/mappings/net/minecraft/world/attribute/WeightedAttributeList.mapping
+++ b/mappings/net/minecraft/world/attribute/WeightedAttributeList.mapping
@@ -1,0 +1,9 @@
+CLASS net/minecraft/class_12211 net/minecraft/world/attribute/WeightedAttributeList
+	FIELD field_63767 entries Lit/unimi/dsi/fastutil/objects/Reference2DoubleArrayMap;
+	METHOD method_75710 clear ()V
+	METHOD method_75711 add (DLnet/minecraft/class_12199;)Lnet/minecraft/class_12211;
+		ARG 1 weight
+		ARG 3 attributes
+	METHOD method_75712 interpolate (Lnet/minecraft/class_12197;Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 1 attribute
+		ARG 2 defaultValue

--- a/mappings/net/minecraft/world/attribute/WorldEnvironmentAttributeAccess.mapping
+++ b/mappings/net/minecraft/world/attribute/WorldEnvironmentAttributeAccess.mapping
@@ -1,0 +1,24 @@
+CLASS net/minecraft/class_12205 net/minecraft/world/attribute/WorldEnvironmentAttributeAccess
+	FIELD field_63739 dimensionAttributes Lnet/minecraft/class_12199;
+	FIELD field_63740 biomeAccess Lnet/minecraft/class_4543;
+	FIELD field_63741 biomeModifiedAttributes Ljava/util/Set;
+	METHOD <init> (Lnet/minecraft/class_6880;Lnet/minecraft/class_5455;Lnet/minecraft/class_4543;)V
+		ARG 1 dimensionType
+		ARG 2 dynamicRegistryManager
+		ARG 3 biomeAccess
+	METHOD method_75698 getInternal (Lnet/minecraft/class_12197;Lnet/minecraft/class_243;Lnet/minecraft/class_12211;Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 1 attribute
+		ARG 2 pos
+		ARG 3 pool
+		ARG 4 defaultValue
+	METHOD method_75699 getDimensionAttributeValue (Lnet/minecraft/class_12197;Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 1 attribute
+		ARG 2 defaultValue
+	METHOD method_75700 (Lnet/minecraft/class_6880$class_6883;)Ljava/util/stream/Stream;
+		ARG 0 e
+	METHOD method_75701 getDimensionAttributeValue_ (Lnet/minecraft/class_12197;)Ljava/lang/Object;
+		ARG 1 attribute
+	METHOD method_75702 getClamped (Lnet/minecraft/class_12197;Lnet/minecraft/class_243;Lnet/minecraft/class_12211;)Ljava/lang/Object;
+		ARG 1 attribute
+		ARG 2 pos
+		ARG 3 pool

--- a/mappings/net/minecraft/world/biome/Biome.mapping
+++ b/mappings/net/minecraft/world/biome/Biome.mapping
@@ -12,9 +12,13 @@ CLASS net/minecraft/class_1959 net/minecraft/world/biome/Biome
 	FIELD field_26635 generationSettings Lnet/minecraft/class_5485;
 	FIELD field_26750 REGISTRY_ENTRY_LIST_CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_30978 MAX_TEMPERATURE_CACHE_SIZE I
+	FIELD field_63809 environmentAttributes Lnet/minecraft/class_12199;
 	METHOD <init> (Lnet/minecraft/class_1959$class_5482;Lnet/minecraft/class_12199;Lnet/minecraft/class_4763;Lnet/minecraft/class_5485;Lnet/minecraft/class_5483;)V
 		ARG 1 weather
 		ARG 2 effects
+		ARG 3 biomeEffects
+		ARG 4 generationSettings
+		ARG 5 spawnSettings
 	METHOD method_8685 canSetIce (Lnet/minecraft/class_4538;Lnet/minecraft/class_2338;Z)Z
 		ARG 1 world
 		ARG 2 pos
@@ -69,6 +73,7 @@ CLASS net/minecraft/class_1959 net/minecraft/world/biome/Biome
 	METHOD method_66386 getGrassColor ()I
 	METHOD method_68145 getDryFoliageColor ()I
 	METHOD method_68146 getDefaultDryFoliageColor ()I
+	METHOD method_75734 getEnvironmentAttributes ()Lnet/minecraft/class_12199;
 	CLASS 1
 		METHOD rehash (I)V
 			ARG 1 n
@@ -80,6 +85,7 @@ CLASS net/minecraft/class_1959 net/minecraft/world/biome/Biome
 		FIELD field_26636 spawnSettings Lnet/minecraft/class_5483;
 		FIELD field_26637 generationSettings Lnet/minecraft/class_5485;
 		FIELD field_41767 precipitation Z
+		FIELD field_63810 environmentAttributeBuilder Lnet/minecraft/class_12199$class_12200;
 		METHOD method_8727 downfall (F)Lnet/minecraft/class_1959$class_1960;
 			ARG 1 downfall
 		METHOD method_8747 temperature (F)Lnet/minecraft/class_1959$class_1960;
@@ -95,6 +101,17 @@ CLASS net/minecraft/class_1959 net/minecraft/world/biome/Biome
 			ARG 1 spawnSettings
 		METHOD method_48164 precipitation (Z)Lnet/minecraft/class_1959$class_1960;
 			ARG 1 precipitation
+		METHOD method_75736 setEnvironmentAttributeModifier (Lnet/minecraft/class_12197;Lnet/minecraft/class_12212;Ljava/lang/Object;)Lnet/minecraft/class_1959$class_1960;
+			ARG 1 attribute
+			ARG 2 modifier
+			ARG 3 value
+		METHOD method_75737 setEnvironmentAttribute (Lnet/minecraft/class_12197;Ljava/lang/Object;)Lnet/minecraft/class_1959$class_1960;
+			ARG 1 attribute
+			ARG 2 value
+		METHOD method_75738 addEnvironmentAttributes (Lnet/minecraft/class_12199$class_12200;)Lnet/minecraft/class_1959$class_1960;
+			ARG 1 builder
+		METHOD method_75739 addEnvironmentAttributes (Lnet/minecraft/class_12199;)Lnet/minecraft/class_1959$class_1960;
+			ARG 1 map
 	CLASS class_1963 Precipitation
 		FIELD field_46251 CODEC Lcom/mojang/serialization/Codec;
 		FIELD field_46252 name Ljava/lang/String;

--- a/mappings/net/minecraft/world/biome/BiomeEffects.mapping
+++ b/mappings/net/minecraft/world/biome/BiomeEffects.mapping
@@ -7,6 +7,10 @@ CLASS net/minecraft/class_4763 net/minecraft/world/biome/BiomeEffects
 	FIELD field_57099 dryFoliageColor Ljava/util/Optional;
 	METHOD <init> (ILjava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Lnet/minecraft/class_4763$class_5486;)V
 		ARG 1 fogColor
+		ARG 2 foliageColor
+		ARG 3 dryFoliageColor
+		ARG 4 grassColor
+		ARG 5 grassColorModifier
 	METHOD method_24388 getWaterColor ()I
 	METHOD method_30811 getFoliageColor ()Ljava/util/Optional;
 	METHOD method_30812 getGrassColor ()Ljava/util/Optional;
@@ -19,6 +23,8 @@ CLASS net/minecraft/class_4763 net/minecraft/world/biome/BiomeEffects
 		ARG 0 effects
 	METHOD method_68147 getDryFoliageColor ()Ljava/util/Optional;
 	METHOD method_68148 (Lnet/minecraft/class_4763;)Ljava/util/Optional;
+		ARG 0 effects
+	METHOD method_75741 (Lnet/minecraft/class_4763;)Ljava/lang/Integer;
 		ARG 0 effects
 	CLASS class_4764 Builder
 		FIELD field_22072 waterColor Ljava/util/OptionalInt;

--- a/mappings/net/minecraft/world/biome/OverworldBiomeCreator.mapping
+++ b/mappings/net/minecraft/world/biome/OverworldBiomeCreator.mapping
@@ -134,3 +134,6 @@ CLASS net/minecraft/class_5478 net/minecraft/world/biome/OverworldBiomeCreator
 	METHOD method_43232 createMangroveSwamp (Lnet/minecraft/class_7871;Lnet/minecraft/class_7871;)Lnet/minecraft/class_1959;
 		ARG 0 featureLookup
 		ARG 1 carverLookup
+	METHOD method_75847 biome (FF)Lnet/minecraft/class_1959$class_1960;
+		ARG 0 temperature
+		ARG 1 downfall

--- a/mappings/net/minecraft/world/dimension/DimensionType.mapping
+++ b/mappings/net/minecraft/world/dimension/DimensionType.mapping
@@ -10,11 +10,21 @@ CLASS net/minecraft/class_2874 net/minecraft/world/dimension/DimensionType
 	FIELD field_28136 MIN_HEIGHT I
 	FIELD field_31440 MOON_PHASES [Lnet/minecraft/class_12131;
 	FIELD field_51951 PACKET_CODEC Lnet/minecraft/class_9139;
+	FIELD field_63812 NETWORK_CODEC Lcom/mojang/serialization/Codec;
 	METHOD <init> (Ljava/util/OptionalLong;ZZZDIIILnet/minecraft/class_6862;Lnet/minecraft/class_2960;FLnet/minecraft/class_2874$class_7512;Lnet/minecraft/class_12199;)V
 		ARG 1 fixedTime
 		ARG 2 hasSkylight
 		ARG 3 hasCeiling
 		ARG 4 ultrawarm
+		ARG 5 coordinateScale
+		ARG 7 minY
+		ARG 8 height
+		ARG 9 logicalHeight
+		ARG 10 infiniburn
+		ARG 11 effects
+		ARG 12 ambientLight
+		ARG 13 monsterSettings
+		ARG 14 attributes
 	METHOD comp_655 effects ()Lnet/minecraft/class_2960;
 	METHOD comp_847 monsterSettings ()Lnet/minecraft/class_2874$class_7512;
 	METHOD method_12488 getSaveDirectory (Lnet/minecraft/class_5321;Ljava/nio/file/Path;)Ljava/nio/file/Path;
@@ -34,5 +44,7 @@ CLASS net/minecraft/class_2874 net/minecraft/world/dimension/DimensionType
 		ARG 1 toDimension
 	METHOD method_44222 monsterSpawnLightTest ()Lnet/minecraft/class_6017;
 	METHOD method_44223 monsterSpawnBlockLightLimit ()I
+	METHOD method_75746 createDimensionCodec (Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
+		ARG 0 attributeCodec
 	CLASS class_7512 MonsterSettings
 		FIELD field_39414 CODEC Lcom/mojang/serialization/MapCodec;


### PR DESCRIPTION
Map environment attributes and some rendering code.

Dubious names:

* `class_12227` → `Transformation`
* `class_12237` → `SkeletonGlyph`
* Arg 5 of `method_70848` (`DrawContext#fill`) → `invert` (This is true for all text selections except in the creative inventory and anvil screen text field widgets.)