### PR TITLE
[Issue] - Reorder shape fields in PointedDripstoneBlock mapping

### DIFF
--- a/mappings/net/minecraft/block/PointedDripstoneBlock.mapping
+++ b/mappings/net/minecraft/block/PointedDripstoneBlock.mapping
@@ -5,9 +5,9 @@ CLASS net/minecraft/class_5689 net/minecraft/block/PointedDripstoneBlock
 	FIELD field_28053 TIP_MERGE_SHAPE Lnet/minecraft/class_265;
 	FIELD field_28054 UP_TIP_SHAPE Lnet/minecraft/class_265;
 	FIELD field_28055 DOWN_TIP_SHAPE Lnet/minecraft/class_265;
-	FIELD field_28056 FRUSTUM_SHAPE Lnet/minecraft/class_265;
-	FIELD field_28057 MIDDLE_SHAPE Lnet/minecraft/class_265;
-	FIELD field_28058 BASE_SHAPE Lnet/minecraft/class_265;
+	FIELD field_28056 MIDDLE_SHAPE Lnet/minecraft/class_265;
+	FIELD field_28057 BASE_SHAPE Lnet/minecraft/class_265;
+	FIELD field_28058 FRUSTUM_SHAPE Lnet/minecraft/class_265;
 	FIELD field_31203 DOWN_TIP_Y D
 	FIELD field_31204 MAX_HORIZONTAL_MODEL_OFFSET F
 	FIELD field_31211 WATER_DRIP_CHANCE F


### PR DESCRIPTION
[Issue](https://github.com/FabricMC/yarn/issues/4323)

This pull request makes a minor update to the field order in the mapping for the `PointedDripstoneBlock` class. The change simply reorders the declarations of the `FRUSTUM_SHAPE`, `MIDDLE_SHAPE`, and `BASE_SHAPE` fields to match their order in the source code. 