### PR TITLE
[Issue] - Rename velocityModified to knockedBack in Entity.mapping

### DIFF
--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -139,7 +139,7 @@ CLASS net/minecraft/class_1297 net/minecraft/entity/Entity
 	FIELD field_6032 AIR Lnet/minecraft/class_2940;
 	FIELD field_6034 vehicle Lnet/minecraft/class_1297;
 	FIELD field_6036 lastY D
-	FIELD field_6037 velocityModified Z
+	FIELD field_6037 knockedBack Z
 	FIELD field_6038 lastRenderX D
 	FIELD field_17046 movementMultiplier Lnet/minecraft/class_243;
 	FIELD field_18064 POSE Lnet/minecraft/class_2940;


### PR DESCRIPTION
[Issue](https://github.com/FabricMC/yarn/issues/4206)

This pull request makes a minor change to the field naming in the `Entity` class mapping. The field previously named `velocityModified` has been renamed to `knockedBack`, which likely improves clarity regarding its purpose.

* Renamed the field `field_6037` in the `Entity` class mapping from `velocityModified` to `knockedBack` in `mappings/net/minecraft/entity/Entity.mapping`.