### PR TITLE
[Issue] - Rename input and event mapping classes for clarity.

### DIFF
--- a/mappings/net/minecraft/client/Mouse.mapping
+++ b/mappings/net/minecraft/client/Mouse.mapping
@@ -90,7 +90,7 @@ CLASS net/minecraft/class_312 net/minecraft/client/Mouse
 	METHOD method_68884 scaleY (Lnet/minecraft/class_1041;D)D
 		ARG 0 window
 		ARG 1 y
-	METHOD method_74190 modifyMouseInput (Lnet/minecraft/class_11910;Z)Lnet/minecraft/class_11910;
+	METHOD method_74190 modifyMouseButtonEvent (Lnet/minecraft/class_11910;Z)Lnet/minecraft/class_11910;
 		ARG 1 input
 		ARG 2 pressed
 	CLASS class_12291 MouseClickTime

--- a/mappings/net/minecraft/client/gui/Click.mapping
+++ b/mappings/net/minecraft/client/gui/Click.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/class_11909 net/minecraft/client/gui/Click
-	METHOD method_74245 button ()I

--- a/mappings/net/minecraft/client/gui/PointerEvent.mapping
+++ b/mappings/net/minecraft/client/gui/PointerEvent.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_11909 net/minecraft/client/gui/PointerEvent
+	METHOD method_74245 button ()I

--- a/mappings/net/minecraft/client/input/InputEvent.mapping
+++ b/mappings/net/minecraft/client/input/InputEvent.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_11907 net/minecraft/client/input/AbstractInput
+CLASS net/minecraft/class_11907 net/minecraft/client/input/InputEvent
 	FIELD field_62593 NOT_A_NUMBER I
 	METHOD method_74228 getKeycode ()I
 	METHOD method_74229 isEnterOrSpace ()Z

--- a/mappings/net/minecraft/client/input/KeyInput.mapping
+++ b/mappings/net/minecraft/client/input/KeyInput.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/class_11908 net/minecraft/client/input/KeyInput
-	CLASS class_12146 KeyAction

--- a/mappings/net/minecraft/client/input/KeyboardEvent.mapping
+++ b/mappings/net/minecraft/client/input/KeyboardEvent.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_11908 net/minecraft/client/input/KeyboardEvent
+	CLASS class_12146 KeyAction

--- a/mappings/net/minecraft/client/input/MouseButtonEvent.mapping
+++ b/mappings/net/minecraft/client/input/MouseButtonEvent.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_11910 net/minecraft/client/input/MouseInput
+CLASS net/minecraft/class_11910 net/minecraft/client/input/MouseButtonEvent
 	FIELD comp_4801 button I
 	METHOD comp_4801 button ()I
 	CLASS class_12147 MouseAction

--- a/mappings/net/minecraft/client/input/TextInputEvent.mapping
+++ b/mappings/net/minecraft/client/input/TextInputEvent.mapping
@@ -1,3 +1,3 @@
-CLASS net/minecraft/class_11905 net/minecraft/client/input/CharInput
+CLASS net/minecraft/class_11905 net/minecraft/client/input/TextInputEvent
 	METHOD method_74226 asString ()Ljava/lang/String;
 	METHOD method_74227 isValidChar ()Z

--- a/unpick-definitions/glfw/key.unpick
+++ b/unpick-definitions/glfw/key.unpick
@@ -126,7 +126,7 @@ group int key
 target_method net.minecraft.client.util.InputUtil isKeyPressed (Lnet/minecraft/client/util/Window;I)Z
 	param 1 key
 
-target_method net.minecraft.client.input.KeyInput key ()I
+target_method net.minecraft.client.input.KeyboardEvent key ()I
 	return key
 
 target_method org.lwjgl.glfw.GLFW glfwGetKeyName (II)Ljava/lang/String;

--- a/unpick-definitions/glfw/key_or_button_state.unpick
+++ b/unpick-definitions/glfw/key_or_button_state.unpick
@@ -5,10 +5,10 @@ group int key_or_button_state
 	net.minecraft.client.util.InputUtil.GLFW_PRESS
 	net.minecraft.client.util.InputUtil.GLFW_REPEAT
 
-target_method net.minecraft.client.Keyboard onKey (JILnet/minecraft/client/input/KeyInput;)V
+target_method net.minecraft.client.Keyboard onKey (JILnet/minecraft/client/input/KeyboardEvent;)V
 	param 1 key_or_button_state
 
-target_method net.minecraft.client.Mouse onMouseButton (JLnet/minecraft/client/input/MouseInput;I)V
+target_method net.minecraft.client.Mouse onMouseButton (JLnet/minecraft/client/input/MouseButtonEvent;I)V
 	param 2 key_or_button_state
 
 target_method org.lwjgl.glfw.GLFW glfwGetKey (JI)I

--- a/unpick-definitions/glfw/key_or_mouse_button.unpick
+++ b/unpick-definitions/glfw/key_or_mouse_button.unpick
@@ -143,7 +143,7 @@ target_method net.minecraft.client.util.InputUtil$Key <init> (Ljava/lang/String;
 target_method net.minecraft.client.util.InputUtil$Key getCode ()I
 	return key_or_mouse_button
 
-target_method net.minecraft.client.input.AbstractInput getKeycode ()I
+target_method net.minecraft.client.input.InputEvent getKeycode ()I
 	return key_or_mouse_button
 
 target_field net.minecraft.client.util.InputUtil$Key code I key_or_mouse_button

--- a/unpick-definitions/glfw/mouse_button.unpick
+++ b/unpick-definitions/glfw/mouse_button.unpick
@@ -10,8 +10,5 @@ group int mouse_button
 	org.lwjgl.glfw.GLFW.GLFW_MOUSE_BUTTON_7
 	org.lwjgl.glfw.GLFW.GLFW_MOUSE_BUTTON_8
 
-target_method net.minecraft.client.input.MouseInput button ()I
-	return mouse_button
-
-target_method net.minecraft.client.gui.Click button ()I
+target_method net.minecraft.client.input.MouseButtonEvent button ()I
 	return mouse_button


### PR DESCRIPTION
[Issue](https://github.com/FabricMC/yarn/issues/4322)

This pull request refactors input event class names and updates their usage throughout the codebase to improve clarity and consistency. The main changes involve renaming several input-related classes and updating method and target references to match the new names. These updates help make the codebase easier to understand and maintain by using more descriptive event names.

**Input event class renames and updates:**

* Renamed `AbstractInput` to `InputEvent`, `CharInput` to `TextInputEvent`, `KeyInput` to `KeyboardEvent`, and `MouseInput` to `MouseButtonEvent` in their respective mapping files. [[1]](diffhunk://#diff-9cf6f84a2e966a0ed7383c5db1044b70aa6c63a42e09f5afff79f6fe08f75b4cL1-R1) [[2]](diffhunk://#diff-267c576855c43bd58510b7afef0551fdbf9535b19d01f5ea5549f0c9759ad957L1-R1) [[3]](diffhunk://#diff-b9cc6da8eecb40b26da1551d798ac8c6e09407e36f197052bc14803183f8ae04L1-L2) [[4]](diffhunk://#diff-04fa2cd16757bd20b5a6774cee96731439e561c350e802b694351d0e2c75d236R1-R2) [[5]](diffhunk://#diff-d3981cfa9b68148ad5ee8aa9b50aa2151a3dba85773593cbbc4162eb0160c119L1-R1)
* Updated method and target references in unpick definition files to use the new class names (`KeyboardEvent`, `MouseButtonEvent`, `InputEvent`, etc.) instead of the old names. [[1]](diffhunk://#diff-d83003f972d66bafade7d2988329001427cd0455fd555bbbb0f4595181cb8b2aL129-R129) [[2]](diffhunk://#diff-9e0f3304e08b628b643ed3ef8aa7cfa6f14e8dfe184c3f7e270bcdef0fc30ef3L8-R11) [[3]](diffhunk://#diff-40e760e4f723b641d60a652a26cf64c0ec7e2d3a29d6f0c582911b30275f25dcL146-R146) [[4]](diffhunk://#diff-4768ef07bfb37f10bf8bbfd8c757ae616edfe9e096753564ff4c41839519effdL13-R13)

**GUI event mapping improvements:**

* Moved the `Click` class and its `button()` method to `PointerEvent` to better reflect its purpose and usage. [[1]](diffhunk://#diff-afeb4cf9eb77e47fc989040d496441d2f0af0787906e40232ffefa9e714b03fbL1-L2) [[2]](diffhunk://#diff-de26f84cc9e4d140870725bb2f6bd49388a604855e885baa74f636aeef14b701R1-R2)

**Mouse event method renaming:**

* Renamed the `modifyMouseInput` method in the `Mouse` class to `modifyMouseButtonEvent` for clarity.