### PR TITLE
[Issue][4399] - Rename abilityResyncCountdown to flightToggleCooldown

### DIFF
--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_1657 net/minecraft/entity/player/PlayerEntity
 	FIELD field_7484 itemCooldownManager Lnet/minecraft/class_1796;
 	FIELD field_7486 enderChestInventory Lnet/minecraft/class_1730;
 	FIELD field_7487 sleepTimer I
-	FIELD field_7489 abilityResyncCountdown I
+	FIELD field_7489 flightToggleCooldown I
 	FIELD field_7490 isSubmergedInWater Z
 	FIELD field_7491 ABSORPTION_AMOUNT Lnet/minecraft/class_2940;
 	FIELD field_7493 hungerManager Lnet/minecraft/class_1702;


### PR DESCRIPTION
This pull request makes a targeted change to the `PlayerEntity` class mapping by renaming a field for clarity. The field previously named `abilityResyncCountdown` has been renamed to `flightToggleCooldown`, which better reflects its purpose.

- **Field renaming for clarity:**
  - Renamed the field `field_7489` in `PlayerEntity` from `abilityResyncCountdown` to `flightToggleCooldown` to more accurately describe its function.