### PR TITLE
25w44a GameRules

### DIFF
--- a/mappings/net/minecraft/client/gui/screen/world/CreateWorldScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/world/CreateWorldScreen.mapping
@@ -161,6 +161,8 @@ CLASS net/minecraft/class_525 net/minecraft/client/gui/screen/world/CreateWorldS
 		ARG 1 combinedDynamicRegistries
 		ARG 2 levelProperties
 		ARG 3 dataPackTempDir
+	METHOD method_65519 (Lnet/minecraft/class_525;Lnet/minecraft/class_364;)V
+		ARG 1 clickableWidget
 	CLASS class_8093 GameTab
 		FIELD field_42175 GAME_TAB_TITLE_TEXT Lnet/minecraft/class_2561;
 		FIELD field_42176 ALLOW_COMMANDS_TEXT Lnet/minecraft/class_2561;

--- a/mappings/net/minecraft/registry/Registries.mapping
+++ b/mappings/net/minecraft/registry/Registries.mapping
@@ -97,6 +97,7 @@ CLASS net/minecraft/class_7923 net/minecraft/registry/Registries
 	FIELD field_63644 PERMISSION_CHECK_TYPE Lnet/minecraft/class_2378;
 	FIELD field_63925 ENVIRONMENTAL_ATTRIBUTE Lnet/minecraft/class_2378;
 	FIELD field_63926 ATTRIBUTE_TYPE Lnet/minecraft/class_2378;
+	FIELD field_64251 GAME_RULE Lnet/minecraft/class_2378;
 	METHOD method_47452 (Lnet/minecraft/class_2378;)Ljava/lang/Object;
 		ARG 0 registry
 	METHOD method_47453 (Lnet/minecraft/class_2378;)Ljava/lang/Object;

--- a/mappings/net/minecraft/test/TestEnvironmentDefinition.mapping
+++ b/mappings/net/minecraft/test/TestEnvironmentDefinition.mapping
@@ -34,6 +34,11 @@ CLASS net/minecraft/class_10665 net/minecraft/test/TestEnvironmentDefinition
 			ARG 1 functionId
 	CLASS class_10668 GameRules
 		FIELD field_56205 CODEC Lcom/mojang/serialization/MapCodec;
+		METHOD method_76326 resetValue (Lnet/minecraft/class_3218;Lnet/minecraft/class_12279;)V
+			ARG 1 serverWorld
+			ARG 2 rule
+		METHOD method_76328 (Lnet/minecraft/class_3218;Lnet/minecraft/class_12279;)V
+			ARG 2 rule
 	CLASS class_10670 TimeOfDay
 		FIELD field_56206 CODEC Lcom/mojang/serialization/MapCodec;
 		METHOD method_67066 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;

--- a/mappings/net/minecraft/util/Identifier.mapping
+++ b/mappings/net/minecraft/util/Identifier.mapping
@@ -185,3 +185,4 @@ CLASS net/minecraft/class_2960 net/minecraft/util/Identifier
 	METHOD method_60936 ofValidated (Ljava/lang/String;Ljava/lang/String;)Lnet/minecraft/class_2960;
 		ARG 0 namespace
 		ARG 1 path
+	METHOD method_76041 toShortString ()Ljava/lang/String;

--- a/mappings/net/minecraft/world/Visitor.mapping
+++ b/mappings/net/minecraft/world/Visitor.mapping
@@ -4,6 +4,7 @@ CLASS net/minecraft/class_4311 net/minecraft/world/Visitor
 		COMMENT Visit a game rule.
 		COMMENT
 		COMMENT <p>It is expected all game rules regardless of type will be visited using this method.
+		ARG 1 rule
 	METHOD method_27329 visitBoolean (Lnet/minecraft/class_12279;)V
 		COMMENT Visit a boolean rule.
 		COMMENT

--- a/mappings/net/minecraft/world/rule/GameRule.mapping
+++ b/mappings/net/minecraft/world/rule/GameRule.mapping
@@ -5,14 +5,14 @@ CLASS net/minecraft/class_12279 net/minecraft/world/rule/GameRule
 	FIELD field_64170 acceptor Lnet/minecraft/class_1928$class_5199;
 	FIELD field_64171 codec Lcom/mojang/serialization/Codec;
 	FIELD field_64172 commandResultSupplier Ljava/util/function/ToIntFunction;
-	FIELD field_64173 value Ljava/lang/Object;
+	FIELD field_64173 defaultValue Ljava/lang/Object;
 	FIELD field_64174 featureSet Lnet/minecraft/class_7699;
 	METHOD <init> (Lnet/minecraft/class_5198;Lnet/minecraft/class_11845;Lcom/mojang/brigadier/arguments/ArgumentType;Lnet/minecraft/class_1928$class_5199;Lcom/mojang/serialization/Codec;Ljava/util/function/ToIntFunction;Ljava/lang/Object;Lnet/minecraft/class_7699;)V
 		ARG 1 category
 		ARG 2 type
 		ARG 4 acceptor
 		ARG 6 commandResultSupplier
-		ARG 7 value
+		ARG 7 defaultValue
 		ARG 8 featureSet
 	METHOD method_76144 getSimplifiedPath ()Ljava/lang/String;
 	METHOD method_76145 accept (Lnet/minecraft/class_4311;)V
@@ -30,5 +30,5 @@ CLASS net/minecraft/class_12279 net/minecraft/world/rule/GameRule
 	METHOD method_76153 getType ()Lnet/minecraft/class_11845;
 	METHOD method_76154 getArgumentType ()Lcom/mojang/brigadier/arguments/ArgumentType;
 	METHOD method_76155 getCodec ()Lcom/mojang/serialization/Codec;
-	METHOD method_76156 getValue ()Ljava/lang/Object;
+	METHOD method_76156 getDefaultValue ()Ljava/lang/Object;
 	METHOD method_76157 getFeatureSet ()Lnet/minecraft/class_7699;

--- a/mappings/net/minecraft/world/rule/GameRule.mapping
+++ b/mappings/net/minecraft/world/rule/GameRule.mapping
@@ -1,0 +1,34 @@
+CLASS net/minecraft/class_12279 net/minecraft/world/rule/GameRule
+	FIELD field_64167 category Lnet/minecraft/class_5198;
+	FIELD field_64168 type Lnet/minecraft/class_11845;
+	FIELD field_64169 argumentType Lcom/mojang/brigadier/arguments/ArgumentType;
+	FIELD field_64170 acceptor Lnet/minecraft/class_1928$class_5199;
+	FIELD field_64171 codec Lcom/mojang/serialization/Codec;
+	FIELD field_64172 commandResultSupplier Ljava/util/function/ToIntFunction;
+	FIELD field_64173 value Ljava/lang/Object;
+	FIELD field_64174 featureSet Lnet/minecraft/class_7699;
+	METHOD <init> (Lnet/minecraft/class_5198;Lnet/minecraft/class_11845;Lcom/mojang/brigadier/arguments/ArgumentType;Lnet/minecraft/class_1928$class_5199;Lcom/mojang/serialization/Codec;Ljava/util/function/ToIntFunction;Ljava/lang/Object;Lnet/minecraft/class_7699;)V
+		ARG 1 category
+		ARG 2 type
+		ARG 4 acceptor
+		ARG 6 commandResultSupplier
+		ARG 7 value
+		ARG 8 featureSet
+	METHOD method_76144 getSimplifiedPath ()Ljava/lang/String;
+	METHOD method_76145 accept (Lnet/minecraft/class_4311;)V
+		ARG 1 visitor
+	METHOD method_76146 getValueName (Ljava/lang/Object;)Ljava/lang/String;
+		ARG 1 value
+	METHOD method_76147 deserialize (Ljava/lang/String;)Lcom/mojang/serialization/DataResult;
+		ARG 1 value
+	METHOD method_76148 getId ()Lnet/minecraft/class_2960;
+	METHOD method_76149 getCommandResult (Ljava/lang/Object;)I
+		ARG 1 value
+	METHOD method_76150 getTranslationKey ()Ljava/lang/String;
+	METHOD method_76151 getValueClass ()Ljava/lang/Class;
+	METHOD method_76152 getCategory ()Lnet/minecraft/class_5198;
+	METHOD method_76153 getType ()Lnet/minecraft/class_11845;
+	METHOD method_76154 getArgumentType ()Lcom/mojang/brigadier/arguments/ArgumentType;
+	METHOD method_76155 getCodec ()Lcom/mojang/serialization/Codec;
+	METHOD method_76156 getValue ()Ljava/lang/Object;
+	METHOD method_76157 getFeatureSet ()Lnet/minecraft/class_7699;

--- a/mappings/net/minecraft/world/rule/GameRules.mapping
+++ b/mappings/net/minecraft/world/rule/GameRules.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_1928 net/minecraft/world/GameRules
+CLASS net/minecraft/class_1928 net/minecraft/world/rule/GameRules
 	FIELD field_9196 rules Lnet/minecraft/class_12280;
 	FIELD field_19388 DO_MOB_GRIEFING Lnet/minecraft/class_12279;
 		COMMENT A {@linkplain Rule game rule} which regulates whether mobs can modify the world.
@@ -38,8 +38,15 @@ CLASS net/minecraft/class_1928 net/minecraft/world/GameRules
 		ARG 1 enabledFeatures
 	METHOD <init> (Lnet/minecraft/class_7699;Lnet/minecraft/class_12280;)V
 		ARG 1 enabledFeatures
+		ARG 2 rules
 	METHOD method_8359 register (Ljava/lang/String;Lnet/minecraft/class_5198;Lnet/minecraft/class_11845;Lcom/mojang/brigadier/arguments/ArgumentType;Lcom/mojang/serialization/Codec;Ljava/lang/Object;Lnet/minecraft/class_7699;Lnet/minecraft/class_1928$class_5199;Ljava/util/function/ToIntFunction;)Lnet/minecraft/class_12279;
+		ARG 0 name
 		ARG 1 category
+		ARG 2 type
+		ARG 5 defaultValue
+		ARG 6 featureSet
+		ARG 7 acceptor
+		ARG 8 commandResultSupplier
 	METHOD method_20744 accept (Lnet/minecraft/class_4311;)V
 		COMMENT Make the visitor visit all registered game rules.
 		COMMENT
@@ -47,6 +54,62 @@ CLASS net/minecraft/class_1928 net/minecraft/world/GameRules
 		ARG 1 visitor
 	METHOD method_27325 copy (Lnet/minecraft/class_7699;)Lnet/minecraft/class_1928;
 		ARG 1 enabledFeatures
+	METHOD method_76181 streamRules ()Ljava/util/stream/Stream;
+	METHOD method_76182 createCodec (Lnet/minecraft/class_7699;)Lcom/mojang/serialization/Codec;
+		ARG 0 featureSet
+	METHOD method_76184 (Lnet/minecraft/class_7699;Lnet/minecraft/class_12280;)Lnet/minecraft/class_1928;
+		ARG 1 rules
+	METHOD method_76185 getValue (Lnet/minecraft/class_12279;)Ljava/lang/Object;
+		ARG 1 rule
+	METHOD method_76186 setValue (Lnet/minecraft/class_12279;Ljava/lang/Object;Lnet/minecraft/server/MinecraftServer;)V
+		ARG 1 rule
+		ARG 2 value
+		ARG 3 server
+	METHOD method_76187 updateValue (Lnet/minecraft/class_12280;Lnet/minecraft/class_12279;Lnet/minecraft/server/MinecraftServer;)V
+		ARG 1 rules
+		ARG 2 rule
+		ARG 3 server
+	METHOD method_76188 updateValues (Lnet/minecraft/class_12280;Lnet/minecraft/server/MinecraftServer;)V
+		ARG 1 rules
+		ARG 2 server
+	METHOD method_76189 (Lnet/minecraft/class_12280;Lnet/minecraft/server/MinecraftServer;Lnet/minecraft/class_12279;)V
+		ARG 3 rule
+	METHOD method_76190 (Lnet/minecraft/class_4311;Lnet/minecraft/class_12279;)V
+		ARG 1 rule
+	METHOD method_76191 (Lnet/minecraft/class_1928;)Lnet/minecraft/class_12280;
+		ARG 0 gameRules
+	METHOD method_76192 updateValues (Lnet/minecraft/class_1928;Lnet/minecraft/server/MinecraftServer;)V
+		ARG 1 rules
+		ARG 2 server
+	METHOD method_76193 (Ljava/lang/Boolean;)I
+		ARG 0 bool
+	METHOD method_76195 registerIntRule (Ljava/lang/String;Lnet/minecraft/class_5198;II)Lnet/minecraft/class_12279;
+		ARG 0 name
+		ARG 1 category
+		ARG 2 defaultValue
+		ARG 3 minValue
+	METHOD method_76196 registerIntRule (Ljava/lang/String;Lnet/minecraft/class_5198;III)Lnet/minecraft/class_12279;
+		ARG 0 name
+		ARG 1 category
+		ARG 2 defaultValue
+		ARG 3 minValue
+		ARG 4 maxValue
+	METHOD method_76197 registerIntRule (Ljava/lang/String;Lnet/minecraft/class_5198;IIILnet/minecraft/class_7699;)Lnet/minecraft/class_12279;
+		ARG 0 name
+		ARG 1 category
+		ARG 2 defaultValue
+		ARG 3 minValue
+		ARG 4 maxValue
+		ARG 5 featureSet
+	METHOD method_76198 registerBooleanRule (Ljava/lang/String;Lnet/minecraft/class_5198;Z)Lnet/minecraft/class_12279;
+		ARG 0 name
+		ARG 1 category
+		ARG 2 defaultValue
+	METHOD method_76199 getDefault (Lnet/minecraft/class_2378;)Lnet/minecraft/class_12279;
+		ARG 0 registry
+	METHOD method_76200 getRuleValueName (Lnet/minecraft/class_12279;)Ljava/lang/String;
+		ARG 1 rule
 	CLASS class_5199 Acceptor
 		METHOD call (Lnet/minecraft/class_4311;Lnet/minecraft/class_12279;)V
 			ARG 1 consumer
+			ARG 2 rule

--- a/mappings/net/minecraft/world/rule/ServerGameRules.mapping
+++ b/mappings/net/minecraft/world/rule/ServerGameRules.mapping
@@ -1,0 +1,40 @@
+CLASS net/minecraft/class_12280 net/minecraft/world/rule/ServerGameRules
+	FIELD field_64176 CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_64177 ruleValueMap Lit/unimi/dsi/fastutil/objects/Reference2ObjectMap;
+	METHOD equals (Ljava/lang/Object;)Z
+		ARG 1 o
+	METHOD method_76163 create ()Lnet/minecraft/class_12280;
+	METHOD method_76164 contains (Lnet/minecraft/class_12279;)Z
+		ARG 1 rule
+	METHOD method_76165 putValue (Lnet/minecraft/class_12279;Ljava/lang/Object;)V
+		ARG 1 rule
+		ARG 2 value
+	METHOD method_76166 copyFrom (Lnet/minecraft/class_12280;)Lnet/minecraft/class_12280;
+		ARG 0 rules
+	METHOD method_76167 copyValue (Lnet/minecraft/class_12280;Lnet/minecraft/class_12279;Lnet/minecraft/class_12280;)V
+		ARG 0 oldRules
+		ARG 1 rule
+		ARG 2 newRules
+	METHOD method_76168 copyValuesIf (Lnet/minecraft/class_12280;Ljava/util/function/Predicate;)V
+		ARG 1 rules
+	METHOD method_76169 (Lit/unimi/dsi/fastutil/objects/Reference2ObjectOpenHashMap;Lnet/minecraft/class_12279;)V
+		ARG 1 gameRule
+	METHOD method_76170 create (Ljava/util/Map;)Lnet/minecraft/class_12280;
+	METHOD method_76171 create (Ljava/util/stream/Stream;)Lnet/minecraft/class_12280;
+	METHOD method_76172 getRules ()Ljava/util/Set;
+	METHOD method_76173 getValue (Lnet/minecraft/class_12279;)Ljava/lang/Object;
+		ARG 1 rule
+	METHOD method_76174 merge (Lnet/minecraft/class_12280;)Lnet/minecraft/class_12280;
+		ARG 1 override
+	METHOD method_76175 getSize ()I
+	METHOD method_76176 remove (Lnet/minecraft/class_12279;)Ljava/lang/Object;
+		ARG 1 rule
+	METHOD method_76177 getRuleValueMap ()Lit/unimi/dsi/fastutil/objects/Reference2ObjectMap;
+	METHOD method_76178 (Lnet/minecraft/class_12279;)Z
+		ARG 0 rule
+	CLASS class_12281 Builder
+		FIELD field_64178 ruleValueMap Lit/unimi/dsi/fastutil/objects/Reference2ObjectMap;
+		METHOD method_76179 build ()Lnet/minecraft/class_12280;
+		METHOD method_76180 putValue (Lnet/minecraft/class_12279;Ljava/lang/Object;)Lnet/minecraft/class_12280$class_12281;
+			ARG 1 rule
+			ARG 2 value


### PR DESCRIPTION
Adds mappings for GameRules. Since this is my first time contributing to yarn, I hope this pull request is satisfactory.

I'm somewhat unsure about these names, especially all the `updateValue` methods in GameRules, `copyValuesIf` in ServerGameRules, and `toShortString` in Identifier. I'd consider naming ServerGameRules to GameRuleContainer, but I'm not sure which is better. Additionally, I'm not sure whether putValue or setValue is better for some methods, so there is a mix of both throughout the classes.

All gamerule-related classes have been moved under `net/minecraft/world/rule`.