### PR TITLE
Add mapping for WorldBorderWarningTimeFix  class

### DIFF
--- a/mappings/net/minecraft/datafixer/fix/GameRuleRegistryFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/GameRuleRegistryFix.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_12255 net/minecraft/datafixer/fix/GameRuleRegistryFix
 	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;)V
-		ARG 1 schema
+		ARG 1 outputSchema
 	METHOD method_76065 clamp (Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/Dynamic;
 	METHOD method_76066 clamp (Lcom/mojang/serialization/Dynamic;I)Lcom/mojang/serialization/Dynamic;
 		ARG 1 min

--- a/mappings/net/minecraft/datafixer/fix/GameRuleRegistryFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/GameRuleRegistryFix.mapping
@@ -1,0 +1,11 @@
+CLASS net/minecraft/class_12255 net/minecraft/datafixer/fix/GameRuleRegistryFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;)V
+		ARG 1 schema
+	METHOD method_76065 clamp (Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/Dynamic;
+	METHOD method_76066 clamp (Lcom/mojang/serialization/Dynamic;I)Lcom/mojang/serialization/Dynamic;
+		ARG 1 min
+	METHOD method_76067 clamp (Lcom/mojang/serialization/Dynamic;II)Lcom/mojang/serialization/Dynamic;
+		ARG 1 min
+		ARG 2 max
+	METHOD method_76068 isTrue (Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/Dynamic;
+	METHOD method_76069 isFalse (Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/Dynamic;

--- a/mappings/net/minecraft/datafixer/fix/GameRuleRegistryFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/GameRuleRegistryFix.mapping
@@ -1,6 +1,6 @@
 CLASS net/minecraft/class_12255 net/minecraft/datafixer/fix/GameRuleRegistryFix
 	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;)V
-		ARG 1 outputSchema
+		ARG 1 schema
 	METHOD method_76065 clamp (Lcom/mojang/serialization/Dynamic;)Lcom/mojang/serialization/Dynamic;
 	METHOD method_76066 clamp (Lcom/mojang/serialization/Dynamic;I)Lcom/mojang/serialization/Dynamic;
 		ARG 1 min

--- a/mappings/net/minecraft/datafixer/fix/WorldBorderWarningTimeFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/WorldBorderWarningTimeFix.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_12256 net/minecraft/datafixer/fix/WorldBorderWarningTimeFix
+	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;)V
+		ARG 1 outputSchema

--- a/mappings/net/minecraft/datafixer/fix/WorldBorderWarningTimeFix.mapping
+++ b/mappings/net/minecraft/datafixer/fix/WorldBorderWarningTimeFix.mapping
@@ -1,3 +1,0 @@
-CLASS net/minecraft/class_12256 net/minecraft/datafixer/fix/WorldBorderWarningTimeFix
-	METHOD <init> (Lcom/mojang/datafixers/schemas/Schema;)V
-		ARG 1 outputSchema


### PR DESCRIPTION
Also renamed input argument of constructor of GameRuleRegistryFix to outputSchema to match other classes in net.minecraft.datafixer.fix.
