### PR TITLE
[Issue][4249] - Add passenger field and method to TeleportTarget mapp…

### DIFF
--- a/mappings/net/minecraft/world/TeleportTarget.mapping
+++ b/mappings/net/minecraft/world/TeleportTarget.mapping
@@ -5,10 +5,10 @@ CLASS net/minecraft/class_5454 net/minecraft/world/TeleportTarget
 	FIELD comp_2822 velocity Lnet/minecraft/class_243;
 	FIELD comp_2823 yaw F
 	FIELD comp_2824 pitch F
+	FIELD comp_3285 passenger Z
 	FIELD field_52245 NO_OP Lnet/minecraft/class_5454$class_9823;
 	FIELD field_52246 SEND_TRAVEL_THROUGH_PORTAL_PACKET Lnet/minecraft/class_5454$class_9823;
 	FIELD field_52247 ADD_PORTAL_CHUNK_TICKET Lnet/minecraft/class_5454$class_9823;
-	FIELD comp_3285 passenger Z
 	METHOD <init> (Lnet/minecraft/class_3218;Lnet/minecraft/class_243;Lnet/minecraft/class_243;FFLjava/util/Set;Lnet/minecraft/class_5454$class_9823;)V
 		ARG 1 world
 		ARG 2 pos
@@ -28,6 +28,7 @@ CLASS net/minecraft/class_5454 net/minecraft/world/TeleportTarget
 	METHOD comp_2822 velocity ()Lnet/minecraft/class_243;
 	METHOD comp_2823 yaw ()F
 	METHOD comp_2824 pitch ()F
+	METHOD comp_3285 passenger ()Z
 	METHOD method_60635 missingSpawnBlock (Lnet/minecraft/class_3222;Lnet/minecraft/class_5454$class_9823;)Lnet/minecraft/class_5454;
 		ARG 0 player
 		ARG 1 postDimensionTransition
@@ -49,7 +50,6 @@ CLASS net/minecraft/class_5454 net/minecraft/world/TeleportTarget
 	METHOD method_74892 noRespawnPointSet (Lnet/minecraft/class_3222;Lnet/minecraft/class_5454$class_9823;)Lnet/minecraft/class_5454;
 		ARG 0 player
 		ARG 1 postDimensionTransition
-	METHOD comp_3285 passenger ()Z
 	CLASS class_9823 PostDimensionTransition
 		METHOD method_61027 (Lnet/minecraft/class_5454$class_9823;Lnet/minecraft/class_1297;)V
 			ARG 2 entity

--- a/mappings/net/minecraft/world/TeleportTarget.mapping
+++ b/mappings/net/minecraft/world/TeleportTarget.mapping
@@ -8,6 +8,7 @@ CLASS net/minecraft/class_5454 net/minecraft/world/TeleportTarget
 	FIELD field_52245 NO_OP Lnet/minecraft/class_5454$class_9823;
 	FIELD field_52246 SEND_TRAVEL_THROUGH_PORTAL_PACKET Lnet/minecraft/class_5454$class_9823;
 	FIELD field_52247 ADD_PORTAL_CHUNK_TICKET Lnet/minecraft/class_5454$class_9823;
+	FIELD comp_3285 passenger Z
 	METHOD <init> (Lnet/minecraft/class_3218;Lnet/minecraft/class_243;Lnet/minecraft/class_243;FFLjava/util/Set;Lnet/minecraft/class_5454$class_9823;)V
 		ARG 1 world
 		ARG 2 pos
@@ -48,6 +49,7 @@ CLASS net/minecraft/class_5454 net/minecraft/world/TeleportTarget
 	METHOD method_74892 noRespawnPointSet (Lnet/minecraft/class_3222;Lnet/minecraft/class_5454$class_9823;)Lnet/minecraft/class_5454;
 		ARG 0 player
 		ARG 1 postDimensionTransition
+	METHOD comp_3285 passenger ()Z
 	CLASS class_9823 PostDimensionTransition
 		METHOD method_61027 (Lnet/minecraft/class_5454$class_9823;Lnet/minecraft/class_1297;)V
 			ARG 2 entity


### PR DESCRIPTION
Issue - [4249](https://github.com/FabricMC/yarn/issues/4249)

This pull request makes a small update to the `TeleportTarget` class mapping by introducing support for a new field and method related to passenger status. These changes help clarify and expose whether a teleport target is associated with a passenger entity.

Most important changes:

**Passenger support in `TeleportTarget`:**

* Added a new boolean field `comp_3285` named `passenger` to indicate passenger status in the `TeleportTarget` class mapping.
* Added a new method `comp_3285 passenger()` that returns the passenger status as a boolean in the `TeleportTarget` class mapping.