### PR TITLE
[4402] - Rename addTask to addFailureTask in TestContext

### DIFF
--- a/mappings/net/minecraft/test/TestContext.mapping
+++ b/mappings/net/minecraft/test/TestContext.mapping
@@ -249,7 +249,7 @@ CLASS net/minecraft/class_4516 net/minecraft/test/TestContext
 		ARG 2 pos
 	METHOD method_36026 pushButton (Lnet/minecraft/class_2338;)V
 		ARG 1 pos
-	METHOD method_36028 addTask (Ljava/lang/Runnable;)V
+	METHOD method_36028 addFailureTask (Ljava/lang/Runnable;)V
 		ARG 1 task
 	METHOD method_36031 dontExpectEntityAt (Lnet/minecraft/class_1299;III)V
 		ARG 1 type


### PR DESCRIPTION
[4402](https://github.com/FabricMC/yarn/issues/4402)
TestContext.addTask is misleadingly named. The method creates a timed task runner that runs the given Runnable every tick, and if the runnable ever stops throwing, the test fails. This is effectively a continuous negative assertion -- the opposite of what "addTask" implies.

Renamed to addFailureTask to better communicate that this method expects the task to always fail, and that the test will fail if the task ever succeeds.