### PR TITLE
[Issue] - Rename setEvent to setEventIfAbsent in Timer.mapping.

### DIFF
--- a/mappings/net/minecraft/world/timer/Timer.mapping
+++ b/mappings/net/minecraft/world/timer/Timer.mapping
@@ -15,7 +15,8 @@ CLASS net/minecraft/class_236 net/minecraft/world/timer/Timer
 	METHOD method_980 serialize (Lnet/minecraft/class_236$class_237;)Lnet/minecraft/class_2487;
 		ARG 1 event
 	METHOD method_982 toNbt ()Lnet/minecraft/class_2499;
-	METHOD method_985 setEvent (Ljava/lang/String;JLnet/minecraft/class_234;)V
+	METHOD method_985 setEventIfAbsent (Ljava/lang/String;JLnet/minecraft/class_234;)V
+		COMMENT @deprecated Previously named {@code setEvent}.
 		ARG 1 name
 		ARG 2 triggerTime
 		ARG 4 callback

--- a/mappings/net/minecraft/world/timer/Timer.mapping
+++ b/mappings/net/minecraft/world/timer/Timer.mapping
@@ -16,7 +16,6 @@ CLASS net/minecraft/class_236 net/minecraft/world/timer/Timer
 		ARG 1 event
 	METHOD method_982 toNbt ()Lnet/minecraft/class_2499;
 	METHOD method_985 setEventIfAbsent (Ljava/lang/String;JLnet/minecraft/class_234;)V
-		COMMENT @deprecated Previously named {@code setEvent}.
 		ARG 1 name
 		ARG 2 triggerTime
 		ARG 4 callback


### PR DESCRIPTION
[Issue](https://github.com/FabricMC/yarn/issues/4361)

This pull request makes a small change to the `Timer` class mapping, renaming the `setEvent` method to `setEventIfAbsent` and marking it as deprecated. This improves clarity regarding the method's intended usage.

* Renamed the method `setEvent` to `setEventIfAbsent` in the `Timer` class mapping, and added a deprecation comment to indicate the previous name.