### PR TITLE
Fix PLAYER_SLIM duplicate

### DIFF
--- a/mappings/net/minecraft/client/render/entity/model/EntityModelLayers.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/EntityModelLayers.mapping
@@ -51,7 +51,7 @@ CLASS net/minecraft/class_5602 net/minecraft/client/render/entity/model/EntityMo
 	FIELD field_61694 HUSK_BABY_EQUIPMENT Lnet/minecraft/class_11677;
 	FIELD field_61695 HUSK_EQUIPMENT Lnet/minecraft/class_11677;
 	FIELD field_61696 GIANT_EQUIPMENT Lnet/minecraft/class_11677;
-	FIELD field_61697 PLAYER_SLIM Lnet/minecraft/class_11677;
+	FIELD field_61697 PLAYER_EQUIPMENT_SLIM Lnet/minecraft/class_11677;
 	FIELD field_61698 PIGLIN_BABY_EQUIPMENT Lnet/minecraft/class_11677;
 	FIELD field_61699 PIGLIN_BRUTE_EQUIPMENT Lnet/minecraft/class_11677;
 	FIELD field_61700 PIGLIN_EQUIPMENT Lnet/minecraft/class_11677;


### PR DESCRIPTION
Two fields in EntityModelLayers have the name `PLAYER_SLIM` (one is the EntityModelLayer and the other is the EquipmentModelData.

This pull request renames the EquipmentModelData field to `PLAYER_EQUIPMENT_SLIM`.

Also affects 1.21.9 and may affect newer versions too.