### PR TITLE
Rename the NautilusRenderState class to NautilusEntityRenderState

### DIFF
--- a/mappings/net/minecraft/client/render/entity/state/NautilusEntityRenderState.mapping
+++ b/mappings/net/minecraft/client/render/entity/state/NautilusEntityRenderState.mapping
@@ -1,3 +1,3 @@
-CLASS net/minecraft/class_12158 net/minecraft/client/render/entity/state/NautilusRenderState
+CLASS net/minecraft/class_12158 net/minecraft/client/render/entity/state/NautilusEntityRenderState
 	FIELD field_63606 saddleStack Lnet/minecraft/class_1799;
 	FIELD field_63607 armorStack Lnet/minecraft/class_1799;


### PR DESCRIPTION
I noticed when mapping Minecraft snapshot 25w45a that I named this class inconsistently in #4328 compared to existing entity render state classes.