### PR TITLE
Map holidays

### DIFF
--- a/mappings/net/minecraft/util/Holidays.mapping
+++ b/mappings/net/minecraft/util/Holidays.mapping
@@ -1,0 +1,10 @@
+CLASS net/minecraft/class_12240 net/minecraft/util/Holidays
+	FIELD field_63942 HALLOWEEN_PERIOD Lcom/google/common/collect/Range;
+	FIELD field_63943 HALLOWEEN Ljava/time/MonthDay;
+	FIELD field_63944 CHRISTMAS_PERIOD Ljava/util/List;
+	FIELD field_63945 CHRISTMAS_EVE Ljava/time/MonthDay;
+	FIELD field_63946 NEW_YEARS_DAY Ljava/time/MonthDay;
+	METHOD method_75874 now ()Ljava/time/MonthDay;
+	METHOD method_75875 isAroundHalloween ()Z
+	METHOD method_75876 isHalloween ()Z
+	METHOD method_75877 isAroundChristmas ()Z


### PR DESCRIPTION
In Minecraft snapshot 25w43a, code tied to specific holidays or the periods surrounding these holidays were refactored to reference `MonthDay` values from a common class. This pull request maps that class, using the `ChestBlockEntityRenderer.isAroundChristmas` method as an existing convention.