### PR TITLE
Publish unpick definitions alone as a separate artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,28 +242,12 @@ tasks.register('tinyJar', Jar) {
 	}
 }
 
-tasks.register('compressTiny', FileInputOutput) {
+tasks.register('compressTiny', net.fabricmc.filament.task.GzipTask) {
 	dependsOn tinyJar, mergeTiny
 	group = buildMappingGroup
 
 	input = mergeTiny.output
-	output = new File(libs, "yarn-tiny-${yarnVersion}.gz")
-
-	doLast {
-		def buffer = new byte[1024]
-		def fileOutputStream = new FileOutputStream(outputFile)
-		def outputStream = new GZIPOutputStream(fileOutputStream)
-		def fileInputStream = new FileInputStream(inputFile)
-
-		def length
-		while ((length = fileInputStream.read(buffer)) > 0) {
-			outputStream.write(buffer, 0, length)
-		}
-
-		fileInputStream.close()
-		outputStream.finish()
-		outputStream.close()
-	}
+	fileName = "yarn-tiny-${yarnVersion}"
 }
 
 clean.doFirst {

--- a/build.gradle
+++ b/build.gradle
@@ -385,9 +385,9 @@ tasks.register('v2MergedYarnJar', Jar) {
 	}
 }
 
-tasks.register("unpickDefinitionsJar", Jar) {
+tasks.register("extrasJar", Jar) {
 	group = "mapping build"
-	archiveFileName = "yarn-${yarnVersion}-unpick-definitions.jar"
+	archiveFileName = "yarn-${yarnVersion}-extras.jar"
 	from(remapUnpickDefinitionsIntermediary) {
 		rename remapUnpickDefinitionsIntermediary.output.get().asFile.name, "extras/definitions.unpick"
 	}
@@ -395,6 +395,10 @@ tasks.register("unpickDefinitionsJar", Jar) {
 		expand version: project.version
 		rename unpickMetaFile.name, "extras/unpick.json"
 	}
+	from(remapAnnotationsIntermediary.output) {
+		rename remapAnnotationsIntermediary.output.get().asFile.name, "extras/annotations.json"
+	}
+	destinationDirectory.set(file("build/libs"))
 	manifest {
 		attributes("Minecraft-Version-Id": minecraft_version)
 	}
@@ -635,8 +639,8 @@ publishing {
 			artifact(v2MergedYarnJar) {
 				classifier = "mergedv2"
 			}
-			artifact(unpickDefinitionsJar) {
-				classifier = "unpick"
+			artifact(extrasJar) {
+				classifier = "extras"
 			}
 			artifact javadocJar
 		}

--- a/build.gradle
+++ b/build.gradle
@@ -385,6 +385,21 @@ tasks.register('v2MergedYarnJar', Jar) {
 	}
 }
 
+tasks.register("unpickDefinitionsJar", Jar) {
+	group = "mapping build"
+	archiveFileName = "yarn-${yarnVersion}-unpick-definitions.jar"
+	from(remapUnpickDefinitionsIntermediary) {
+		rename remapUnpickDefinitionsIntermediary.output.get().asFile.name, "extras/definitions.unpick"
+	}
+	from(file(unpickMetaFile)) {
+		expand version: project.version
+		rename unpickMetaFile.name, "extras/unpick.json"
+	}
+	manifest {
+		attributes("Minecraft-Version-Id": minecraft_version)
+	}
+}
+
 tasks.register('mapNamedJar', MapJarTask) {
 	dependsOn mergeV2, unpickIntermediaryJar
 	group = mapJarGroup
@@ -620,7 +635,7 @@ publishing {
 			artifact(v2MergedYarnJar) {
 				classifier = "mergedv2"
 			}
-			artifact(gzipUnpickDefinitions.output) {
+			artifact(unpickDefinitionsJar) {
 				classifier = "unpick"
 			}
 			artifact javadocJar

--- a/build.gradle
+++ b/build.gradle
@@ -636,6 +636,9 @@ publishing {
 			artifact(v2MergedYarnJar) {
 				classifier = "mergedv2"
 			}
+			artifact(gzipUnpickDefinitions.output) {
+				classifier = "unpick"
+			}
 			artifact javadocJar
 		}
 

--- a/filament/src/main/java/net/fabricmc/filament/FilamentGradlePlugin.java
+++ b/filament/src/main/java/net/fabricmc/filament/FilamentGradlePlugin.java
@@ -12,7 +12,6 @@ import org.gradle.api.tasks.Delete;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 
-import net.fabricmc.filament.task.GzipTask;
 import net.fabricmc.filament.task.unpick.CombineUnpickDefinitionsTask;
 import net.fabricmc.filament.task.DownloadTask;
 import net.fabricmc.filament.task.GeneratePackageInfoMappingsTask;
@@ -63,16 +62,11 @@ public final class FilamentGradlePlugin implements Plugin<Project> {
 		tasks.register("javadocLint", JavadocLintTask.class);
 
 		var combineUnpickDefinitions = tasks.register("combineUnpickDefinitions", CombineUnpickDefinitionsTask.class);
-		var remapUnpick = tasks.register("remapUnpickDefinitionsIntermediary", RemapUnpickDefinitionsTask.class, task -> {
+		tasks.register("remapUnpickDefinitionsIntermediary", RemapUnpickDefinitionsTask.class, task -> {
 			task.dependsOn(combineUnpickDefinitions);
 			task.getInput().set(combineUnpickDefinitions.flatMap(CombineUnpickDefinitionsTask::getOutput));
 			task.getSourceNamespace().set("named");
 			task.getTargetNamespace().set("intermediary");
-		});
-
-		tasks.register("gzipUnpickDefinitions", GzipTask.class, task -> {
-			task.getInput().set(remapUnpick.flatMap(RemapUnpickDefinitionsTask::getOutput));
-			task.getFileName().set("definitions.unpick");
 		});
 
 		var cleanFilament = tasks.register("cleanFilament", Delete.class, task -> task.delete(extension.getCacheDirectory()));

--- a/filament/src/main/java/net/fabricmc/filament/FilamentGradlePlugin.java
+++ b/filament/src/main/java/net/fabricmc/filament/FilamentGradlePlugin.java
@@ -12,6 +12,7 @@ import org.gradle.api.tasks.Delete;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 
+import net.fabricmc.filament.task.GzipTask;
 import net.fabricmc.filament.task.unpick.CombineUnpickDefinitionsTask;
 import net.fabricmc.filament.task.DownloadTask;
 import net.fabricmc.filament.task.GeneratePackageInfoMappingsTask;
@@ -62,11 +63,16 @@ public final class FilamentGradlePlugin implements Plugin<Project> {
 		tasks.register("javadocLint", JavadocLintTask.class);
 
 		var combineUnpickDefinitions = tasks.register("combineUnpickDefinitions", CombineUnpickDefinitionsTask.class);
-		tasks.register("remapUnpickDefinitionsIntermediary", RemapUnpickDefinitionsTask.class, task -> {
+		var remapUnpick = tasks.register("remapUnpickDefinitionsIntermediary", RemapUnpickDefinitionsTask.class, task -> {
 			task.dependsOn(combineUnpickDefinitions);
 			task.getInput().set(combineUnpickDefinitions.flatMap(CombineUnpickDefinitionsTask::getOutput));
 			task.getSourceNamespace().set("named");
 			task.getTargetNamespace().set("intermediary");
+		});
+
+		tasks.register("gzipUnpickDefinitions", GzipTask.class, task -> {
+			task.getInput().set(remapUnpick.flatMap(RemapUnpickDefinitionsTask::getOutput));
+			task.getFileName().set("definitions.unpick");
 		});
 
 		var cleanFilament = tasks.register("cleanFilament", Delete.class, task -> task.delete(extension.getCacheDirectory()));

--- a/filament/src/main/java/net/fabricmc/filament/task/GzipTask.java
+++ b/filament/src/main/java/net/fabricmc/filament/task/GzipTask.java
@@ -1,0 +1,48 @@
+package net.fabricmc.filament.task;
+
+import net.fabricmc.filament.task.base.FileOutputTask;
+
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.GZIPOutputStream;
+
+public abstract class GzipTask extends FileOutputTask {
+
+	@InputFile
+	public abstract RegularFileProperty getInput();
+
+	@Input
+	public abstract Property<String> getFileName();
+
+	public GzipTask() {
+		this.getOutput().convention(
+				this.getFileName().zip(this.getProject().getLayout().getBuildDirectory(), (name, dir) -> {
+					return dir.file(name + ".gz");
+				})
+		);
+	}
+
+	@TaskAction
+	public void gzip() throws Exception {
+		Path inputPath = getInput().getAsFile().get().toPath();
+		Path outputPath = getOutputPath();
+
+		try (InputStream fis = Files.newInputStream(inputPath);
+			 OutputStream fos = Files.newOutputStream(outputPath);
+			 GZIPOutputStream gzos = new GZIPOutputStream(fos)) {
+			byte[] buffer = new byte[8192];
+			int len;
+			while ((len = fis.read(buffer)) != -1) {
+				gzos.write(buffer, 0, len);
+			}
+		}
+	}
+}

--- a/filament/src/main/java/net/fabricmc/filament/task/GzipTask.java
+++ b/filament/src/main/java/net/fabricmc/filament/task/GzipTask.java
@@ -1,6 +1,10 @@
 package net.fabricmc.filament.task;
 
-import net.fabricmc.filament.task.base.FileOutputTask;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.GZIPOutputStream;
 
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
@@ -8,14 +12,9 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.TaskAction;
 
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.zip.GZIPOutputStream;
+import net.fabricmc.filament.task.base.FileOutputTask;
 
 public abstract class GzipTask extends FileOutputTask {
-
 	@InputFile
 	public abstract RegularFileProperty getInput();
 
@@ -36,10 +35,11 @@ public abstract class GzipTask extends FileOutputTask {
 		Path outputPath = getOutputPath();
 
 		try (InputStream fis = Files.newInputStream(inputPath);
-			 OutputStream fos = Files.newOutputStream(outputPath);
-			 GZIPOutputStream gzos = new GZIPOutputStream(fos)) {
+				OutputStream fos = Files.newOutputStream(outputPath);
+				GZIPOutputStream gzos = new GZIPOutputStream(fos)) {
 			byte[] buffer = new byte[8192];
 			int len;
+
 			while ((len = fis.read(buffer)) != -1) {
 				gzos.write(buffer, 0, len);
 			}


### PR DESCRIPTION
This is useful for external consumers that do not need or want the actual mappings, which take up the vast majority of the jar publication size