### PR TITLE
[25w45a] Add mappings for environment attribute timelines

### DIFF
--- a/mappings/net/minecraft/client/world/ClientWorld.mapping
+++ b/mappings/net/minecraft/client/world/ClientWorld.mapping
@@ -27,6 +27,7 @@ CLASS net/minecraft/class_638 net/minecraft/client/world/ClientWorld
 	FIELD field_62026 endLightFlashManager Lnet/minecraft/class_11743;
 	FIELD field_62027 blockParticlesManager Lnet/minecraft/class_11741;
 	FIELD field_62596 worldBorder Lnet/minecraft/class_2784;
+	FIELD field_64444 environmentAttributeAccess Lnet/minecraft/class_12205;
 	METHOD <init> (Lnet/minecraft/class_634;Lnet/minecraft/class_638$class_5271;Lnet/minecraft/class_5321;Lnet/minecraft/class_6880;IILnet/minecraft/class_761;ZJI)V
 		ARG 1 networkHandler
 		ARG 2 properties
@@ -184,6 +185,14 @@ CLASS net/minecraft/class_638 net/minecraft/client/world/ClientWorld
 		ARG 2 direction
 	METHOD method_74918 getParticlesMode (Z)Lnet/minecraft/class_4066;
 	METHOD method_74919 addParticle (Lnet/minecraft/class_2394;ZZDDDDDD)V
+	METHOD method_76540 (ILjava/lang/Integer;I)Ljava/lang/Integer;
+		ARG 2 color
+		ARG 3 time
+	METHOD method_76541 addClientSideAttributes (Lnet/minecraft/class_12205$class_12314;)Lnet/minecraft/class_12205$class_12314;
+		ARG 1 builder
+	METHOD method_76542 (Ljava/lang/Float;I)Ljava/lang/Float;
+		ARG 1 factor
+		ARG 2 time
 	CLASS class_5271 Properties
 		FIELD field_24433 hardcore Z
 		FIELD field_24438 time J

--- a/mappings/net/minecraft/data/tag/vanilla/VanillaTimelineTagProvider.mapping
+++ b/mappings/net/minecraft/data/tag/vanilla/VanillaTimelineTagProvider.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_12339 net/minecraft/data/tag/vanilla/VanillaTimelineTagProvider
+	METHOD <init> (Lnet/minecraft/class_7784;Ljava/util/concurrent/CompletableFuture;)V
+		ARG 1 output
+		ARG 2 registriesFuture

--- a/mappings/net/minecraft/registry/tag/TimelineTags.mapping
+++ b/mappings/net/minecraft/registry/tag/TimelineTags.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_12300 net/minecraft/registry/tag/TimelineTags
+	METHOD method_76334 of (Ljava/lang/String;)Lnet/minecraft/class_6862;
+		ARG 0 name

--- a/mappings/net/minecraft/server/world/ServerWorld.mapping
+++ b/mappings/net/minecraft/server/world/ServerWorld.mapping
@@ -38,6 +38,7 @@ CLASS net/minecraft/class_3218 net/minecraft/server/world/ServerWorld
 	FIELD field_49172 pathNodeTypeCache Lnet/minecraft/class_9315;
 	FIELD field_59630 waypointHandler Lnet/minecraft/class_11179;
 	FIELD field_62841 subscriptionTracker Lnet/minecraft/class_12026;
+	FIELD field_64261 environmentAttributeAccess Lnet/minecraft/class_12205;
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;Ljava/util/concurrent/Executor;Lnet/minecraft/class_32$class_5143;Lnet/minecraft/class_5268;Lnet/minecraft/class_5321;Lnet/minecraft/class_5363;ZJLjava/util/List;ZLnet/minecraft/class_8565;)V
 		ARG 1 server
 		ARG 2 workerExecutor

--- a/mappings/net/minecraft/util/TriState.mapping
+++ b/mappings/net/minecraft/util/TriState.mapping
@@ -1,3 +1,8 @@
 CLASS net/minecraft/class_9851 net/minecraft/util/TriState
+	FIELD field_64315 CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_64316 name Ljava/lang/String;
+	METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
+		ARG 3 name
 	METHOD method_61348 asBoolean (Z)Z
 		ARG 1 fallback
+	METHOD method_76393 ofBoolean (Z)Lnet/minecraft/class_9851;

--- a/mappings/net/minecraft/util/math/Easing.mapping
+++ b/mappings/net/minecraft/util/math/Easing.mapping
@@ -1,3 +1,61 @@
 CLASS net/minecraft/class_12101 net/minecraft/util/math/Easing
 	METHOD method_75043 inOutSine (F)F
-		ARG 0 value
+		ARG 0 t
+	METHOD method_75044 outBack (F)F
+		ARG 0 t
+	METHOD method_75045 outQuart (F)F
+		ARG 0 t
+	METHOD method_75046 outCubic (F)F
+		ARG 0 t
+	METHOD method_75047 inOutExpo (F)F
+		ARG 0 t
+	METHOD method_75048 inQuad (F)F
+		ARG 0 t
+	METHOD method_75049 outCirc (F)F
+		ARG 0 t
+	METHOD method_75050 inOutElastic (F)F
+		ARG 0 t
+	METHOD method_75051 inCirc (F)F
+		ARG 0 f
+	METHOD method_75052 inOutBack (F)F
+		ARG 0 t
+	METHOD method_76336 inBack (F)F
+		ARG 0 t
+	METHOD method_76337 inBounce (F)F
+		ARG 0 t
+	METHOD method_76338 inCubic (F)F
+		ARG 0 t
+	METHOD method_76339 inElastic (F)F
+		ARG 0 t
+	METHOD method_76340 inExpo (F)F
+		ARG 0 t
+	METHOD method_76341 inQuart (F)F
+		ARG 0 t
+	METHOD method_76342 inQuint (F)F
+		ARG 0 t
+	METHOD method_76343 inSine (F)F
+		ARG 0 t
+	METHOD method_76344 inOutBounce (F)F
+		ARG 0 t
+	METHOD method_76345 inOutCirc (F)F
+		ARG 0 t
+	METHOD method_76346 inOutCubic (F)F
+		ARG 0 t
+	METHOD method_76347 inOutQuad (F)F
+		ARG 0 t
+	METHOD method_76348 inOutQuart (F)F
+		ARG 0 t
+	METHOD method_76349 inOutQuint (F)F
+		ARG 0 t
+	METHOD method_76350 outBounce (F)F
+		ARG 0 t
+	METHOD method_76351 outElastic (F)F
+		ARG 0 t
+	METHOD method_76352 outExpo (F)F
+		ARG 0 t
+	METHOD method_76353 outQuad (F)F
+		ARG 0 t
+	METHOD method_76354 outQuint (F)F
+		ARG 0 t
+	METHOD method_76355 outSine (F)F
+		ARG 0 t

--- a/mappings/net/minecraft/util/math/Interpolator.mapping
+++ b/mappings/net/minecraft/util/math/Interpolator.mapping
@@ -11,3 +11,14 @@ CLASS net/minecraft/class_12210 net/minecraft/util/math/Interpolator
 		ARG 2 a
 		ARG 3 b
 	METHOD method_75709 ofColor ()Lnet/minecraft/class_12210;
+	METHOD method_76426 angle (F)Lnet/minecraft/class_12210;
+		ARG 0 maxDeviation
+	METHOD method_76427 (FFLjava/lang/Float;Ljava/lang/Float;)Ljava/lang/Float;
+		ARG 1 t
+		ARG 2 a
+		ARG 3 b
+	METHOD method_76428 (FLjava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+		ARG 0 t
+		ARG 1 a
+		ARG 2 b
+	METHOD method_76429 first ()Lnet/minecraft/class_12210;

--- a/mappings/net/minecraft/world/MoonPhase.mapping
+++ b/mappings/net/minecraft/world/MoonPhase.mapping
@@ -2,7 +2,9 @@ CLASS net/minecraft/class_12131 net/minecraft/world/MoonPhase
 	FIELD field_63433 COUNT I
 	FIELD field_63434 index I
 	FIELD field_63435 name Ljava/lang/String;
+	FIELD field_64379 DAY_LENGTH I
 	METHOD <init> (Ljava/lang/String;IILjava/lang/String;)V
 		ARG 3 index
 		ARG 4 name
 	METHOD method_75261 getIndex ()I
+	METHOD method_76466 phaseTicks ()I

--- a/mappings/net/minecraft/world/attribute/ColorModifier.mapping
+++ b/mappings/net/minecraft/world/attribute/ColorModifier.mapping
@@ -4,7 +4,14 @@ CLASS net/minecraft/class_12216 net/minecraft/world/attribute/ColorModifier
 	FIELD field_63797 SUBTRACT Lnet/minecraft/class_12216;
 	FIELD field_63798 MULTIPLY_RGB Lnet/minecraft/class_12216;
 	FIELD field_64129 MULTIPLY_ARGB Lnet/minecraft/class_12216;
+	FIELD field_64354 BLEND_TO_GRAY Lnet/minecraft/class_12216;
+	CLASS 2
+		METHOD method_76436 (FLnet/minecraft/class_12216$class_12318;Lnet/minecraft/class_12216$class_12318;)Lnet/minecraft/class_12216$class_12318;
+			ARG 0 t
+			ARG 1 a
+			ARG 2 b
 	CLASS class_12217 Rgb
 	CLASS class_12258 Argb
 		METHOD method_76084 (Ljava/lang/Integer;)Lcom/mojang/datafixers/util/Either;
 			ARG 0 argb
+	CLASS class_12318 BlendToGrayArg

--- a/mappings/net/minecraft/world/attribute/EnvironmentAttributeModification.mapping
+++ b/mappings/net/minecraft/world/attribute/EnvironmentAttributeModification.mapping
@@ -1,0 +1,13 @@
+CLASS net/minecraft/class_12310 net/minecraft/world/attribute/EnvironmentAttributeModification
+	CLASS class_12311 Constant
+		METHOD applyConstant (Ljava/lang/Object;)Ljava/lang/Object;
+			ARG 1 value
+	CLASS class_12312 Positional
+		METHOD applyPositional (Ljava/lang/Object;Lnet/minecraft/class_243;Lnet/minecraft/class_12211;)Ljava/lang/Object;
+			ARG 1 value
+			ARG 2 pos
+			ARG 3 weightedAttributeList
+	CLASS class_12313 TimeBased
+		METHOD applyTimeBased (Ljava/lang/Object;I)Ljava/lang/Object;
+			ARG 1 value
+			ARG 2 time

--- a/mappings/net/minecraft/world/attribute/WeatherAttributes.mapping
+++ b/mappings/net/minecraft/world/attribute/WeatherAttributes.mapping
@@ -1,0 +1,19 @@
+CLASS net/minecraft/class_12316 net/minecraft/world/attribute/WeatherAttributes
+	FIELD field_64349 RAIN_EFFECTS Lnet/minecraft/class_12199;
+	FIELD field_64350 THUNDER_EFFECTS Lnet/minecraft/class_12199;
+	FIELD field_64351 ATTRIBUTES Ljava/util/Set;
+	METHOD method_76430 addWeatherAttributes (Lnet/minecraft/class_12205$class_12314;Lnet/minecraft/class_12316$class_12317;)V
+		ARG 0 builder
+		ARG 1 weather
+	METHOD method_76431 addWeatherAttribute (Lnet/minecraft/class_12205$class_12314;Lnet/minecraft/class_12316$class_12317;Lnet/minecraft/class_12197;)V
+		ARG 0 builder
+		ARG 1 weather
+		ARG 2 attribute
+	METHOD method_76432 (Lnet/minecraft/class_12316$class_12317;Lnet/minecraft/class_12199$class_12201;Lnet/minecraft/class_12197;Lnet/minecraft/class_12199$class_12201;Ljava/lang/Object;I)Ljava/lang/Object;
+		ARG 4 value
+		ARG 5 time
+	CLASS class_12317 WeatherAccess
+		METHOD method_76433 getRainGradient ()F
+		METHOD method_76434 ofWorld (Lnet/minecraft/class_1937;)Lnet/minecraft/class_12316$class_12317;
+			ARG 0 world
+		METHOD method_76435 getThunderGradient ()F

--- a/mappings/net/minecraft/world/attribute/WorldEnvironmentAttributeAccess.mapping
+++ b/mappings/net/minecraft/world/attribute/WorldEnvironmentAttributeAccess.mapping
@@ -1,1 +1,92 @@
 CLASS net/minecraft/class_12205 net/minecraft/world/attribute/WorldEnvironmentAttributeAccess
+	FIELD field_64321 entries Ljava/util/Map;
+	METHOD <init> (Ljava/util/Map;)V
+		ARG 1 modificationsByAttribute
+	METHOD method_76394 builder ()Lnet/minecraft/class_12205$class_12314;
+	METHOD method_76395 (Lnet/minecraft/class_12197;Lnet/minecraft/class_4543;Ljava/lang/Object;Lnet/minecraft/class_243;Lnet/minecraft/class_12211;)Ljava/lang/Object;
+		ARG 2 value
+		ARG 3 pos
+		ARG 4 weightedAttributeList
+	METHOD method_76396 computeEntry (Lnet/minecraft/class_12197;Ljava/util/List;)Lnet/minecraft/class_12205$class_12315;
+		ARG 1 attribute
+		ARG 2 mods
+	METHOD method_76398 addModifiersFromBiomes (Lnet/minecraft/class_12205$class_12314;Lnet/minecraft/class_12197;Lnet/minecraft/class_4543;)V
+		ARG 0 builder
+		ARG 1 attribute
+		ARG 2 biomeAccess
+	METHOD method_76399 addModifiersFromWorld (Lnet/minecraft/class_12205$class_12314;Lnet/minecraft/class_1937;)V
+		ARG 0 builder
+		ARG 1 world
+	METHOD method_76400 (Lnet/minecraft/class_12205$class_12314;Lnet/minecraft/class_4543;Lnet/minecraft/class_12197;)V
+		ARG 2 attribute
+	METHOD method_76401 addModifiersFromDimension (Lnet/minecraft/class_12205$class_12314;Lnet/minecraft/class_2874;)V
+		ARG 0 builder
+		ARG 1 dimensionType
+	METHOD method_76402 (Lnet/minecraft/class_12205$class_12314;Ljava/util/function/LongSupplier;Lnet/minecraft/class_6880;)V
+		ARG 2 attribute
+	METHOD method_76403 addModifiersFromBiomes (Lnet/minecraft/class_12205$class_12314;Lnet/minecraft/class_7225;Lnet/minecraft/class_4543;)V
+		ARG 0 builder
+		ARG 1 biome
+		ARG 2 biomeAccess
+	METHOD method_76404 (Lnet/minecraft/class_6880$class_6883;)Ljava/util/stream/Stream;
+		ARG 0 biome
+	METHOD method_76405 tick ()V
+	METHOD method_76406 getDefaultValue (Lnet/minecraft/class_12197;)Ljava/lang/Object;
+		ARG 1 attribute
+	METHOD method_76407 (Lnet/minecraft/class_12197;Ljava/util/List;)V
+		ARG 1 attribute
+		ARG 2 mods
+	METHOD method_76408 isPositional (Lnet/minecraft/class_12197;)Z
+		ARG 1 attribute
+	METHOD method_76409 getEntry (Lnet/minecraft/class_12197;)Lnet/minecraft/class_12205$class_12315;
+		ARG 1 attribute
+	CLASS class_12314 Builder
+		FIELD field_64322 modifications Ljava/util/Map;
+		METHOD method_76410 build ()Lnet/minecraft/class_12205;
+		METHOD method_76412 constant (Lnet/minecraft/class_12197;Lnet/minecraft/class_12310$class_12311;)Lnet/minecraft/class_12205$class_12314;
+			ARG 1 attribute
+			ARG 2 mod
+		METHOD method_76413 positional (Lnet/minecraft/class_12197;Lnet/minecraft/class_12310$class_12312;)Lnet/minecraft/class_12205$class_12314;
+			ARG 1 attribute
+			ARG 2 mod
+		METHOD method_76414 timeBased (Lnet/minecraft/class_12197;Lnet/minecraft/class_12310$class_12313;)Lnet/minecraft/class_12205$class_12314;
+			ARG 1 attribute
+			ARG 2 mod
+		METHOD method_76415 addModification (Lnet/minecraft/class_12197;Lnet/minecraft/class_12310;)Lnet/minecraft/class_12205$class_12314;
+			ARG 1 attribute
+			ARG 2 mod
+		METHOD method_76416 addFromMap (Lnet/minecraft/class_12197;Lnet/minecraft/class_12199;)Lnet/minecraft/class_12205$class_12314;
+			ARG 1 attribute
+			ARG 2 attributeMap
+		METHOD method_76417 addFromMap (Lnet/minecraft/class_12199;)Lnet/minecraft/class_12205$class_12314;
+			ARG 1 attributes
+		METHOD method_76418 world (Lnet/minecraft/class_1937;)Lnet/minecraft/class_12205$class_12314;
+			ARG 1 world
+		METHOD method_76419 addModificationFromTimeline (Lnet/minecraft/class_6880;Lnet/minecraft/class_12197;Ljava/util/function/LongSupplier;)V
+			ARG 1 timeline
+			ARG 2 attribute
+			ARG 3 timeSupplier
+		METHOD method_76420 addFromTimeline (Lnet/minecraft/class_6880;Ljava/util/function/LongSupplier;)Lnet/minecraft/class_12205$class_12314;
+			ARG 1 attribute
+			ARG 2 timeSupplier
+	CLASS class_12315 Entry
+		FIELD field_64323 attribute Lnet/minecraft/class_12197;
+		FIELD field_64324 defaultValue Ljava/lang/Object;
+		FIELD field_64325 modifications Ljava/util/List;
+		FIELD field_64326 positional Z
+		FIELD field_64327 cachedValue Ljava/lang/Object;
+		FIELD field_64328 age I
+		METHOD <init> (Lnet/minecraft/class_12197;Ljava/lang/Object;Ljava/util/List;Z)V
+			ARG 1 attribute
+			ARG 2 defaultValue
+			ARG 3 modifications
+			ARG 4 positional
+		METHOD method_76421 tick ()V
+		METHOD method_76422 getAt (Lnet/minecraft/class_243;Lnet/minecraft/class_12211;)Ljava/lang/Object;
+			ARG 1 pos
+			ARG 2 weightedAttributeList
+		METHOD method_76423 get ()Ljava/lang/Object;
+		METHOD method_76424 computeAt (Lnet/minecraft/class_243;Lnet/minecraft/class_12211;)Ljava/lang/Object;
+			ARG 1 pos
+			ARG 2 weightedAttributeList
+		METHOD method_76425 compute ()Ljava/lang/Object;

--- a/mappings/net/minecraft/world/attribute/timeline/EasingType.mapping
+++ b/mappings/net/minecraft/world/attribute/timeline/EasingType.mapping
@@ -1,0 +1,45 @@
+CLASS net/minecraft/class_12301 net/minecraft/world/attribute/timeline/EasingType
+	FIELD field_64275 EASING_TYPES_BY_NAME Lnet/minecraft/class_5699$class_10388;
+	FIELD field_64276 CODEC Lcom/mojang/serialization/Codec;
+	METHOD apply (F)F
+		ARG 1 x
+	METHOD method_76356 (F)F
+		ARG 0 x
+	METHOD method_76357 cubicBezierSymmetric (FF)Lnet/minecraft/class_12301;
+		ARG 0 x1
+		ARG 1 y1
+	METHOD method_76358 cubicBezier (FFFF)Lnet/minecraft/class_12301;
+		ARG 0 x1
+		ARG 1 y1
+		ARG 2 x2
+		ARG 3 y2
+	METHOD method_76360 register (Ljava/lang/String;Lnet/minecraft/class_12301;)Lnet/minecraft/class_12301;
+		ARG 0 name
+		ARG 1 easingType
+	METHOD method_76361 (F)F
+		ARG 0 x
+	CLASS class_12302 CubicBezier
+		COMMENT A cubic Bézier curve used for interpolation. The first and last control points
+		COMMENT are fixed at (0, 0) and at (1, 1).
+		FIELD field_64302 MAX_NEWTON_ITERATIONS I
+		FIELD field_64303 controlPoints Lnet/minecraft/class_12301$class_12304;
+		FIELD field_64304 xParams Lnet/minecraft/class_12301$class_12302$class_12303;
+		FIELD field_64305 yParams Lnet/minecraft/class_12301$class_12302$class_12303;
+		METHOD <init> (Lnet/minecraft/class_12301$class_12304;)V
+			ARG 1 controlPoints
+		METHOD equals (Ljava/lang/Object;)Z
+			ARG 1 other
+		METHOD method_76364 computeParameters (FF)Lnet/minecraft/class_12301$class_12302$class_12303;
+			COMMENT {@code z0} is fixed at 0 and {@code z3} is fixed at 1.
+			ARG 0 z1
+			ARG 1 z2
+		CLASS class_12303 Parameters
+			COMMENT Describes the parameters of a cubic Bézier curve in one axis. The constant
+			COMMENT coefficient is always 0 because the curve starts at (0, 0).
+			METHOD method_76365 apply (F)F
+				ARG 1 t
+			METHOD method_76366 derivative (F)F
+				ARG 1 t
+	CLASS class_12304 CubicBezierControlPoints
+		FIELD field_64306 CODEC Lcom/mojang/serialization/Codec;
+		METHOD method_76369 validate ()Lcom/mojang/serialization/DataResult;

--- a/mappings/net/minecraft/world/attribute/timeline/Keyframe.mapping
+++ b/mappings/net/minecraft/world/attribute/timeline/Keyframe.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_12305 net/minecraft/world/attribute/timeline/Keyframe
+	METHOD method_76372 createCodec (Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/Codec;
+		ARG 0 valueCodec

--- a/mappings/net/minecraft/world/attribute/timeline/Timeline.mapping
+++ b/mappings/net/minecraft/world/attribute/timeline/Timeline.mapping
@@ -1,0 +1,36 @@
+CLASS net/minecraft/class_12329 net/minecraft/world/attribute/timeline/Timeline
+	FIELD field_64398 CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_64399 NETWORK_CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_64400 TRACKS_BY_ATTRIBUTE_CODEC Lcom/mojang/serialization/Codec;
+	FIELD field_64401 periodTicks Ljava/util/Optional;
+	FIELD field_64402 tracks Ljava/util/Map;
+	METHOD <init> (Ljava/util/Optional;Ljava/util/Map;)V
+		ARG 1 periodTicks
+		ARG 2 entries
+	METHOD method_76478 builder ()Lnet/minecraft/class_12329$class_12330;
+	METHOD method_76479 getModification (Lnet/minecraft/class_12197;Ljava/util/function/LongSupplier;)Lnet/minecraft/class_12328;
+		ARG 1 attribute
+		ARG 2 timeSupplier
+	METHOD method_76481 getEffectiveTimeOfDay (Lnet/minecraft/class_1937;)J
+		ARG 1 world
+	METHOD method_76482 retainSyncedAttributes (Lnet/minecraft/class_12329;)Lnet/minecraft/class_12329;
+		ARG 0 timeline
+	METHOD method_76484 getPeriod ()Ljava/util/Optional;
+	METHOD method_76485 getRawTimeOfDay (Lnet/minecraft/class_1937;)J
+		ARG 1 world
+	METHOD method_76486 validate (Lnet/minecraft/class_12329;)Lcom/mojang/serialization/DataResult;
+		ARG 0 timeline
+	METHOD method_76487 getAttributes ()Ljava/util/Set;
+	CLASS class_12330 Builder
+		FIELD field_64403 periodTicks Ljava/util/Optional;
+		FIELD field_64404 entries Lcom/google/common/collect/ImmutableMap$Builder;
+		METHOD method_76490 build ()Lnet/minecraft/class_12329;
+		METHOD method_76491 period (I)Lnet/minecraft/class_12329$class_12330;
+			ARG 1 periodTicks
+		METHOD method_76492 entry (Lnet/minecraft/class_12197;Lnet/minecraft/class_12212;Ljava/util/function/Consumer;)Lnet/minecraft/class_12329$class_12330;
+			ARG 1 attribute
+			ARG 2 modifier
+			ARG 3 builderCallback
+		METHOD method_76493 entry (Lnet/minecraft/class_12197;Ljava/util/function/Consumer;)Lnet/minecraft/class_12329$class_12330;
+			ARG 1 attribute
+			ARG 2 builderCallback

--- a/mappings/net/minecraft/world/attribute/timeline/Timeline.mapping
+++ b/mappings/net/minecraft/world/attribute/timeline/Timeline.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_12329 net/minecraft/world/attribute/timeline/Timeline
+	FIELD field_64397 REGISTRY_CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_64398 CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_64399 NETWORK_CODEC Lcom/mojang/serialization/Codec;
 	FIELD field_64400 TRACKS_BY_ATTRIBUTE_CODEC Lcom/mojang/serialization/Codec;

--- a/mappings/net/minecraft/world/attribute/timeline/TimelineEntry.mapping
+++ b/mappings/net/minecraft/world/attribute/timeline/TimelineEntry.mapping
@@ -1,0 +1,17 @@
+CLASS net/minecraft/class_12327 net/minecraft/world/attribute/timeline/TimelineEntry
+	METHOD method_76471 createCodec (Lnet/minecraft/class_12197;)Lcom/mojang/serialization/Codec;
+		ARG 0 attribute
+	METHOD method_76472 createMapCodec (Lnet/minecraft/class_12197;Lnet/minecraft/class_12212;)Lcom/mojang/serialization/MapCodec;
+		ARG 0 attribute
+		ARG 1 modifier
+	METHOD method_76473 toModification (Lnet/minecraft/class_12197;Ljava/util/Optional;Ljava/util/function/LongSupplier;)Lnet/minecraft/class_12328;
+		ARG 1 attribute
+		ARG 2 period
+		ARG 3 timeSupplier
+	METHOD method_76474 (Lnet/minecraft/class_12212;Lnet/minecraft/class_12306;)Lnet/minecraft/class_12327;
+		ARG 1 argumentTrack
+	METHOD method_76475 validateKeyframesInPeriod (Lnet/minecraft/class_12327;I)Lcom/mojang/serialization/DataResult;
+		ARG 0 entry
+		ARG 1 period
+	METHOD method_76477 (Lnet/minecraft/class_12197;Lnet/minecraft/class_12212;)Lcom/mojang/serialization/MapCodec;
+		ARG 1 modifier

--- a/mappings/net/minecraft/world/attribute/timeline/Timelines.mapping
+++ b/mappings/net/minecraft/world/attribute/timeline/Timelines.mapping
@@ -1,0 +1,54 @@
+CLASS net/minecraft/class_12331 net/minecraft/world/attribute/timeline/Timelines
+	FIELD field_64411 NIGHT_SKY_LIGHT_COLOR I
+	FIELD field_64414 NIGHT_FOG_COLOR I
+	FIELD field_64415 NIGHT_CLOUD_COLOR I
+	METHOD method_76494 (Lnet/minecraft/class_12301;Lnet/minecraft/class_12306$class_12307;)V
+		ARG 1 track
+	METHOD method_76495 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track
+	METHOD method_76496 key (Ljava/lang/String;)Lnet/minecraft/class_5321;
+		ARG 0 path
+	METHOD method_76497 bootstrap (Lnet/minecraft/class_7891;)V
+		ARG 0 registry
+	METHOD method_76498 (Lnet/minecraft/class_12301;Lnet/minecraft/class_12306$class_12307;)V
+		ARG 1 track
+	METHOD method_76499 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track
+	METHOD method_76500 (Lnet/minecraft/class_12301;Lnet/minecraft/class_12306$class_12307;)V
+		ARG 1 track
+	METHOD method_76501 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track
+	METHOD method_76502 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track
+	METHOD method_76503 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track
+	METHOD method_76504 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track
+	METHOD method_76505 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track
+	METHOD method_76506 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track
+	METHOD method_76507 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track
+	METHOD method_76508 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track
+	METHOD method_76509 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track
+	METHOD method_76510 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track
+	METHOD method_76511 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track
+	METHOD method_76512 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track
+	METHOD method_76513 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track
+	METHOD method_76514 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track
+	METHOD method_76515 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track
+	METHOD method_76516 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track
+	METHOD method_76517 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track
+	METHOD method_76518 (Lnet/minecraft/class_12306$class_12307;)V
+		ARG 0 track

--- a/mappings/net/minecraft/world/attribute/timeline/Track.mapping
+++ b/mappings/net/minecraft/world/attribute/timeline/Track.mapping
@@ -1,0 +1,20 @@
+CLASS net/minecraft/class_12306 net/minecraft/world/attribute/timeline/Track
+	METHOD method_76376 validateKeyframesInPeriod (Lnet/minecraft/class_12306;I)Lcom/mojang/serialization/DataResult;
+		ARG 0 track
+		ARG 1 period
+	METHOD method_76377 createCodec (Lcom/mojang/serialization/Codec;)Lcom/mojang/serialization/MapCodec;
+		ARG 0 valueCodec
+	METHOD method_76379 validateKeyframes (Ljava/util/List;)Lcom/mojang/serialization/DataResult;
+		ARG 0 keyframes
+	METHOD method_76380 createEvaluator (Ljava/util/Optional;Lnet/minecraft/class_12210;)Lnet/minecraft/class_12308;
+		ARG 1 period
+		ARG 2 interpolator
+	CLASS class_12307 Builder
+		FIELD field_64307 keyframes Lcom/google/common/collect/ImmutableList$Builder;
+		FIELD field_64308 easingType Lnet/minecraft/class_12301;
+		METHOD method_76383 build ()Lnet/minecraft/class_12306;
+		METHOD method_76384 keyframe (ILjava/lang/Object;)Lnet/minecraft/class_12306$class_12307;
+			ARG 1 ticks
+			ARG 2 value
+		METHOD method_76385 easingType (Lnet/minecraft/class_12301;)Lnet/minecraft/class_12306$class_12307;
+			ARG 1 easingType

--- a/mappings/net/minecraft/world/attribute/timeline/TrackAttributeModification.mapping
+++ b/mappings/net/minecraft/world/attribute/timeline/TrackAttributeModification.mapping
@@ -1,0 +1,12 @@
+CLASS net/minecraft/class_12328 net/minecraft/world/attribute/timeline/TrackAttributeModification
+	FIELD field_64392 modifiers Lnet/minecraft/class_12212;
+	FIELD field_64393 evaluator Lnet/minecraft/class_12308;
+	FIELD field_64394 timeSupplier Ljava/util/function/LongSupplier;
+	FIELD field_64395 lastComputedTime I
+	FIELD field_64396 lastComputedValue Ljava/lang/Object;
+	METHOD <init> (Ljava/util/Optional;Lnet/minecraft/class_12212;Lnet/minecraft/class_12306;Lnet/minecraft/class_12210;Ljava/util/function/LongSupplier;)V
+		ARG 1 period
+		ARG 2 modifiers
+		ARG 3 track
+		ARG 4 interpolator
+		ARG 5 timeSupplier

--- a/mappings/net/minecraft/world/attribute/timeline/TrackEvaluator.mapping
+++ b/mappings/net/minecraft/world/attribute/timeline/TrackEvaluator.mapping
@@ -1,0 +1,28 @@
+CLASS net/minecraft/class_12308 net/minecraft/world/attribute/timeline/TrackEvaluator
+	FIELD field_64309 period Ljava/util/Optional;
+	FIELD field_64310 interpolator Lnet/minecraft/class_12210;
+	FIELD field_64311 segments Ljava/util/List;
+	METHOD <init> (Lnet/minecraft/class_12306;Ljava/util/Optional;Lnet/minecraft/class_12210;)V
+		ARG 1 track
+		ARG 2 period
+		ARG 3 interpolator
+	METHOD method_76386 get (J)Ljava/lang/Object;
+		ARG 1 time
+	METHOD method_76387 addSegmentsOfKeyframe (Lnet/minecraft/class_12306;Ljava/util/List;Ljava/util/List;)V
+		ARG 0 track
+		ARG 1 keyframes
+		ARG 2 segmentsOut
+	METHOD method_76388 convertToSegments (Lnet/minecraft/class_12306;Ljava/util/Optional;)Ljava/util/List;
+		ARG 0 track
+		ARG 1 period
+	METHOD method_76389 getSegmentForTime (J)Lnet/minecraft/class_12308$class_12309;
+		ARG 1 time
+	METHOD method_76390 periodize (J)J
+		ARG 1 time
+	CLASS class_12309 Segment
+		METHOD <init> (Lnet/minecraft/class_12306;Lnet/minecraft/class_12305;ILnet/minecraft/class_12305;I)V
+			ARG 1 track
+			ARG 2 fromKeyframe
+			ARG 3 fromTicks
+			ARG 4 toKeyframe
+			ARG 5 toTicks

--- a/mappings/net/minecraft/world/dimension/DimensionType.mapping
+++ b/mappings/net/minecraft/world/dimension/DimensionType.mapping
@@ -11,9 +11,20 @@ CLASS net/minecraft/class_2874 net/minecraft/world/dimension/DimensionType
 	FIELD field_51951 PACKET_CODEC Lnet/minecraft/class_9139;
 	FIELD field_63812 NETWORK_CODEC Lcom/mojang/serialization/Codec;
 	METHOD <init> (ZZZDIIILnet/minecraft/class_6862;FLnet/minecraft/class_2874$class_7512;Lnet/minecraft/class_2874$class_12326;Lnet/minecraft/class_2874$class_12325;Lnet/minecraft/class_12199;Lnet/minecraft/class_6885;)V
+		ARG 1 hasFixedTime
 		ARG 2 hasSkylight
 		ARG 3 hasCeiling
+		ARG 4 coordinateScale
+		ARG 6 minY
+		ARG 7 height
+		ARG 8 logicalHeight
+		ARG 9 infiniburn
+		ARG 10 ambientLight
+		ARG 11 monsterSettings
+		ARG 12 skybox
+		ARG 13 cardinalLightType
 		ARG 14 attributes
+		ARG 15 timelines
 	METHOD comp_847 monsterSettings ()Lnet/minecraft/class_2874$class_7512;
 	METHOD comp_5219 hasFixedTime ()Z
 	METHOD method_12488 getSaveDirectory (Lnet/minecraft/class_5321;Ljava/nio/file/Path;)Ljava/nio/file/Path;
@@ -28,7 +39,16 @@ CLASS net/minecraft/class_2874 net/minecraft/world/dimension/DimensionType
 		ARG 0 attributesCodec
 	METHOD method_75747 (Lcom/mojang/serialization/Codec;Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 		ARG 1 instance
+	METHOD method_76467 getSkybox ()Z
 	CLASS class_7512 MonsterSettings
 		FIELD field_39414 CODEC Lcom/mojang/serialization/MapCodec;
 		METHOD method_75748 (Lcom/mojang/serialization/codecs/RecordCodecBuilder$Instance;)Lcom/mojang/datafixers/kinds/App;
 			ARG 0 instance
+	CLASS class_12325 CardinalLightType
+		FIELD field_64383 name Ljava/lang/String;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
+			ARG 3 name
+	CLASS class_12326 Skybox
+		FIELD field_64389 name Ljava/lang/String;
+		METHOD <init> (Ljava/lang/String;ILjava/lang/String;)V
+			ARG 3 name


### PR DESCRIPTION
Unsure of `EnvironmentAttributeModification` for `class_12310`. This has three subclasses, which I’m calling `Constant`, `Positional`, and `TimeBased`, which encode modifications to attribute values, but is distinct from the existing `EnvironmentAttributeModifier`.