### PR TITLE
Map zombie nautilus variants

### DIFF
--- a/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
@@ -3,6 +3,8 @@ CLASS net/minecraft/class_897 net/minecraft/client/render/entity/EntityRenderer
 	FIELD field_4673 shadowRadius F
 	FIELD field_4676 dispatcher Lnet/minecraft/class_898;
 	FIELD field_27761 textRenderer Lnet/minecraft/class_327;
+	METHOD <init> (Lnet/minecraft/class_5617$class_5618;)V
+		ARG 1 context
 	METHOD method_3921 hasLabel (Lnet/minecraft/class_1297;D)Z
 		COMMENT Determines whether the passed entity should render with a nameplate above its head.
 		COMMENT

--- a/mappings/net/minecraft/client/render/entity/ZombieNautilusEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/ZombieNautilusEntityRenderer.mapping
@@ -1,0 +1,8 @@
+CLASS net/minecraft/class_12336 net/minecraft/client/render/entity/ZombieNautilusEntityRenderer
+	FIELD field_64457 models Ljava/util/Map;
+	METHOD method_76550 createModels (Lnet/minecraft/class_5617$class_5618;)Ljava/util/Map;
+		ARG 0 context
+	METHOD method_76554 (Lnet/minecraft/class_12158;)Lnet/minecraft/class_1799;
+		ARG 0 state
+	METHOD method_76555 (Lnet/minecraft/class_12158;)Lnet/minecraft/class_1799;
+		ARG 0 state

--- a/mappings/net/minecraft/client/render/entity/model/EntityModelPartNames.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/EntityModelPartNames.mapping
@@ -188,6 +188,28 @@ CLASS net/minecraft/class_6230 net/minecraft/client/render/entity/model/EntityMo
 		COMMENT The key of a lower mouth model part, whose value is {@value}.
 	FIELD field_63564 SHELL Ljava/lang/String;
 		COMMENT The key of a shell model part, whose value is {@value}.
+	FIELD field_64433 YELLOW_CORAL Ljava/lang/String;
+		COMMENT The key of a yellow coral model part, whose value is {@value}.
+	FIELD field_64434 YELLOW_CORAL_FIRST Ljava/lang/String;
+		COMMENT The key of a first yellow coral model part, whose value is {@value}.
+	FIELD field_64435 YELLOW_CORAL_SECOND Ljava/lang/String;
+		COMMENT The key of a second yellow coral model part, whose value is {@value}.
+	FIELD field_64436 PINK_CORAL Ljava/lang/String;
+		COMMENT The key of a pink coral model part, whose value is {@value}.
+	FIELD field_64437 PINK_CORAL_SECOND Ljava/lang/String;
+		COMMENT The key of a second pink coral model part, whose value is {@value}.
+	FIELD field_64438 BLUE_CORAL Ljava/lang/String;
+		COMMENT The key of a blue coral model part, whose value is {@value}.
+	FIELD field_64439 BLUE_CORAL_FIRST Ljava/lang/String;
+		COMMENT The key of a first blue coral model part, whose value is {@value}.
+	FIELD field_64440 BLUE_CORAL_SECOND Ljava/lang/String;
+		COMMENT The key of a second blue coral model part, whose value is {@value}.
+	FIELD field_64441 RED_CORAL Ljava/lang/String;
+		COMMENT The key of a red coral model part, whose value is {@value}.
+	FIELD field_64442 RED_CORAL_FIRST Ljava/lang/String;
+		COMMENT The key of a first red coral model part, whose value is {@value}.
+	FIELD field_64443 RED_CORAL_SECOND Ljava/lang/String;
+		COMMENT The key of a second red coral model part, whose value is {@value}.
 	METHOD method_70935 getTentacleName (I)Ljava/lang/String;
 		COMMENT @return The key of a tentacle model part, suffixed with {@code index}.
 		ARG 0 index

--- a/mappings/net/minecraft/client/render/entity/model/ZombieNautilusCoralEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/ZombieNautilusCoralEntityModel.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_12334 net/minecraft/client/render/entity/model/ZombieNautilusCoralEntityModel
+	FIELD field_64431 corals Lnet/minecraft/class_630;
+	METHOD method_76539 getTexturedModelData ()Lnet/minecraft/class_5607;

--- a/mappings/net/minecraft/client/render/entity/state/NautilusEntityRenderState.mapping
+++ b/mappings/net/minecraft/client/render/entity/state/NautilusEntityRenderState.mapping
@@ -1,3 +1,4 @@
 CLASS net/minecraft/class_12158 net/minecraft/client/render/entity/state/NautilusEntityRenderState
 	FIELD field_63606 saddleStack Lnet/minecraft/class_1799;
 	FIELD field_63607 armorStack Lnet/minecraft/class_1799;
+	FIELD field_64458 variant Lnet/minecraft/class_12319;

--- a/mappings/net/minecraft/component/DataComponentTypes.mapping
+++ b/mappings/net/minecraft/component/DataComponentTypes.mapping
@@ -25,6 +25,7 @@ CLASS net/minecraft/class_9334 net/minecraft/component/DataComponentTypes
 	FIELD field_56508 COW_VARIANT Lnet/minecraft/class_9331;
 	FIELD field_56595 CHICKEN_VARIANT Lnet/minecraft/class_9331;
 	FIELD field_57109 WOLF_SOUND_VARIANT Lnet/minecraft/class_9331;
+	FIELD field_64474 ZOMBIE_NAUTILUS_VARIANT Lnet/minecraft/class_9331;
 	METHOD method_57884 (Lnet/minecraft/class_9331$class_9332;)Lnet/minecraft/class_9331$class_9332;
 		ARG 0 builder
 	METHOD method_57885 (Lnet/minecraft/class_9331$class_9332;)Lnet/minecraft/class_9331$class_9332;
@@ -233,4 +234,6 @@ CLASS net/minecraft/class_9334 net/minecraft/component/DataComponentTypes
 	METHOD method_75512 (Lnet/minecraft/class_9331$class_9332;)Lnet/minecraft/class_9331$class_9332;
 		ARG 0 builder
 	METHOD method_75513 (Lnet/minecraft/class_9331$class_9332;)Lnet/minecraft/class_9331$class_9332;
+		ARG 0 builder
+	METHOD method_76571 (Lnet/minecraft/class_9331$class_9332;)Lnet/minecraft/class_9331$class_9332;
 		ARG 0 builder

--- a/mappings/net/minecraft/entity/data/TrackedDataHandlerRegistry.mapping
+++ b/mappings/net/minecraft/entity/data/TrackedDataHandlerRegistry.mapping
@@ -39,6 +39,7 @@ CLASS net/minecraft/class_2943 net/minecraft/entity/data/TrackedDataHandlerRegis
 	FIELD field_61079 OXIDATION_LEVEL Lnet/minecraft/class_2941;
 	FIELD field_61080 COPPER_GOLEM_STATE Lnet/minecraft/class_2941;
 	FIELD field_63001 PROFILE Lnet/minecraft/class_2941;
+	FIELD field_64257 ZOMBIE_NAUTILUS_VARIANT Lnet/minecraft/class_2941;
 	METHOD method_12719 getId (Lnet/minecraft/class_2941;)I
 		ARG 0 handler
 	METHOD method_12720 register (Lnet/minecraft/class_2941;)V

--- a/mappings/net/minecraft/entity/mob/ZombieNautilusEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/ZombieNautilusEntity.mapping
@@ -1,2 +1,6 @@
 CLASS net/minecraft/class_12119 net/minecraft/entity/mob/ZombieNautilusEntity
+	FIELD field_64373 VARIANT Lnet/minecraft/class_2940;
 	METHOD method_75184 createZombieNautilusAttributes ()Lnet/minecraft/class_5132$class_5133;
+	METHOD method_76452 setVariant (Lnet/minecraft/class_6880;)V
+		ARG 1 variant
+	METHOD method_76453 getVariant ()Lnet/minecraft/class_6880;

--- a/mappings/net/minecraft/entity/mob/ZombieNautilusVariant.mapping
+++ b/mappings/net/minecraft/entity/mob/ZombieNautilusVariant.mapping
@@ -1,0 +1,14 @@
+CLASS net/minecraft/class_12319 net/minecraft/entity/mob/ZombieNautilusVariant
+	FIELD field_64362 NETWORK_CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_64363 ENTRY_CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_64364 ENTRY_PACKET_CODEC Lnet/minecraft/class_9139;
+	METHOD <init> (Lnet/minecraft/class_10693;)V
+		ARG 1 modelAndTexture
+	METHOD method_76445 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance
+	METHOD method_76446 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
+		ARG 0 instance
+	CLASS class_12320 Model
+		FIELD field_64368 id Ljava/lang/String;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
+			ARG 3 id

--- a/mappings/net/minecraft/entity/mob/ZombieNautilusVariants.mapping
+++ b/mappings/net/minecraft/entity/mob/ZombieNautilusVariants.mapping
@@ -1,0 +1,20 @@
+CLASS net/minecraft/class_12321 net/minecraft/entity/mob/ZombieNautilusVariants
+	FIELD field_64370 TEMPERATE Lnet/minecraft/class_5321;
+	FIELD field_64371 WARM Lnet/minecraft/class_5321;
+	FIELD field_64372 DEFAULT Lnet/minecraft/class_5321;
+	METHOD method_76448 of (Lnet/minecraft/class_2960;)Lnet/minecraft/class_5321;
+		ARG 0 id
+	METHOD method_76449 bootstrap (Lnet/minecraft/class_7891;)V
+		ARG 0 registry
+	METHOD method_76450 register (Lnet/minecraft/class_7891;Lnet/minecraft/class_5321;Lnet/minecraft/class_12319$class_12320;Ljava/lang/String;Lnet/minecraft/class_6862;)V
+		ARG 0 registry
+		ARG 1 key
+		ARG 2 model
+		ARG 3 textureName
+		ARG 4 biomes
+	METHOD method_76451 register (Lnet/minecraft/class_7891;Lnet/minecraft/class_5321;Lnet/minecraft/class_12319$class_12320;Ljava/lang/String;Lnet/minecraft/class_10702;)V
+		ARG 0 registry
+		ARG 1 key
+		ARG 2 model
+		ARG 3 textureName
+		ARG 4 spawnConditions


### PR DESCRIPTION
This pull request maps zombie nautilus variants, which structurally are equivalent to [pig variants](https://github.com/FabricMC/yarn/pull/4080). The implementation is slightly questionable:

- Much like existing mob variants, the `ZombieNautilusVariants` class holds fields for each variant, as well as an additional field representing the default variant, which is used to initialize the entity's data tracker. For zombie nautiluses, the field goes unused, with the variant's field being used directly instead.
- Model part names for each numbered coral face as well as its parent exist. The pink coral has a parent part name and a second part name, but not a first part name.
- The numbered part names for the blue coral are formatted as `blue_<ordinal>` instead of `blue_coral_<ordinal>`. The added field names and documentation reject this inconsistency.